### PR TITLE
Add prettier to detox folder

### DIFF
--- a/detox/.eslintrc
+++ b/detox/.eslintrc
@@ -16,7 +16,12 @@
     "react",
     "react-native",
     "promise",
+    "prettier",
     "jest"
+  ],
+  "extends": [
+    "prettier",
+    "prettier/react"
   ],
   "rules": {
     /*
@@ -203,13 +208,6 @@
     "id-blacklist": 0,
     "id-length": 0,
     "id-match": 0,
-    "indent": [
-      "error",
-      2,
-      {
-        "SwitchCase": 1
-      }
-    ],
     "jsx-quotes": "error",
     "key-spacing": [
       "error",
@@ -293,17 +291,9 @@
     "no-underscore-dangle": 0,
     "no-unneeded-ternary": "error",
     "no-whitespace-before-property": "error",
-    "object-curly-spacing": [
-      "error",
-      "never"
-    ],
     "one-var": 0,
     "one-var-declaration-per-line": 0,
     "operator-assignment": 0,
-    "operator-linebreak": [
-      "error",
-      "before"
-    ],
     "padded-blocks": [
       "error",
       "never"
@@ -348,10 +338,6 @@
      *                             ECMAScript 6
      */
     "arrow-body-style": 0,
-    "arrow-parens": [
-      "error",
-      "always"
-    ],
     "arrow-spacing": [
       "error",
       {
@@ -388,6 +374,19 @@
     "yield-star-spacing": [
       "error",
       "after"
+    ],
+    /*
+     *                              babel plugin
+     */
+    "babel/object-shorthand": 0,
+    "babel/no-await-in-loop": 0,
+    /*
+     *                              prettier plugin
+     */
+    "prettier/prettier": [
+      "error", {
+        "useTabs": true
+      }
     ],
     /*
      *                              promise

--- a/detox/package.json
+++ b/detox/package.json
@@ -31,13 +31,16 @@
   },
   "devDependencies": {
     "eslint": "^4.11.0",
+    "eslint-config-prettier": "2.5.0",
     "eslint-plugin-jest": "^20.0.3",
+    "eslint-plugin-prettier": "2.2.0",
     "eslint-plugin-promise": "^3.4.2",
     "eslint-plugin-react": "^7.1.0",
     "eslint-plugin-react-native": "^3.1.0",
     "jest": "^20.0.4",
     "minimist": "^1.2.0",
-    "mockdate": "^2.0.1"
+    "mockdate": "^2.0.1",
+    "prettier": "1.7.0"
   },
   "dependencies": {
     "child-process-promise": "^2.2.0",


### PR DESCRIPTION
This is the first PR to help deliver https://github.com/wix/detox/issues/223 

This Pr adds support for prettier as part of detox's linting pipeline. In the future you can automagically fix errors with:

```shell
npm run lint -- --fix
```

In a separate PR I will add support for connecting this up to the CI pipeline, and husky for pre-push validations :+1: