### PR TITLE
Better Android emulator sync

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -45,11 +45,13 @@
     "detox-server": "^2.1.0",
     "fs-extra": "^4.0.2",
     "get-port": "^2.1.0",
+    "ini": "^1.3.4",
     "lodash": "^4.14.1",
     "npmlog": "^4.0.2",
     "shell-utils": "^1.0.9",
     "telnet-client": "0.15.3",
-    "ws": "^1.1.1"
+    "ws": "^1.1.1",
+    "tail":"^1.2.3"
   },
   "engines": {
     "node": ">=7.6"

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -31,7 +31,8 @@ class Client {
   }
 
   async cleanup() {
-    console.log(this.isConnected);
+    clearTimeout(this.slowInvocationStatusHandler);
+
     if (this.isConnected) {
       await this.sendAction(new actions.Cleanup(this.successfulTestRun));
       this.isConnected = false;

--- a/detox/src/devices/AndroidDriver.js
+++ b/detox/src/devices/AndroidDriver.js
@@ -58,7 +58,7 @@ class AndroidDriver extends DeviceDriverBase {
     }
 
     this.instrumentationProcess = spawn(`adb`, [`-s`, `${deviceId}`, `shell`, `am`, `instrument`, `-w`, `-r`, `${args.join(' ')}`, `-e`, `debug`,
-                                                `false`, `${bundleId}.test/android.support.test.runner.AndroidJUnitRunner`]);
+      `false`, `${bundleId}.test/android.support.test.runner.AndroidJUnitRunner`]);
     log.verbose(this.instrumentationProcess.spawnargs.join(" "));
     log.verbose('Instrumentation spawned, childProcess.pid: ', this.instrumentationProcess.pid);
     this.instrumentationProcess.stdout.on('data', function(data) {
@@ -93,7 +93,7 @@ class AndroidDriver extends DeviceDriverBase {
 
   terminateInstrumentation() {
     if (this.instrumentationProcess) {
-      this.instrumentationProcess.kill('SIGHUP');
+      this.instrumentationProcess.kill();
       this.instrumentationProcess = null;
     }
   }

--- a/detox/src/devices/android/AAPT.js
+++ b/detox/src/devices/android/AAPT.js
@@ -22,7 +22,7 @@ class AAPT {
   async getPackageName(apkPath) {
     await this._prepare();
     const process = await exec(`${this.aaptBin} dump badging "${apkPath}"`);
-    let packageName = new RegExp(/package: name='([^']+)'/g).exec(process.stdout);
+    const packageName = new RegExp(/package: name='([^']+)'/g).exec(process.stdout);
     return packageName[1];
   }
 }

--- a/detox/src/devices/android/EmulatorTelnet.js
+++ b/detox/src/devices/android/EmulatorTelnet.js
@@ -4,13 +4,12 @@ const os = require('os');
 const fs = require('fs-extra');
 
 class EmulatorTelnet {
-
   constructor() {
     this.connection = new Telnet();
   }
 
   async connect(port) {
-    let params = {
+    const params = {
       host: 'localhost',
       port: port,
       shellPrompt: /^OK$/m,
@@ -24,7 +23,6 @@ class EmulatorTelnet {
     await this.connection.connect(params);
     const auth = await fs.readFile(path.join(os.homedir(), '.emulator_console_auth_token'), 'utf8');
     await this.exec(`auth ${auth}`);
-
   }
 
   async exec(command) {
@@ -38,11 +36,11 @@ class EmulatorTelnet {
       this.connection.shell((error, stream) => {
         stream.write(`${command}\n`);
         stream.on('data', (data) => {
-            const result = data.toString();
-            if (result.includes('\n')) {
-              resolve(result);
-            }
+          const result = data.toString();
+          if (result.includes('\n')) {
+            resolve(result);
           }
+        }
         );
       });
     });

--- a/detox/src/utils/exec.js
+++ b/detox/src/utils/exec.js
@@ -4,6 +4,9 @@ const exec = require('child-process-promise').exec;
 
 let _operationCounter = 0;
 
+/**
+
+ */
 async function execWithRetriesAndLogs(bin, options, statusLogs, retries = 10, interval = 1000) {
   _operationCounter++;
 
@@ -17,7 +20,7 @@ async function execWithRetriesAndLogs(bin, options, statusLogs, retries = 10, in
   log.verbose(`${_operationCounter}: ${cmd}`);
 
   let result;
-  await retry({ retries, interval }, async () => {
+  await retry({retries, interval}, async () => {
     if (statusLogs && statusLogs.trying) {
       log.info(`${_operationCounter}: ${statusLogs.trying}`);
     }


### PR DESCRIPTION
1. Making sure all child proccesses are closed, fixing issues with Mocha 4 and Jest
2. Spawning a detached emulator process, gaining same behaviour as we have in iOS, which leaves simulator open when tests are done
3. Applying fix on broken emulator config.ini
4. Better sync through reading getprop dev.bootcomplete