### PR TITLE
Add prettier formatting for code generation

### DIFF
--- a/generation/.prettierrc
+++ b/generation/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "useTabs": true
+}

--- a/generation/package.json
+++ b/generation/package.json
@@ -6,16 +6,27 @@
   "private": true,
   "scripts": {
     "build": "./index.js",
-    "test": "jest"
+    "test": "jest",
+    "precommit": "lint-staged",
+    "format": "prettier ./**/*.{js,json,css,md} --write"
   },
   "author": "DanielMSchmidt <danielmschmidt92@gmail.com>",
   "license": "MIT",
+  "lint-staged": {
+    "*.{js,json,css,md}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
   "devDependencies": {
     "babel-generator": "^6.25.0",
     "babel-types": "^6.25.0",
+    "husky": "^0.14.3",
     "jest": "^20.0.4",
     "lerna": "2.0.0-rc.4",
+    "lint-staged": "^6.0.0",
     "objective-c-parser": "1.1.0",
+    "prettier": "^1.8.2",
     "remove": "^0.1.5"
   },
   "jest": {


### PR DESCRIPTION
This is part of the general effort to forget about code formatting altogether 👍  I would apply the formatting by running `cd generation/ && npm run format` after we merge this