### PR TITLE
Updated Guide.RunningOnCI to include Bitrise instructions

### DIFF
--- a/docs/Guide.RunningOnCI.md
+++ b/docs/Guide.RunningOnCI.md
@@ -1,4 +1,4 @@
-# Running Tests on CI (like Travis)
+# Running Tests on CI (Travis or Bitrise)
 
 > When your test suite is finally ready, it should be set up to run automatically on your CI server on every git push. This will alert you if new changes to the app break existing functionality.
 
@@ -44,7 +44,9 @@ detox test --configuration ios.sim.release --cleanup
 
 <br>
 
-## Appendix: Running Detox on Travis-CI
+## Appendix
+
+### • Running Detox on [Travis CI](https://travis-ci.org/)
 
 Detox's own build is running on Travis, check out Detox's [.travis.yml](/.travis.yml) file to see how it's done.
 
@@ -79,4 +81,96 @@ script:
 - detox build --configuration ios.sim.release
 - detox test --configuration ios.sim.release --cleanup
 
+```
+
+### • Running Detox on [Bitrise](https://www.bitrise.io/)
+
+Bitrise is a popular CI service for automating React Native apps. If you are looking to get started with Bitrise, check out [this](http://blog.bitrise.io/2017/07/25/how-to-set-up-a-react-native-app-on-bitrise.html) guide.
+
+You can run Detox on Bitrise by adding a `tests` workflow. Here's what the Bitrise **.yml** file looks like for doing so:
+
+```yml
+---
+format_version: 1.1.0
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+workflows:
+  _tests_setup:
+    steps:
+    - activate-ssh-key: {}
+    - git-clone:
+        inputs:
+        - clone_depth: ''
+    - script@1.1.4:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            npm cache verify
+            npm install
+        title: Install Packages
+    before_run: 
+    after_run: 
+  _detox_tests:
+    before_run: []
+    after_run: []
+    steps:
+    - npm:
+        inputs:
+        - command: install -g detox-cli
+        title: Install Detox CLI
+    - npm@0.9.0:
+        inputs:
+        - command: install -g react-native-cli
+        title: Install React Native CLI
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            brew tap facebook/fb
+            export CODE_SIGNING_REQUIRED=NO
+            brew install fbsimctl
+            brew tap wix/brew
+            brew install applesimutils --HEAD
+        title: Install Detox Utils
+    - script@1.1.4:
+        title: Start Packager in Background
+        inputs:
+        - content: |-
+            #!/bin/bash
+            npm run start &
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            detox build --configuration ios.sim.release
+        title: Build Detox app
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            detox test --configuration ios.sim.release
+        - is_debug: 'yes'
+        title: Run Detox Integration Tests
+  tests:
+    before_run:
+    - _tests_setup
+    - _detox_tests
+    steps:
+    - slack@2.6.2:
+        inputs:
+        - webhook_url: ##SLACK_WEBHOOK_URL
+        - channel: "#builds"
+        - from_username_on_error: Bitrise CI - Tests Shall Not Pass!!
+        - from_username: Bitrise CI - Integration & Unit Tests Passing
+        - message: |-
+            *Build succeeded*: $BITRISE_GIT_MESSAGE
+            *Branch*: $BITRISE_GIT_BRANCH
+
+            Fuck it! Ship it!
+        - message_on_error: |-
+            *Build failed*: $BITRISE_GIT_MESSAGE
+            *Branch*: $BITRISE_GIT_BRANCH
+
+            _I believe in you!! Please try again._
+        - emoji: ":shipit:"
+        - emoji_on_error: ":bug:"
 ```


### PR DESCRIPTION
I use Detox for testing our React Native app and it's been great so far. When it was time to put it on CI, I struggled a little bit to get it working on Bitrise (as we have been using Bitrise for running unit tests so far).

Hence after spending hours trying to getting Detox to work on Bitrise, I finally figure it out and so I thought I should share the solution so others can benefit from it. 

I have update the docs to show how to setup Detox on Bitrise. Hope this helps. 

Let me know if I need to make any changes. Thanks.