### PR TITLE
Update README for required Xcode version

### DIFF
--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -12,7 +12,7 @@ Running Detox (on iOS) requires the following:
 
 * Mac with macOS (at least macOS El Capitan 10.11)
 
-* Xcode 8.2+ with Xcode command line tools
+* Xcode 8.3+ with Xcode command line tools
 > TIP: Verify Xcode command line tools is installed by typing `gcc -v` in terminal (shows a popup if not installed)
 
 * A working [React Native](https://facebook.github.io/react-native/docs/getting-started.html) app you want to test


### PR DESCRIPTION
Latest applesimutils require Xcode 8.3+ and is required by detox, so I think we should update this version here :)