### PR TITLE
Support for filtering platform specific tests in detox-cli 

### DIFF
--- a/examples/demo-react-native/e2e/init.js
+++ b/examples/demo-react-native/e2e/init.js
@@ -1,4 +1,3 @@
-require('babel-polyfill');
 const detox = require('detox');
 const config = require('../package.json').detox;
 


### PR DESCRIPTION
`detox test -c ios.sim.release --platform ios` will skip tests marked with `:android:` in their name
`detox test -c android.emu.release --platform android` will skip tests marked with `:ios:` in their name