### PR TITLE
Add snapshot tests for matchers

### DIFF
--- a/detox/src/android/__snapshots__/matcher.test.js.snap
+++ b/detox/src/android/__snapshots__/matcher.test.js.snap
@@ -1,0 +1,262 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`android matcher snapshots 1`] = `
+Object {
+  "args": Array [
+    "mySelector",
+  ],
+  "method": "matcherForContentDescription",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 2`] = `
+Object {
+  "args": Array [
+    "mySelector",
+  ],
+  "method": "matcherForTestId",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 3`] = `
+Object {
+  "args": Array [
+    "mySelector",
+  ],
+  "method": "matcherForClass",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 4`] = `
+Object {
+  "args": Array [
+    "mySelector",
+  ],
+  "method": "matcherForText",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 5`] = `
+Object {
+  "args": Array [
+    "mySelector",
+  ],
+  "method": "matcherForContentDescription",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 6`] = `
+Object {
+  "args": Array [
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "mySelector",
+        ],
+        "method": "matcherForContentDescription",
+        "target": Object {
+          "type": "Class",
+          "value": "com.wix.detox.espresso.DetoxMatcher",
+        },
+      },
+    },
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "myOtherSelector",
+        ],
+        "method": "matcherForContentDescription",
+        "target": Object {
+          "type": "Class",
+          "value": "com.wix.detox.espresso.DetoxMatcher",
+        },
+      },
+    },
+  ],
+  "method": "matcherWithAncestor",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 7`] = `
+Object {
+  "args": Array [
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "mySelector",
+        ],
+        "method": "matcherForContentDescription",
+        "target": Object {
+          "type": "Class",
+          "value": "com.wix.detox.espresso.DetoxMatcher",
+        },
+      },
+    },
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "myOtherSelector",
+        ],
+        "method": "matcherForContentDescription",
+        "target": Object {
+          "type": "Class",
+          "value": "com.wix.detox.espresso.DetoxMatcher",
+        },
+      },
+    },
+  ],
+  "method": "matcherWithDescendant",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 8`] = `
+Object {
+  "args": Array [
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "mySelector",
+        ],
+        "method": "matcherForContentDescription",
+        "target": Object {
+          "type": "Class",
+          "value": "com.wix.detox.espresso.DetoxMatcher",
+        },
+      },
+    },
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "myOtherSelector",
+        ],
+        "method": "matcherForContentDescription",
+        "target": Object {
+          "type": "Class",
+          "value": "com.wix.detox.espresso.DetoxMatcher",
+        },
+      },
+    },
+  ],
+  "method": "matcherForAnd",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 9`] = `
+Object {
+  "args": Array [
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "mySelector",
+        ],
+        "method": "matcherForContentDescription",
+        "target": Object {
+          "type": "Class",
+          "value": "com.wix.detox.espresso.DetoxMatcher",
+        },
+      },
+    },
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "myOtherSelector",
+        ],
+        "method": "matcherForContentDescription",
+        "target": Object {
+          "type": "Class",
+          "value": "com.wix.detox.espresso.DetoxMatcher",
+        },
+      },
+    },
+  ],
+  "method": "matcherForOr",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 10`] = `
+Object {
+  "args": Array [],
+  "method": "matcherForSufficientlyVisible",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 11`] = `
+Object {
+  "args": Array [],
+  "method": "matcherForNotVisible",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 12`] = `
+Object {
+  "args": Array [],
+  "method": "matcherForNotNull",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;
+
+exports[`android matcher snapshots 13`] = `
+Object {
+  "args": Array [],
+  "method": "matcherForNull",
+  "target": Object {
+    "type": "Class",
+    "value": "com.wix.detox.espresso.DetoxMatcher",
+  },
+}
+`;

--- a/detox/src/android/matcher.test.js
+++ b/detox/src/android/matcher.test.js
@@ -1,0 +1,26 @@
+describe('android matcher', async () => {
+  let m;
+
+  beforeEach(() => {
+    m = require('./matcher');
+  });
+
+  // These snapshots preserve the output of the matchers against unwanted change
+  it("snapshots", () => {
+    const textBasedMatchers = ['LabelMatcher', 'IdMatcher', 'TypeMatcher', 'TextMatcher', 'ValueMatcher'];
+    const chainableMatchers = ['withAncestor', 'withDescendant', 'and', 'or'];
+    const noArgsMatchers = ['VisibleMatcher', 'NotVisibleMatcher', 'ExistsMatcher', 'NotExistsMatcher'];
+
+    textBasedMatchers.forEach(matcher => {
+      expect(new m[matcher]("mySelector")._call()).toMatchSnapshot();
+    });
+
+    chainableMatchers.forEach(matcher => {
+      expect(new m.LabelMatcher("mySelector")[matcher](new m.LabelMatcher("myOtherSelector"))._call()).toMatchSnapshot()
+    });
+
+    noArgsMatchers.forEach(matcher => {
+      expect(new m[matcher]()._call()).toMatchSnapshot();
+    });
+  });
+});

--- a/detox/src/ios/__snapshots__/matcher.test.js.snap
+++ b/detox/src/ios/__snapshots__/matcher.test.js.snap
@@ -1,0 +1,249 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ios matcher snapshots 1`] = `
+Object {
+  "args": Array [
+    "mySelector",
+  ],
+  "method": "detox_matcherForAccessibilityLabel:",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 2`] = `
+Object {
+  "args": Array [
+    "mySelector",
+  ],
+  "method": "matcherForAccessibilityID:",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 3`] = `
+Object {
+  "args": Array [
+    "mySelector",
+  ],
+  "method": "detoxMatcherForClass:",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 4`] = `
+Object {
+  "args": Array [
+    "mySelector",
+  ],
+  "method": "detoxMatcherForText:",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 5`] = `
+Object {
+  "args": Array [
+    "mySelector",
+  ],
+  "method": "matcherForAccessibilityValue:",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 6`] = `
+Object {
+  "args": Array [
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "mySelector",
+        ],
+        "method": "detox_matcherForAccessibilityLabel:",
+        "target": Object {
+          "type": "Class",
+          "value": "GREYMatchers",
+        },
+      },
+    },
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "myOtherSelector",
+        ],
+        "method": "detox_matcherForAccessibilityLabel:",
+        "target": Object {
+          "type": "Class",
+          "value": "GREYMatchers",
+        },
+      },
+    },
+  ],
+  "method": "detoxMatcherForBoth:andAncestorMatcher:",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 7`] = `
+Object {
+  "args": Array [
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "mySelector",
+        ],
+        "method": "detox_matcherForAccessibilityLabel:",
+        "target": Object {
+          "type": "Class",
+          "value": "GREYMatchers",
+        },
+      },
+    },
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "myOtherSelector",
+        ],
+        "method": "detox_matcherForAccessibilityLabel:",
+        "target": Object {
+          "type": "Class",
+          "value": "GREYMatchers",
+        },
+      },
+    },
+  ],
+  "method": "detoxMatcherForBoth:andDescendantMatcher:",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 8`] = `
+Object {
+  "args": Array [
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "mySelector",
+        ],
+        "method": "detox_matcherForAccessibilityLabel:",
+        "target": Object {
+          "type": "Class",
+          "value": "GREYMatchers",
+        },
+      },
+    },
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "myOtherSelector",
+        ],
+        "method": "detox_matcherForAccessibilityLabel:",
+        "target": Object {
+          "type": "Class",
+          "value": "GREYMatchers",
+        },
+      },
+    },
+  ],
+  "method": "detoxMatcherForBoth:and:",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 9`] = `
+Object {
+  "args": Array [
+    Object {
+      "type": "Invocation",
+      "value": Object {
+        "args": Array [
+          "mySelector",
+        ],
+        "method": "detox_matcherForAccessibilityLabel:",
+        "target": Object {
+          "type": "Class",
+          "value": "GREYMatchers",
+        },
+      },
+    },
+  ],
+  "method": "detoxMatcherForNot:",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 10`] = `
+Object {
+  "args": Array [],
+  "method": "matcherForSufficientlyVisible",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 11`] = `
+Object {
+  "args": Array [],
+  "method": "matcherForNotVisible",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 12`] = `
+Object {
+  "args": Array [],
+  "method": "matcherForNotNil",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;
+
+exports[`ios matcher snapshots 13`] = `
+Object {
+  "args": Array [],
+  "method": "matcherForNil",
+  "target": Object {
+    "type": "Class",
+    "value": "GREYMatchers",
+  },
+}
+`;

--- a/detox/src/ios/matcher.test.js
+++ b/detox/src/ios/matcher.test.js
@@ -1,0 +1,26 @@
+describe('ios matcher', async () => {
+  let m;
+
+  beforeEach(() => {
+    m = require('./matchers');
+  });
+
+  // These snapshots preserve the output of the matchers against unwanted change
+  it("snapshots", () => {
+    const textBasedMatchers = ['LabelMatcher', 'IdMatcher', 'TypeMatcher', 'TextMatcher', 'ValueMatcher'];
+    const chainableMatchers = ['withAncestor', 'withDescendant', 'and', 'not'];
+    const noArgsMatchers = ['VisibleMatcher', 'NotVisibleMatcher', 'ExistsMatcher', 'NotExistsMatcher'];
+
+    textBasedMatchers.forEach(matcher => {
+      expect(new m[matcher]("mySelector")._call()).toMatchSnapshot();
+    });
+
+    chainableMatchers.forEach(matcher => {
+      expect(new m.LabelMatcher("mySelector")[matcher](new m.LabelMatcher("myOtherSelector"))._call()).toMatchSnapshot()
+    });
+
+    noArgsMatchers.forEach(matcher => {
+      expect(new m[matcher]()._call()).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
This enables us to refactor matchers more easily, e.g. move towards the generated code