### PR TITLE
Change to decoupled binary config format

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -54,6 +54,7 @@
     "commander": "^2.9.0",
     "detox-server": "^2.0.4",
     "get-port": "^2.1.0",
+    "glob": "^7.1.2",
     "lodash": "^4.14.1",
     "npmlog": "^4.0.2",
     "react-native-invoke": "^0.2.1",

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -66,8 +66,13 @@ class Detox {
       throw new Error(`'${deviceConfig.type}' is not supported`);
     }
 
+    const appName = this.userConfig.appName;
+    if (!appName) {
+      configuration.throwOnEmptyAppName();
+    }
+
     const deviceDriver = new deviceClass(this.client);
-    this.device = new Device(deviceConfig, sessionConfig, deviceDriver);
+    this.device = new Device(deviceConfig, sessionConfig, deviceDriver, appName, this.userConfig.binary);
     await this.device.prepare(params);
     global.device = this.device;
   }

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -10,6 +10,7 @@ const DetoxServer = require('detox-server');
 const URL = require('url').URL;
 const _ = require('lodash');
 const ArtifactsPathsProvider = require('./artifacts/ArtifactsPathsProvider');
+const appContext = require('./utils/appContext');
 
 log.level = argparse.getArgValue('loglevel') || 'info';
 log.addLevel('wss', 999, {fg: 'blue', bg: 'black'}, 'wss');
@@ -65,13 +66,19 @@ class Detox {
     if (!deviceClass) {
       throw new Error(`'${deviceConfig.type}' is not supported`);
     }
+    const deviceDriver = new deviceClass(this.client);
 
-    const appName = this.userConfig.appName;
+    let appName = this.userConfig.appName;
     if (!appName) {
-      configuration.throwOnEmptyAppName();
+      log.info("appName was not found in config, we will set it for you");
+      try {
+        appName = await appContext.getAppName(deviceDriver.getPlatform());
+        log.info(`Got the appName, its "${appName}". If this is wrong, please set the appName config property`);
+      } catch (e) {
+        throw new Error("You neither set the appName, nor could we find it anywhere. Please set it in your configuration.");
+      }
     }
 
-    const deviceDriver = new deviceClass(this.client);
     this.device = new Device(deviceConfig, sessionConfig, deviceDriver, appName, this.userConfig.binary);
     await this.device.prepare(params);
     global.device = this.device;

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -58,6 +58,7 @@ describe('Detox', () => {
   it(`Config with no appName, should not throw but find the right app name`, async () => {
     Detox = require('./Detox');
     const Device = require('./devices/Device');
+    const SimulatorDriver = require('./devices/SimulatorDriver');
     const appContext = require('./utils/appContext');
     appContext.getAppName = jest.fn(() => "fancyApp");
 
@@ -65,8 +66,9 @@ describe('Detox', () => {
     await detox.init();
 
     expect(Device).toHaveBeenCalled();
-    const appName = Device.mock.calls[0][3];
-    expect(appName).toBe("fancyApp");
+    expect(SimulatorDriver.mock.instances.length).toBe(1);
+    expect(SimulatorDriver.mock.instances[0].getBinaryPath.mock.calls.length).toBe(1);
+    expect(SimulatorDriver.mock.instances[0].getBinaryPath.mock.calls[0][0]).toBe("fancyApp");
   });
 
   it(`Config with no appName should throw if appName could not be found`, async () => {

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -55,8 +55,26 @@ describe('Detox', () => {
     }
   });
 
-  it(`Config with no appName, should throw`, async () => {
+  it(`Config with no appName, should not throw but find the right app name`, async () => {
     Detox = require('./Detox');
+    const Device = require('./devices/Device');
+    const appContext = require('./utils/appContext');
+    appContext.getAppName = jest.fn(() => "fancyApp");
+
+    detox = new Detox(schemes.invalidNoAppName);
+    await detox.init();
+
+    expect(Device).toHaveBeenCalled();
+    const appName = Device.mock.calls[0][3];
+    expect(appName).toBe("fancyApp");
+  });
+
+  it(`Config with no appName should throw if appName could not be found`, async () => {
+    Detox = require('./Detox');
+    const Device = require('./devices/Device');
+    const appContext = require('./utils/appContext');
+    appContext.getAppName = jest.fn(() => { throw new Error("Not found") });
+
     try {
       detox = new Detox(schemes.invalidNoAppName);
       await detox.init();

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -55,6 +55,17 @@ describe('Detox', () => {
     }
   });
 
+  it(`Config with no appName, should throw`, async () => {
+    Detox = require('./Detox');
+    try {
+      detox = new Detox(schemes.invalidNoAppName);
+      await detox.init();
+      fail("Did not throw");
+    } catch (ex) {
+      expect(ex).toBeDefined();
+    }
+  });
+
   it(`Config with emulator, should throw`, async () => {
     Detox = require('./Detox');
     try {

--- a/detox/src/configuration.js
+++ b/detox/src/configuration.js
@@ -26,6 +26,9 @@ function validateSession(session) {
 function throwOnEmptyName() {
   throw new DetoxConfigError(`'name' property is missing, should hold the device name to run on (e.g. "iPhone 7", "iPhone 7, iOS 10.2"`);
 }
+function throwOnEmptyAppName() {
+  throw new DetoxConfigError(`'appName' property is missing, should hold the application name used in the build process (e.g. "facebook", "demoApp")`);
+}
 
 function throwOnEmptyType() {
   throw new DetoxConfigError(`'type' property is missing, should hold the device type to test on (currently only simulator is supported: ios.simulator or ios.none)`);
@@ -44,5 +47,6 @@ module.exports = {
   validateSession,
   throwOnEmptyName,
   throwOnEmptyType,
-  throwOnEmptyBinaryPath
+  throwOnEmptyBinaryPath,
+  throwOnEmptyAppName
 };

--- a/detox/src/configuration.js
+++ b/detox/src/configuration.js
@@ -26,10 +26,6 @@ function validateSession(session) {
 function throwOnEmptyName() {
   throw new DetoxConfigError(`'name' property is missing, should hold the device name to run on (e.g. "iPhone 7", "iPhone 7, iOS 10.2"`);
 }
-function throwOnEmptyAppName() {
-  throw new DetoxConfigError(`'appName' property is missing, should hold the application name used in the build process (e.g. "facebook", "demoApp")`);
-}
-
 function throwOnEmptyType() {
   throw new DetoxConfigError(`'type' property is missing, should hold the device type to test on (currently only simulator is supported: ios.simulator or ios.none)`);
 }
@@ -47,6 +43,5 @@ module.exports = {
   validateSession,
   throwOnEmptyName,
   throwOnEmptyType,
-  throwOnEmptyBinaryPath,
-  throwOnEmptyAppName
+  throwOnEmptyBinaryPath
 };

--- a/detox/src/configuration.test.js
+++ b/detox/src/configuration.test.js
@@ -33,6 +33,26 @@ describe('configuration', () => {
     testFaultySession(schemes.invalidSessionNoSessionId.session);
   });
 
+  describe("externally invoked errors", () => {
+    it(`should throw appName missing error`, () => {
+      try {
+        configuration.throwOnEmptyName();
+        fail("No error thrown");
+      } catch (ex) {
+        expect(ex).toBeDefined();
+      }
+    });
+
+    it(`should throw empty build path error`, () => {
+      try {
+        configuration.throwOnEmptyBinaryPath();
+        fail("No error thrown");
+      } catch (ex) {
+        expect(ex).toBeDefined();
+      }
+    });
+  });
+
   function testFaultySession(config) {
     try {
       configuration.validateSession(config);

--- a/detox/src/configurations.mock.js
+++ b/detox/src/configurations.mock.js
@@ -1,7 +1,20 @@
 const validOneDeviceNoSession = {
+  "appName": "example",
+  "binary": {
+    "ios": "ios/build/Build/Products/"
+  },
   "configurations": {
     "ios.sim.release": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
+      "type": "ios.simulator",
+      "name": "iPhone 7 Plus, iOS 10.2"
+    }
+  }
+};
+
+const validOneDeviceNoSessionNoBinary = {
+  "appName": "example",
+  "configurations": {
+    "ios.sim.release": {
       "type": "ios.simulator",
       "name": "iPhone 7 Plus, iOS 10.2"
     }
@@ -9,6 +22,7 @@ const validOneDeviceNoSession = {
 };
 
 const validOneIosNoneDeviceNoSession = {
+  "appName": "example",
   "configurations": {
     "ios.none": {
       "type": "ios.none",
@@ -18,6 +32,7 @@ const validOneIosNoneDeviceNoSession = {
 };
 
 const validTwoDevicesNoSession = {
+  "appName": "example",
   "configurations": {
     "ios.sim.release": {
       "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
@@ -33,6 +48,7 @@ const validTwoDevicesNoSession = {
 };
 
 const invalidDeviceNoBinary = {
+  "appName": "example",
   "configurations": {
     "ios.sim.release": {
       "type": "ios.simulator",
@@ -42,11 +58,13 @@ const invalidDeviceNoBinary = {
 };
 
 const invalidNoDevice = {
+  "appName": "example",
   "configurations": {
   }
 };
 
 const invalidDeviceNoDeviceType = {
+  "appName": "example",
   "configurations": {
     "ios.sim.release": {
       "binaryPath": "here",
@@ -55,7 +73,17 @@ const invalidDeviceNoDeviceType = {
   }
 };
 
+const invalidNoAppName = {
+  "configurations": {
+    "ios.sim.release": {
+      "type": "ios.simulator",
+      "name": "iPhone 7 Plus, iOS 10.2"
+    }
+  }
+};
+
 const invalidDeviceNoDeviceName = {
+  "appName": "example",
   "configurations": {
     "ios.sim.release": {
       "binaryPath": "here",
@@ -65,6 +93,7 @@ const invalidDeviceNoDeviceName = {
 };
 
 const validOneDeviceAndSession = {
+  "appName": "example",
   "session": {
     "server": "ws://localhost:8099",
     "sessionId": "test"
@@ -79,18 +108,21 @@ const validOneDeviceAndSession = {
 };
 
 const invalidSessionNoSessionId = {
+  "appName": "example",
   "session": {
     "server": "ws://localhost:8099"
   }
 };
 
 const invalidSessionNoServer = {
+  "appName": "example",
   "session": {
     "sessionId": "test"
   }
 };
 
 const invalidOneDeviceTypeEmulatorNoSession = {
+  "appName": "example",
   "configurations": {
     "ios.sim.release": {
       "binaryPath": "some.apk",
@@ -101,6 +133,7 @@ const invalidOneDeviceTypeEmulatorNoSession = {
 };
 
 const sessionPerConfiguration = {
+  "appName": "example",
   "configurations": {
     "ios.sim.none": {
       "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
@@ -124,6 +157,7 @@ const sessionPerConfiguration = {
 };
 
 const sessionInCommonAndInConfiguration = {
+  "appName": "example",
   "session": {
     "server": "ws://localhost:1111",
     "sessionId": "test_1"
@@ -142,6 +176,7 @@ const sessionInCommonAndInConfiguration = {
 };
 
 const validOneEmulator = {
+  "appName": "example",
   "configurations": {
     "android.emu.release": {
       "binaryPath": "android/app/build/outputs/apk/app-debug.apk",
@@ -163,6 +198,7 @@ module.exports = {
   invalidSessionNoSessionId,
   invalidSessionNoServer,
   invalidOneDeviceTypeEmulatorNoSession,
+  invalidNoAppName,
   sessionPerConfiguration,
   sessionInCommonAndInConfiguration,
   validOneEmulator

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -7,17 +7,19 @@ const ArtifactsCopier = require('../artifacts/ArtifactsCopier');
 
 class Device {
 
-  constructor(deviceConfig, sessionConfig, deviceDriver) {
+  constructor(deviceConfig, sessionConfig, deviceDriver, appName, binaryPaths = {}) {
     this._deviceConfig = deviceConfig;
     this._sessionConfig = sessionConfig;
     this.deviceDriver = deviceDriver;
     this._processes = {};
     this._artifactsCopier = new ArtifactsCopier(deviceDriver);
+    const defaultBinaryPathOverwrite = binaryPaths[this.deviceDriver.getPlatform()];
+    const binaryPath = this._getAbsolutePath(this.deviceDriver.getBinaryPath(appName, deviceConfig.release, defaultBinaryPathOverwrite));
+    this._binaryPath = deviceConfig.binaryPath || binaryPath;
     this.deviceDriver.validateDeviceConfig(deviceConfig);
   }
 
   async prepare(params = {}) {
-    this._binaryPath = this._getAbsolutePath(this._deviceConfig.binaryPath);
     this._deviceId = await this.deviceDriver.acquireFreeDevice(this._deviceConfig.name);
     this._bundleId = await this.deviceDriver.getBundleIdFromBinary(this._binaryPath);
     this._artifactsCopier.prepare(this._deviceId);

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -7,16 +7,14 @@ const ArtifactsCopier = require('../artifacts/ArtifactsCopier');
 
 class Device {
 
-  constructor(deviceConfig, sessionConfig, deviceDriver, appName, binaryPaths = {}) {
+  constructor(deviceConfig, sessionConfig, deviceDriver, binaryPath) {
     this._deviceConfig = deviceConfig;
     this._sessionConfig = sessionConfig;
     this.deviceDriver = deviceDriver;
     this._processes = {};
     this._artifactsCopier = new ArtifactsCopier(deviceDriver);
-    const defaultBinaryPathOverwrite = binaryPaths[this.deviceDriver.getPlatform()];
-    const binaryPath = this._getAbsolutePath(this.deviceDriver.getBinaryPath(appName, deviceConfig.release, defaultBinaryPathOverwrite));
-    this._binaryPath = deviceConfig.binaryPath || binaryPath;
     this.deviceDriver.validateDeviceConfig(deviceConfig);
+    this._binaryPath = this._getAbsolutePath(binaryPath);
   }
 
   async prepare(params = {}) {

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -58,7 +58,8 @@ describe('Device', () => {
     driver.getBinaryPath.mockReturnValue("/computed/path/to/binary");
     driver.defaultLaunchArgsPrefix.mockReturnValue('-');
     driver.acquireFreeDevice.mockReturnValue('mockDeviceId');
-    const device = new Device(validScheme.configurations['ios.sim.release'], validScheme.session, driver, validScheme.appName, validScheme.binary);
+    const binaryPath = "./Path/to/binary";
+    const device = new Device(validScheme.configurations['ios.sim.release'], validScheme.session, driver, binaryPath);
 
     device.deviceDriver.getPlatform.mockReset();
     return device;
@@ -69,7 +70,8 @@ describe('Device', () => {
     const driver = new SimulatorDriver(client);
     driver.getBinaryPath.mockReturnValue("/computed/path/to/binary");
     driver.acquireFreeDevice.mockReturnValue('mockDeviceId');
-    const device = new Device(validScheme.configurations['ios.sim.release'], validScheme.session, driver, validScheme.appName, validScheme.binary);
+    const binaryPath = "./Path/to/binary";
+    const device = new Device(validScheme.configurations['ios.sim.release'], validScheme.session, driver, binaryPath);
 
     device.deviceDriver.getPlatform.mockReset();
     return device;
@@ -80,13 +82,14 @@ describe('Device', () => {
     const driver = new IosDriver(client);
     driver.getBinaryPath.mockReturnValue("/computed/path/to/binary");
     driver.acquireFreeDevice.mockReturnValue('mockDeviceId');
-    const device = new Device(validIosNoneScheme.configurations['ios.none'], validScheme.session, driver, validIosNoneScheme.appName, validIosNoneScheme.binary);
+    const binaryPath = "./Path/to/binary";
+    const device = new Device(validIosNoneScheme.configurations['ios.none'], validScheme.session, driver, binaryPath);
 
     device.deviceDriver.getPlatform.mockReset();
     return device;
   }
 
-  it(`valid scheme, no binary, should throw`, async () => {
+  it(`valid scheme, no binary, build doesn't exist should throw`, async () => {
     try {
       device = validDevice(false);
       fail('should throw');
@@ -425,7 +428,7 @@ describe('Device', () => {
 
   it(`new Device() with invalid device config (no binary) should throw`, async () => {
     try {
-      new Device(invalidDeviceNoBinary.configurations['ios.sim.release'], validScheme.session, new SimulatorDriver(client));
+      new Device(invalidDeviceNoBinary.configurations['ios.sim.release'], validScheme.session, new SimulatorDriver(client), "./relative/bin/path");
       fail('should throw');
     } catch (ex) {
       expect(ex).toBeDefined();
@@ -434,7 +437,7 @@ describe('Device', () => {
 
   it(`new Device() with invalid device config (no device name) should throw`, async () => {
     try {
-      new Device(invalidDeviceNoDeviceName.configurations['ios.sim.release'], validScheme.session, new SimulatorDriver(client));
+      new Device(invalidDeviceNoDeviceName.configurations['ios.sim.release'], validScheme.session, new SimulatorDriver(client), "./relative/bin/path");
       fail('should throw');
     } catch (ex) {
       expect(ex).toBeDefined();

--- a/detox/src/devices/DeviceDriverBase.js
+++ b/detox/src/devices/DeviceDriverBase.js
@@ -110,11 +110,15 @@ class DeviceDriverBase {
 
   }
 
-  validateDeviceConfig(deviceConfig) {
+  getBinaryPath(name, release, basePath) {
 
   }
 
   getPlatform() {
+
+  }
+
+  validateDeviceConfig(deviceConfig) {
 
   }
 

--- a/detox/src/devices/EmulatorDriver.js
+++ b/detox/src/devices/EmulatorDriver.js
@@ -11,6 +11,7 @@ const DeviceDriverBase = require('./DeviceDriverBase');
 const EspressoDetox = 'com.wix.detox.espresso.EspressoDetox';
 //ANDROID_SDK_ROOT
 const ANDROID_HOME = process.env.ANDROID_HOME;
+const DEFAULT_BASE_BUILD_PATH = "android/app/build/outputs/apk";
 
 class EmulatorDriver extends DeviceDriverBase {
 
@@ -125,6 +126,12 @@ class EmulatorDriver extends DeviceDriverBase {
 
   getPlatform() {
     return 'android';
+  }
+
+  getBinaryPath(name, release, basePath = DEFAULT_BASE_BUILD_PATH) {
+    // TODO: find the right output path for android
+    // android/app/build/outputs/apk
+    // return `${basePath}/${release ? 'Release' : 'Debug'}-iphonesimulator/${name}.app`;
   }
 
   async enableSynchronization() {

--- a/detox/src/devices/IosDriver.js
+++ b/detox/src/devices/IosDriver.js
@@ -8,6 +8,8 @@ const invoke = require('../invoke');
 const GREYConfiguration = require('./../ios/earlgreyapi/GREYConfiguration');
 const argparse = require('../utils/argparse');
 
+const DEFAULT_BASE_BUILD_PATH = "ios/build/Build/Products";
+
 class IosDriver extends DeviceDriverBase {
 
   constructor(client) {
@@ -73,6 +75,11 @@ class IosDriver extends DeviceDriverBase {
 
   getPlatform() {
     return 'ios';
+  }
+
+  getBinaryPath(name, release, basePath = DEFAULT_BASE_BUILD_PATH) {
+    // ios/build/Build/Products/Release-iphonesimulator/example.app
+    return `${basePath}/${release ? 'Release' : 'Debug'}-iphonesimulator/${name}.app`;
   }
 }
 

--- a/detox/src/devices/SimulatorDriver.js
+++ b/detox/src/devices/SimulatorDriver.js
@@ -70,10 +70,6 @@ class SimulatorDriver extends IosDriver {
   }
 
   validateDeviceConfig(deviceConfig) {
-    if (!deviceConfig.binaryPath) {
-      configuration.throwOnEmptyBinaryPath();
-    }
-
     if (!deviceConfig.name) {
       configuration.throwOnEmptyName();
     }

--- a/detox/src/utils/appContext.js
+++ b/detox/src/utils/appContext.js
@@ -1,0 +1,85 @@
+const nodeGlob = require("glob");
+const log = require('npmlog');
+const fs = require("fs");
+
+function glob(pattern, options) {
+  return new Promise((resolve, reject) => {
+    nodeGlob(pattern, options, (err, files) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(files);
+      }
+    });
+  });
+}
+
+async function getAppNameFromAppDelegate() {
+  let filePaths;
+  try {
+    filePaths = await glob("ios/**/AppDelegate.m");
+    if (filePaths.length < 1) {
+      log.warn(`Found no AppDelegate.m`);
+      return '';
+    }
+    if (filePaths.length > 1) {
+      log.verbose(`Found more than one AppDelegate.m, picking the first of ${filePaths}`);
+    }
+  } catch (e) {
+    log.verbose(`Error while finding the file`, e);
+    return '';
+  }
+  const filePath = filePaths[0];
+
+  const moduleNameRegex = /moduleName:@"(.*)"/;
+  const appDelegate = fs.readFileSync(filePath, 'utf8');
+
+  const matches = moduleNameRegex.exec(appDelegate);
+  if (!matches) {
+    throw new Error("Could not find the app name from AppDelegate.m");
+  }
+
+  return matches[1];
+}
+
+async function getAppNameFromAndroidManifest() {
+  let filePaths;
+  try {
+    filePaths = await glob("android/**/AndroidManifest.xml");
+    if (filePaths.length < 1) {
+      log.warn(`Found no AndroidManifest.xml`);
+      return '';
+    }
+    if (filePaths.length > 1) {
+      log.verbose(`Found more than one AndroidManifest.xml, picking the first of ${filePaths}`);
+    }
+  } catch (e) {
+    log.verbose(`Error while finding the file`, e);
+    return '';
+  }
+
+  const filePath = filePaths[0];
+  const packageNameRegex = /package="com\.(.*)"/;
+  const androidManifest = fs.readFileSync(filePath, 'utf8');
+  const matches = packageNameRegex.exec(androidManifest);
+
+  if (!matches) {
+    throw new Error("Could not find the app name from AndroidManifest.xml");
+  }
+  return matches[1];
+}
+
+async function getAppName(platform) {
+  if (platform === "ios") {
+    return getAppNameFromAppDelegate();
+  }
+
+  if (platform === "android") {
+    return getAppNameFromAndroidManifest();
+  }
+  return "";
+}
+
+module.exports = {
+  getAppName
+};

--- a/detox/src/utils/appContext.mock.js
+++ b/detox/src/utils/appContext.mock.js
@@ -1,0 +1,116 @@
+const iOSFileContent = `
+#import "AppDelegate.h"
+#import <React/RCTRootView.h>
+#import <React/RCTPushNotificationManager.h>
+#import <React/RCTLinkingManager.h>
+
+@import UserNotifications;
+
+@interface AppDelegate () <UNUserNotificationCenterDelegate>
+
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+	// this conditional init loads Detox only when command line arguments are given
+	// in normal execution, Detox is not loaded and there's zero impact on the app
+	
+	NSURL *jsCodeLocation;
+	
+	// this is a simple variant over the default React Native starter project which loads the bundle
+	// in Debug from the packager (OPTION 1) and in Release from a local resource (OPTION 2)
+#ifdef DEBUG
+	jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle?platform=ios&dev=true"];
+#else
+	jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+	
+	RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
+														moduleName:@"myiOSApp"
+												 initialProperties:nil
+													 launchOptions:launchOptions];
+	rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+	
+	self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+	UIViewController *rootViewController = [UIViewController new];
+	rootViewController.view = rootView;
+	self.window.rootViewController = rootViewController;
+	[self.window makeKeyAndVisible];
+	
+	[UNUserNotificationCenter currentNotificationCenter].delegate = self;
+	
+	return YES;
+}
+
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+    return [RCTLinkingManager application:application openURL:url
+                        sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
+                               annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
+	return YES;
+}
+
+// Required for the notification event. You must call the completion handler after handling the remote notification.
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
+fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
+{
+	[RCTPushNotificationManager didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+}
+
+// Required for the localNotification event.
+- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
+{
+	[RCTPushNotificationManager didReceiveLocalNotification:notification];
+}
+
+@end
+`;
+
+const androidFileContent = `
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.myAndroidApp"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+    <uses-sdk
+        android:minSdkVersion="16"
+        android:targetSdkVersion="22" />
+
+    <application
+      android:name=".MainApplication"
+      android:allowBackup="true"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:theme="@style/AppTheme">
+      <activity
+        android:name=".MainActivity"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:windowSoftInputMode="adjustResize">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+            <category android:name="android.intent.category.DEFAULT" />
+        </intent-filter>
+          <intent-filter>
+              <action android:name="android.intent.action.VIEW" />
+              <category android:name="android.intent.category.DEFAULT" />
+              <category android:name="android.intent.category.BROWSABLE" />
+              <data android:scheme="detoxtesturlscheme"/>
+          </intent-filter>
+      </activity>
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+
+</manifest>
+`;
+
+module.exports = {
+  androidFileContent,
+  iOSFileContent
+};

--- a/detox/src/utils/appContext.test.js
+++ b/detox/src/utils/appContext.test.js
@@ -1,0 +1,128 @@
+const mock = require('./appContext.mock');
+const mockIosFileContent = mock.iOSFileContent;
+const mockAndroidFileContent = mock.androidFileContent;
+
+let appContext;
+
+describe('appContext', () => {
+  describe('getAppName', () => {
+    it("should return empty string if platform is unknown", async () => {
+      appContext = require('./appContext');
+      const result = await appContext.getAppName("blackberry");
+      expect(result).toBe("");
+    });
+    describe("ios", () => {
+      it("should get name from app delegate on ios", async () => {
+        jest.mock('glob', () => (pattern, options, cb) => cb(null, ["ios/build/AppDelegate.m"]));
+        jest.mock("fs", () => ({
+          readFileSync: jest.fn(() => mockIosFileContent)
+        }));
+        appContext = require('./appContext');
+
+        const name = await appContext.getAppName("ios");
+        expect(name).toBe("myiOSApp");
+      });
+
+      it("should return an empty string if no file is found", async () => {
+        jest.mock('glob', () => (pattern, options, cb) => cb(null, []));
+        appContext = require('./appContext');
+
+        const name = await appContext.getAppName("ios");
+        expect(name).toBe("");
+      });
+
+      it("should return an empty string if an error is thrown", async () => {
+        jest.mock('glob', () => (pattern, options, cb) => cb(new Error("something went wrong"), null));
+        appContext = require('./appContext');
+
+        const name = await appContext.getAppName("ios");
+        expect(name).toBe("");
+      });
+
+      it("should pick the first file if multiple are found", async () => {
+        jest.mock('glob', () => (pattern, options, cb) => cb(null, ["ios/build/AppDelegate.m", "ios/foo/AppDelegate.m"]));
+        jest.mock("fs", () => ({
+          readFileSync: jest.fn(() => mockIosFileContent)
+        }));
+        const fs = require("fs");
+        appContext = require('./appContext');
+
+        const name = await appContext.getAppName("ios");
+        expect(name).toBe("myiOSApp");
+        expect(fs.readFileSync).toHaveBeenCalledWith("ios/build/AppDelegate.m", "utf8");
+      });
+
+      it("should throw if no names can be found in appDelegate", async () => {
+        jest.mock('glob', () => (pattern, options, cb) => cb(null, ["ios/build/AppDelegate.m"]));
+        jest.mock("fs", () => ({
+          readFileSync: jest.fn(() => mockIosFileContent.replace("moduleName", "modName"))
+        }));
+        appContext = require('./appContext');
+
+        try {
+          const name = await appContext.getAppName("ios");
+          fail("Should have thrown");
+        } catch (e) {
+          expect(e).toBeDefined();
+        }
+      });
+    });
+
+    describe("android", () => {
+      it("should get name from android manifest in android", async () => {
+        jest.mock('glob', () => (pattern, options, cb) => cb(null, ["android/src/main/AndroidManifest.xml"]));
+        jest.mock("fs", () => ({
+          readFileSync: jest.fn(() => mockAndroidFileContent)
+        }));
+        appContext = require('./appContext');
+
+        const name = await appContext.getAppName("android");
+        expect(name).toBe("myAndroidApp");
+      });
+
+      it("should return an empty string if no file is found", async () => {
+        jest.mock('glob', () => (pattern, options, cb) => cb(null, []));
+        appContext = require('./appContext');
+
+        const name = await appContext.getAppName("android");
+        expect(name).toBe("");
+      });
+
+      it("should return an empty string if an error is thrown", async () => {
+        jest.mock('glob', () => (pattern, options, cb) => cb(new Error("something went wrong"), null));
+        appContext = require('./appContext');
+
+        const name = await appContext.getAppName("android");
+        expect(name).toBe("");
+      });
+
+      it("should pick the first file if multiple are found", async () => {
+        jest.mock('glob', () => (pattern, options, cb) => cb(null, ["android/src/main/AndroidManifest.xml", "android/src/other/AndroidManifest.xml"]));
+        jest.mock("fs", () => ({
+          readFileSync: jest.fn(() => mockAndroidFileContent)
+        }));
+        const fs = require("fs");
+        appContext = require('./appContext');
+
+        const name = await appContext.getAppName("android");
+        expect(name).toBe("myAndroidApp");
+        expect(fs.readFileSync).toHaveBeenCalledWith("android/src/main/AndroidManifest.xml", "utf8");
+      });
+
+      it("should throw if no names can be found in appDelegate", async () => {
+        jest.mock('glob', () => (pattern, options, cb) => cb(null, ["android/src/main/AndroidManifest.xml"]));
+        jest.mock("fs", () => ({
+          readFileSync: jest.fn(() => mockAndroidFileContent.replace("package=", "pkg="))
+        }));
+        appContext = require('./appContext');
+
+        try {
+          const name = await appContext.getAppName("android");
+          fail("Should have thrown");
+        } catch (e) {
+          expect(e).toBeDefined();
+        }
+      });
+    });
+  });
+});

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -19,14 +19,10 @@
 		"mocha": "^3.2.0"
 	},
 	"detox": {
-		"appName": "example",
 		"specs": "e2e",
 		"__session": {
 			"server": "ws://localhost:8099",
 			"sessionId": "test"
-		},
-		"binary": {
-			"ios": "ios/build/Build/Products/"
 		},
 		"configurations": {
 			"ios.sim.debug": {

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -19,20 +19,23 @@
 		"mocha": "^3.2.0"
 	},
 	"detox": {
+		"appName": "example",
 		"specs": "e2e",
 		"__session": {
 			"server": "ws://localhost:8099",
 			"sessionId": "test"
 		},
+		"binary": {
+			"ios": "ios/build/Build/Products/"
+		},
 		"configurations": {
 			"ios.sim.debug": {
-				"binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
 				"build": "set -o pipefail && xcodebuild -project ios/example.xcodeproj -scheme example_ci -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
 				"type": "ios.simulator",
 				"name": "iPhone 7 Plus"
 			},
 			"ios.sim.release": {
-				"binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
+				"release": true,
 				"build": "set -o pipefail && export CODE_SIGNING_REQUIRED=NO && export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -project ios/example.xcodeproj -scheme example_ci -configuration Release -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
 				"type": "ios.simulator",
 				"name": "iPhone 7 Plus"
@@ -44,19 +47,19 @@
 					"server": "ws://localhost:8099",
 					"sessionId": "test"
 				}
-	    },
-      "android.emu.debug": {
-        "binaryPath": "android/app/build/outputs/apk/app-debug.apk",
-        "build": "pushd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && popd",
-        "type": "android.emulator",
-        "name": "Nexus_5X_API_24_-_GPlay"
-      },
-      "android.emu.release": {
-        "binaryPath": "android/app/build/outputs/apk/app-release.apk",
-        "build": "pushd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && popd",
-        "type": "android.emulator",
-        "name": "Nexus_5X_API_24_-_GPlay"
-      }
-    }
+			},
+			"android.emu.debug": {
+				"binaryPath": "android/app/build/outputs/apk/app-debug.apk",
+				"build": "pushd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && popd",
+				"type": "android.emulator",
+				"name": "Nexus_5X_API_24_-_GPlay"
+			},
+			"android.emu.release": {
+				"binaryPath": "android/app/build/outputs/apk/app-release.apk",
+				"build": "pushd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && popd",
+				"type": "android.emulator",
+				"name": "Nexus_5X_API_24_-_GPlay"
+			}
+		}
 	}
 }

--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -1,16 +1,45 @@
 # Configuration Options
 
 ## Configuring package.json 
+
+### App Name
+`appName` holds the name of your app as it's named in your file system, e.g. `/some/path/example.app` would have the appName `example`
+
+**Example:**
+
+```json
+	...
+	"detox": {
+		"appName": "example"
+	}
+```
+
+### Binary
+`binary` configures where detox searches for your binaries for each platform.
+
+**Example:**
+
+```json
+	...
+	"detox": {
+		"binary": {
+			"ios": "ios/build/Build/Products" // default
+		}
+	}
+```
+
+
 ### Device Configuration
 `configurations` holds all the device configurations, if there is only one configuration in `configurations` `detox build` and `detox test` will default to it, to choose a specific configuration use `--configuration` param<br>
 	
 
 |Configuration Params|Details|
 |---|---|
-|`binaryPath`|relative path to the ipa/app due to be  tested (make sure you build the app in a project relative path)|
+|`binaryPath`| **[optional]** relative path to the ipa/app due to be  tested (make sure you build the app in a project relative path)|
 |`type`|device type, currently only `ios.simulator` is supported|
 |`name`|device name, aligns to the device list avaliable through `fbsimctl list` for example, this is one line of the output of `fbsimctl list`: `A3C93900-6D17-4830-8FBE-E102E4BBCBB9  iPhone 7  Shutdown  iPhone 7  iOS 10.2`, ir order to choose the first `iPhone 7` regardless of OS version, use `iPhone 7`. <br>To be OS specific use `iPhone 7, iOS 10.2`|
 |`build`| **[optional]** build command (either `xcodebuild`, `react-native run-ios`, etc...), will be later available through detox CLI tool.|
+|`release`| **[optional]** use the release version (defaults to `false`)|
 	
 **Example:**
 

--- a/docs/Guide.RunningOnCI.md
+++ b/docs/Guide.RunningOnCI.md
@@ -16,9 +16,10 @@ We will need to create a [release device configuration for Detox](/docs/APIRef.C
 
 ```json
 "detox": {
+  "appName": "example",
   "configurations": {
     "ios.sim.release": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
+      "release": true,
       "build": "xcodebuild -project ios/example.xcodeproj -scheme example -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
       "type": "ios.simulator",
       "name": "iPhone 7"

--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -94,9 +94,9 @@ The basic configuration for Detox should be in your `package.json` file under th
 	
 ```json
 "detox": {
+  "appName": "example",
   "configurations": {
     "ios.sim.debug": {
-      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
       "build": "xcodebuild -project ios/example.xcodeproj -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
       "type": "ios.simulator",
       "name": "iPhone 7"
@@ -104,12 +104,12 @@ The basic configuration for Detox should be in your `package.json` file under th
   } 
 }
 ```
-	
-In the above configuration example, change `example` to your actual project name. Under the key `"binaryPath"`, `example.app` should be `<your_project_name>.app`. Under the key `"build"`, `example.xcodeproj` should be `<your_project_name>.xcodeproj` and `-scheme example` should be `-scheme <your_project_name>`.
+
+In the above configuration example, change `example` to your actual project name. Under the key `"appName"`, `example` should be `<your_project_name>`, exactly as the built `.app` file is called. Under the key `"build"`, `example.xcodeproj` should be `<your_project_name>.xcodeproj` and `-scheme example` should be `-scheme <your_project_name>`.
 
 Also make sure the simulator model specified under the key `"name"` (`iPhone 7` above) is actually available on your machine (it was installed by Xcode). Check this by typing `fbsimctl list` in terminal to display all available simulators.
 
-> TIP: To test a release version, replace 'Debug' with 'Release' in the binaryPath and build properties. For full configuration options see Configuration under the API Reference.
+> TIP: To test a release version, add `"release": true` to your configuration. For full configuration options see Configuration under the API Reference.
 
 <br>
 


### PR DESCRIPTION
This allows us to have a less verbose config, tackling the first part of #175.
This will introduce a breaking change (`appName` field), we might want to add a warning first instead of an error.
