### PR TITLE
Stop transpiling detox and detox-server, use sources and require node >=7.6

### DIFF
--- a/detox-cli/package.json
+++ b/detox-cli/package.json
@@ -27,10 +27,6 @@
     "minimist": "^1.2.0"
   },
   "devDependencies": {
-    "babel-jest": "*",
-    "babel-plugin-transform-async-to-generator": "^6.5.0",
-    "babel-polyfill": "*",
-    "babel-preset-es2015": "*",
     "jest": "*"
   },
   "homepage": "https://github.com/wix/detox#readme",

--- a/detox-server/package.json
+++ b/detox-server/package.json
@@ -35,17 +35,16 @@
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.4",
     "babel-polyfill": "^6.8.0",
-    "babel-preset-latest": "^6.22.0",
+    "babel-preset-env": "^1.6.1",
     "babel-register": "^6.8.0"
   },
   "babel": {
-    "env": {
-      "test": {
-        "presets": [
-          "latest"
-        ],
-        "retainLines": true
-      }
-    }
+    "presets": [
+      ["env", {
+        "targets": {
+          "node": "current"
+        }
+      }]
+    ]
   }
 }

--- a/detox-server/package.json
+++ b/detox-server/package.json
@@ -14,8 +14,7 @@
   },
   "scripts": {
     "start": "node src/cli.js",
-    "test": ":",
-    "prepublish": "npm run build"
+    "test": ":"
   },
   "bugs": {
     "url": "https://github.com/wix/detox/issues"

--- a/detox-server/package.json
+++ b/detox-server/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/wix/detox/issues"
   },
   "homepage": "https://github.com/wix/detox/detox-server",
-  "main": "lib/index.js",
+  "main": "./src/index.js",
   "author": "Tal Kol <talkol@gmail.com>",
   "license": "MIT",
   "dependencies": {

--- a/detox-server/package.json
+++ b/detox-server/package.json
@@ -13,7 +13,6 @@
     "detox-server": "src/cli.js"
   },
   "scripts": {
-    "build": "node src -d lib",
     "start": "node src/cli.js",
     "test": ":",
     "prepublish": "npm run build"

--- a/detox-server/package.json
+++ b/detox-server/package.json
@@ -10,11 +10,11 @@
     "url": "https://github.com/wix/detox.git"
   },
   "bin": {
-    "detox-server": "lib/cli.js"
+    "detox-server": "src/cli.js"
   },
   "scripts": {
-    "build": "BABEL_ENV=test babel src -d lib",
-    "start": "node lib/cli.js",
+    "build": "node src -d lib",
+    "start": "node src/cli.js",
     "test": ":",
     "prepublish": "npm run build"
   },
@@ -29,9 +29,5 @@
     "lodash": "^4.13.1",
     "npmlog": "^4.0.2",
     "ws": "^1.1.0"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0"
   }
 }

--- a/detox-server/package.json
+++ b/detox-server/package.json
@@ -31,20 +31,7 @@
     "ws": "^1.1.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-core": "^6.8.0",
-    "babel-eslint": "^6.0.4",
-    "babel-polyfill": "^6.8.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-register": "^6.8.0"
-  },
-  "babel": {
-    "presets": [
-      ["env", {
-        "targets": {
-          "node": "current"
-        }
-      }]
-    ]
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0"
   }
 }

--- a/detox/.eslintrc
+++ b/detox/.eslintrc
@@ -3,7 +3,6 @@
     "es6": true,
     "node": true
   },
-  "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 8,
     "sourceType": "module",
@@ -16,7 +15,6 @@
   "plugins": [
     "react",
     "react-native",
-    "babel",
     "promise",
     "jest"
   ],
@@ -391,15 +389,6 @@
       "error",
       "after"
     ],
-    /*
-     *                              babel plugin
-     */
-    "babel/object-curly-spacing": [
-      "error",
-      "never"
-    ],
-    "babel/object-shorthand": 0,
-    "babel/no-await-in-loop": 0,
     /*
      *                              promise
      */

--- a/detox/package.json
+++ b/detox/package.json
@@ -30,18 +30,15 @@
     "postinstall": "scripts/postinstall.sh"
   },
   "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-core": "^6.8.0",
-    "babel-eslint": "^7.2.3",
-    "babel-polyfill": "^6.8.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-register": "^6.8.0",
-    "eslint": "^4.1.1",
-    "eslint-plugin-babel": "4.x.x",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
+    "babel-eslint": "^8.0.2",
+    "eslint": "^4.11.0",
+    "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-promise": "^3.4.2",
     "eslint-plugin-react": "^7.1.0",
-    "eslint-plugin-react-native": "^2.3.2",
+    "eslint-plugin-react-native": "^3.1.0",
     "jest": "^20.0.4",
     "minimist": "^1.2.0",
     "mockdate": "^2.0.1"
@@ -57,15 +54,6 @@
     "shell-utils": "^1.0.9",
     "telnet-client": "0.15.3",
     "ws": "^1.1.1"
-  },
-  "babel": {
-    "presets": [
-      ["env", {
-        "targets": {
-          "node": "current"
-        }
-      }]
-    ]
   },
   "jest": {
     "roots": [

--- a/detox/package.json
+++ b/detox/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/wix/detox/issues"
   },
   "homepage": "https://github.com/wix/detox/detox",
-  "main": "./lib/index.js",
+  "main": "./src/index.js",
   "author": "Tal Kol <talkol@gmail.com>",
   "license": "MIT",
   "scripts": {
@@ -30,11 +30,7 @@
     "postinstall": "scripts/postinstall.sh"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
     "eslint": "^4.11.0",
-    "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-promise": "^3.4.2",
     "eslint-plugin-react": "^7.1.0",
@@ -54,7 +50,7 @@
     "shell-utils": "^1.0.9",
     "telnet-client": "0.15.3",
     "ws": "^1.1.1"
-  },  
+  },
   "engines": {
     "node": ">=7.6"
   },

--- a/detox/package.json
+++ b/detox/package.json
@@ -54,6 +54,9 @@
     "shell-utils": "^1.0.9",
     "telnet-client": "0.15.3",
     "ws": "^1.1.1"
+  },  
+  "engines": {
+    "node": ">=7.6"
   },
   "jest": {
     "roots": [

--- a/detox/package.json
+++ b/detox/package.json
@@ -34,7 +34,7 @@
     "babel-core": "^6.8.0",
     "babel-eslint": "^7.2.3",
     "babel-polyfill": "^6.8.0",
-    "babel-preset-latest": "^6.22.0",
+    "babel-preset-env": "^1.6.1",
     "babel-register": "^6.8.0",
     "eslint": "^4.1.1",
     "eslint-plugin-babel": "4.x.x",
@@ -59,14 +59,13 @@
     "ws": "^1.1.1"
   },
   "babel": {
-    "env": {
-      "test": {
-        "presets": [
-          "latest"
-        ],
-        "retainLines": true
-      }
-    }
+    "presets": [
+      ["env", {
+        "targets": {
+          "node": "current"
+        }
+      }]
+    ]
   },
   "jest": {
     "roots": [

--- a/detox/scripts/build.sh
+++ b/detox/scripts/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e
 
 echo -e "\nTranspiling JavaScript sources"
-BABEL_ENV=test babel src -d lib
 
 if [ `uname` == "Darwin" ]; then
   echo -e "\nPackaging Detox iOS sources"

--- a/detox/scripts/build.sh
+++ b/detox/scripts/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-echo -e "\nTranspiling JavaScript sources"
-
 if [ `uname` == "Darwin" ]; then
   echo -e "\nPackaging Detox iOS sources"
   rm -fr Detox-ios-src.tbz

--- a/detox/test/.flowconfig
+++ b/detox/test/.flowconfig
@@ -8,7 +8,6 @@
 .*/node_modules/node-haste/.*
 
 # Ugh
-.*/node_modules/babel.*
 .*/node_modules/babylon.*
 .*/node_modules/invariant.*
 

--- a/detox/test/e2e/init.js
+++ b/detox/test/e2e/init.js
@@ -1,4 +1,4 @@
-const detox = require('../../src/index');
+const detox = require('detox');
 const config = require('../package.json').detox;
 
 before(async () => {

--- a/docs/Troubleshooting.RunningTests.md
+++ b/docs/Troubleshooting.RunningTests.md
@@ -63,9 +63,7 @@ child_process.js:531
 
 **Solution:** This error means that your version of Node does not support `async-await` syntax. You should do one of the two:
 
-1. Update Node to a version **higher than 7.6.0**, this versions will provide native support for async-await, and will spare the need to babel the test code (**recommended**, as it will save babel setup boilerplate, and make it easier to debug you tests).
-
-2. If you can't use a newer version of Node, you'll need to babel your test code, read more about it [here](https://babeljs.io/)
+1. Update Node to a version **higher than 7.6.0**, these versions will provide native support for async-await.
 
 <br>
 


### PR DESCRIPTION
### Overview

Remove deprecated package and updated to latest suggest package per Babel docs.

![image](https://user-images.githubusercontent.com/1743953/32740813-c443ca58-c869-11e7-8e1e-e84a64a5d017.png)

### Discussion
I was noticing errors with a project that was not importing _babel-preset-latest_ as a dev dependency. Rather than importing deprecated code I went ahead and updated to current logic. 

_Example:_
```js
detox test
```
would return 
`Couldn't find preset "latest" relative to directory "/Users/arista/***/node_modules/detox"` 