### PR TITLE
device: add `resetContentAndSettings`

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -159,6 +159,10 @@ class Device {
     await this.deviceDriver.disableSynchronization();
   }
 
+  async resetContentAndSettings() {
+    await this.deviceDriver.resetContentAndSettings(this._deviceId);
+  }
+
   getPlatform() {
     return this.deviceDriver.getPlatform(this._deviceId);
   }

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -389,6 +389,13 @@ describe('Device', () => {
     expect(device.deviceDriver.disableSynchronization).toHaveBeenCalledTimes(1);
   });
 
+  it(`resetContentAndSettings() should pass to device driver`, async () => {
+    device = validDevice();
+    await device.resetContentAndSettings();
+
+    expect(device.deviceDriver.resetContentAndSettings).toHaveBeenCalledTimes(1);
+  });
+
   it(`getPlatform() should pass to device driver`, async () => {
     device = validDevice();
     device.getPlatform();

--- a/detox/src/devices/DeviceDriverBase.js
+++ b/detox/src/devices/DeviceDriverBase.js
@@ -87,6 +87,10 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
+  async resetContentAndSettings() {
+    return await Promise.resolve('');
+  }
+
   defaultLaunchArgsPrefix() {
     return '';
   }

--- a/detox/src/devices/Fbsimctl.js
+++ b/detox/src/devices/Fbsimctl.js
@@ -173,6 +173,14 @@ class Fbsimctl {
     await this._execFbsimctlCommand(options);
   }
 
+  async resetContentAndSettings(udid) {
+    await this.shutdown(udid);
+    const result = await exec.execWithRetriesAndLogs(`/usr/bin/xcrun simctl erase ${udid}`);
+    const resultCode = parseInt(result.stdout.trim().split(':')[1]);
+    await this.boot(udid);
+    return resultCode;
+  }
+
   async _execFbsimctlCommand(options, statusLogs, retries, interval) {
     const bin = `fbsimctl --json`;
     return await exec.execWithRetriesAndLogs(bin, options, statusLogs, retries, interval);

--- a/detox/src/devices/Fbsimctl.test.js
+++ b/detox/src/devices/Fbsimctl.test.js
@@ -168,6 +168,17 @@ describe('Fbsimctl', () => {
     await validateFbsimctlisCalledOn(fbsimctl, async () => fbsimctl.setLocation(simUdid));
   });
 
+  it(`resetContentAndSettings() - is triggering shutdown, exec and boot`, async() => {
+    fs.existsSync.mockReturnValue(true);
+    exec.mockReturnValue({stdout: "appId: 22 \n"});
+    fbsimctl.shutdown = jest.fn();
+    fbsimctl.boot = jest.fn();
+    await fbsimctl.resetContentAndSettings(simUdid);
+    expect(fbsimctl.shutdown).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(fbsimctl.boot).toHaveBeenCalledTimes(1);
+  });
+
   it(`exec simulator command successfully`, async() => {
     const result = returnSuccessfulWithValue("");
     exec.mockReturnValue(Promise.resolve(result));

--- a/detox/src/devices/SimulatorDriver.js
+++ b/detox/src/devices/SimulatorDriver.js
@@ -65,6 +65,10 @@ class SimulatorDriver extends IosDriver {
     await this._applesimutils.setPermissions(deviceId, bundleId, permissions);
   }
 
+  async resetContentAndSettings(deviceId) {
+    return await this._fbsimctl.resetContentAndSettings(deviceId);
+  }
+
   validateDeviceConfig(deviceConfig) {
     if (!deviceConfig.binaryPath) {
       configuration.throwOnEmptyBinaryPath();

--- a/detox/test/e2e/f-device.js
+++ b/detox/test/e2e/f-device.js
@@ -1,4 +1,4 @@
-describe.only('Device', () => {
+describe('Device', () => {
   it('reloadReactNative - should tap successfully', async () => {
     await device.reloadReactNative();
     await element(by.label('Sanity')).tap();

--- a/detox/test/e2e/f-device.js
+++ b/detox/test/e2e/f-device.js
@@ -1,4 +1,4 @@
-describe('Device', () => {
+describe.only('Device', () => {
   it('reloadReactNative - should tap successfully', async () => {
     await device.reloadReactNative();
     await element(by.label('Sanity')).tap();
@@ -36,6 +36,15 @@ describe('Device', () => {
     await device.sendToHome();
     await device.launchApp();
 
+    await expect(element(by.label('Hello!!!'))).toBeVisible();
+  });
+
+  it('resetContentAndSettings() + install() + relaunch() - should tap successfully', async () => {
+    await device.resetContentAndSettings();
+    await device.installApp();
+    await device.launchApp({ newInstance: true });
+    await element(by.label('Sanity')).tap();
+    await element(by.label('Say Hello')).tap();
     await expect(element(by.label('Hello!!!'))).toBeVisible();
   });
 

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -18,6 +18,7 @@
 - [`device.setURLBlacklist([urls])`](#deviceseturlblacklisturls)
 - [`device.enableSynchronization()`](#deviceenablesynchronization)
 - [`device.disableSynchronization()`](#devicedisablesynchronization)
+- [`device.resetContentAndSettings()`](#resetcontentandsettings)
 
 ### `device.launchApp(params)`
 Launch the app defined in the current [`configuration`](APIRef.Configuration.md).
@@ -190,4 +191,13 @@ Disable [EarlGrey's synchronization mechanism](https://github.com/google/EarlGre
 
 ```js
 await device.disableSynchronization();
+```
+
+
+### `device.resetContentAndSettings()`
+Resets the Simulator to clean state (like the Simulator > Reset Content and Settings... menu item), especially removing
+previously set permissions.
+
+```js
+await device.resetContentAndSettings();
 ```


### PR DESCRIPTION
I added a new method to device to cleanup the device (like "Simulator > Reset Content and Settings" menu-item does), because I want to test specific screens which are only shown when the permissions are not set yet (e.g. a screen for explaining why the specific permission is needed)