### PR TITLE
Add duration of element.longPress for iOS

### DIFF
--- a/detox/src/ios/expect.js
+++ b/detox/src/ios/expect.js
@@ -65,9 +65,13 @@ class TapAtPointAction extends Action {
 }
 
 class LongPressAction extends Action {
-  constructor() {
+  constructor(duration) {
     super();
-    this._call = invoke.callDirectly(GreyActions.actionForLongPress());
+    if (typeof duration !== 'number') {
+      this._call = invoke.callDirectly(GreyActions.actionForLongPress());
+    } else {
+      this._call = invoke.callDirectly(GreyActions.actionForLongPressWithDuration(duration / 1000));
+    }
   }
 }
 
@@ -268,8 +272,8 @@ class Element {
   async tapAtPoint(value) {
     return await new ActionInteraction(this, new TapAtPointAction(value)).execute();
   }
-  async longPress() {
-    return await new ActionInteraction(this, new LongPressAction()).execute();
+  async longPress(duration) {
+    return await new ActionInteraction(this, new LongPressAction(duration)).execute();
   }
   async multiTap(value) {
     return await new ActionInteraction(this, new MultiTapAction(value)).execute();

--- a/detox/src/ios/expect.test.js
+++ b/detox/src/ios/expect.test.js
@@ -101,6 +101,7 @@ describe('expect', async () => {
     await e.element(e.by.label('Tap Me')).tap();
     await e.element(e.by.label('Tap Me')).tapAtPoint({x: 10, y:10});
     await e.element(e.by.label('Tap Me')).longPress();
+    await e.element(e.by.label('Tap Me')).longPress(2000);
     await e.element(e.by.id('UniqueId819')).multiTap(3);
     await e.element(e.by.id('UniqueId937')).typeText('passcode');
     await e.element(e.by.id('UniqueId005')).clearText();

--- a/detox/test/e2e/c-actions.js
+++ b/detox/test/e2e/c-actions.js
@@ -17,13 +17,18 @@ describe('Actions', () => {
     await expect(element(by.text('Long Press Working!!!'))).toBeVisible();
   });
 
+  it(':ios: should long press with duration on an element', async () => {
+    await element(by.text('Long Press Me 1.5s')).longPress(1500);
+    await expect(element(by.text('Long Press With Duration Working!!!'))).toBeVisible();
+  });
+
   it('should multi tap on an element', async () => {
     await element(by.id('UniqueId819')).multiTap(3);
     await expect(element(by.id('UniqueId819'))).toHaveText('Taps: 3');
   });
 
   it('should tap on an element at point', async () => {
-    await element(by.id('View7990')).tapAtPoint({ x: 180, y: 140 });
+    await element(by.id('View7990')).tapAtPoint({ x: 180, y: 160 });
     await expect(element(by.id('UniqueId819'))).toHaveText('Taps: 1');
   });
 

--- a/detox/test/src/Screens/ActionsScreen.js
+++ b/detox/test/src/Screens/ActionsScreen.js
@@ -32,6 +32,13 @@ export default class ActionsScreen extends Component {
           <Text style={{ color: 'blue', marginBottom: 20, textAlign: 'center' }}>Tap Me</Text>
         </TouchableOpacity>
 
+        <TouchableOpacity
+          delayLongPress={1200}
+          onLongPress={this.onButtonPress.bind(this, 'Long Press With Duration Working')}
+        >
+          <Text style={{ color: 'blue', marginBottom: 20, textAlign: 'center' }}>Long Press Me 1.5s</Text>
+        </TouchableOpacity>
+
         <TouchableOpacity onPress={this.onLongTimeout.bind(this)}
         >
           <Text testID='WhyDoAllTheTestIDsHaveTheseStrangeNames' style={{ color: 'blue', marginBottom: 20, textAlign: 'center' }}>Tap Me For Long Timeout</Text>

--- a/docs/APIRef.ActionsOnElement.md
+++ b/docs/APIRef.ActionsOnElement.md
@@ -31,8 +31,9 @@ Simulate tap on an element.
 await element(by.id('tappable')).tap();
 ```
 
-### `longPress()`
-Simulate long press on an element.
+### `longPress(duration)`
+Simulate long press on an element.<br>
+duration - long press time interval. (iOS only)<br>
 
 ```js
 await element(by.id('tappable')).longPress();


### PR DESCRIPTION
Related to #410. I also added the test case `Long Press Me 1.5s`.