### PR TITLE
convert setLocation params to string with comma as decimal separator

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -140,8 +140,8 @@ class Device {
   }
 
   async setLocation(lat, lon) {
-    lat = (lat + '').replace('.', ',');
-    lon = (lon + '').replace('.', ',');
+    lat = String(lat).replace('.', ',');
+    lon = String(lon).replace('.', ',');
     await this.deviceDriver.setLocation(this._deviceId, lat, lon);
   }
 

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -140,6 +140,8 @@ class Device {
   }
 
   async setLocation(lat, lon) {
+    lat = (lat + '').replace('.', ',');
+    lon = (lon + '').replace('.', ',');
     await this.deviceDriver.setLocation(this._deviceId, lat, lon);
   }
 

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -365,7 +365,7 @@ describe('Device', () => {
     device = validDevice();
     await device.setLocation(30, 30);
 
-    expect(device.deviceDriver.setLocation).toHaveBeenCalledWith(device._deviceId, 30, 30);
+    expect(device.deviceDriver.setLocation).toHaveBeenCalledWith(device._deviceId, '30', '30');
   });
 
   it(`setURLBlacklist() should pass to device driver`, async () => {


### PR DESCRIPTION
using numbers with decimals for lat/long in setLocation results in an error, it has to be passed as string with a comma as decimal separator to `fbsimctl`