### PR TITLE
output UI Hierarchy on test failure

### DIFF
--- a/detox/ios/Detox/TestFailureHandler.m
+++ b/detox/ios/Detox/TestFailureHandler.m
@@ -13,6 +13,9 @@
 - (void)handleException:(GREYFrameworkException *)exception details:(NSString *)details
 {
     NSLog(@"Detox Test Failed: %@", exception);
+    UIWindow* window = [[UIApplication sharedApplication] keyWindow];
+    NSLog(@"UI Hierarchy on test failure: %@", [GREYElementHierarchy hierarchyStringForElement:window]);
+
     if (self.delegate) [self.delegate onTestFailed:[exception description]];
 }
 


### PR DESCRIPTION
This frequently provides super useful information that can tell why the test failed.

Here's the output of a (manual) test failure:

```
DETOX app: 2016-10-05 16:13:00.193 example[28117:558468] UI Hierarchy on test failure: <UIWindow:0x7fe843150bd0; AX=N; AX.frame={{0, 0}, {375, 667}}; AX.activationPoint={187.5, 333.5}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 0}, {375, 667}}; opaque; alpha=1>
  |--<RCTRootView:0x7fe840c02010; AX=N; AX.frame={{0, 0}, {375, 667}}; AX.activationPoint={187.5, 333.5}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 0}, {375, 667}}; opaque; alpha=1>
  |  |--<RCTRootContentView:0x7fe843165200; AX=N; AX.label='    World!!! '; AX.frame={{0, 0}, {375, 667}}; AX.activationPoint={187.5, 333.5}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 0}, {375, 667}}; opaque; alpha=1>
  |  |  |--<RCTView:0x7fe840c96410; AX=N; AX.label='   World!!! '; AX.frame={{0, 0}, {375, 667}}; AX.activationPoint={187.5, 333.5}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 0}, {375, 667}}; opaque; alpha=1>
  |  |  |  |--<RCTView:0x7fe840cb99d0; AX=N; AX.label='  World!!!'; AX.frame={{0, 0}, {375, 667}}; AX.activationPoint={187.5, 333.5}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 0}, {375, 667}}; opaque; alpha=1>
  |  |  |  |  |--<RCTView:0x7fe840cb6fe0; AX=N; AX.label=' World!!!'; AX.frame={{0, 0}, {375, 667}}; AX.activationPoint={187.5, 333.5}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 0}, {375, 667}}; opaque; alpha=1>
  |  |  |  |  |  |--<RCTText:0x7fe840de7c50; AX=Y; AX.label='World!!!'; AX.frame={{144.5, 328.5}, {86.5, 30}}; AX.activationPoint={187.75, 343.5}; AX.traits='UIAccessibilityTraitStaticText'; AX.focused='N'; frame={{144.5, 328.5}, {86.5, 30}}; alpha=1>
  |  |  |  |  |  |  |--<RCTView:0x7fe840dd7680; AX=N; AX.frame={{144.5, 328.5}, {0, 0}}; AX.activationPoint={144.5, 328.5}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 0}, {0, 0}}; opaque; alpha=1>
  |  |  |  |  |  |  |--<RCTView:0x7fe8434b6640; AX=N; AX.frame={{144.5, 328.5}, {0, 0}}; AX.activationPoint={144.5, 328.5}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 0}, {0, 0}}; opaque; alpha=1>
  |  |  |  |--<RCTView:0x7fe84350ff80; AX=N; AX.frame={{0, 667}, {0, 0}}; AX.activationPoint={0, 667}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 667}, {0, 0}}; opaque; alpha=1>
```
So for example, you can see that an element with AX label='World!!!' exists.