### PR TITLE
Let Linting run before unit tests

### DIFF
--- a/detox/.eslintrc
+++ b/detox/.eslintrc
@@ -65,7 +65,7 @@
     "array-callback-return": 0,
     "block-scoped-var": "error",
     "complexity": 0,
-    "consistent-return": "error",
+    "consistent-return": "warn",
     "curly": [
       "error",
       "all"
@@ -142,7 +142,7 @@
     "no-delete-var": "error",
     "no-label-var": "error",
     "no-restricted-globals": "error",
-    "no-shadow": "error",
+    "no-shadow": 1,
     "no-shadow-restricted-names": "error",
     "no-undef": 0,
     "no-undef-init": "error",
@@ -333,7 +333,7 @@
     "space-infix-ops": "error",
     "space-unary-ops": "error",
     "spaced-comment": 0,
-    "wrap-regex": "error",
+    "wrap-regex": 0,
     /*
      *                             ECMAScript 6
      */

--- a/detox/package.json
+++ b/detox/package.json
@@ -38,7 +38,9 @@
     "eslint-plugin-promise": "^3.4.2",
     "eslint-plugin-react": "^7.1.0",
     "eslint-plugin-react-native": "^3.1.0",
+    "husky": "^0.14.3",
     "jest": "^20.0.4",
+    "lint-staged": "^6.0.0",
     "minimist": "^1.2.0",
     "mockdate": "^2.0.1",
     "prettier": "1.7.0"

--- a/detox/package.json
+++ b/detox/package.json
@@ -24,6 +24,7 @@
     "build": "scripts/build.sh",
     "lint": "eslint src",
     "unit": "jest --coverage --verbose",
+    "pretest": "npm run lint",
     "test": "npm run unit",
     "unit:watch": "jest --watch",
     "prepublish": "npm run build",

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -1,146 +1,160 @@
-const log = require('npmlog');
-const Device = require('./devices/Device');
-const IosDriver = require('./devices/IosDriver');
-const SimulatorDriver = require('./devices/SimulatorDriver');
-const EmulatorDriver = require('./devices/EmulatorDriver');
-const AttachedAndroidDriver = require('./devices/AttachedAndroidDriver');
-const argparse = require('./utils/argparse');
-const configuration = require('./configuration');
-const Client = require('./client/Client');
-const DetoxServer = require('detox-server');
-const URL = require('url').URL;
-const _ = require('lodash');
-const ArtifactsPathsProvider = require('./artifacts/ArtifactsPathsProvider');
+const log = require("npmlog");
+const Device = require("./devices/Device");
+const IosDriver = require("./devices/IosDriver");
+const SimulatorDriver = require("./devices/SimulatorDriver");
+const EmulatorDriver = require("./devices/EmulatorDriver");
+const AttachedAndroidDriver = require("./devices/AttachedAndroidDriver");
+const argparse = require("./utils/argparse");
+const configuration = require("./configuration");
+const Client = require("./client/Client");
+const DetoxServer = require("detox-server");
+const URL = require("url").URL;
+const _ = require("lodash");
+const ArtifactsPathsProvider = require("./artifacts/ArtifactsPathsProvider");
 
-log.level = argparse.getArgValue('loglevel') || 'info';
-log.addLevel('wss', 999, {fg: 'blue', bg: 'black'}, 'wss');
-log.heading = 'detox';
+log.level = argparse.getArgValue("loglevel") || "info";
+log.addLevel("wss", 999, { fg: "blue", bg: "black" }, "wss");
+log.heading = "detox";
 
 const DEVICE_CLASSES = {
-  'ios.simulator': SimulatorDriver,
-  'ios.none': IosDriver,
-  'android.emulator': EmulatorDriver,
-  'android.attached': AttachedAndroidDriver,
+	"ios.simulator": SimulatorDriver,
+	"ios.none": IosDriver,
+	"android.emulator": EmulatorDriver,
+	"android.attached": AttachedAndroidDriver
 };
 
 class Detox {
-  constructor(userConfig) {
-    if (!userConfig) {
-      throw new Error(`No configuration was passed to detox, make sure you pass a config when calling 'detox.init(config)'`);
-    }
+	constructor(userConfig) {
+		if (!userConfig) {
+			throw new Error(
+				`No configuration was passed to detox, make sure you pass a config when calling 'detox.init(config)'`
+			);
+		}
 
-    this.userConfig = userConfig;
-    this.client = null;
-    this.device = null;
-    this._currentTestNumber = 0;
-    const artifactsLocation = argparse.getArgValue('artifacts-location');
-    if (artifactsLocation !== undefined) {
-      try {
-        this._artifactsPathsProvider = new ArtifactsPathsProvider(artifactsLocation);
-      } catch (ex) {
-        log.warn(ex);
-      }
-    }
-  }
+		this.userConfig = userConfig;
+		this.client = null;
+		this.device = null;
+		this._currentTestNumber = 0;
+		const artifactsLocation = argparse.getArgValue("artifacts-location");
+		if (artifactsLocation !== undefined) {
+			try {
+				this._artifactsPathsProvider = new ArtifactsPathsProvider(
+					artifactsLocation
+				);
+			} catch (ex) {
+				log.warn(ex);
+			}
+		}
+	}
 
-  async init(params = {launchApp: true}) {
-    if (!(this.userConfig.configurations && _.size(this.userConfig.configurations) >= 1)) {
-      throw new Error(`No configured devices`);
-    }
+	async init(params = { launchApp: true }) {
+		if (
+			!(
+				this.userConfig.configurations &&
+				_.size(this.userConfig.configurations) >= 1
+			)
+		) {
+			throw new Error(`No configured devices`);
+		}
 
-    const deviceConfig = await this._getDeviceConfig();
-    if (!deviceConfig.type) {
-      configuration.throwOnEmptyType();
-    }
+		const deviceConfig = await this._getDeviceConfig();
+		if (!deviceConfig.type) {
+			configuration.throwOnEmptyType();
+		}
 
-    const [sessionConfig, shouldStartServer] = await this._chooseSession(deviceConfig);
+		const [sessionConfig, shouldStartServer] = await this._chooseSession(
+			deviceConfig
+		);
 
-    if (shouldStartServer) {
-      this.server = new DetoxServer(new URL(sessionConfig.server).port);
-    }
+		if (shouldStartServer) {
+			this.server = new DetoxServer(new URL(sessionConfig.server).port);
+		}
 
-    this.client = new Client(sessionConfig);
-    await this.client.connect();
+		this.client = new Client(sessionConfig);
+		await this.client.connect();
 
-    const deviceClass = DEVICE_CLASSES[deviceConfig.type];
-    if (!deviceClass) {
-      throw new Error(`'${deviceConfig.type}' is not supported`);
-    }
+		const deviceClass = DEVICE_CLASSES[deviceConfig.type];
+		if (!deviceClass) {
+			throw new Error(`'${deviceConfig.type}' is not supported`);
+		}
 
-    const deviceDriver = new deviceClass(this.client);
-    this.device = new Device(deviceConfig, sessionConfig, deviceDriver);
-    await this.device.prepare(params);
-    global.device = this.device;
-  }
+		const deviceDriver = new deviceClass(this.client);
+		this.device = new Device(deviceConfig, sessionConfig, deviceDriver);
+		await this.device.prepare(params);
+		global.device = this.device;
+	}
 
-  async cleanup() {
-    if (this.client) {
-      await this.client.cleanup();
-    }
+	async cleanup() {
+		if (this.client) {
+			await this.client.cleanup();
+		}
 
-    if (this.device) {
-      await this.device._cleanup();
-    }
+		if (this.device) {
+			await this.device._cleanup();
+		}
 
-    if (this.server) {
-      this.server.close();
-    }
+		if (this.server) {
+			this.server.close();
+		}
 
-    if (argparse.getArgValue('cleanup') && this.device) {
-      await this.device.shutdown();
-    }
-  }
+		if (argparse.getArgValue("cleanup") && this.device) {
+			await this.device.shutdown();
+		}
+	}
 
-  async beforeEach(...testNameComponents) {
-    this._currentTestNumber++;
-    if (this._artifactsPathsProvider !== undefined) {
-      const testArtifactsPath = this._artifactsPathsProvider.createPathForTest(this._currentTestNumber, ...testNameComponents);
-      this.device.setArtifactsDestination(testArtifactsPath);
-    }
-  }
+	async beforeEach(...testNameComponents) {
+		this._currentTestNumber++;
+		if (this._artifactsPathsProvider !== undefined) {
+			const testArtifactsPath = this._artifactsPathsProvider.createPathForTest(
+				this._currentTestNumber,
+				...testNameComponents
+			);
+			this.device.setArtifactsDestination(testArtifactsPath);
+		}
+	}
 
-  async afterEach(suiteName, testName) {
-    if(this._artifactsPathsProvider !== undefined) {
-      await this.device.finalizeArtifacts();
-    }
-  }
+	async afterEach(suiteName, testName) {
+		if (this._artifactsPathsProvider !== undefined) {
+			await this.device.finalizeArtifacts();
+		}
+	}
 
-  async _chooseSession(deviceConfig) {
-    let session = deviceConfig.session;
-    let shouldStartServer = false;
+	async _chooseSession(deviceConfig) {
+		let session = deviceConfig.session;
+		let shouldStartServer = false;
 
-    if (!session) {
-      session = this.userConfig.session;
-    }
+		if (!session) {
+			session = this.userConfig.session;
+		}
 
-    if (!session) {
-      session = await configuration.defaultSession();
-      shouldStartServer = true;
-    }
+		if (!session) {
+			session = await configuration.defaultSession();
+			shouldStartServer = true;
+		}
 
-    configuration.validateSession(session);
+		configuration.validateSession(session);
 
-    return [session, shouldStartServer];
-  }
+		return [session, shouldStartServer];
+	}
 
-  async _getDeviceConfig() {
-    const configurationName = argparse.getArgValue('configuration');
-    const configurations = this.userConfig.configurations;
+	async _getDeviceConfig() {
+		const configurationName = argparse.getArgValue("configuration");
+		const configurations = this.userConfig.configurations;
 
-    let deviceConfig;
-    if (!configurationName && _.size(configurations) === 1) {
-      deviceConfig = _.values(configurations)[0];
-    } else {
-      deviceConfig = configurations[configurationName];
-    }
+		let deviceConfig;
+		if (!configurationName && _.size(configurations) === 1) {
+			deviceConfig = _.values(configurations)[0];
+		} else {
+			deviceConfig = configurations[configurationName];
+		}
 
-    if (!deviceConfig) {
-      throw new Error(`Cannot determine which configuration to use. use --configuration to choose one of the following:
+		if (!deviceConfig) {
+			throw new Error(`Cannot determine which configuration to use. use --configuration to choose one of the following:
                       ${Object.keys(configurations)}`);
-    }
+		}
 
-    return deviceConfig;
-  }
+		return deviceConfig;
+	}
 }
 
 module.exports = Detox;

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -1,237 +1,245 @@
-const schemes = require('./configurations.mock');
+const schemes = require("./configurations.mock");
 
-describe('Detox', () => {
-  let fs;
-  let Detox;
-  let detox;
-  const clientMockData = {lastConstructorArguments: null};
-  const deviceMockData = {lastConstructorArguments: null};
+describe("Detox", () => {
+	let fs;
+	let Detox;
+	let detox;
+	const clientMockData = { lastConstructorArguments: null };
+	const deviceMockData = { lastConstructorArguments: null };
 
-  beforeEach(async () => {
-    function setCustomMock(modulePath, dataObject) {
-      const JestMock = jest.genMockFromModule(modulePath);
-      class FinalMock extends JestMock {
-        constructor(...rest) {
-          super(rest);
-          dataObject.lastConstructorArguments = rest;
-        }
-      }
-      jest.setMock(modulePath, FinalMock);
-    }
+	beforeEach(async () => {
+		function setCustomMock(modulePath, dataObject) {
+			const JestMock = jest.genMockFromModule(modulePath);
+			class FinalMock extends JestMock {
+				constructor(...rest) {
+					super(rest);
+					dataObject.lastConstructorArguments = rest;
+				}
+			}
+			jest.setMock(modulePath, FinalMock);
+		}
 
-    jest.mock('npmlog');
-    jest.mock('fs');
-    fs = require('fs');
-    jest.mock('./ios/expect');
-    setCustomMock('./client/Client', clientMockData);
-    setCustomMock('./devices/Device', deviceMockData);
+		jest.mock("npmlog");
+		jest.mock("fs");
+		fs = require("fs");
+		jest.mock("./ios/expect");
+		setCustomMock("./client/Client", clientMockData);
+		setCustomMock("./devices/Device", deviceMockData);
 
-    process.env = {};
+		process.env = {};
 
-    jest.mock('./devices/IosDriver');
-    jest.mock('./devices/SimulatorDriver');
-    jest.mock('./devices/Device');
-    jest.mock('detox-server');
-    jest.mock('./client/Client');
-  });
+		jest.mock("./devices/IosDriver");
+		jest.mock("./devices/SimulatorDriver");
+		jest.mock("./devices/Device");
+		jest.mock("detox-server");
+		jest.mock("./client/Client");
+	});
 
-  it(`No config is passed to init, should throw`, async () => {
-    Detox = require('./Detox');
-    try {
-      detox = new Detox();
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+	it(`No config is passed to init, should throw`, async () => {
+		Detox = require("./Detox");
+		try {
+			detox = new Detox();
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`Config with no devices, should throw`, async () => {
-    Detox = require('./Detox');
-    try {
-      detox = new Detox(schemes.invalidNoDevice);
-      await detox.init();
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+	it(`Config with no devices, should throw`, async () => {
+		Detox = require("./Detox");
+		try {
+			detox = new Detox(schemes.invalidNoDevice);
+			await detox.init();
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`Config with emulator, should throw`, async () => {
-    Detox = require('./Detox');
-    try {
-      detox = new Detox(schemes.invalidOneDeviceTypeEmulatorNoSession);
-      await detox.init();
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+	it(`Config with emulator, should throw`, async () => {
+		Detox = require("./Detox");
+		try {
+			detox = new Detox(schemes.invalidOneDeviceTypeEmulatorNoSession);
+			await detox.init();
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`Passing --cleanup should shutdown the currently running device`, async () => {
-    process.env.cleanup = true;
-    Detox = require('./Detox');
+	it(`Passing --cleanup should shutdown the currently running device`, async () => {
+		process.env.cleanup = true;
+		Detox = require("./Detox");
 
-    detox = new Detox(schemes.validOneDeviceNoSession);
-    await detox.init();
-    await detox.cleanup();
-    expect(detox.device.shutdown).toHaveBeenCalledTimes(1);
-  });
+		detox = new Detox(schemes.validOneDeviceNoSession);
+		await detox.init();
+		await detox.cleanup();
+		expect(detox.device.shutdown).toHaveBeenCalledTimes(1);
+	});
 
-  it(`Not passing --cleanup should keep the currently running device up`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox(schemes.validOneDeviceNoSession);
-    await detox.init();
-    await detox.cleanup();
-    expect(detox.device.shutdown).toHaveBeenCalledTimes(0);
-  });
+	it(`Not passing --cleanup should keep the currently running device up`, async () => {
+		Detox = require("./Detox");
+		detox = new Detox(schemes.validOneDeviceNoSession);
+		await detox.init();
+		await detox.cleanup();
+		expect(detox.device.shutdown).toHaveBeenCalledTimes(0);
+	});
 
-  it(`One valid device, detox should init with generated session config and default to this device`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox(schemes.validOneDeviceNoSession);
-    await detox.init();
-    expect(clientMockData.lastConstructorArguments[0]).toBeDefined();
-  });
+	it(`One valid device, detox should init with generated session config and default to this device`, async () => {
+		Detox = require("./Detox");
+		detox = new Detox(schemes.validOneDeviceNoSession);
+		await detox.init();
+		expect(clientMockData.lastConstructorArguments[0]).toBeDefined();
+	});
 
-  it(`One valid device, detox should use session config and default to this device`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox(schemes.validOneDeviceAndSession);
-    await detox.init();
+	it(`One valid device, detox should use session config and default to this device`, async () => {
+		Detox = require("./Detox");
+		detox = new Detox(schemes.validOneDeviceAndSession);
+		await detox.init();
 
-    expect(clientMockData.lastConstructorArguments[0]).toBe(schemes.validOneDeviceAndSession.session);
-  });
+		expect(clientMockData.lastConstructorArguments[0]).toBe(
+			schemes.validOneDeviceAndSession.session
+		);
+	});
 
-  it(`Two valid devices, detox should init with the device passed in '--configuration' cli option`, async () => {
-    process.env.configuration = 'ios.sim.debug';
-    Detox = require('./Detox');
+	it(`Two valid devices, detox should init with the device passed in '--configuration' cli option`, async () => {
+		process.env.configuration = "ios.sim.debug";
+		Detox = require("./Detox");
 
-    detox = new Detox(schemes.validTwoDevicesNoSession);
-    await detox.init();
-    expect(deviceMockData.lastConstructorArguments[0]).toEqual(schemes.validTwoDevicesNoSession.configurations['ios.sim.debug']);
-  });
+		detox = new Detox(schemes.validTwoDevicesNoSession);
+		await detox.init();
+		expect(deviceMockData.lastConstructorArguments[0]).toEqual(
+			schemes.validTwoDevicesNoSession.configurations["ios.sim.debug"]
+		);
+	});
 
-  it(`Two valid devices, detox should throw if device passed in '--configuration' cli option doesn't exist`, async () => {
-    process.env.configuration = 'nonexistent';
-    Detox = require('./Detox');
+	it(`Two valid devices, detox should throw if device passed in '--configuration' cli option doesn't exist`, async () => {
+		process.env.configuration = "nonexistent";
+		Detox = require("./Detox");
 
-    detox = new Detox(schemes.validTwoDevicesNoSession);
+		detox = new Detox(schemes.validTwoDevicesNoSession);
 
-    try {
-      await detox.init();
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+		try {
+			await detox.init();
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`Two valid devices, detox should throw if device passed in '--configuration' cli option doesn't exist`, async () => {
-    process.env.configuration = 'nonexistent';
-    Detox = require('./Detox');
+	it(`Two valid devices, detox should throw if device passed in '--configuration' cli option doesn't exist`, async () => {
+		process.env.configuration = "nonexistent";
+		Detox = require("./Detox");
 
-    detox = new Detox(schemes.validTwoDevicesNoSession);
+		detox = new Detox(schemes.validTwoDevicesNoSession);
 
-    try {
-      await detox.init();
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+		try {
+			await detox.init();
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`One invalid device (no device name), detox should throw`, async () => {
-    Detox = require('./Detox');
+	it(`One invalid device (no device name), detox should throw`, async () => {
+		Detox = require("./Detox");
 
-    detox = new Detox(schemes.invalidDeviceNoDeviceName);
+		detox = new Detox(schemes.invalidDeviceNoDeviceName);
 
-    try {
-      await detox.init();
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+		try {
+			await detox.init();
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`One invalid device, detox should throw`, async () => {
-    Detox = require('./Detox');
+	it(`One invalid device, detox should throw`, async () => {
+		Detox = require("./Detox");
 
-    detox = new Detox(schemes.invalidDeviceNoDeviceType);
+		detox = new Detox(schemes.invalidDeviceNoDeviceType);
 
-    try {
-      await detox.init();
-      fail('should have thrown');
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+		try {
+			await detox.init();
+			fail("should have thrown");
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`cleanup on a non initialized detox should not throw`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox(schemes.invalidDeviceNoDeviceType);
-    detox.cleanup();
-  });
+	it(`cleanup on a non initialized detox should not throw`, async () => {
+		Detox = require("./Detox");
+		detox = new Detox(schemes.invalidDeviceNoDeviceType);
+		detox.cleanup();
+	});
 
-  it(`Detox should use session defined per configuration - none`, async () => {
-    process.env.configuration = 'ios.sim.none';
-    Detox = require('./Detox');
-    detox = new Detox(schemes.sessionPerConfiguration);
-    await detox.init();
+	it(`Detox should use session defined per configuration - none`, async () => {
+		process.env.configuration = "ios.sim.none";
+		Detox = require("./Detox");
+		detox = new Detox(schemes.sessionPerConfiguration);
+		await detox.init();
 
-    const expectedSession = schemes.sessionPerConfiguration.configurations['ios.sim.none'].session;
-    expect(clientMockData.lastConstructorArguments[0]).toBe(expectedSession);
-  });
+		const expectedSession =
+			schemes.sessionPerConfiguration.configurations["ios.sim.none"].session;
+		expect(clientMockData.lastConstructorArguments[0]).toBe(expectedSession);
+	});
 
-  it(`Detox should use session defined per configuration - release`, async () => {
-    process.env.configuration = 'ios.sim.release';
-    Detox = require('./Detox');
-    detox = new Detox(schemes.sessionPerConfiguration);
-    await detox.init();
+	it(`Detox should use session defined per configuration - release`, async () => {
+		process.env.configuration = "ios.sim.release";
+		Detox = require("./Detox");
+		detox = new Detox(schemes.sessionPerConfiguration);
+		await detox.init();
 
-    const expectedSession = schemes.sessionPerConfiguration.configurations['ios.sim.release'].session;
-    expect(clientMockData.lastConstructorArguments[0]).toBe(expectedSession);
-  });
+		const expectedSession =
+			schemes.sessionPerConfiguration.configurations["ios.sim.release"].session;
+		expect(clientMockData.lastConstructorArguments[0]).toBe(expectedSession);
+	});
 
-  it(`Detox should prefer session defined per configuration over common session`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox(schemes.sessionInCommonAndInConfiguration);
-    await detox.init();
+	it(`Detox should prefer session defined per configuration over common session`, async () => {
+		Detox = require("./Detox");
+		detox = new Detox(schemes.sessionInCommonAndInConfiguration);
+		await detox.init();
 
-    const expectedSession = schemes.sessionInCommonAndInConfiguration.configurations['ios.sim.none'].session;
-    expect(clientMockData.lastConstructorArguments[0]).toBe(expectedSession);
-  });
+		const expectedSession =
+			schemes.sessionInCommonAndInConfiguration.configurations["ios.sim.none"]
+				.session;
+		expect(clientMockData.lastConstructorArguments[0]).toBe(expectedSession);
+	});
 
-  it(`beforeEach() - should set device artifacts destination`, async () => {
-    process.env.artifactsLocation = '/tmp';
-    Detox = require('./Detox');
-    detox = new Detox(schemes.validOneDeviceAndSession);
-    await detox.init();
-    await detox.beforeEach('a', 'b', 'c');
-    expect(device.setArtifactsDestination).toHaveBeenCalledTimes(1);
-  });
+	it(`beforeEach() - should set device artifacts destination`, async () => {
+		process.env.artifactsLocation = "/tmp";
+		Detox = require("./Detox");
+		detox = new Detox(schemes.validOneDeviceAndSession);
+		await detox.init();
+		await detox.beforeEach("a", "b", "c");
+		expect(device.setArtifactsDestination).toHaveBeenCalledTimes(1);
+	});
 
-  it(`beforeEach() - should not set device artifacts destination if artifacts not set in cli args`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox(schemes.validOneDeviceAndSession);
-    await detox.init();
-    await detox.beforeEach('a', 'b', 'c');
-    expect(device.setArtifactsDestination).toHaveBeenCalledTimes(0);
-  });
+	it(`beforeEach() - should not set device artifacts destination if artifacts not set in cli args`, async () => {
+		Detox = require("./Detox");
+		detox = new Detox(schemes.validOneDeviceAndSession);
+		await detox.init();
+		await detox.beforeEach("a", "b", "c");
+		expect(device.setArtifactsDestination).toHaveBeenCalledTimes(0);
+	});
 
-  it(`afterEach() - should call device.finalizeArtifacts`, async () => {
-    process.env.artifactsLocation = '/tmp';
-    Detox = require('./Detox');
-    detox = new Detox(schemes.validOneDeviceAndSession);
-    await detox.init();
-    await detox.afterEach();
-    expect(device.finalizeArtifacts).toHaveBeenCalledTimes(1);
-  });
+	it(`afterEach() - should call device.finalizeArtifacts`, async () => {
+		process.env.artifactsLocation = "/tmp";
+		Detox = require("./Detox");
+		detox = new Detox(schemes.validOneDeviceAndSession);
+		await detox.init();
+		await detox.afterEach();
+		expect(device.finalizeArtifacts).toHaveBeenCalledTimes(1);
+	});
 
-  it(`afterEach() - should not call device.finalizeArtifacts if artifacts not set in cli arg`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox(schemes.validOneDeviceAndSession);
-    await detox.init();
-    await detox.afterEach();
-    expect(device.finalizeArtifacts).toHaveBeenCalledTimes(0);
-  });
+	it(`afterEach() - should not call device.finalizeArtifacts if artifacts not set in cli arg`, async () => {
+		Detox = require("./Detox");
+		detox = new Detox(schemes.validOneDeviceAndSession);
+		await detox.init();
+		await detox.afterEach();
+		expect(device.finalizeArtifacts).toHaveBeenCalledTimes(0);
+	});
 
-  it(`the constructor should catch exception from ArtifactsPathsProvider`, async () => {
-    process.env.artifactsLocation = '/tmp';
-    fs.mkdirSync = jest.fn(() => {
-      throw Error('Could not create artifacts root dir');
-    });
-    Detox = require('./Detox');
-    detox = new Detox(schemes.validOneDeviceAndSession);
-  });
+	it(`the constructor should catch exception from ArtifactsPathsProvider`, async () => {
+		process.env.artifactsLocation = "/tmp";
+		fs.mkdirSync = jest.fn(() => {
+			throw Error("Could not create artifacts root dir");
+		});
+		Detox = require("./Detox");
+		detox = new Detox(schemes.validOneDeviceAndSession);
+	});
 });

--- a/detox/src/android/espressoapi/DetoxAction.js
+++ b/detox/src/android/espressoapi/DetoxAction.js
@@ -4,77 +4,112 @@
 	For more information see generation/README.md.
 */
 
-
-
 class DetoxAction {
-  static multiClick(times) {
-    if (typeof times !== "number") throw new Error("times should be a number, but got " + (times + (" (" + (typeof times + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "com.wix.detox.espresso.DetoxAction"
-      },
-      method: "multiClick",
-      args: [{
-        type: "Integer",
-        value: times
-      }]
-    };
-  }
+	static multiClick(times) {
+		if (typeof times !== "number") {
+			throw new Error(
+				"times should be a number, but got " +
+					(times + (" (" + (typeof times + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "com.wix.detox.espresso.DetoxAction"
+			},
+			method: "multiClick",
+			args: [
+				{
+					type: "Integer",
+					value: times
+				}
+			]
+		};
+	}
 
-  static tapAtLocation(x, y) {
-    if (typeof x !== "number") throw new Error("x should be a number, but got " + (x + (" (" + (typeof x + ")"))));
-    if (typeof y !== "number") throw new Error("y should be a number, but got " + (y + (" (" + (typeof y + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "com.wix.detox.espresso.DetoxAction"
-      },
-      method: "tapAtLocation",
-      args: [{
-        type: "Integer",
-        value: x
-      }, {
-        type: "Integer",
-        value: y
-      }]
-    };
-  }
+	static tapAtLocation(x, y) {
+		if (typeof x !== "number") {
+			throw new Error(
+				"x should be a number, but got " + (x + (" (" + (typeof x + ")")))
+			);
+		}
+		if (typeof y !== "number") {
+			throw new Error(
+				"y should be a number, but got " + (y + (" (" + (typeof y + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "com.wix.detox.espresso.DetoxAction"
+			},
+			method: "tapAtLocation",
+			args: [
+				{
+					type: "Integer",
+					value: x
+				},
+				{
+					type: "Integer",
+					value: y
+				}
+			]
+		};
+	}
 
-  static scrollToEdge(edge) {
-    if (typeof edge !== "number") throw new Error("edge should be a number, but got " + (edge + (" (" + (typeof edge + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "com.wix.detox.espresso.DetoxAction"
-      },
-      method: "scrollToEdge",
-      args: [{
-        type: "Integer",
-        value: edge
-      }]
-    };
-  }
+	static scrollToEdge(edge) {
+		if (typeof edge !== "number") {
+			throw new Error(
+				"edge should be a number, but got " +
+					(edge + (" (" + (typeof edge + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "com.wix.detox.espresso.DetoxAction"
+			},
+			method: "scrollToEdge",
+			args: [
+				{
+					type: "Integer",
+					value: edge
+				}
+			]
+		};
+	}
 
-  static scrollInDirection(direction, amountInDP) {
-    if (typeof direction !== "number") throw new Error("direction should be a number, but got " + (direction + (" (" + (typeof direction + ")"))));
-    if (typeof amountInDP !== "number") throw new Error("amountInDP should be a number, but got " + (amountInDP + (" (" + (typeof amountInDP + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "com.wix.detox.espresso.DetoxAction"
-      },
-      method: "scrollInDirection",
-      args: [{
-        type: "Integer",
-        value: direction
-      }, {
-        type: "double",
-        value: amountInDP
-      }]
-    };
-  }
-
+	static scrollInDirection(direction, amountInDP) {
+		if (typeof direction !== "number") {
+			throw new Error(
+				"direction should be a number, but got " +
+					(direction + (" (" + (typeof direction + ")")))
+			);
+		}
+		if (typeof amountInDP !== "number") {
+			throw new Error(
+				"amountInDP should be a number, but got " +
+					(amountInDP + (" (" + (typeof amountInDP + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "com.wix.detox.espresso.DetoxAction"
+			},
+			method: "scrollInDirection",
+			args: [
+				{
+					type: "Integer",
+					value: direction
+				},
+				{
+					type: "double",
+					value: amountInDP
+				}
+			]
+		};
+	}
 }
 
 module.exports = DetoxAction;

--- a/detox/src/android/espressoapi/DetoxAction.js
+++ b/detox/src/android/espressoapi/DetoxAction.js
@@ -1,115 +1,81 @@
+/* eslint-disable */
 /**
 
 	This code is generated.
 	For more information see generation/README.md.
 */
 
+
+
 class DetoxAction {
-	static multiClick(times) {
-		if (typeof times !== "number") {
-			throw new Error(
-				"times should be a number, but got " +
-					(times + (" (" + (typeof times + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "com.wix.detox.espresso.DetoxAction"
-			},
-			method: "multiClick",
-			args: [
-				{
-					type: "Integer",
-					value: times
-				}
-			]
-		};
-	}
+  static multiClick(times) {
+    if (typeof times !== "number") throw new Error("times should be a number, but got " + (times + (" (" + (typeof times + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.espresso.DetoxAction"
+      },
+      method: "multiClick",
+      args: [{
+        type: "Integer",
+        value: times
+      }]
+    };
+  }
 
-	static tapAtLocation(x, y) {
-		if (typeof x !== "number") {
-			throw new Error(
-				"x should be a number, but got " + (x + (" (" + (typeof x + ")")))
-			);
-		}
-		if (typeof y !== "number") {
-			throw new Error(
-				"y should be a number, but got " + (y + (" (" + (typeof y + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "com.wix.detox.espresso.DetoxAction"
-			},
-			method: "tapAtLocation",
-			args: [
-				{
-					type: "Integer",
-					value: x
-				},
-				{
-					type: "Integer",
-					value: y
-				}
-			]
-		};
-	}
+  static tapAtLocation(x, y) {
+    if (typeof x !== "number") throw new Error("x should be a number, but got " + (x + (" (" + (typeof x + ")"))));
+    if (typeof y !== "number") throw new Error("y should be a number, but got " + (y + (" (" + (typeof y + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.espresso.DetoxAction"
+      },
+      method: "tapAtLocation",
+      args: [{
+        type: "Integer",
+        value: x
+      }, {
+        type: "Integer",
+        value: y
+      }]
+    };
+  }
 
-	static scrollToEdge(edge) {
-		if (typeof edge !== "number") {
-			throw new Error(
-				"edge should be a number, but got " +
-					(edge + (" (" + (typeof edge + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "com.wix.detox.espresso.DetoxAction"
-			},
-			method: "scrollToEdge",
-			args: [
-				{
-					type: "Integer",
-					value: edge
-				}
-			]
-		};
-	}
+  static scrollToEdge(edge) {
+    if (typeof edge !== "number") throw new Error("edge should be a number, but got " + (edge + (" (" + (typeof edge + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.espresso.DetoxAction"
+      },
+      method: "scrollToEdge",
+      args: [{
+        type: "Integer",
+        value: edge
+      }]
+    };
+  }
 
-	static scrollInDirection(direction, amountInDP) {
-		if (typeof direction !== "number") {
-			throw new Error(
-				"direction should be a number, but got " +
-					(direction + (" (" + (typeof direction + ")")))
-			);
-		}
-		if (typeof amountInDP !== "number") {
-			throw new Error(
-				"amountInDP should be a number, but got " +
-					(amountInDP + (" (" + (typeof amountInDP + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "com.wix.detox.espresso.DetoxAction"
-			},
-			method: "scrollInDirection",
-			args: [
-				{
-					type: "Integer",
-					value: direction
-				},
-				{
-					type: "double",
-					value: amountInDP
-				}
-			]
-		};
-	}
+  static scrollInDirection(direction, amountInDP) {
+    if (typeof direction !== "number") throw new Error("direction should be a number, but got " + (direction + (" (" + (typeof direction + ")"))));
+    if (typeof amountInDP !== "number") throw new Error("amountInDP should be a number, but got " + (amountInDP + (" (" + (typeof amountInDP + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.espresso.DetoxAction"
+      },
+      method: "scrollInDirection",
+      args: [{
+        type: "Integer",
+        value: direction
+      }, {
+        type: "double",
+        value: amountInDP
+      }]
+    };
+  }
+
 }
 
 module.exports = DetoxAction;

--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -1,6 +1,6 @@
-const invoke = require('../invoke');
-const matchers = require('./matcher');
-const DetoxActionApi = require('./espressoapi/DetoxAction');
+const invoke = require("../invoke");
+const matchers = require("./matcher");
+const DetoxActionApi = require("./espressoapi/DetoxAction");
 const Matcher = matchers.Matcher;
 const LabelMatcher = matchers.LabelMatcher;
 const IdMatcher = matchers.IdMatcher;
@@ -16,343 +16,545 @@ const ValueMatcher = matchers.ValueMatcher;
 let invocationManager;
 
 function setInvocationManager(im) {
-  invocationManager = im;
+	invocationManager = im;
 }
 
-const ViewActions = 'android.support.test.espresso.action.ViewActions';
-const ViewAssertions = 'android.support.test.espresso.assertion.ViewAssertions';
-const DetoxMatcher = 'com.wix.detox.espresso.DetoxMatcher';
-const DetoxAction = 'com.wix.detox.espresso.DetoxAction';
-const DetoxAssertion = 'com.wix.detox.espresso.DetoxAssertion';
-const EspressoDetox = 'com.wix.detox.espresso.EspressoDetox';
+const ViewActions = "android.support.test.espresso.action.ViewActions";
+const ViewAssertions = "android.support.test.espresso.assertion.ViewAssertions";
+const DetoxMatcher = "com.wix.detox.espresso.DetoxMatcher";
+const DetoxAction = "com.wix.detox.espresso.DetoxAction";
+const DetoxAssertion = "com.wix.detox.espresso.DetoxAssertion";
+const EspressoDetox = "com.wix.detox.espresso.EspressoDetox";
 
 class Action {}
 
 class TapAction extends Action {
-  constructor() {
-    super();
-    this._call = invoke.call(invoke.Android.Class(ViewActions), 'click');
-  }
+	constructor() {
+		super();
+		this._call = invoke.call(invoke.Android.Class(ViewActions), "click");
+	}
 }
 
 class TapAtPointAction extends Action {
-  constructor(value) {
-    super();
-    this._call = invoke.callDirectly(DetoxActionApi.tapAtLocation(value.x, value.y));
-  }
+	constructor(value) {
+		super();
+		this._call = invoke.callDirectly(
+			DetoxActionApi.tapAtLocation(value.x, value.y)
+		);
+	}
 }
 
 class LongPressAction extends Action {
-  constructor() {
-    super();
-    this._call = invoke.call(invoke.Android.Class(ViewActions), 'longClick');
-  }
+	constructor() {
+		super();
+		this._call = invoke.call(invoke.Android.Class(ViewActions), "longClick");
+	}
 }
 
 class MultiClickAction extends Action {
-  constructor(times) {
-    super();
-    this._call = invoke.callDirectly(DetoxActionApi.multiClick(times));
-  }
+	constructor(times) {
+		super();
+		this._call = invoke.callDirectly(DetoxActionApi.multiClick(times));
+	}
 }
 
 class TypeTextAction extends Action {
-  constructor(value) {
-    super();
-    if (typeof value !== 'string') throw new Error(`TypeTextAction ctor argument must be a string, got ${typeof value}`);
-    this._call = invoke.call(invoke.Android.Class(ViewActions), 'typeText', value);
-  }
+	constructor(value) {
+		super();
+		if (typeof value !== "string") {
+			throw new Error(
+				`TypeTextAction ctor argument must be a string, got ${typeof value}`
+			);
+		}
+		this._call = invoke.call(
+			invoke.Android.Class(ViewActions),
+			"typeText",
+			value
+		);
+	}
 }
 
 class ReplaceTextAction extends Action {
-  constructor(value) {
-    super();
-    if (typeof value !== 'string') throw new Error(`ReplaceTextAction ctor argument must be a string, got ${typeof value}`);
-    this._call = invoke.call(invoke.Android.Class(ViewActions), 'replaceText', value);
-  }
+	constructor(value) {
+		super();
+		if (typeof value !== "string") {
+			throw new Error(
+				`ReplaceTextAction ctor argument must be a string, got ${typeof value}`
+			);
+		}
+		this._call = invoke.call(
+			invoke.Android.Class(ViewActions),
+			"replaceText",
+			value
+		);
+	}
 }
 
 class ClearTextAction extends Action {
-  constructor() {
-    super();
-    this._call = invoke.call(invoke.Android.Class(ViewActions), 'clearText');
-  }
+	constructor() {
+		super();
+		this._call = invoke.call(invoke.Android.Class(ViewActions), "clearText");
+	}
 }
 
 class ScrollAmountAction extends Action {
-  constructor(direction, amount) {
-    super();
-    if (typeof direction !== 'string') throw new Error(`ScrollAmountAction ctor 1st argument must be a string, got ${typeof direction}`);
-    switch (direction) {
-      case 'left': direction = 1; break;
-      case 'right': direction = 2; break;
-      case 'up': direction = 3; break;
-      case 'down': direction = 4; break;
-      default: throw new Error(`ScrollAmountAction direction must be a 'left'/'right'/'up'/'down', got ${direction}`);
-    }
-    if (typeof amount !== 'number') throw new Error(`ScrollAmountAction ctor 2nd argument must be a number, got ${typeof amount}`);
-    this._call = invoke.call(invoke.Android.Class(DetoxAction), 'scrollInDirection', invoke.Android.Integer(direction), invoke.Android.Double(amount));
-  }
+	constructor(direction, amount) {
+		super();
+		if (typeof direction !== "string") {
+			throw new Error(
+				`ScrollAmountAction ctor 1st argument must be a string, got ${typeof direction}`
+			);
+		}
+		switch (direction) {
+			case "left":
+				direction = 1;
+				break;
+			case "right":
+				direction = 2;
+				break;
+			case "up":
+				direction = 3;
+				break;
+			case "down":
+				direction = 4;
+				break;
+			default:
+				throw new Error(
+					`ScrollAmountAction direction must be a 'left'/'right'/'up'/'down', got ${direction}`
+				);
+		}
+		if (typeof amount !== "number") {
+			throw new Error(
+				`ScrollAmountAction ctor 2nd argument must be a number, got ${typeof amount}`
+			);
+		}
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxAction),
+			"scrollInDirection",
+			invoke.Android.Integer(direction),
+			invoke.Android.Double(amount)
+		);
+	}
 }
 
 class ScrollEdgeAction extends Action {
-  constructor(edge) {
-    super();
-    if (typeof edge !== 'string') throw new Error(`ScrollEdgeAction ctor 1st argument must be a string, got ${typeof edge}`);
-    switch (edge) {
-      case 'left': edge = 1; break;
-      case 'right': edge = 2; break;
-      case 'top': edge = 3; break;
-      case 'bottom': edge = 4; break;
-      default: throw new Error(`ScrollEdgeAction edge must be a 'left'/'right'/'top'/'bottom', got ${edge}`);
-    }
-    this._call = invoke.call(invoke.Android.Class(DetoxAction), 'scrollToEdge', invoke.Android.Integer(edge));
-  }
+	constructor(edge) {
+		super();
+		if (typeof edge !== "string") {
+			throw new Error(
+				`ScrollEdgeAction ctor 1st argument must be a string, got ${typeof edge}`
+			);
+		}
+		switch (edge) {
+			case "left":
+				edge = 1;
+				break;
+			case "right":
+				edge = 2;
+				break;
+			case "top":
+				edge = 3;
+				break;
+			case "bottom":
+				edge = 4;
+				break;
+			default:
+				throw new Error(
+					`ScrollEdgeAction edge must be a 'left'/'right'/'top'/'bottom', got ${edge}`
+				);
+		}
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxAction),
+			"scrollToEdge",
+			invoke.Android.Integer(edge)
+		);
+	}
 }
 
 class SwipeAction extends Action {
-  // This implementation ignores the percentage parameter
-  constructor(direction, speed, percentage) {
-    super();
-    if (typeof direction !== 'string') throw new Error(`SwipeAction ctor 1st argument must be a string, got ${typeof direction}`);
-    if (typeof speed !== 'string') throw new Error(`SwipeAction ctor 2nd argument must be a string, got ${typeof speed}`);
-    switch (direction) {
-      case 'left': direction = 1; break;
-      case 'right': direction = 2; break;
-      case 'up': direction = 3; break;
-      case 'down': direction = 4; break;
-      default: throw new Error(`SwipeAction direction must be a 'left'/'right'/'up'/'down', got ${direction}`);
-    }
-    if (speed === 'fast') {
-      this._call = invoke.call(invoke.Android.Class(DetoxAction), 'swipeInDirection', invoke.Android.Integer(direction), invoke.Android.Boolean(true));
-    } else if (speed === 'slow') {
-      this._call = invoke.call(invoke.Android.Class(DetoxAction), 'swipeInDirection', invoke.Android.Integer(direction), invoke.Android.Boolean(false));
-    } else {
-      throw new Error(`SwipeAction speed must be a 'fast'/'slow', got ${speed}`);
-    }
-  }
+	// This implementation ignores the percentage parameter
+	constructor(direction, speed, percentage) {
+		super();
+		if (typeof direction !== "string") {
+			throw new Error(
+				`SwipeAction ctor 1st argument must be a string, got ${typeof direction}`
+			);
+		}
+		if (typeof speed !== "string") {
+			throw new Error(
+				`SwipeAction ctor 2nd argument must be a string, got ${typeof speed}`
+			);
+		}
+		switch (direction) {
+			case "left":
+				direction = 1;
+				break;
+			case "right":
+				direction = 2;
+				break;
+			case "up":
+				direction = 3;
+				break;
+			case "down":
+				direction = 4;
+				break;
+			default:
+				throw new Error(
+					`SwipeAction direction must be a 'left'/'right'/'up'/'down', got ${direction}`
+				);
+		}
+		if (speed === "fast") {
+			this._call = invoke.call(
+				invoke.Android.Class(DetoxAction),
+				"swipeInDirection",
+				invoke.Android.Integer(direction),
+				invoke.Android.Boolean(true)
+			);
+		} else if (speed === "slow") {
+			this._call = invoke.call(
+				invoke.Android.Class(DetoxAction),
+				"swipeInDirection",
+				invoke.Android.Integer(direction),
+				invoke.Android.Boolean(false)
+			);
+		} else {
+			throw new Error(
+				`SwipeAction speed must be a 'fast'/'slow', got ${speed}`
+			);
+		}
+	}
 }
 
 class Interaction {
-  async execute() {
-    //if (!this._call) throw new Error(`Interaction.execute cannot find a valid _call, got ${typeof this._call}`);
-    await invocationManager.execute(this._call);
-  }
+	async execute() {
+		//if (!this._call) throw new Error(`Interaction.execute cannot find a valid _call, got ${typeof this._call}`);
+		await invocationManager.execute(this._call);
+	}
 }
 
 class ActionInteraction extends Interaction {
-  constructor(element, action) {
-    super();
-    this._call = invoke.call(invoke.Android.Class(EspressoDetox), 'perform', element._call, action._call);
-    // TODO: move this.execute() here from the caller
-  }
+	constructor(element, action) {
+		super();
+		this._call = invoke.call(
+			invoke.Android.Class(EspressoDetox),
+			"perform",
+			element._call,
+			action._call
+		);
+		// TODO: move this.execute() here from the caller
+	}
 }
 
 class MatcherAssertionInteraction extends Interaction {
-  constructor(element, matcher) {
-    super();
-    this._call = invoke.call(invoke.Android.Class(DetoxAssertion), 'assertMatcher', element._call, matcher._call);
-    // TODO: move this.execute() here from the caller
-  }
+	constructor(element, matcher) {
+		super();
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxAssertion),
+			"assertMatcher",
+			element._call,
+			matcher._call
+		);
+		// TODO: move this.execute() here from the caller
+	}
 }
 
 class WaitForInteraction extends Interaction {
-  constructor(element, matcher) {
-    super();
-    this._element = element;
-    this._originalMatcher = matcher;
-    // we need to override the original matcher for the element and add matcher to it as well
-    this._element._selectElementWithMatcher(this._element._originalMatcher.and(this._originalMatcher));
-  }
+	constructor(element, matcher) {
+		super();
+		this._element = element;
+		this._originalMatcher = matcher;
+		// we need to override the original matcher for the element and add matcher to it as well
+		this._element._selectElementWithMatcher(
+			this._element._originalMatcher.and(this._originalMatcher)
+		);
+	}
 
-  async withTimeout(timeout) {
-    if (typeof timeout !== 'number') throw new Error(`WaitForInteraction withTimeout argument must be a number, got ${typeof timeout}`);
-    if (timeout < 0) throw new Error('timeout must be larger than 0');
+	async withTimeout(timeout) {
+		if (typeof timeout !== "number") {
+			throw new Error(
+				`WaitForInteraction withTimeout argument must be a number, got ${typeof timeout}`
+			);
+		}
+		if (timeout < 0) {
+			throw new Error("timeout must be larger than 0");
+		}
 
-    this._call = invoke.call(invoke.Android.Class(DetoxAssertion), 'waitForAssertMatcher', this._element._call, this._originalMatcher._call, invoke.Android.Double(timeout/1000));
-    await this.execute();
-  }
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxAssertion),
+			"waitForAssertMatcher",
+			this._element._call,
+			this._originalMatcher._call,
+			invoke.Android.Double(timeout / 1000)
+		);
+		await this.execute();
+	}
 
-  whileElement(searchMatcher) {
-    return new WaitForActionInteraction(this._element, this._originalMatcher, searchMatcher);
-  }
+	whileElement(searchMatcher) {
+		return new WaitForActionInteraction(
+			this._element,
+			this._originalMatcher,
+			searchMatcher
+		);
+	}
 }
 
 class WaitForActionInteraction extends Interaction {
-  constructor(element, matcher, searchMatcher) {
-    super();
-    //if (!(element instanceof Element)) throw new Error(`WaitForActionInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
-    //if (!(matcher instanceof Matcher)) throw new Error(`WaitForActionInteraction ctor 2nd argument must be a valid Matcher, got ${typeof matcher}`);
-    if (!(searchMatcher instanceof Matcher)) throw new Error(`WaitForActionInteraction ctor 3rd argument must be a valid Matcher, got ${typeof searchMatcher}`);
-    this._element = element;
-    this._originalMatcher = matcher;
-    this._searchMatcher = searchMatcher;
-  }
-  async _execute(searchAction) {
-    //if (!searchAction instanceof Action) throw new Error(`WaitForActionInteraction _execute argument must be a valid Action, got ${typeof searchAction}`);
-    this._call = invoke.call(invoke.Android.Class(DetoxAssertion), 'waitForAssertMatcherWithSearchAction',
-      this._element._call, this._originalMatcher._call, searchAction._call, this._searchMatcher._call);
-    await this.execute();
-  }
-  async scroll(amount, direction = 'down') {
-    await this._execute(new ScrollAmountAction(direction, amount));
-  }
+	constructor(element, matcher, searchMatcher) {
+		super();
+		//if (!(element instanceof Element)) throw new Error(`WaitForActionInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
+		//if (!(matcher instanceof Matcher)) throw new Error(`WaitForActionInteraction ctor 2nd argument must be a valid Matcher, got ${typeof matcher}`);
+		if (!(searchMatcher instanceof Matcher)) {
+			throw new Error(
+				`WaitForActionInteraction ctor 3rd argument must be a valid Matcher, got ${typeof searchMatcher}`
+			);
+		}
+		this._element = element;
+		this._originalMatcher = matcher;
+		this._searchMatcher = searchMatcher;
+	}
+	async _execute(searchAction) {
+		//if (!searchAction instanceof Action) throw new Error(`WaitForActionInteraction _execute argument must be a valid Action, got ${typeof searchAction}`);
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxAssertion),
+			"waitForAssertMatcherWithSearchAction",
+			this._element._call,
+			this._originalMatcher._call,
+			searchAction._call,
+			this._searchMatcher._call
+		);
+		await this.execute();
+	}
+	async scroll(amount, direction = "down") {
+		await this._execute(new ScrollAmountAction(direction, amount));
+	}
 }
 
 class Element {
-  constructor(matcher) {
-    this._originalMatcher = matcher;
-    this._selectElementWithMatcher(this._originalMatcher);
-  }
-  _selectElementWithMatcher(matcher) {
-    if (!(matcher instanceof Matcher)) throw new Error(`Element _selectElementWithMatcher argument must be a valid Matcher, got ${typeof matcher}`);
-    this._call = invoke.call(invoke.Espresso, 'onView', matcher._call);
-  }
-  atIndex(index) {
-    if (typeof index !== 'number') throw new Error(`Element atIndex argument must be a number, got ${typeof index}`);
-    const matcher = this._originalMatcher;
-    this._originalMatcher._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForAtIndex', invoke.Android.Integer(index), matcher._call);
-    this._selectElementWithMatcher(this._originalMatcher);
-    return this;
-  }
-  async tap() {
-    return await new ActionInteraction(this, new TapAction()).execute();
-  }
-  async tapAtPoint(value) {
-    return await new ActionInteraction(this, new TapAtPointAction(value)).execute();
-  }
-  async longPress() {
-    return await new ActionInteraction(this, new LongPressAction()).execute();
-  }
-  async multiTap(times) {
-    return await new ActionInteraction(this, new MultiClickAction(times)).execute();
-  }
-  async typeText(value) {
-    return await new ActionInteraction(this, new TypeTextAction(value)).execute();
-  }
-  async replaceText(value) {
-    return await new ActionInteraction(this, new ReplaceTextAction(value)).execute();
-  }
-  async clearText() {
-    return await new ActionInteraction(this, new ClearTextAction()).execute();
-  }
-  async scroll(amount, direction = 'down') {
-    // override the user's element selection with an extended matcher that looks for UIScrollView children
-    // this._selectElementWithMatcher(this._originalMatcher._extendToDescendantScrollViews());
-    return await new ActionInteraction(this, new ScrollAmountAction(direction, amount)).execute();
-  }
-  async scrollTo(edge) {
-    // override the user's element selection with an extended matcher that looks for UIScrollView children
-    this._selectElementWithMatcher(this._originalMatcher._extendToDescendantScrollViews());
-    return await new ActionInteraction(this, new ScrollEdgeAction(edge)).execute();
-  }
-  async swipe(direction, speed = 'fast', percentage = 0) {
-    // override the user's element selection with an extended matcher that avoids RN issues with RCTScrollView
-    this._selectElementWithMatcher(this._originalMatcher._avoidProblematicReactNativeElements());
-    return await new ActionInteraction(this, new SwipeAction(direction, speed, percentage)).execute();
-  }
+	constructor(matcher) {
+		this._originalMatcher = matcher;
+		this._selectElementWithMatcher(this._originalMatcher);
+	}
+	_selectElementWithMatcher(matcher) {
+		if (!(matcher instanceof Matcher)) {
+			throw new Error(
+				`Element _selectElementWithMatcher argument must be a valid Matcher, got ${typeof matcher}`
+			);
+		}
+		this._call = invoke.call(invoke.Espresso, "onView", matcher._call);
+	}
+	atIndex(index) {
+		if (typeof index !== "number") {
+			throw new Error(
+				`Element atIndex argument must be a number, got ${typeof index}`
+			);
+		}
+		const matcher = this._originalMatcher;
+		this._originalMatcher._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForAtIndex",
+			invoke.Android.Integer(index),
+			matcher._call
+		);
+		this._selectElementWithMatcher(this._originalMatcher);
+		return this;
+	}
+	async tap() {
+		return await new ActionInteraction(this, new TapAction()).execute();
+	}
+	async tapAtPoint(value) {
+		return await new ActionInteraction(
+			this,
+			new TapAtPointAction(value)
+		).execute();
+	}
+	async longPress() {
+		return await new ActionInteraction(this, new LongPressAction()).execute();
+	}
+	async multiTap(times) {
+		return await new ActionInteraction(
+			this,
+			new MultiClickAction(times)
+		).execute();
+	}
+	async typeText(value) {
+		return await new ActionInteraction(
+			this,
+			new TypeTextAction(value)
+		).execute();
+	}
+	async replaceText(value) {
+		return await new ActionInteraction(
+			this,
+			new ReplaceTextAction(value)
+		).execute();
+	}
+	async clearText() {
+		return await new ActionInteraction(this, new ClearTextAction()).execute();
+	}
+	async scroll(amount, direction = "down") {
+		// override the user's element selection with an extended matcher that looks for UIScrollView children
+		// this._selectElementWithMatcher(this._originalMatcher._extendToDescendantScrollViews());
+		return await new ActionInteraction(
+			this,
+			new ScrollAmountAction(direction, amount)
+		).execute();
+	}
+	async scrollTo(edge) {
+		// override the user's element selection with an extended matcher that looks for UIScrollView children
+		this._selectElementWithMatcher(
+			this._originalMatcher._extendToDescendantScrollViews()
+		);
+		return await new ActionInteraction(
+			this,
+			new ScrollEdgeAction(edge)
+		).execute();
+	}
+	async swipe(direction, speed = "fast", percentage = 0) {
+		// override the user's element selection with an extended matcher that avoids RN issues with RCTScrollView
+		this._selectElementWithMatcher(
+			this._originalMatcher._avoidProblematicReactNativeElements()
+		);
+		return await new ActionInteraction(
+			this,
+			new SwipeAction(direction, speed, percentage)
+		).execute();
+	}
 }
 
 class Expect {}
 
 class ExpectElement extends Expect {
-  constructor(element) {
-    super();
-    this._element = element;
-  }
-  async toBeVisible() {
-    return await new MatcherAssertionInteraction(this._element, new VisibleMatcher()).execute();
-  }
-  async toBeNotVisible() {
-    return await invocationManager.execute(invoke.call(invoke.Android.Class(DetoxAssertion), 'assertNotVisible', this._element._call));
-  }
-  async toExist() {
-    return await new MatcherAssertionInteraction(this._element, new ExistsMatcher()).execute();
-  }
-  async toNotExist() {
-    return await invocationManager.execute(invoke.call(invoke.Android.Class(DetoxAssertion), 'assertNotExists', this._element._call));
-  }
-  async toHaveText(value) {
-    return await new MatcherAssertionInteraction(this._element, new TextMatcher(value)).execute();
-  }
-  async toHaveLabel(value) {
-    return await new MatcherAssertionInteraction(this._element, new LabelMatcher(value)).execute();
-  }
-  async toHaveId(value) {
-    return await new MatcherAssertionInteraction(this._element, new IdMatcher(value)).execute();
-  }
-  async toHaveValue(value) {
-    return await new MatcherAssertionInteraction(this._element, new ValueMatcher(value)).execute();
-  }
+	constructor(element) {
+		super();
+		this._element = element;
+	}
+	async toBeVisible() {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new VisibleMatcher()
+		).execute();
+	}
+	async toBeNotVisible() {
+		return await invocationManager.execute(
+			invoke.call(
+				invoke.Android.Class(DetoxAssertion),
+				"assertNotVisible",
+				this._element._call
+			)
+		);
+	}
+	async toExist() {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new ExistsMatcher()
+		).execute();
+	}
+	async toNotExist() {
+		return await invocationManager.execute(
+			invoke.call(
+				invoke.Android.Class(DetoxAssertion),
+				"assertNotExists",
+				this._element._call
+			)
+		);
+	}
+	async toHaveText(value) {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new TextMatcher(value)
+		).execute();
+	}
+	async toHaveLabel(value) {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new LabelMatcher(value)
+		).execute();
+	}
+	async toHaveId(value) {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new IdMatcher(value)
+		).execute();
+	}
+	async toHaveValue(value) {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new ValueMatcher(value)
+		).execute();
+	}
 }
 
 class WaitFor {}
 
 class WaitForElement extends WaitFor {
-  constructor(element) {
-    super();
-    //if ((!element instanceof Element)) throw new Error(`WaitForElement ctor argument must be a valid Element, got ${typeof element}`);
-    this._element = element;
-  }
-  toBeVisible() {
-    return new WaitForInteraction(this._element, new VisibleMatcher());
-  }
-  toBeNotVisible() {
-    return new WaitForInteraction(this._element, new NotVisibleMatcher());
-  }
-  toExist() {
-    return new WaitForInteraction(this._element, new ExistsMatcher());
-  }
-  toNotExist() {
-    return new WaitForInteraction(this._element, new NotExistsMatcher());
-  }
-  toHaveText(text) {
-    return new WaitForInteraction(this._element, new TextMatcher(text));
-  }
-  toHaveValue(value) {
-    return new WaitForInteraction(this._element, new ValueMatcher(value));
-  }
-  toNotHaveValue(value) {
-    return new WaitForInteraction(this._element, new ValueMatcher(value).not());
-  }
+	constructor(element) {
+		super();
+		//if ((!element instanceof Element)) throw new Error(`WaitForElement ctor argument must be a valid Element, got ${typeof element}`);
+		this._element = element;
+	}
+	toBeVisible() {
+		return new WaitForInteraction(this._element, new VisibleMatcher());
+	}
+	toBeNotVisible() {
+		return new WaitForInteraction(this._element, new NotVisibleMatcher());
+	}
+	toExist() {
+		return new WaitForInteraction(this._element, new ExistsMatcher());
+	}
+	toNotExist() {
+		return new WaitForInteraction(this._element, new NotExistsMatcher());
+	}
+	toHaveText(text) {
+		return new WaitForInteraction(this._element, new TextMatcher(text));
+	}
+	toHaveValue(value) {
+		return new WaitForInteraction(this._element, new ValueMatcher(value));
+	}
+	toNotHaveValue(value) {
+		return new WaitForInteraction(this._element, new ValueMatcher(value).not());
+	}
 }
 
 function expect(element) {
-  if (element instanceof Element) return new ExpectElement(element);
-  throw new Error(`expect() argument is invalid, got ${typeof element}`);
+	if (element instanceof Element) {
+		return new ExpectElement(element);
+	}
+	throw new Error(`expect() argument is invalid, got ${typeof element}`);
 }
 
 function waitFor(element) {
-  if (element instanceof Element) return new WaitForElement(element);
-  throw new Error(`waitFor() argument is invalid, got ${typeof element}`);
+	if (element instanceof Element) {
+		return new WaitForElement(element);
+	}
+	throw new Error(`waitFor() argument is invalid, got ${typeof element}`);
 }
 
 function element(matcher) {
-  return new Element(matcher);
+	return new Element(matcher);
 }
 
 const by = {
-  accessibilityLabel: (value) => new LabelMatcher(value),
-  label: (value) => new LabelMatcher(value),
-  id: (value) => new IdMatcher(value),
-  type: (value) => new TypeMatcher(value),
-  traits: (value) => new TraitsMatcher(value),
-  value: (value) => new ValueMatcher(value),
-  text: (value) => new TextMatcher(value)
+	accessibilityLabel: value => new LabelMatcher(value),
+	label: value => new LabelMatcher(value),
+	id: value => new IdMatcher(value),
+	type: value => new TypeMatcher(value),
+	traits: value => new TraitsMatcher(value),
+	value: value => new ValueMatcher(value),
+	text: value => new TextMatcher(value)
 };
 
 const exportGlobals = () => {
-  global.element = element;
-  global.expect = expect;
-  global.waitFor = waitFor;
-  global.by = by;
+	global.element = element;
+	global.expect = expect;
+	global.waitFor = waitFor;
+	global.by = by;
 };
 
 module.exports = {
-  setInvocationManager,
-  exportGlobals,
-  expect,
-  waitFor,
-  element,
-  by
+	setInvocationManager,
+	exportGlobals,
+	expect,
+	waitFor,
+	element,
+	by
 };

--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -98,14 +98,15 @@ class ClearTextAction extends Action {
 }
 
 class ScrollAmountAction extends Action {
-	constructor(direction, amount) {
+	constructor(directionName, amount) {
 		super();
-		if (typeof direction !== "string") {
+		if (typeof directionName !== "string") {
 			throw new Error(
-				`ScrollAmountAction ctor 1st argument must be a string, got ${typeof direction}`
+				`ScrollAmountAction ctor 1st argument must be a string, got ${typeof directionName}`
 			);
 		}
-		switch (direction) {
+		let direction;
+		switch (directionName) {
 			case "left":
 				direction = 1;
 				break;
@@ -138,14 +139,15 @@ class ScrollAmountAction extends Action {
 }
 
 class ScrollEdgeAction extends Action {
-	constructor(edge) {
+	constructor(edgeName) {
 		super();
-		if (typeof edge !== "string") {
+		if (typeof edgeName !== "string") {
 			throw new Error(
-				`ScrollEdgeAction ctor 1st argument must be a string, got ${typeof edge}`
+				`ScrollEdgeAction ctor 1st argument must be a string, got ${typeof edgeName}`
 			);
 		}
-		switch (edge) {
+		let edge;
+		switch (edgeName) {
 			case "left":
 				edge = 1;
 				break;
@@ -173,11 +175,11 @@ class ScrollEdgeAction extends Action {
 
 class SwipeAction extends Action {
 	// This implementation ignores the percentage parameter
-	constructor(direction, speed, percentage) {
+	constructor(directionName, speed, percentage) {
 		super();
-		if (typeof direction !== "string") {
+		if (typeof directionName !== "string") {
 			throw new Error(
-				`SwipeAction ctor 1st argument must be a string, got ${typeof direction}`
+				`SwipeAction ctor 1st argument must be a string, got ${typeof directionName}`
 			);
 		}
 		if (typeof speed !== "string") {
@@ -185,7 +187,8 @@ class SwipeAction extends Action {
 				`SwipeAction ctor 2nd argument must be a string, got ${typeof speed}`
 			);
 		}
-		switch (direction) {
+		let direction;
+		switch (directionName) {
 			case "left":
 				direction = 1;
 				break;

--- a/detox/src/android/expect.test.js
+++ b/detox/src/android/expect.test.js
@@ -259,8 +259,9 @@ async function expectToThrow(func) {
 
 class MockExecutor {
 	async execute(invocation) {
+		let invoke = invocation;
 		if (typeof invocation === "function") {
-			invocation = invocation();
+			invoke = invocation();
 		}
 		expect(invocation.target).toBeDefined();
 		expect(invocation.target.type).toBeDefined();

--- a/detox/src/android/expect.test.js
+++ b/detox/src/android/expect.test.js
@@ -1,198 +1,291 @@
-describe('expect', async () => {
-  let e;
+describe("expect", async () => {
+	let e;
 
-  beforeEach(() => {
-    e = require('./expect');
-    e.setInvocationManager(new MockExecutor());
-  });
+	beforeEach(() => {
+		e = require("./expect");
+		e.setInvocationManager(new MockExecutor());
+	});
 
-  it(`element by accessibilityLabel`, async () => {
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toBeVisible();
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toBeNotVisible();
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toExist();
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toNotExist();
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveText('text');
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveLabel('label');
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveId('id');
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveValue('value');
-  });
+	it(`element by accessibilityLabel`, async () => {
+		await e.expect(e.element(e.by.accessibilityLabel("test"))).toBeVisible();
+		await e.expect(e.element(e.by.accessibilityLabel("test"))).toBeNotVisible();
+		await e.expect(e.element(e.by.accessibilityLabel("test"))).toExist();
+		await e.expect(e.element(e.by.accessibilityLabel("test"))).toNotExist();
+		await e
+			.expect(e.element(e.by.accessibilityLabel("test")))
+			.toHaveText("text");
+		await e
+			.expect(e.element(e.by.accessibilityLabel("test")))
+			.toHaveLabel("label");
+		await e.expect(e.element(e.by.accessibilityLabel("test"))).toHaveId("id");
+		await e
+			.expect(e.element(e.by.accessibilityLabel("test")))
+			.toHaveValue("value");
+	});
 
-  it(`element by label (for backwards compat)`, async () => {
-    await e.expect(e.element(e.by.label('test'))).toBeVisible();
-    await e.expect(e.element(e.by.label('test'))).toBeNotVisible();
-    await e.expect(e.element(e.by.label('test'))).toExist();
-    await e.expect(e.element(e.by.label('test'))).toNotExist();
-    await e.expect(e.element(e.by.label('test'))).toHaveText('text');
-    await e.expect(e.element(e.by.label('test'))).toHaveLabel('label');
-    await e.expect(e.element(e.by.label('test'))).toHaveId('id');
-    await e.expect(e.element(e.by.label('test'))).toHaveValue('value');
-  });
+	it(`element by label (for backwards compat)`, async () => {
+		await e.expect(e.element(e.by.label("test"))).toBeVisible();
+		await e.expect(e.element(e.by.label("test"))).toBeNotVisible();
+		await e.expect(e.element(e.by.label("test"))).toExist();
+		await e.expect(e.element(e.by.label("test"))).toNotExist();
+		await e.expect(e.element(e.by.label("test"))).toHaveText("text");
+		await e.expect(e.element(e.by.label("test"))).toHaveLabel("label");
+		await e.expect(e.element(e.by.label("test"))).toHaveId("id");
+		await e.expect(e.element(e.by.label("test"))).toHaveValue("value");
+	});
 
-  it(`element by id`, async () => {
-    await e.expect(e.element(e.by.id('test'))).toBeVisible();
-  });
+	it(`element by id`, async () => {
+		await e.expect(e.element(e.by.id("test"))).toBeVisible();
+	});
 
-  it(`element by type`, async () => {
-    await e.expect(e.element(e.by.type('test'))).toBeVisible();
-  });
-  
-  it(`element by traits`, async () => {
-    await e.expect(e.element(e.by.traits(['button', 'link', 'header', 'search']))).toBeVisible();
-    await e.expect(e.element(e.by.traits(['image', 'selected', 'plays', 'key']))).toBeNotVisible();
-    await e.expect(e.element(e.by.traits(['text', 'summary', 'disabled', 'frequentUpdates']))).toBeNotVisible();
-    await e.expect(e.element(e.by.traits(['startsMedia', 'adjustable', 'allowsDirectInteraction', 'pageTurn']))).toBeNotVisible();
-  });
-  
-  it(`matcher helpers`, async () => {
-    await e.expect(e.element(e.by.id('test').withAncestor(e.by.id('ancestor')))).toBeVisible();
-    await e.expect(e.element(e.by.id('test').withDescendant(e.by.id('descendant')))).toBeVisible();
-    await e.expect(e.element(e.by.id('test').and(e.by.type('type')))).toBeVisible();
-    await e.expect(e.element(e.by.id('test').not())).toBeVisible();
-    await e.expect(e.element(e.by.id('test').or(e.by.id('test2')))).toBeVisible();
-  });
+	it(`element by type`, async () => {
+		await e.expect(e.element(e.by.type("test"))).toBeVisible();
+	});
 
-  it(`expect with wrong parameters should throw`, async () => {
-    await expectToThrow(() => e.expect('notAnElement'));
-    await expectToThrow(() => e.expect(e.element('notAMatcher')));
-  });
+	it(`element by traits`, async () => {
+		await e
+			.expect(e.element(e.by.traits(["button", "link", "header", "search"])))
+			.toBeVisible();
+		await e
+			.expect(e.element(e.by.traits(["image", "selected", "plays", "key"])))
+			.toBeNotVisible();
+		await e
+			.expect(
+				e.element(
+					e.by.traits(["text", "summary", "disabled", "frequentUpdates"])
+				)
+			)
+			.toBeNotVisible();
+		await e
+			.expect(
+				e.element(
+					e.by.traits([
+						"startsMedia",
+						"adjustable",
+						"allowsDirectInteraction",
+						"pageTurn"
+					])
+				)
+			)
+			.toBeNotVisible();
+	});
 
-  it(`matchers with wrong parameters should throw`, async () => {
-    await expectToThrow(() => e.element(e.by.label(5)));
-    await expectToThrow(() => e.element(e.by.accessibilityLabel(5)));
-    await expectToThrow(() => e.element(e.by.id(5)));
-    await expectToThrow(() => e.element(e.by.type(0)));
-    await expectToThrow(() => e.by.traits(1));
-    await expectToThrow(() => e.by.traits(['nonExistentTrait']));
-    await expectToThrow(() => e.element(e.by.value(0)));
-    await expectToThrow(() => e.element(e.by.text(0)));
-    await expectToThrow(() => e.element(e.by.id('test').withAncestor('notAMatcher')));
-    await expectToThrow(() => e.element(e.by.id('test').withDescendant('notAMatcher')));
-    await expectToThrow(() => e.element(e.by.id('test').and('notAMatcher')));
-    await expectToThrow(() => e.element(e.by.id('test').or('notAMatcher')));
-  });
+	it(`matcher helpers`, async () => {
+		await e
+			.expect(e.element(e.by.id("test").withAncestor(e.by.id("ancestor"))))
+			.toBeVisible();
+		await e
+			.expect(e.element(e.by.id("test").withDescendant(e.by.id("descendant"))))
+			.toBeVisible();
+		await e
+			.expect(e.element(e.by.id("test").and(e.by.type("type"))))
+			.toBeVisible();
+		await e.expect(e.element(e.by.id("test").not())).toBeVisible();
+		await e
+			.expect(e.element(e.by.id("test").or(e.by.id("test2"))))
+			.toBeVisible();
+	});
 
-  it(`waitFor (element)`, async () => {
-    await e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout(0);
-    await e.waitFor(e.element(e.by.id('id'))).toBeVisible();
-    await e.waitFor(e.element(e.by.id('id'))).toBeNotVisible();
-    await e.waitFor(e.element(e.by.id('id'))).toExist();
-    await e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout(0);
-    await e.waitFor(e.element(e.by.id('id'))).toNotExist().withTimeout(0);
-    await e.waitFor(e.element(e.by.id('id'))).toHaveText('text');
-    await e.waitFor(e.element(e.by.id('id'))).toHaveValue('value');
-    await e.waitFor(e.element(e.by.id('id'))).toNotHaveValue('value');
+	it(`expect with wrong parameters should throw`, async () => {
+		await expectToThrow(() => e.expect("notAnElement"));
+		await expectToThrow(() => e.expect(e.element("notAMatcher")));
+	});
 
-    await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).scroll(50, 'down');
-    await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).scroll(50);
-  });
+	it(`matchers with wrong parameters should throw`, async () => {
+		await expectToThrow(() => e.element(e.by.label(5)));
+		await expectToThrow(() => e.element(e.by.accessibilityLabel(5)));
+		await expectToThrow(() => e.element(e.by.id(5)));
+		await expectToThrow(() => e.element(e.by.type(0)));
+		await expectToThrow(() => e.by.traits(1));
+		await expectToThrow(() => e.by.traits(["nonExistentTrait"]));
+		await expectToThrow(() => e.element(e.by.value(0)));
+		await expectToThrow(() => e.element(e.by.text(0)));
+		await expectToThrow(() =>
+			e.element(e.by.id("test").withAncestor("notAMatcher"))
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("test").withDescendant("notAMatcher"))
+		);
+		await expectToThrow(() => e.element(e.by.id("test").and("notAMatcher")));
+		await expectToThrow(() => e.element(e.by.id("test").or("notAMatcher")));
+	});
 
-  it(`waitFor (element) with wrong parameters should throw`, async () => {
-    await expectToThrow(() => e.waitFor('notAnElement'));
-    await expectToThrow(() => e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout('notANumber'));
-    await expectToThrow(() => e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout(-1));
-    await expectToThrow(() => e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement('notAnElement'));
-  });
+	it(`waitFor (element)`, async () => {
+		await e
+			.waitFor(e.element(e.by.id("id")))
+			.toExist()
+			.withTimeout(0);
+		await e.waitFor(e.element(e.by.id("id"))).toBeVisible();
+		await e.waitFor(e.element(e.by.id("id"))).toBeNotVisible();
+		await e.waitFor(e.element(e.by.id("id"))).toExist();
+		await e
+			.waitFor(e.element(e.by.id("id")))
+			.toExist()
+			.withTimeout(0);
+		await e
+			.waitFor(e.element(e.by.id("id")))
+			.toNotExist()
+			.withTimeout(0);
+		await e.waitFor(e.element(e.by.id("id"))).toHaveText("text");
+		await e.waitFor(e.element(e.by.id("id"))).toHaveValue("value");
+		await e.waitFor(e.element(e.by.id("id"))).toNotHaveValue("value");
 
-  it(`waitFor (element) with non-elements should throw`, async () => {
-    await expectToThrow(() => e.waitFor('notAnElement').toBeVisible());
-  });
+		await e
+			.waitFor(e.element(e.by.id("id")))
+			.toBeVisible()
+			.whileElement(e.by.id("id2"))
+			.scroll(50, "down");
+		await e
+			.waitFor(e.element(e.by.id("id")))
+			.toBeVisible()
+			.whileElement(e.by.id("id2"))
+			.scroll(50);
+	});
 
-  it(`interactions`, async () => {
-    await e.element(e.by.label('Tap Me')).tap();
-    await e.element(e.by.label('Tap Me')).tapAtPoint({x: 100, y: 200});
-    await e.element(e.by.label('Tap Me')).longPress();
-    await e.element(e.by.id('UniqueId819')).multiTap(3);
-    await e.element(e.by.id('UniqueId937')).typeText('passcode');
-    await e.element(e.by.id('UniqueId005')).clearText();
-    await e.element(e.by.id('UniqueId005')).replaceText('replaceTo');
-    await e.element(e.by.id('ScrollView161')).scroll(100);
-    await e.element(e.by.id('ScrollView161')).scroll(100, 'down');
-    await e.element(e.by.id('ScrollView161')).scroll(100, 'up');
-    await e.element(e.by.id('ScrollView161')).scroll(100, 'right');
-    await e.element(e.by.id('ScrollView161')).scroll(100, 'left');
-    await e.element(e.by.id('ScrollView161')).scrollTo('bottom');
-    await e.element(e.by.id('ScrollView161')).scrollTo('top');
-    await e.element(e.by.id('ScrollView161')).scrollTo('left');
-    await e.element(e.by.id('ScrollView161')).scrollTo('right');
-    await e.element(e.by.id('ScrollView799')).swipe('down');
-    await e.element(e.by.id('ScrollView799')).swipe('down', 'fast');
-    await e.element(e.by.id('ScrollView799')).swipe('up', 'slow');
-    await e.element(e.by.id('ScrollView799')).swipe('left', 'fast');
-    await e.element(e.by.id('ScrollView799')).swipe('right', 'slow');
-    await e.element(e.by.id('ScrollView799')).swipe('down', 'fast', 0.9);
-    await e.element(e.by.id('ScrollView799')).swipe('up', 'slow', 0.9);
-    await e.element(e.by.id('ScrollView799')).swipe('left', 'fast', 0.9);
-    await e.element(e.by.id('ScrollView799')).swipe('right', 'slow', 0.9);
-    await e.element(e.by.id('ScrollView799')).atIndex(1);
-  });
+	it(`waitFor (element) with wrong parameters should throw`, async () => {
+		await expectToThrow(() => e.waitFor("notAnElement"));
+		await expectToThrow(() =>
+			e
+				.waitFor(e.element(e.by.id("id")))
+				.toExist()
+				.withTimeout("notANumber")
+		);
+		await expectToThrow(() =>
+			e
+				.waitFor(e.element(e.by.id("id")))
+				.toExist()
+				.withTimeout(-1)
+		);
+		await expectToThrow(() =>
+			e
+				.waitFor(e.element(e.by.id("id")))
+				.toBeVisible()
+				.whileElement("notAnElement")
+		);
+	});
 
-  it(`interactions with wrong parameters should throw`, async () => {
-    await expectToThrow(() => e.element(e.by.id('UniqueId819')).multiTap('NaN'));
-    await expectToThrow(() => e.element(e.by.id('UniqueId937')).typeText(0));
-    await expectToThrow(() => e.element(e.by.id('UniqueId005')).replaceText(3));
-    await expectToThrow(() => e.element(e.by.id('ScrollView161')).scroll('NaN', 'down'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView161')).scroll(100, 'noDirection'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView161')).scroll(100, 0));
-    await expectToThrow(() => e.element(e.by.id('ScrollView161')).scrollTo(0));
-    await expectToThrow(() => e.element(e.by.id('ScrollView161')).scrollTo('noDirection'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe(4, 'fast'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('noDirection', 0));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('noDirection', 'fast'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('down', 'NotFastNorSlow'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('down', 'NotFastNorSlow', 0.9));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).atIndex('NaN'));
-  });
+	it(`waitFor (element) with non-elements should throw`, async () => {
+		await expectToThrow(() => e.waitFor("notAnElement").toBeVisible());
+	});
 
-  it(`exportGlobals() should export api functions`, async () => {
-    const originalExpect = expect;
-    e.exportGlobals();
-    const newExpect = expect;
-    global.expect = originalExpect;
+	it(`interactions`, async () => {
+		await e.element(e.by.label("Tap Me")).tap();
+		await e.element(e.by.label("Tap Me")).tapAtPoint({ x: 100, y: 200 });
+		await e.element(e.by.label("Tap Me")).longPress();
+		await e.element(e.by.id("UniqueId819")).multiTap(3);
+		await e.element(e.by.id("UniqueId937")).typeText("passcode");
+		await e.element(e.by.id("UniqueId005")).clearText();
+		await e.element(e.by.id("UniqueId005")).replaceText("replaceTo");
+		await e.element(e.by.id("ScrollView161")).scroll(100);
+		await e.element(e.by.id("ScrollView161")).scroll(100, "down");
+		await e.element(e.by.id("ScrollView161")).scroll(100, "up");
+		await e.element(e.by.id("ScrollView161")).scroll(100, "right");
+		await e.element(e.by.id("ScrollView161")).scroll(100, "left");
+		await e.element(e.by.id("ScrollView161")).scrollTo("bottom");
+		await e.element(e.by.id("ScrollView161")).scrollTo("top");
+		await e.element(e.by.id("ScrollView161")).scrollTo("left");
+		await e.element(e.by.id("ScrollView161")).scrollTo("right");
+		await e.element(e.by.id("ScrollView799")).swipe("down");
+		await e.element(e.by.id("ScrollView799")).swipe("down", "fast");
+		await e.element(e.by.id("ScrollView799")).swipe("up", "slow");
+		await e.element(e.by.id("ScrollView799")).swipe("left", "fast");
+		await e.element(e.by.id("ScrollView799")).swipe("right", "slow");
+		await e.element(e.by.id("ScrollView799")).swipe("down", "fast", 0.9);
+		await e.element(e.by.id("ScrollView799")).swipe("up", "slow", 0.9);
+		await e.element(e.by.id("ScrollView799")).swipe("left", "fast", 0.9);
+		await e.element(e.by.id("ScrollView799")).swipe("right", "slow", 0.9);
+		await e.element(e.by.id("ScrollView799")).atIndex(1);
+	});
 
-    expect(newExpect).not.toEqual(originalExpect);
-    expect(element).toBeDefined();
-    expect(waitFor).toBeDefined();
-    expect(by).toBeDefined();
-  });
+	it(`interactions with wrong parameters should throw`, async () => {
+		await expectToThrow(() =>
+			e.element(e.by.id("UniqueId819")).multiTap("NaN")
+		);
+		await expectToThrow(() => e.element(e.by.id("UniqueId937")).typeText(0));
+		await expectToThrow(() => e.element(e.by.id("UniqueId005")).replaceText(3));
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView161")).scroll("NaN", "down")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView161")).scroll(100, "noDirection")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView161")).scroll(100, 0)
+		);
+		await expectToThrow(() => e.element(e.by.id("ScrollView161")).scrollTo(0));
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView161")).scrollTo("noDirection")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).swipe(4, "fast")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).swipe("noDirection", 0)
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).swipe("noDirection", "fast")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).swipe("down", "NotFastNorSlow")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).swipe("down", "NotFastNorSlow", 0.9)
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).atIndex("NaN")
+		);
+	});
+
+	it(`exportGlobals() should export api functions`, async () => {
+		const originalExpect = expect;
+		e.exportGlobals();
+		const newExpect = expect;
+		global.expect = originalExpect;
+
+		expect(newExpect).not.toEqual(originalExpect);
+		expect(element).toBeDefined();
+		expect(waitFor).toBeDefined();
+		expect(by).toBeDefined();
+	});
 });
 
 async function expectToThrow(func) {
-  try {
-    await func();
-  } catch (ex) {
-    expect(ex).toBeDefined();
-  }
+	try {
+		await func();
+	} catch (ex) {
+		expect(ex).toBeDefined();
+	}
 }
 
 class MockExecutor {
-  async execute(invocation) {
-    if (typeof invocation === 'function') {
-      invocation = invocation();
-    }
-    expect(invocation.target).toBeDefined();
-    expect(invocation.target.type).toBeDefined();
-    expect(invocation.target.value).toBeDefined();
+	async execute(invocation) {
+		if (typeof invocation === "function") {
+			invocation = invocation();
+		}
+		expect(invocation.target).toBeDefined();
+		expect(invocation.target.type).toBeDefined();
+		expect(invocation.target.value).toBeDefined();
 
-    this.recurse(invocation);
-    await this.timeout(1);
-  }
+		this.recurse(invocation);
+		await this.timeout(1);
+	}
 
-  recurse(invocation) {
-    for (const key in invocation) {
-      if (invocation.hasOwnProperty(key)) {
-        if (invocation[key] instanceof Object) {
-          this.recurse(invocation[key]);
-        }
-        if (key === 'target' && invocation[key].type === 'Invocation') {
-          const innerValue = invocation.target.value;
-          expect(innerValue.target.type).toBeDefined();
-          expect(innerValue.target.value).toBeDefined();
-        }
-      }
-    }
-  }
+	recurse(invocation) {
+		for (const key in invocation) {
+			if (invocation.hasOwnProperty(key)) {
+				if (invocation[key] instanceof Object) {
+					this.recurse(invocation[key]);
+				}
+				if (key === "target" && invocation[key].type === "Invocation") {
+					const innerValue = invocation.target.value;
+					expect(innerValue.target.type).toBeDefined();
+					expect(innerValue.target.value).toBeDefined();
+				}
+			}
+		}
+	}
 
-  async timeout(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
+	async timeout(ms) {
+		return new Promise(resolve => setTimeout(resolve, ms));
+	}
 }

--- a/detox/src/android/matcher.js
+++ b/detox/src/android/matcher.js
@@ -1,144 +1,242 @@
-const invoke = require('../invoke');
+const invoke = require("../invoke");
 
-const DetoxMatcher = 'com.wix.detox.espresso.DetoxMatcher';
+const DetoxMatcher = "com.wix.detox.espresso.DetoxMatcher";
 
 class Matcher {
-  withAncestor(matcher) {
-    if (!(matcher instanceof Matcher)) throw new Error(`Matcher withAncestor argument must be a valid Matcher, got ${typeof matcher}`);
-    const _originalMatcherCall = this._call;
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherWithAncestor', _originalMatcherCall, matcher._call);
-    return this;
-  }
-  withDescendant(matcher) {
-    if (!(matcher instanceof Matcher)) throw new Error(`Matcher withDescendant argument must be a valid Matcher, got ${typeof matcher}`);
-    const _originalMatcherCall = this._call;
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherWithDescendant', _originalMatcherCall, matcher._call);
-    return this;
-  }
-  and(matcher) {
-    if (!(matcher instanceof Matcher)) throw new Error(`Matcher and argument must be a valid Matcher, got ${typeof matcher}`);
-    const _originalMatcherCall = this._call;
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForAnd', _originalMatcherCall, matcher._call);
-    return this;
-  }
-  or(matcher) {
-    if (!(matcher instanceof Matcher)) throw new Error(`Matcher and argument must be a valid Matcher, got ${typeof matcher}`);
-    const _originalMatcherCall = this._call;
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForOr', _originalMatcherCall, matcher._call);
-    return this;
-  }
-  not() {
-    const _originalMatcherCall = this._call;
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForNot', _originalMatcherCall);
-    return this;
-  }
-  
-  _avoidProblematicReactNativeElements() {
-    /*
+	withAncestor(matcher) {
+		if (!(matcher instanceof Matcher)) {
+			throw new Error(
+				`Matcher withAncestor argument must be a valid Matcher, got ${typeof matcher}`
+			);
+		}
+		const _originalMatcherCall = this._call;
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherWithAncestor",
+			_originalMatcherCall,
+			matcher._call
+		);
+		return this;
+	}
+	withDescendant(matcher) {
+		if (!(matcher instanceof Matcher)) {
+			throw new Error(
+				`Matcher withDescendant argument must be a valid Matcher, got ${typeof matcher}`
+			);
+		}
+		const _originalMatcherCall = this._call;
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherWithDescendant",
+			_originalMatcherCall,
+			matcher._call
+		);
+		return this;
+	}
+	and(matcher) {
+		if (!(matcher instanceof Matcher)) {
+			throw new Error(
+				`Matcher and argument must be a valid Matcher, got ${typeof matcher}`
+			);
+		}
+		const _originalMatcherCall = this._call;
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForAnd",
+			_originalMatcherCall,
+			matcher._call
+		);
+		return this;
+	}
+	or(matcher) {
+		if (!(matcher instanceof Matcher)) {
+			throw new Error(
+				`Matcher and argument must be a valid Matcher, got ${typeof matcher}`
+			);
+		}
+		const _originalMatcherCall = this._call;
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForOr",
+			_originalMatcherCall,
+			matcher._call
+		);
+		return this;
+	}
+	not() {
+		const _originalMatcherCall = this._call;
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForNot",
+			_originalMatcherCall
+		);
+		return this;
+	}
+
+	_avoidProblematicReactNativeElements() {
+		/*
     const _originalMatcherCall = this._call;
     this._call = invoke.call(invoke.IOS.Class('GREYMatchers'), 'detoxMatcherAvoidingProblematicReactNativeElements:', _originalMatcherCall);
     */
-    return this;
-  }
-  _extendToDescendantScrollViews() {
-    /*
+		return this;
+	}
+	_extendToDescendantScrollViews() {
+		/*
     const _originalMatcherCall = this._call;
     this._call = invoke.call(invoke.IOS.Class('GREYMatchers'), 'detoxMatcherForScrollChildOfMatcher:', _originalMatcherCall);
     */
-    return this;
-  }
-  
+		return this;
+	}
 }
 
 class LabelMatcher extends Matcher {
-  constructor(value) {
-    super();
-    if (typeof value !== 'string') throw new Error(`LabelMatcher ctor argument must be a string, got ${typeof value}`);
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForContentDescription', value);
-  }
+	constructor(value) {
+		super();
+		if (typeof value !== "string") {
+			throw new Error(
+				`LabelMatcher ctor argument must be a string, got ${typeof value}`
+			);
+		}
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForContentDescription",
+			value
+		);
+	}
 }
 
 class IdMatcher extends Matcher {
-  constructor(value) {
-    super();
-    if (typeof value !== 'string') throw new Error(`IdMatcher ctor argument must be a string, got ${typeof value}`);
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForTestId', value);
-  }
+	constructor(value) {
+		super();
+		if (typeof value !== "string") {
+			throw new Error(
+				`IdMatcher ctor argument must be a string, got ${typeof value}`
+			);
+		}
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForTestId",
+			value
+		);
+	}
 }
 
 class TypeMatcher extends Matcher {
-  constructor(value) {
-    super();
-    if (typeof value !== 'string') throw new Error(`TypeMatcher ctor argument must be a string, got ${typeof value}`);
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForClass', value);
-  }
+	constructor(value) {
+		super();
+		if (typeof value !== "string") {
+			throw new Error(
+				`TypeMatcher ctor argument must be a string, got ${typeof value}`
+			);
+		}
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForClass",
+			value
+		);
+	}
 }
 
 class VisibleMatcher extends Matcher {
-  constructor() {
-    super();
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForSufficientlyVisible');
-  }
+	constructor() {
+		super();
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForSufficientlyVisible"
+		);
+	}
 }
 
 class NotVisibleMatcher extends Matcher {
-  constructor() {
-    super();
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForNotVisible');
-  }
+	constructor() {
+		super();
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForNotVisible"
+		);
+	}
 }
 
 class ExistsMatcher extends Matcher {
-  constructor() {
-    super();
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForNotNull');
-  }
+	constructor() {
+		super();
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForNotNull"
+		);
+	}
 }
 
 class NotExistsMatcher extends Matcher {
-  constructor() {
-    super();
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForNull');
-  }
+	constructor() {
+		super();
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForNull"
+		);
+	}
 }
 
 class TextMatcher extends Matcher {
-  constructor(value) {
-    super();
-    if (typeof value !== 'string') throw new Error(`TextMatcher ctor argument must be a string, got ${typeof value}`);
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForText', value);
-  }
+	constructor(value) {
+		super();
+		if (typeof value !== "string") {
+			throw new Error(
+				`TextMatcher ctor argument must be a string, got ${typeof value}`
+			);
+		}
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForText",
+			value
+		);
+	}
 }
 
 class ValueMatcher extends Matcher {
-  constructor(value) {
-    super();
-    if (typeof value !== 'string') throw new Error(`ValueMatcher ctor argument must be a string, got ${typeof value}`);
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForContentDescription', value);
-  }
+	constructor(value) {
+		super();
+		if (typeof value !== "string") {
+			throw new Error(
+				`ValueMatcher ctor argument must be a string, got ${typeof value}`
+			);
+		}
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForContentDescription",
+			value
+		);
+	}
 }
 
 // TODO
 // Please be aware, that this is just a dummy matcher
 class TraitsMatcher extends Matcher {
-  constructor(value) {
-    super();
-    if ((typeof value !== 'object') || (!value instanceof Array)) throw new Error(`TraitsMatcher ctor argument must be an array, got ${typeof value}`);
-    
-    this._call = invoke.call(invoke.Android.Class(DetoxMatcher), 'matcherForAnything');
-  }
+	constructor(value) {
+		super();
+		if (typeof value !== "object" || !value instanceof Array) {
+			throw new Error(
+				`TraitsMatcher ctor argument must be an array, got ${typeof value}`
+			);
+		}
+
+		this._call = invoke.call(
+			invoke.Android.Class(DetoxMatcher),
+			"matcherForAnything"
+		);
+	}
 }
 
 module.exports = {
-  Matcher,
-  LabelMatcher,
-  IdMatcher,
-  TypeMatcher,
-  TraitsMatcher,
-  VisibleMatcher,
-  NotVisibleMatcher,
-  ExistsMatcher,
-  NotExistsMatcher,
-  TextMatcher,
-  ValueMatcher
+	Matcher,
+	LabelMatcher,
+	IdMatcher,
+	TypeMatcher,
+	TraitsMatcher,
+	VisibleMatcher,
+	NotVisibleMatcher,
+	ExistsMatcher,
+	NotExistsMatcher,
+	TextMatcher,
+	ValueMatcher
 };

--- a/detox/src/artifacts/ArtifactsCopier.js
+++ b/detox/src/artifacts/ArtifactsCopier.js
@@ -1,56 +1,53 @@
-const log = require('npmlog');
-const sh = require('../utils/sh')
+const log = require("npmlog");
+const sh = require("../utils/sh");
 
 class ArtifactsCopier {
-  constructor(deviceDriver) {
-    this._deviceDriver = deviceDriver;
-    this._currentLaunchNumber = 0;
-    this._currentTestArtifactsDestination = undefined;
-  }
+	constructor(deviceDriver) {
+		this._deviceDriver = deviceDriver;
+		this._currentLaunchNumber = 0;
+		this._currentTestArtifactsDestination = undefined;
+	}
 
-  prepare(deviceId) {
-    this._deviceId = deviceId;
-  }
+	prepare(deviceId) {
+		this._deviceId = deviceId;
+	}
 
-  setArtifactsDestination(artifactsDestination) {
-    this._currentTestArtifactsDestination = artifactsDestination;
-    this._currentLaunchNumber = 1;
-  }
+	setArtifactsDestination(artifactsDestination) {
+		this._currentTestArtifactsDestination = artifactsDestination;
+		this._currentLaunchNumber = 1;
+	}
 
-  async handleAppRelaunch() {
-    await this._copyArtifacts();
-    this._currentLaunchNumber++;
-  }
+	async handleAppRelaunch() {
+		await this._copyArtifacts();
+		this._currentLaunchNumber++;
+	}
 
-  async finalizeArtifacts() {
-    await this._copyArtifacts();
-  }
+	async finalizeArtifacts() {
+		await this._copyArtifacts();
+	}
 
-  async _copyArtifacts() {
-    const copy = async (sourcePath, destinationSuffix) => {
-      const destinationPath = `${this._currentTestArtifactsDestination}/${this._currentLaunchNumber}.${destinationSuffix}`;
-      const cpArgs = `"${sourcePath}" "${destinationPath}"`;
-      try {
-        await sh.cp(cpArgs);
-      } catch (ex) {
-        log.warn(`Couldn't copy (cp ${cpArgs})`);
-      }
-    }
-    
-    if(this._currentTestArtifactsDestination === undefined) {
-      return;
-    }
+	async _copyArtifacts() {
+		const copy = async (sourcePath, destinationSuffix) => {
+			const destinationPath = `${this._currentTestArtifactsDestination}/${this
+				._currentLaunchNumber}.${destinationSuffix}`;
+			const cpArgs = `"${sourcePath}" "${destinationPath}"`;
+			try {
+				await sh.cp(cpArgs);
+			} catch (ex) {
+				log.warn(`Couldn't copy (cp ${cpArgs})`);
+			}
+		};
 
-    const {stdout, stderr} = this._deviceDriver.getLogsPaths(this._deviceId);
-    const pathsMapping = [
-      [stdout, 'out.log'],
-      [stderr, 'err.log']
-    ];
-    for (const [sourcePath, destinationSuffix] of pathsMapping) {
-      await copy(sourcePath, destinationSuffix);
-    }
-  }
+		if (this._currentTestArtifactsDestination === undefined) {
+			return;
+		}
 
+		const { stdout, stderr } = this._deviceDriver.getLogsPaths(this._deviceId);
+		const pathsMapping = [[stdout, "out.log"], [stderr, "err.log"]];
+		for (const [sourcePath, destinationSuffix] of pathsMapping) {
+			await copy(sourcePath, destinationSuffix);
+		}
+	}
 }
 
 module.exports = ArtifactsCopier;

--- a/detox/src/artifacts/ArtifactsPathsProvider.js
+++ b/detox/src/artifacts/ArtifactsPathsProvider.js
@@ -1,36 +1,38 @@
-const fs = require('fs');
-const _ = require('lodash');
-const log = require('npmlog');
+const fs = require("fs");
+const _ = require("lodash");
+const log = require("npmlog");
 
 class ArtifactsPathsProvider {
-  constructor(destinationParent) {
-    if(!destinationParent) {
-      throw new Error('destinationParent should not be undefined');
-    }
-    this._destinationRoot = `${destinationParent}/detox_artifacts.${new Date().toISOString()}`;
-    try {
-      fs.mkdirSync(this._destinationRoot);
-    } catch (ex) {
-      throw new Error(`Could not create artifacts root dir: ${this._destinationRoot}`);
-    }
-  }
+	constructor(destinationParent) {
+		if (!destinationParent) {
+			throw new Error("destinationParent should not be undefined");
+		}
+		this._destinationRoot = `${destinationParent}/detox_artifacts.${new Date().toISOString()}`;
+		try {
+			fs.mkdirSync(this._destinationRoot);
+		} catch (ex) {
+			throw new Error(
+				`Could not create artifacts root dir: ${this._destinationRoot}`
+			);
+		}
+	}
 
-  createPathForTest(number, ...nameComponents) {
-    if(number !== parseInt(number) || number <= 0) {
-      throw new Error('The number should be a positive integer');
-    }
+	createPathForTest(number, ...nameComponents) {
+		if (number !== parseInt(number) || number <= 0) {
+			throw new Error("The number should be a positive integer");
+		}
 
-    const lastPathComponent = [number].concat(nameComponents).join('.');
-    const pathForTest = `${this._destinationRoot}/${lastPathComponent}`;
-    try {
-      fs.mkdirSync(pathForTest);
-    } catch (ex) {
-      log.warn(`Could not create artifacts test dir: ${pathForTest}`);
-      return undefined;
-    }
+		const lastPathComponent = [number].concat(nameComponents).join(".");
+		const pathForTest = `${this._destinationRoot}/${lastPathComponent}`;
+		try {
+			fs.mkdirSync(pathForTest);
+		} catch (ex) {
+			log.warn(`Could not create artifacts test dir: ${pathForTest}`);
+			return undefined;
+		}
 
-    return pathForTest;
-  }
+		return pathForTest;
+	}
 }
 
 module.exports = ArtifactsPathsProvider;

--- a/detox/src/artifacts/ArtifactsPathsProvider.test.js
+++ b/detox/src/artifacts/ArtifactsPathsProvider.test.js
@@ -1,66 +1,75 @@
-const _ = require('lodash');
+const _ = require("lodash");
 
-describe('ArtifactsPathsProvider', () => {
-  let ArtifactsPathsProvider;
-  let fs;
-  let mockedDateString = '2017-07-13T06:31:48.544Z';
-  let log;
+describe("ArtifactsPathsProvider", () => {
+	let ArtifactsPathsProvider;
+	let fs;
+	const mockedDateString = "2017-07-13T06:31:48.544Z";
+	let log;
 
-  beforeEach(() => {
-    jest.mock('fs');
-    fs = require('fs');
-    jest.mock('npmlog');
-    log = require('npmlog');
+	beforeEach(() => {
+		jest.mock("fs");
+		fs = require("fs");
+		jest.mock("npmlog");
+		log = require("npmlog");
 
-    ArtifactsPathsProvider = require('./ArtifactsPathsProvider');
-    require('mockdate').set(new Date(mockedDateString));
-  });
+		ArtifactsPathsProvider = require("./ArtifactsPathsProvider");
+		require("mockdate").set(new Date(mockedDateString));
+	});
 
-  it('constructor - should throw on undefined destinationRoot', () => {
-    expect(() => {
-      new ArtifactsPathsProvider();
-    }).toThrowError(/undefined/);
-  });
+	it("constructor - should throw on undefined destinationRoot", () => {
+		expect(() => {
+			new ArtifactsPathsProvider();
+		}).toThrowError(/undefined/);
+	});
 
-  it('constructor - should throw if can\'t create run directory in the destination', () => {
-    fs.mkdirSync = jest.fn(() => {throw 'some'});
-    expect(() => {
-      new ArtifactsPathsProvider('/tmp');
-    }).toThrowError(/Could not create artifacts root dir/);
-  });
+	it("constructor - should throw if can't create run directory in the destination", () => {
+		fs.mkdirSync = jest.fn(() => {
+			throw "some";
+		});
+		expect(() => {
+			new ArtifactsPathsProvider("/tmp");
+		}).toThrowError(/Could not create artifacts root dir/);
+	});
 
-  it('createPathForTest() - should throw on invalid number', () => {
-    function testForNumber(number) {
-      expect(() => {
-        (new ArtifactsPathsProvider('/tmp')).createPathForTest(number);
-      }).toThrowError(/should be a positive integer/);
-    }
-    testForNumber(undefined);
-    testForNumber('1');
-    testForNumber(-2);
-    testForNumber(0);
-    testForNumber('1.2');
-  });
+	it("createPathForTest() - should throw on invalid number", () => {
+		function testForNumber(number) {
+			expect(() => {
+				new ArtifactsPathsProvider("/tmp").createPathForTest(number);
+			}).toThrowError(/should be a positive integer/);
+		}
+		testForNumber(undefined);
+		testForNumber("1");
+		testForNumber(-2);
+		testForNumber(0);
+		testForNumber("1.2");
+	});
 
-  it('createPathForTest() - should return proper path for no components', () => {
-    expect((new ArtifactsPathsProvider('/tmp')).createPathForTest(1)).
-      toEqual(`/tmp/detox_artifacts.${mockedDateString}/1`);
-  });
+	it("createPathForTest() - should return proper path for no components", () => {
+		expect(new ArtifactsPathsProvider("/tmp").createPathForTest(1)).toEqual(
+			`/tmp/detox_artifacts.${mockedDateString}/1`
+		);
+	});
 
-  it('createPathForTest() - should return proper path for no 1 component', () => {
-    expect((new ArtifactsPathsProvider('/tmp')).createPathForTest(1, 'a')).
-      toEqual(`/tmp/detox_artifacts.${mockedDateString}/1.a`);
-  });
+	it("createPathForTest() - should return proper path for no 1 component", () => {
+		expect(
+			new ArtifactsPathsProvider("/tmp").createPathForTest(1, "a")
+		).toEqual(`/tmp/detox_artifacts.${mockedDateString}/1.a`);
+	});
 
-  it('createPathForTest() - should return proper path for no 2 components', () => {
-    expect((new ArtifactsPathsProvider('/tmp')).createPathForTest(1, 'a', 'b')).
-      toEqual(`/tmp/detox_artifacts.${mockedDateString}/1.a.b`);
-  });
+	it("createPathForTest() - should return proper path for no 2 components", () => {
+		expect(
+			new ArtifactsPathsProvider("/tmp").createPathForTest(1, "a", "b")
+		).toEqual(`/tmp/detox_artifacts.${mockedDateString}/1.a.b`);
+	});
 
-  it('createPathsForTest() - should catch mkdirSync exception', () => {
-    const artifactsPathsProvider = new ArtifactsPathsProvider('/tmp');
-    fs.mkdirSync = jest.fn(() => {throw 'some'});
-    artifactsPathsProvider.createPathForTest(1);
-    expect(log.warn).toHaveBeenCalledWith('Could not create artifacts test dir: /tmp/detox_artifacts.2017-07-13T06:31:48.544Z/1');
-  });
+	it("createPathsForTest() - should catch mkdirSync exception", () => {
+		const artifactsPathsProvider = new ArtifactsPathsProvider("/tmp");
+		fs.mkdirSync = jest.fn(() => {
+			throw "some";
+		});
+		artifactsPathsProvider.createPathForTest(1);
+		expect(log.warn).toHaveBeenCalledWith(
+			"Could not create artifacts test dir: /tmp/detox_artifacts.2017-07-13T06:31:48.544Z/1"
+		);
+	});
 });

--- a/detox/src/artifacts/ArtifactsPathsProvider.test.js
+++ b/detox/src/artifacts/ArtifactsPathsProvider.test.js
@@ -18,16 +18,16 @@ describe("ArtifactsPathsProvider", () => {
 
 	it("constructor - should throw on undefined destinationRoot", () => {
 		expect(() => {
-			new ArtifactsPathsProvider();
+			new ArtifactsPathsProvider(); // eslint-disable-line no-new
 		}).toThrowError(/undefined/);
 	});
 
 	it("constructor - should throw if can't create run directory in the destination", () => {
 		fs.mkdirSync = jest.fn(() => {
-			throw "some";
+			throw "some"; // eslint-disable-line no-throw-literal
 		});
 		expect(() => {
-			new ArtifactsPathsProvider("/tmp");
+			new ArtifactsPathsProvider("/tmp"); // eslint-disable-line no-new
 		}).toThrowError(/Could not create artifacts root dir/);
 	});
 
@@ -65,7 +65,7 @@ describe("ArtifactsPathsProvider", () => {
 	it("createPathsForTest() - should catch mkdirSync exception", () => {
 		const artifactsPathsProvider = new ArtifactsPathsProvider("/tmp");
 		fs.mkdirSync = jest.fn(() => {
-			throw "some";
+			throw "some"; // eslint-disable-line no-throw-literal
 		});
 		artifactsPathsProvider.createPathForTest(1);
 		expect(log.warn).toHaveBeenCalledWith(

--- a/detox/src/client/AsyncWebSocket.js
+++ b/detox/src/client/AsyncWebSocket.js
@@ -1,88 +1,89 @@
-const _ = require('lodash');
-const log = require('npmlog');
-const WebSocket = require('ws');
+const _ = require("lodash");
+const log = require("npmlog");
+const WebSocket = require("ws");
 
 class AsyncWebSocket {
+	constructor(url) {
+		this.url = url;
+		this.ws = undefined;
+		this.inFlightPromises = {};
+		this.messageIdCounter = 0;
+	}
 
-  constructor(url) {
-    this.url = url;
-    this.ws = undefined;
-    this.inFlightPromises = {};
-    this.messageIdCounter = 0;
-  }
+	async open() {
+		return new Promise(async (resolve, reject) => {
+			this.ws = new WebSocket(this.url);
+			this.ws.onopen = response => {
+				log.verbose(`ws`, `onOpen ${response}`);
+				resolve(response);
+			};
 
-  async open() {
-    return new Promise(async(resolve, reject) => {
-      this.ws = new WebSocket(this.url);
-      this.ws.onopen = (response) => {
-        log.verbose(`ws`, `onOpen ${response}`);
-        resolve(response);
-      };
+			this.ws.onerror = error => {
+				log.error(`ws`, `onError: ${error}`);
 
-      this.ws.onerror = (error) => {
-        log.error(`ws`, `onError: ${error}`);
+				if (_.size(this.inFlightPromises) === 1) {
+					_.values(this.inFlightPromises)[0].reject(error);
+					this.inFlightPromises = {};
+				} else {
+					throw error;
+				}
+			};
 
-        if (_.size(this.inFlightPromises) === 1) {
-          _.values(this.inFlightPromises)[0].reject(error);
-          this.inFlightPromises = {};
-        } else {
-          throw error;
-        }
-      };
+			this.ws.onmessage = response => {
+				log.verbose(`ws`, `onMessage: ${response.data}`);
+				const pendingId = JSON.parse(response.data).messageId;
+				const pendingPromise = this.inFlightPromises[pendingId];
+				if (pendingPromise) {
+					pendingPromise.resolve(response.data);
+					delete this.inFlightPromises[pendingId];
+				}
+			};
 
-      this.ws.onmessage = (response) => {
-        log.verbose(`ws`, `onMessage: ${response.data}`);
-        let pendingId = JSON.parse(response.data).messageId;
-        let pendingPromise = this.inFlightPromises[pendingId];
-        if (pendingPromise) {
-          pendingPromise.resolve(response.data);
-          delete this.inFlightPromises[pendingId];
-        }
-      };
+			this.inFlightPromises[this.messageIdCounter] = { resolve, reject };
+		});
+	}
 
-      this.inFlightPromises[this.messageIdCounter] = {resolve, reject};
-    });
-  }
+	async send(message, messageId) {
+		if (!this.ws) {
+			throw new Error(
+				`Can't send a message on a closed websocket, init the by calling 'open()'`
+			);
+		}
 
-  async send(message, messageId) {
-    if (!this.ws) {
-      throw new Error(`Can't send a message on a closed websocket, init the by calling 'open()'`);
-    }
+		return new Promise(async (resolve, reject) => {
+			message.messageId = messageId || this.messageIdCounter++;
+			this.inFlightPromises[message.messageId] = { resolve, reject };
+			const messageAsString = JSON.stringify(message);
+			log.verbose(`ws`, `send: ${messageAsString}`);
+			this.ws.send(messageAsString);
+		});
+	}
 
-    return new Promise(async(resolve, reject) => {
-      message.messageId = messageId || this.messageIdCounter++;
-      this.inFlightPromises[message.messageId] = {resolve, reject};
-      const messageAsString = JSON.stringify(message);
-      log.verbose(`ws`, `send: ${messageAsString}`);
-      this.ws.send(messageAsString);
-    });
-  }
+	async close() {
+		return new Promise(async (resolve, reject) => {
+			if (this.ws) {
+				this.ws.onclose = message => {
+					this.ws = null;
+					resolve(message);
+				};
 
-  async close() {
-    return new Promise(async(resolve, reject) => {
-      if (this.ws) {
-        this.ws.onclose = (message) => {
-          this.ws = null;
-          resolve(message);
-        };
+				if (this.ws.readyState !== WebSocket.CLOSED) {
+					this.ws.close();
+				} else {
+					this.ws.onclose();
+				}
+			} else {
+				reject(new Error(`websocket is closed, init the by calling 'open()'`));
+			}
+		});
+	}
 
-        if (this.ws.readyState !== WebSocket.CLOSED) {
-          this.ws.close();
-        } else {
-          this.ws.onclose();
-        }
-      } else {
-        reject(new Error(`websocket is closed, init the by calling 'open()'`));
-      }
-    });
-  }
-
-  isOpen() {
-    if (!this.ws) {
-      return false;
-    }
-    return this.ws.readyState === WebSocket.OPEN;
-  }
+	isOpen() {
+		if (!this.ws) {
+			return false;
+		}
+		return this.ws.readyState === WebSocket.OPEN;
+	}
 }
 
 module.exports = AsyncWebSocket;

--- a/detox/src/client/AsyncWebSocket.test.js
+++ b/detox/src/client/AsyncWebSocket.test.js
@@ -1,182 +1,185 @@
-const _ = require('lodash');
-const config = require('../configurations.mock').validOneDeviceAndSession.session;
+const _ = require("lodash");
+const config = require("../configurations.mock").validOneDeviceAndSession
+	.session;
 
-describe('AsyncWebSocket', () => {
-  let AsyncWebSocket;
-  let WebSocket;
-  let client;
+describe("AsyncWebSocket", () => {
+	let AsyncWebSocket;
+	let WebSocket;
+	let client;
 
-  beforeEach(() => {
-    jest.mock('npmlog');
-    WebSocket = jest.mock('ws');
-    WebSocket.OPEN = 1;
-    WebSocket.CLOSED = 3;
+	beforeEach(() => {
+		jest.mock("npmlog");
+		WebSocket = jest.mock("ws");
+		WebSocket.OPEN = 1;
+		WebSocket.CLOSED = 3;
 
-    AsyncWebSocket = require('./AsyncWebSocket');
-    client = new AsyncWebSocket(config.server);
-  });
+		AsyncWebSocket = require("./AsyncWebSocket");
+		client = new AsyncWebSocket(config.server);
+	});
 
-  it(`new AsyncWebSocket - websocket onOpen should resolve`, async () => {
-    const response = generateResponse('onmessage', 0);
-    const promise = client.open();
-    client.ws.onopen(response);
-    expect(await promise).toEqual(response);
-  });
+	it(`new AsyncWebSocket - websocket onOpen should resolve`, async () => {
+		const response = generateResponse("onmessage", 0);
+		const promise = client.open();
+		client.ws.onopen(response);
+		expect(await promise).toEqual(response);
+	});
 
-  it(`new AsyncWebSocket - websocket onError should reject`, async () => {
-    const error = new Error();
-    const promise = client.open();
+	it(`new AsyncWebSocket - websocket onError should reject`, async () => {
+		const error = new Error();
+		const promise = client.open();
 
-    try {
-      client.ws.onerror(error);
-      await promise;
-    } catch (ex) {
-      expect(ex).toEqual(error);
-    }
-  });
+		try {
+			client.ws.onerror(error);
+			await promise;
+		} catch (ex) {
+			expect(ex).toEqual(error);
+		}
+	});
 
-  it(`send message on a closed connection should throw`, async () => {
-    try {
-      await client.send(generateRequest());
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+	it(`send message on a closed connection should throw`, async () => {
+		try {
+			await client.send(generateRequest());
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`message should have subsequent messageIds`, async () => {
-    await connect(client);
+	it(`message should have subsequent messageIds`, async () => {
+		await connect(client);
 
-    const request = generateRequest();
-    const firstResponse = generateResponse('onmessage', 0);
-    const secondResponse = generateResponse('onmessage', 1);
+		const request = generateRequest();
+		const firstResponse = generateResponse("onmessage", 0);
+		const secondResponse = generateResponse("onmessage", 1);
 
-    const first = client.send(request);
-    expect(request.messageId).toEqual(0);
-    client.ws.onmessage(firstResponse);
-    expect(await first).toEqual(firstResponse.data);
+		const first = client.send(request);
+		expect(request.messageId).toEqual(0);
+		client.ws.onmessage(firstResponse);
+		expect(await first).toEqual(firstResponse.data);
 
-    const second = client.send(request);
-    expect(request.messageId).toEqual(1);
-    client.ws.onmessage(secondResponse);
-    expect(await second).toEqual(secondResponse.data);
-});
+		const second = client.send(request);
+		expect(request.messageId).toEqual(1);
+		client.ws.onmessage(secondResponse);
+		expect(await second).toEqual(secondResponse.data);
+	});
 
-  it(`message response should resolve the calling request`, async () => {
-    await connect(client);
+	it(`message response should resolve the calling request`, async () => {
+		await connect(client);
 
-    const request = generateRequest();
-    const firstResponse = generateResponse('onmessage', 0);
-    const secondResponse = generateResponse('onmessage', 1);
+		const request = generateRequest();
+		const firstResponse = generateResponse("onmessage", 0);
+		const secondResponse = generateResponse("onmessage", 1);
 
-    const first = client.send(request);
-    expect(request.messageId).toEqual(0);
+		const first = client.send(request);
+		expect(request.messageId).toEqual(0);
 
-    const second = client.send(request);
-    expect(request.messageId).toEqual(1);
+		const second = client.send(request);
+		expect(request.messageId).toEqual(1);
 
-    client.ws.onmessage(secondResponse);
-    client.ws.onmessage(firstResponse);
+		client.ws.onmessage(secondResponse);
+		client.ws.onmessage(firstResponse);
 
-    expect(await second).toEqual(secondResponse.data);
-    expect(await first).toEqual(firstResponse.data);
-  });
+		expect(await second).toEqual(secondResponse.data);
+		expect(await first).toEqual(firstResponse.data);
+	});
 
-  it(`message should be ignored if has no pending request`, async () => {
-    await connect(client);
+	it(`message should be ignored if has no pending request`, async () => {
+		await connect(client);
 
-    const initialInflightPromisesSize = _.size(client.inFlightPromises);
-    const response = generateResponse('onmessage', 123);
-    client.ws.onmessage(response);
+		const initialInflightPromisesSize = _.size(client.inFlightPromises);
+		const response = generateResponse("onmessage", 123);
+		client.ws.onmessage(response);
 
-    const finalInflightPromisesSize = _.size(client.inFlightPromises);
-    expect(initialInflightPromisesSize).toEqual(finalInflightPromisesSize);
-  });
+		const finalInflightPromisesSize = _.size(client.inFlightPromises);
+		expect(initialInflightPromisesSize).toEqual(finalInflightPromisesSize);
+	});
 
-  it(`send message should resolve upon returning message`, async () => {
-    await connect(client);
-    const response = generateResponse('onmessage', 0);
+	it(`send message should resolve upon returning message`, async () => {
+		await connect(client);
+		const response = generateResponse("onmessage", 0);
 
-    const promise = client.send(generateRequest());
-    client.ws.onmessage(response);
-    expect(await promise).toEqual(response.data);
-  });
+		const promise = client.send(generateRequest());
+		client.ws.onmessage(response);
+		expect(await promise).toEqual(response.data);
+	});
 
-  it(`send message should reject upon error if there's only one message in flight`, async () => {
-    await connect(client);
-    const error = new Error();
-    const message = client.send(generateRequest());
-    client.ws.onerror(error);
-    try {
-      await message;
-    } catch (ex) {
-      expect(ex).toEqual(error);
-    }
-  });
+	it(`send message should reject upon error if there's only one message in flight`, async () => {
+		await connect(client);
+		const error = new Error();
+		const message = client.send(generateRequest());
+		client.ws.onerror(error);
+		try {
+			await message;
+		} catch (ex) {
+			expect(ex).toEqual(error);
+		}
+	});
 
-  it(`send message should throw upon error if there's more than one message in flight`, async () => {
-    await connect(client);
-    const error = new Error();
-    const message1 = client.send(generateRequest());
-    const message2 = client.send(generateRequest());
+	it(`send message should throw upon error if there's more than one message in flight`, async () => {
+		await connect(client);
+		const error = new Error();
+		const message1 = client.send(generateRequest());
+		const message2 = client.send(generateRequest());
 
-    try {
-      client.ws.onerror(error);
-    } catch (ex) {
-      expect(ex).toEqual(error);
-    }
-  });
+		try {
+			client.ws.onerror(error);
+		} catch (ex) {
+			expect(ex).toEqual(error);
+		}
+	});
 
-  it(`close a connected websocket should close and resolve`, async () => {
-    await connect(client);
-    const promise = client.close();
-    client.ws.onclose({});
-    expect(await promise).toEqual({});
-  });
+	it(`close a connected websocket should close and resolve`, async () => {
+		await connect(client);
+		const promise = client.close();
+		client.ws.onclose({});
+		expect(await promise).toEqual({});
+	});
 
-  it(`close a connected websocket should close and resolve`, async () => {
-    const result = {};
-    await connect(client);
-    client.ws.readyState = WebSocket.OPEN;
-    const promise = client.close();
-    client.ws.onclose(result);
-    expect(await promise).toEqual(result);
-  });
+	it(`close a connected websocket should close and resolve`, async () => {
+		const result = {};
+		await connect(client);
+		client.ws.readyState = WebSocket.OPEN;
+		const promise = client.close();
+		client.ws.onclose(result);
+		expect(await promise).toEqual(result);
+	});
 
-  it(`close a disconnected websocket should resolve`, async () => {
-    await connect(client);
-    client.ws.readyState = WebSocket.CLOSED;
-    await client.close();
-    expect(client.ws).toBeNull();
-  });
+	it(`close a disconnected websocket should resolve`, async () => {
+		await connect(client);
+		client.ws.readyState = WebSocket.CLOSED;
+		await client.close();
+		expect(client.ws).toBeNull();
+	});
 
-  it(`client.isOpen() should return false when closed, open when opened`, async () => {
-    expect(client.isOpen()).toBe(false);
-    await connect(client);
-    client.ws.readyState = WebSocket.OPEN;
-    expect(client.isOpen()).toBe(true);
-  });
+	it(`client.isOpen() should return false when closed, open when opened`, async () => {
+		expect(client.isOpen()).toBe(false);
+		await connect(client);
+		client.ws.readyState = WebSocket.OPEN;
+		expect(client.isOpen()).toBe(true);
+	});
 
-  it(`closing a non-initialized websocket should throw`, async () => {
-    const promise = client.close();
-    try {
-      await promise;
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+	it(`closing a non-initialized websocket should throw`, async () => {
+		const promise = client.close();
+		try {
+			await promise;
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  async function connect(client) {
-    const result = {};
-    const promise = client.open();
-    client.ws.onopen(result);
-    await promise;
-  }
+	async function connect(client) {
+		const result = {};
+		const promise = client.open();
+		client.ws.onopen(result);
+		await promise;
+	}
 
-  function generateRequest(message) {
-    return {message: 'a message'};
-  }
+	function generateRequest(message) {
+		return { message: "a message" };
+	}
 
-  function generateResponse(message, messageId) {
-    return {data: JSON.stringify({response: message, messageId: messageId})};
-  }
+	function generateResponse(message, messageId) {
+		return {
+			data: JSON.stringify({ response: message, messageId: messageId })
+		};
+	}
 });

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -52,15 +52,16 @@ class Client {
 	}
 
 	async execute(invocation) {
+		let invoke = invocation;
 		if (typeof invocation === "function") {
-			invocation = invocation();
+			invoke = invocation();
 		}
 
 		if (this.slowInvocationTimeout) {
 			this.slowInvocationStatusHandler = this.slowInvocationStatus();
 		}
 		try {
-			await this.sendAction(new actions.Invoke(invocation));
+			await this.sendAction(new actions.Invoke(invoke));
 		} catch (err) {
 			this.successfulTestRun = false;
 			throw new Error(err);

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -1,86 +1,86 @@
-const AsyncWebSocket = require('./AsyncWebSocket');
-const actions = require('./actions/actions');
-const argparse = require('../utils/argparse');
+const AsyncWebSocket = require("./AsyncWebSocket");
+const actions = require("./actions/actions");
+const argparse = require("../utils/argparse");
 
 class Client {
-  constructor(config) {
-    this.isConnected = false;
-    this.configuration = config;
-    this.ws = new AsyncWebSocket(config.server);
-    this.slowInvocationStatusHandler = null;
-    this.slowInvocationTimeout = argparse.getArgValue('debug-synchronization');
-    this.successfulTestRun = true; // flag for cleanup
-  }
+	constructor(config) {
+		this.isConnected = false;
+		this.configuration = config;
+		this.ws = new AsyncWebSocket(config.server);
+		this.slowInvocationStatusHandler = null;
+		this.slowInvocationTimeout = argparse.getArgValue("debug-synchronization");
+		this.successfulTestRun = true; // flag for cleanup
+	}
 
-  async connect() {
-    await this.ws.open();
-    await this.sendAction(new actions.Login(this.configuration.sessionId));
-  }
+	async connect() {
+		await this.ws.open();
+		await this.sendAction(new actions.Login(this.configuration.sessionId));
+	}
 
-  async reloadReactNative() {
-    await this.sendAction(new actions.ReloadReactNative(), -1000);
-  }
+	async reloadReactNative() {
+		await this.sendAction(new actions.ReloadReactNative(), -1000);
+	}
 
-  async sendUserNotification(params) {
-    await this.sendAction(new actions.SendUserNotification(params));
-  }
+	async sendUserNotification(params) {
+		await this.sendAction(new actions.SendUserNotification(params));
+	}
 
-  async waitUntilReady() {
-    await this.sendAction(new actions.Ready(), -1000);
-    this.isConnected = true;
-  }
+	async waitUntilReady() {
+		await this.sendAction(new actions.Ready(), -1000);
+		this.isConnected = true;
+	}
 
-  async cleanup() {
-    clearTimeout(this.slowInvocationStatusHandler);
+	async cleanup() {
+		clearTimeout(this.slowInvocationStatusHandler);
 
-    if (this.isConnected) {
-      await this.sendAction(new actions.Cleanup(this.successfulTestRun));
-      this.isConnected = false;
-    }
+		if (this.isConnected) {
+			await this.sendAction(new actions.Cleanup(this.successfulTestRun));
+			this.isConnected = false;
+		}
 
-    if (this.ws.isOpen()) {
-      await this.ws.close();
-    }
-  }
+		if (this.ws.isOpen()) {
+			await this.ws.close();
+		}
+	}
 
-  async currentStatus() {
-    await this.sendAction(new actions.CurrentStatus());
-  }
+	async currentStatus() {
+		await this.sendAction(new actions.CurrentStatus());
+	}
 
-  async openURL(params) {
-    await this.sendAction(new actions.openURL(params));
-  }
+	async openURL(params) {
+		await this.sendAction(new actions.openURL(params));
+	}
 
-  async execute(invocation) {
-    if (typeof invocation === 'function') {
-      invocation = invocation();
-    }
+	async execute(invocation) {
+		if (typeof invocation === "function") {
+			invocation = invocation();
+		}
 
-    if (this.slowInvocationTimeout) {
-      this.slowInvocationStatusHandler = this.slowInvocationStatus();
-    }
-    try {
-      await this.sendAction(new actions.Invoke(invocation));
-    } catch (err) {
-      this.successfulTestRun = false;
-      throw new Error(err);
-    }
-    clearTimeout(this.slowInvocationStatusHandler);
-  }
+		if (this.slowInvocationTimeout) {
+			this.slowInvocationStatusHandler = this.slowInvocationStatus();
+		}
+		try {
+			await this.sendAction(new actions.Invoke(invocation));
+		} catch (err) {
+			this.successfulTestRun = false;
+			throw new Error(err);
+		}
+		clearTimeout(this.slowInvocationStatusHandler);
+	}
 
-  async sendAction(action, messageId) {
-    const response = await this.ws.send(action, messageId);
-    const parsedResponse = JSON.parse(response);
-    await action.handle(parsedResponse);
-    return parsedResponse;
-  }
+	async sendAction(action, messageId) {
+		const response = await this.ws.send(action, messageId);
+		const parsedResponse = JSON.parse(response);
+		await action.handle(parsedResponse);
+		return parsedResponse;
+	}
 
-  slowInvocationStatus() {
-    return setTimeout(async () => {
-      const status = await this.currentStatus();
-      this.slowInvocationStatusHandler = this.slowInvocationStatus();
-    }, this.slowInvocationTimeout);
-  }
+	slowInvocationStatus() {
+		return setTimeout(async () => {
+			const status = await this.currentStatus();
+			this.slowInvocationStatusHandler = this.slowInvocationStatus();
+		}, this.slowInvocationTimeout);
+	}
 }
 
 module.exports = Client;

--- a/detox/src/client/Client.test.js
+++ b/detox/src/client/Client.test.js
@@ -1,172 +1,252 @@
-const config = require('../configurations.mock').validOneDeviceAndSession.session;
-const invoke = require('../invoke');
+const config = require("../configurations.mock").validOneDeviceAndSession
+	.session;
+const invoke = require("../invoke");
 
-describe('Client', () => {
-  let argparse;
-  let WebSocket;
-  let Client;
-  let client;
+describe("Client", () => {
+	let argparse;
+	let WebSocket;
+	let Client;
+	let client;
 
-  beforeEach(() => {
-    jest.mock('npmlog');
-    WebSocket = jest.mock('./AsyncWebSocket');
-    Client = require('./Client');
+	beforeEach(() => {
+		jest.mock("npmlog");
+		WebSocket = jest.mock("./AsyncWebSocket");
+		Client = require("./Client");
 
-    jest.mock('../utils/argparse');
-    argparse = require('../utils/argparse');
-  });
+		jest.mock("../utils/argparse");
+		argparse = require("../utils/argparse");
+	});
 
-  it(`reloadReactNative() - should receive ready from device and resolve`, async () => {
-    await connect();
-    client.ws.send.mockReturnValueOnce(response("ready", {}, 1));
-    await client.reloadReactNative();
-  });
+	it(`reloadReactNative() - should receive ready from device and resolve`, async () => {
+		await connect();
+		client.ws.send.mockReturnValueOnce(response("ready", {}, 1));
+		await client.reloadReactNative();
+	});
 
-  it(`reloadReactNative() - should throw if receives wrong response from device`, async () => {
-    await connect();
-    client.ws.send.mockReturnValueOnce(response("somethingElse", {}, 1));
-    try {
-      await client.reloadReactNative();
+	it(`reloadReactNative() - should throw if receives wrong response from device`, async () => {
+		await connect();
+		client.ws.send.mockReturnValueOnce(response("somethingElse", {}, 1));
+		try {
+			await client.reloadReactNative();
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+	it(`sendUserNotification() - should receive ready from device and resolve`, async () => {
+		await connect();
+		client.ws.send.mockReturnValueOnce(response("userNotificationDone", {}, 1));
+		await client.sendUserNotification();
 
-  it(`sendUserNotification() - should receive ready from device and resolve`, async () => {
-    await connect();
-    client.ws.send.mockReturnValueOnce(response("userNotificationDone", {}, 1));
-    await client.sendUserNotification();
+		expect(client.ws.send).toHaveBeenCalledTimes(2);
+	});
 
-    expect(client.ws.send).toHaveBeenCalledTimes(2);
-  });
+	it(`openURL() - should send an 'openURL' action and resolve when 'openURLDone returns' `, async () => {
+		await connect();
+		client.ws.send.mockReturnValueOnce(response("openURLDone", {}, 1));
+		await client.openURL({ url: "url" });
 
-  it(`openURL() - should send an 'openURL' action and resolve when 'openURLDone returns' `, async () => {
-    await connect();
-    client.ws.send.mockReturnValueOnce(response("openURLDone", {}, 1));
-    await client.openURL({url: 'url'});
+		expect(client.ws.send).toHaveBeenCalledTimes(2);
+	});
 
-    expect(client.ws.send).toHaveBeenCalledTimes(2);
-  });
+	it(`waitUntilReady() - should receive ready from device and resolve`, async () => {
+		await connect();
+		client.ws.send.mockReturnValueOnce(response("ready", {}, 1));
+		await client.waitUntilReady();
 
-  it(`waitUntilReady() - should receive ready from device and resolve`, async () => {
-    await connect();
-    client.ws.send.mockReturnValueOnce(response("ready", {}, 1));
-    await client.waitUntilReady();
+		expect(client.ws.send).toHaveBeenCalledTimes(2);
+	});
 
-    expect(client.ws.send).toHaveBeenCalledTimes(2);
-  });
+	it(`cleanup() - if connected should send cleanup action and close websocket`, async () => {
+		await connect();
+		client.ws.send.mockReturnValueOnce(response("ready", {}, 1));
+		await client.waitUntilReady();
+		client.ws.send.mockReturnValueOnce(response("cleanupDone", {}, 2));
+		await client.cleanup();
 
-  it(`cleanup() - if connected should send cleanup action and close websocket`, async () => {
-    await connect();
-    client.ws.send.mockReturnValueOnce(response("ready", {}, 1));
-    await client.waitUntilReady();
-    client.ws.send.mockReturnValueOnce(response("cleanupDone", {}, 2));
-    await client.cleanup();
+		expect(client.ws.send).toHaveBeenCalledTimes(3);
+	});
 
-    expect(client.ws.send).toHaveBeenCalledTimes(3);
-  });
+	it(`cleanup() - if not connected should do nothing`, async () => {
+		client = new Client(config);
+		client.ws.send.mockReturnValueOnce(response("cleanupDone", {}, 1));
+		await client.cleanup();
 
-  it(`cleanup() - if not connected should do nothing`, async () => {
-    client = new Client(config);
-    client.ws.send.mockReturnValueOnce(response("cleanupDone", {}, 1));
-    await client.cleanup();
+		expect(client.ws.send).not.toHaveBeenCalled();
+	});
 
-    expect(client.ws.send).not.toHaveBeenCalled();
-  });
+	it(`execute() - "invokeResult" on an invocation object should resolve`, async () => {
+		await connect();
+		client.ws.send.mockReturnValueOnce(
+			response("invokeResult", { result: "(GREYElementInteraction)" }, 1)
+		);
 
-  it(`execute() - "invokeResult" on an invocation object should resolve`, async () => {
-    await connect();
-    client.ws.send.mockReturnValueOnce(response("invokeResult", {result: "(GREYElementInteraction)"}, 1));
+		const call = invoke.call(
+			invoke.IOS.Class("GREYMatchers"),
+			"matcherForAccessibilityLabel:",
+			"test"
+		);
+		await client.execute(call());
 
-    const call = invoke.call(invoke.IOS.Class('GREYMatchers'), 'matcherForAccessibilityLabel:', 'test');
-    await client.execute(call());
+		expect(client.ws.send).toHaveBeenCalledTimes(2);
+	});
 
-    expect(client.ws.send).toHaveBeenCalledTimes(2);
-  });
+	async function executeWithSlowInvocation(invocationTime) {
+		argparse.getArgValue.mockReturnValue(2); // set debug-slow-invocations
 
-  async function executeWithSlowInvocation(invocationTime) {
-    argparse.getArgValue.mockReturnValue(2); // set debug-slow-invocations
+		await connect();
 
-    await connect();
+		client.ws.send
+			.mockReturnValueOnce(
+				timeout(invocationTime).then(() =>
+					response("invokeResult", { result: "(GREYElementInteraction)" }, 1)
+				)
+			)
+			.mockReturnValueOnce(
+				response(
+					"currentStatusResult",
+					{
+						state: "busy",
+						resources: [
+							{
+								name: "App State",
+								info: {
+									prettyPrint: "Waiting for network requests to finish.",
+									elements: ["__NSCFLocalDataTask:0x7fc95d72b6c0"],
+									appState: "Waiting for network requests to finish."
+								}
+							},
+							{
+								name: "Dispatch Queue",
+								info: {
+									queue:
+										"OS_dispatch_queue_main: com.apple.main-thread[0x10805ea80] = { xrefcnt = 0x80000000, refcnt = 0x80000000, target = com.apple.root.default-qos.overcommit[0x10805f1c0], width = 0x1, state = 0x000fffe000000403, in-flight = 0, thread = 0x403 }",
+									prettyPrint: "com.apple.main-thread"
+								}
+							}
+						]
+					},
+					2
+				)
+			);
 
-    client.ws.send.mockReturnValueOnce(timeout(invocationTime).then(()=> response("invokeResult", {result:"(GREYElementInteraction)"}, 1)))
-                  .mockReturnValueOnce(response("currentStatusResult", {"state":"busy","resources":[{"name":"App State","info":{"prettyPrint":"Waiting for network requests to finish.","elements":["__NSCFLocalDataTask:0x7fc95d72b6c0"],"appState":"Waiting for network requests to finish."}},{"name":"Dispatch Queue","info":{"queue":"OS_dispatch_queue_main: com.apple.main-thread[0x10805ea80] = { xrefcnt = 0x80000000, refcnt = 0x80000000, target = com.apple.root.default-qos.overcommit[0x10805f1c0], width = 0x1, state = 0x000fffe000000403, in-flight = 0, thread = 0x403 }","prettyPrint":"com.apple.main-thread"}}]}, 2));
+		const call = invoke.call(
+			invoke.IOS.Class("GREYMatchers"),
+			"matcherForAccessibilityLabel:",
+			"test"
+		);
+		await client.execute(call);
+	}
 
-    const call = invoke.call(invoke.IOS.Class('GREYMatchers'), 'matcherForAccessibilityLabel:', 'test');
-    await client.execute(call);
-  }
+	it(`execute() - fast invocation should not trigger "slowInvocationStatus"`, async () => {
+		await executeWithSlowInvocation(1);
+		expect(client.ws.send).toHaveBeenLastCalledWith(
+			{
+				params: {
+					args: ["test"],
+					method: "matcherForAccessibilityLabel:",
+					target: { type: "Class", value: "GREYMatchers" }
+				},
+				type: "invoke"
+			},
+			undefined
+		);
+	});
 
-  it(`execute() - fast invocation should not trigger "slowInvocationStatus"`, async () => {
-    await executeWithSlowInvocation(1);
-    expect(client.ws.send).toHaveBeenLastCalledWith({"params": {"args": ["test"], "method": "matcherForAccessibilityLabel:", "target": {"type": "Class", "value": "GREYMatchers"}}, "type": "invoke"}, undefined);
-  });
+	it(`execute() - slow invocation should trigger "slowInvocationStatus:`, async () => {
+		await executeWithSlowInvocation(4);
+		expect(client.ws.send).toHaveBeenLastCalledWith(
+			{ params: {}, type: "currentStatus" },
+			undefined
+		);
+	});
 
-  it(`execute() - slow invocation should trigger "slowInvocationStatus:`, async () => {
-    await executeWithSlowInvocation(4);
-    expect(client.ws.send).toHaveBeenLastCalledWith({"params": {}, "type": "currentStatus"}, undefined);
-  });
+	it(`execute() - "invokeResult" on an invocation function should resolve`, async () => {
+		await connect();
+		client.ws.send.mockReturnValueOnce(
+			response("invokeResult", { result: "(GREYElementInteraction)" }, 1)
+		);
 
-  it(`execute() - "invokeResult" on an invocation function should resolve`, async () => {
-    await connect();
-    client.ws.send.mockReturnValueOnce(response("invokeResult", {result: "(GREYElementInteraction)"}, 1));
+		const call = invoke.call(
+			invoke.IOS.Class("GREYMatchers"),
+			"matcherForAccessibilityLabel:",
+			"test"
+		);
+		await client.execute(call);
 
-    const call = invoke.call(invoke.IOS.Class('GREYMatchers'), 'matcherForAccessibilityLabel:', 'test');
-    await client.execute(call);
+		expect(client.ws.send).toHaveBeenCalledTimes(2);
+	});
 
-    expect(client.ws.send).toHaveBeenCalledTimes(2);
-  });
+	it(`execute() - "testFailed" result should throw`, async () => {
+		await connect();
+		client.ws.send.mockReturnValueOnce(
+			response("testFailed", { details: "this is an error" }, 1)
+		);
+		const call = invoke.call(
+			invoke.IOS.Class("GREYMatchers"),
+			"matcherForAccessibilityLabel:",
+			"test"
+		);
+		try {
+			await client.execute(call);
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`execute() - "testFailed" result should throw`, async () => {
-    await connect();
-    client.ws.send.mockReturnValueOnce(response("testFailed",  {details: "this is an error"}, 1));
-    const call = invoke.call(invoke.IOS.Class('GREYMatchers'), 'matcherForAccessibilityLabel:', 'test');
-    try {
-      await client.execute(call);
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+	it(`execute() - "error" result should throw`, async () => {
+		await connect();
+		client.ws.send.mockReturnValueOnce(
+			response("error", { details: "this is an error" }),
+			1
+		);
+		const call = invoke.call(
+			invoke.IOS.Class("GREYMatchers"),
+			"matcherForAccessibilityLabel:",
+			"test"
+		);
+		try {
+			await client.execute(call);
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`execute() - "error" result should throw`, async () => {
-    await connect();
-    client.ws.send.mockReturnValueOnce(response("error", {details: "this is an error"}), 1);
-    const call = invoke.call(invoke.IOS.Class('GREYMatchers'), 'matcherForAccessibilityLabel:', 'test');
-    try {
-      await client.execute(call);
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+	it(`execute() - unsupported result should throw`, async () => {
+		await connect();
+		client.ws.send.mockReturnValueOnce(
+			Promise.resolve(`{"unsupported":"unsupported"}`)
+		);
+		const call = invoke.call(
+			invoke.IOS.Class("GREYMatchers"),
+			"matcherForAccessibilityLabel:",
+			"test"
+		);
+		try {
+			await client.execute(call);
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`execute() - unsupported result should throw`, async () => {
-    await connect();
-    client.ws.send.mockReturnValueOnce(Promise.resolve(`{"unsupported":"unsupported"}`));
-    const call = invoke.call(invoke.IOS.Class('GREYMatchers'), 'matcherForAccessibilityLabel:', 'test');
-    try {
-      await client.execute(call);
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+	async function connect() {
+		client = new Client(config);
+		client.ws.send.mockReturnValueOnce(response("loginSuccess", {}, 1));
+		await client.connect();
+		client.ws.isOpen.mockReturnValue(true);
+	}
 
-  async function connect() {
-    client = new Client(config);
-    client.ws.send.mockReturnValueOnce(response("loginSuccess", {}, 1));
-    await client.connect();
-    client.ws.isOpen.mockReturnValue(true);
-  }
+	function response(type, params, messageId) {
+		return Promise.resolve(
+			JSON.stringify({
+				type: type,
+				params: params,
+				messageId: messageId
+			})
+		);
+	}
 
-  function response(type, params, messageId) {
-    return Promise.resolve(
-      JSON.stringify({
-        type: type,
-        params: params,
-        messageId: messageId
-      }));
-  }
-
-  async function timeout(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
+	async function timeout(ms) {
+		return new Promise(resolve => setTimeout(resolve, ms));
+	}
 });

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -5,7 +5,6 @@ class Action {
 	constructor(type, params = {}) {
 		this.type = type;
 		this.params = params;
-		this.messageId;
 	}
 
 	expectResponseOfType(response, type) {

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -1,129 +1,135 @@
-const _ = require('lodash');
-const log = require('npmlog');
+const _ = require("lodash");
+const log = require("npmlog");
 
 class Action {
-  constructor(type, params = {}) {
-    this.type = type;
-    this.params = params;
-    this.messageId;
-  }
+	constructor(type, params = {}) {
+		this.type = type;
+		this.params = params;
+		this.messageId;
+	}
 
-  expectResponseOfType(response, type) {
-    if (response.type !== type) {
-      throw new Error(`was expecting '${type}' , got ${JSON.stringify(response)}`);
-    }
-  }
+	expectResponseOfType(response, type) {
+		if (response.type !== type) {
+			throw new Error(
+				`was expecting '${type}' , got ${JSON.stringify(response)}`
+			);
+		}
+	}
 }
 
 class Login extends Action {
-  constructor(sessionId) {
-    const params = {
-      sessionId: sessionId,
-      role: 'tester'
-    };
-    super('login', params);
-  }
+	constructor(sessionId) {
+		const params = {
+			sessionId: sessionId,
+			role: "tester"
+		};
+		super("login", params);
+	}
 
-  async handle(response) {
-    this.expectResponseOfType(response, 'loginSuccess');
-  }
+	async handle(response) {
+		this.expectResponseOfType(response, "loginSuccess");
+	}
 }
 
 class Ready extends Action {
-  constructor() {
-    super('isReady');
-  }
+	constructor() {
+		super("isReady");
+	}
 
-  async handle(response) {
-    this.expectResponseOfType(response, 'ready');
-  }
+	async handle(response) {
+		this.expectResponseOfType(response, "ready");
+	}
 }
 
 class ReloadReactNative extends Action {
-  constructor() {
-    super('reactNativeReload');
-  }
+	constructor() {
+		super("reactNativeReload");
+	}
 
-  async handle(response) {
-    this.expectResponseOfType(response, 'ready');
-  }
+	async handle(response) {
+		this.expectResponseOfType(response, "ready");
+	}
 }
 
 class Cleanup extends Action {
-  constructor(stopRunner) {
-    const params = {
-      stopRunner: stopRunner
-    };
-    super('cleanup', params);
-  }
+	constructor(stopRunner) {
+		const params = {
+			stopRunner: stopRunner
+		};
+		super("cleanup", params);
+	}
 
-  async handle(response) {
-    this.expectResponseOfType(response, 'cleanupDone');
-  }
+	async handle(response) {
+		this.expectResponseOfType(response, "cleanupDone");
+	}
 }
 
 class Invoke extends Action {
-  constructor(params) {
-    super('invoke', params);
-  }
+	constructor(params) {
+		super("invoke", params);
+	}
 
-  async handle(response) {
-    switch (response.type) {
-      case 'testFailed':
-        throw new Error(response.params.details);
-      case 'invokeResult':
-        break;
-      case 'error':
-        throw new Error(response.params.error);
-      default:
-        throw new Error(`tried to invoke an action on testee, got an unsupported response: ${JSON.stringify(response)}`);
-    }
-  }
+	async handle(response) {
+		switch (response.type) {
+			case "testFailed":
+				throw new Error(response.params.details);
+			case "invokeResult":
+				break;
+			case "error":
+				throw new Error(response.params.error);
+			default:
+				throw new Error(
+					`tried to invoke an action on testee, got an unsupported response: ${JSON.stringify(
+						response
+					)}`
+				);
+		}
+	}
 }
 
 class SendUserNotification extends Action {
-  constructor(params) {
-    super('userNotification', params);
-  }
+	constructor(params) {
+		super("userNotification", params);
+	}
 
-  async handle(response) {
-    this.expectResponseOfType(response, 'userNotificationDone');
-  }
+	async handle(response) {
+		this.expectResponseOfType(response, "userNotificationDone");
+	}
 }
 
 class openURL extends Action {
-  constructor(params) {
-    super('openURL', params);
-  }
+	constructor(params) {
+		super("openURL", params);
+	}
 
-  async handle(response) {
-    this.expectResponseOfType(response, 'openURLDone');
-  }
+	async handle(response) {
+		this.expectResponseOfType(response, "openURLDone");
+	}
 }
 
 class CurrentStatus extends Action {
-  constructor(params) {
-    super('currentStatus', params);
-  }
+	constructor(params) {
+		super("currentStatus", params);
+	}
 
-  async handle(response) {
-    this.expectResponseOfType(response, 'currentStatusResult');
+	async handle(response) {
+		this.expectResponseOfType(response, "currentStatusResult");
 
-    //console.log("res:" + JSON.stringify(response, null, 2));
-    _.forEach(response.params.resources, (resource) => {
-      log.info(`Sync`, `${resource.name}: ${resource.info.prettyPrint}`);
-    });
-    return response;
-  }
+		//console.log("res:" + JSON.stringify(response, null, 2));
+		_.forEach(response.params.resources, resource => {
+			log.info(`Sync`, `${resource.name}: ${resource.info.prettyPrint}`);
+		});
+		return response;
+	}
 }
 
 module.exports = {
-  Login,
-  Ready,
-  Invoke,
-  ReloadReactNative,
-  Cleanup,
-  openURL,
-  SendUserNotification,
-  CurrentStatus
+	Login,
+	Ready,
+	Invoke,
+	ReloadReactNative,
+	Cleanup,
+	openURL,
+	SendUserNotification,
+	CurrentStatus
 };

--- a/detox/src/configuration.js
+++ b/detox/src/configuration.js
@@ -1,48 +1,58 @@
-const CustomError = require('./errors/CustomError');
-const uuid = require('./utils/uuid');
-const getPort = require('get-port');
+const CustomError = require("./errors/CustomError");
+const uuid = require("./utils/uuid");
+const getPort = require("get-port");
 
 async function defaultSession() {
-  return {
-    server: `ws://localhost:${await getPort()}`,
-    sessionId: uuid.UUID()
-  };
+	return {
+		server: `ws://localhost:${await getPort()}`,
+		sessionId: uuid.UUID()
+	};
 }
 
 function validateSession(session) {
-  if (!session) {
-    throw new Error(`No session configuration was found, pass settings under the session property`);
-  }
+	if (!session) {
+		throw new Error(
+			`No session configuration was found, pass settings under the session property`
+		);
+	}
 
-  if (!session.server) {
-    throw new Error(`session.server property is missing, should hold the server address`);
-  }
+	if (!session.server) {
+		throw new Error(
+			`session.server property is missing, should hold the server address`
+		);
+	}
 
-  if (!session.sessionId) {
-    throw new Error(`session.sessionId property is missing, should hold the server session id`);
-  }
+	if (!session.sessionId) {
+		throw new Error(
+			`session.sessionId property is missing, should hold the server session id`
+		);
+	}
 }
 
 function throwOnEmptyName() {
-  throw new DetoxConfigError(`'name' property is missing, should hold the device name to run on (e.g. "iPhone 7", "iPhone 7, iOS 10.2"`);
+	throw new DetoxConfigError(
+		`'name' property is missing, should hold the device name to run on (e.g. "iPhone 7", "iPhone 7, iOS 10.2"`
+	);
 }
 
 function throwOnEmptyType() {
-  throw new DetoxConfigError(`'type' property is missing, should hold the device type to test on (currently only simulator is supported: ios.simulator or ios.none)`);
+	throw new DetoxConfigError(
+		`'type' property is missing, should hold the device type to test on (currently only simulator is supported: ios.simulator or ios.none)`
+	);
 }
 
 function throwOnEmptyBinaryPath() {
-  throw new DetoxConfigError(`'binaryPath' property is missing, should hold the app binary path`);
+	throw new DetoxConfigError(
+		`'binaryPath' property is missing, should hold the app binary path`
+	);
 }
 
-class DetoxConfigError extends CustomError {
-
-}
+class DetoxConfigError extends CustomError {}
 
 module.exports = {
-  defaultSession,
-  validateSession,
-  throwOnEmptyName,
-  throwOnEmptyType,
-  throwOnEmptyBinaryPath
+	defaultSession,
+	validateSession,
+	throwOnEmptyName,
+	throwOnEmptyType,
+	throwOnEmptyBinaryPath
 };

--- a/detox/src/configuration.test.js
+++ b/detox/src/configuration.test.js
@@ -1,43 +1,45 @@
-const _ = require('lodash');
-const schemes = require('./configurations.mock');
+const _ = require("lodash");
+const schemes = require("./configurations.mock");
 
-describe('configuration', () => {
-  let configuration;
-  beforeEach(() => {
-    configuration = require('./configuration');
-  });
+describe("configuration", () => {
+	let configuration;
+	beforeEach(() => {
+		configuration = require("./configuration");
+	});
 
-  it(`generate a default config`, async () => {
-    const config = await configuration.defaultSession();
-    expect(() => config.session.server).toBeDefined();
-    expect(() => config.session.sessionId).toBeDefined();
-  });
+	it(`generate a default config`, async () => {
+		const config = await configuration.defaultSession();
+		expect(() => config.session.server).toBeDefined();
+		expect(() => config.session.sessionId).toBeDefined();
+	});
 
-  it(`providing a valid config`, () => {
-    expect(() => configuration.validateSession(schemes.validOneDeviceAndSession.session)).not.toThrow();
-  });
+	it(`providing a valid config`, () => {
+		expect(() =>
+			configuration.validateSession(schemes.validOneDeviceAndSession.session)
+		).not.toThrow();
+	});
 
-  it(`providing empty server config should throw`, () => {
-    testFaultySession();
-  });
+	it(`providing empty server config should throw`, () => {
+		testFaultySession();
+	});
 
-  it(`providing server config with no session should throw`, () => {
-    testFaultySession(schemes.validOneDeviceNoSession.session);
-  });
+	it(`providing server config with no session should throw`, () => {
+		testFaultySession(schemes.validOneDeviceNoSession.session);
+	});
 
-  it(`providing server config with no session.server should throw`, () => {
-    testFaultySession(schemes.invalidSessionNoServer.session);
-  });
+	it(`providing server config with no session.server should throw`, () => {
+		testFaultySession(schemes.invalidSessionNoServer.session);
+	});
 
-  it(`providing server config with no session.sessionId should throw`, () => {
-    testFaultySession(schemes.invalidSessionNoSessionId.session);
-  });
+	it(`providing server config with no session.sessionId should throw`, () => {
+		testFaultySession(schemes.invalidSessionNoSessionId.session);
+	});
 
-  function testFaultySession(config) {
-    try {
-      configuration.validateSession(config);
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  }
+	function testFaultySession(config) {
+		try {
+			configuration.validateSession(config);
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	}
 });

--- a/detox/src/configurations.mock.js
+++ b/detox/src/configurations.mock.js
@@ -1,189 +1,194 @@
 const validOneDeviceNoSession = {
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.simulator",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
+	configurations: {
+		"ios.sim.release": {
+			binaryPath:
+				"ios/build/Build/Products/Release-iphonesimulator/example.app",
+			type: "ios.simulator",
+			name: "iPhone 7 Plus, iOS 10.2"
+		}
+	}
 };
 
 const validOneIosNoneDeviceNoSession = {
-  "configurations": {
-    "ios.none": {
-      "type": "ios.none",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
+	configurations: {
+		"ios.none": {
+			type: "ios.none",
+			name: "iPhone 7 Plus, iOS 10.2"
+		}
+	}
 };
 
 const validTwoDevicesNoSession = {
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.simulator",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    },
-    "ios.sim.debug": {
-      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
-      "type": "ios.simulator",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
+	configurations: {
+		"ios.sim.release": {
+			binaryPath:
+				"ios/build/Build/Products/Release-iphonesimulator/example.app",
+			type: "ios.simulator",
+			name: "iPhone 7 Plus, iOS 10.2"
+		},
+		"ios.sim.debug": {
+			binaryPath: "ios/build/Build/Products/Debug-iphonesimulator/example.app",
+			type: "ios.simulator",
+			name: "iPhone 7 Plus, iOS 10.2"
+		}
+	}
 };
 
 const invalidDeviceNoBinary = {
-  "configurations": {
-    "ios.sim.release": {
-      "type": "ios.simulator",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
+	configurations: {
+		"ios.sim.release": {
+			type: "ios.simulator",
+			name: "iPhone 7 Plus, iOS 10.2"
+		}
+	}
 };
 
 const invalidNoDevice = {
-  "configurations": {
-  }
+	configurations: {}
 };
 
 const invalidDeviceNoDeviceType = {
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "here",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
+	configurations: {
+		"ios.sim.release": {
+			binaryPath: "here",
+			name: "iPhone 7 Plus, iOS 10.2"
+		}
+	}
 };
 
 const invalidDeviceNoDeviceName = {
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "here",
-      "type": "ios.simulator"
-    }
-  }
+	configurations: {
+		"ios.sim.release": {
+			binaryPath: "here",
+			type: "ios.simulator"
+		}
+	}
 };
 
 const validOneDeviceAndSession = {
-  "session": {
-    "server": "ws://localhost:8099",
-    "sessionId": "test"
-  },
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.simulator",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
+	session: {
+		server: "ws://localhost:8099",
+		sessionId: "test"
+	},
+	configurations: {
+		"ios.sim.release": {
+			binaryPath:
+				"ios/build/Build/Products/Release-iphonesimulator/example.app",
+			type: "ios.simulator",
+			name: "iPhone 7 Plus, iOS 10.2"
+		}
+	}
 };
 
 const pathsTests = {
-  "session": {
-    "server": "ws://localhost:8099",
-    "sessionId": "test"
-  },
-  "configurations": {
-    "absolutePath": {
-      "binaryPath": "/tmp/abcdef/123",
-      "type": "ios.simulator",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    },
-    "relativePath": {
-      "binaryPath": "abcdef/123",
-      "type": "ios.simulator",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
+	session: {
+		server: "ws://localhost:8099",
+		sessionId: "test"
+	},
+	configurations: {
+		absolutePath: {
+			binaryPath: "/tmp/abcdef/123",
+			type: "ios.simulator",
+			name: "iPhone 7 Plus, iOS 10.2"
+		},
+		relativePath: {
+			binaryPath: "abcdef/123",
+			type: "ios.simulator",
+			name: "iPhone 7 Plus, iOS 10.2"
+		}
+	}
 };
 
 const invalidSessionNoSessionId = {
-  "session": {
-    "server": "ws://localhost:8099"
-  }
+	session: {
+		server: "ws://localhost:8099"
+	}
 };
 
 const invalidSessionNoServer = {
-  "session": {
-    "sessionId": "test"
-  }
+	session: {
+		sessionId: "test"
+	}
 };
 
 const invalidOneDeviceTypeEmulatorNoSession = {
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "some.apk",
-      "type": "emulator",
-      "name": "an emulator"
-    }
-  }
+	configurations: {
+		"ios.sim.release": {
+			binaryPath: "some.apk",
+			type: "emulator",
+			name: "an emulator"
+		}
+	}
 };
 
 const sessionPerConfiguration = {
-  "configurations": {
-    "ios.sim.none": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.none",
-      "name": "iPhone 7 Plus, iOS 10.2",
-      "session": {
-        "server": "ws://localhost:1111",
-        "sessionId": "test_1111"
-      }
-    },
-    "ios.sim.release": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.none",
-      "name": "iPhone 7 Plus, iOS 10.2",
-      "session": {
-        "server": "ws://localhost:2222",
-        "sessionId": "test_2222"
-      }
-    }
-  }
+	configurations: {
+		"ios.sim.none": {
+			binaryPath:
+				"ios/build/Build/Products/Release-iphonesimulator/example.app",
+			type: "ios.none",
+			name: "iPhone 7 Plus, iOS 10.2",
+			session: {
+				server: "ws://localhost:1111",
+				sessionId: "test_1111"
+			}
+		},
+		"ios.sim.release": {
+			binaryPath:
+				"ios/build/Build/Products/Release-iphonesimulator/example.app",
+			type: "ios.none",
+			name: "iPhone 7 Plus, iOS 10.2",
+			session: {
+				server: "ws://localhost:2222",
+				sessionId: "test_2222"
+			}
+		}
+	}
 };
 
 const sessionInCommonAndInConfiguration = {
-  "session": {
-    "server": "ws://localhost:1111",
-    "sessionId": "test_1"
-  },
-  "configurations": {
-    "ios.sim.none": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.none",
-      "name": "iPhone 7 Plus, iOS 10.2",
-      "session": {
-        "server": "ws://localhost:2222",
-        "sessionId": "test_2"
-      }
-    }
-  }
+	session: {
+		server: "ws://localhost:1111",
+		sessionId: "test_1"
+	},
+	configurations: {
+		"ios.sim.none": {
+			binaryPath:
+				"ios/build/Build/Products/Release-iphonesimulator/example.app",
+			type: "ios.none",
+			name: "iPhone 7 Plus, iOS 10.2",
+			session: {
+				server: "ws://localhost:2222",
+				sessionId: "test_2"
+			}
+		}
+	}
 };
 
 const validOneEmulator = {
-  "configurations": {
-    "android.emu.release": {
-      "binaryPath": "android/app/build/outputs/apk/app-debug.apk",
-      "type": "android.emulator",
-      "name": "Nexus 5X"
-    }
-  }
+	configurations: {
+		"android.emu.release": {
+			binaryPath: "android/app/build/outputs/apk/app-debug.apk",
+			type: "android.emulator",
+			name: "Nexus 5X"
+		}
+	}
 };
 
 module.exports = {
-  validOneDeviceNoSession,
-  validOneIosNoneDeviceNoSession,
-  validTwoDevicesNoSession,
-  invalidDeviceNoBinary,
-  invalidNoDevice,
-  invalidDeviceNoDeviceType,
-  invalidDeviceNoDeviceName,
-  validOneDeviceAndSession,
-  invalidSessionNoSessionId,
-  invalidSessionNoServer,
-  invalidOneDeviceTypeEmulatorNoSession,
-  sessionPerConfiguration,
-  sessionInCommonAndInConfiguration,
-  validOneEmulator,
-  pathsTests
+	validOneDeviceNoSession,
+	validOneIosNoneDeviceNoSession,
+	validTwoDevicesNoSession,
+	invalidDeviceNoBinary,
+	invalidNoDevice,
+	invalidDeviceNoDeviceType,
+	invalidDeviceNoDeviceName,
+	validOneDeviceAndSession,
+	invalidSessionNoSessionId,
+	invalidSessionNoServer,
+	invalidOneDeviceTypeEmulatorNoSession,
+	sessionPerConfiguration,
+	sessionInCommonAndInConfiguration,
+	validOneEmulator,
+	pathsTests
 };

--- a/detox/src/devices/AndroidDriver.js
+++ b/detox/src/devices/AndroidDriver.js
@@ -163,13 +163,11 @@ class AndroidDriver extends DeviceDriverBase {
 		let adbName;
 		switch (filteredDevices.length) {
 			case 1:
-				const adbDevice = filteredDevices[0];
-				adbName = adbDevice.adbName;
+				adbName = filteredDevices[0].adbName;
 				break;
 			case 0:
 				throw new Error(`Could not find '${name}' on the currently ADB attached devices, 
       try restarting adb 'adb kill-server && adb start-server'`);
-				break;
 			default:
 				throw new Error(
 					`Got more than one device corresponding to the name: ${name}`

--- a/detox/src/devices/AndroidDriver.js
+++ b/detox/src/devices/AndroidDriver.js
@@ -1,174 +1,224 @@
-const {spawn} = require('child_process');
-const path = require('path');
-const fs = require('fs');
-const _ = require('lodash');
-const log = require('npmlog');
-const invoke = require('../invoke');
+const { spawn } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+const _ = require("lodash");
+const log = require("npmlog");
+const invoke = require("../invoke");
 const InvocationManager = invoke.InvocationManager;
-const ADB = require('./android/ADB');
-const AAPT = require('./android/AAPT');
-const DeviceDriverBase = require('./DeviceDriverBase');
+const ADB = require("./android/ADB");
+const AAPT = require("./android/AAPT");
+const DeviceDriverBase = require("./DeviceDriverBase");
 
-const EspressoDetox = 'com.wix.detox.espresso.EspressoDetox';
+const EspressoDetox = "com.wix.detox.espresso.EspressoDetox";
 
 class AndroidDriver extends DeviceDriverBase {
-  constructor(client) {
-    super(client);
-    const expect = require('../android/expect');
-    expect.exportGlobals();
-    this.invocationManager = new InvocationManager(client);
-    expect.setInvocationManager(this.invocationManager);
+	constructor(client) {
+		super(client);
+		const expect = require("../android/expect");
+		expect.exportGlobals();
+		this.invocationManager = new InvocationManager(client);
+		expect.setInvocationManager(this.invocationManager);
 
-    this.adb = new ADB();
-    this.aapt = new AAPT();
-  }
+		this.adb = new ADB();
+		this.aapt = new AAPT();
+	}
 
-  async getBundleIdFromBinary(apkPath) {
-    return await this.aapt.getPackageName(apkPath);
-  }
+	async getBundleIdFromBinary(apkPath) {
+		return await this.aapt.getPackageName(apkPath);
+	}
 
-  async installApp(deviceId, binaryPath) {
-    await this.adb.install(deviceId, binaryPath);
-    await this.adb.install(deviceId, this.getTestApkPath(binaryPath));
-  }
+	async installApp(deviceId, binaryPath) {
+		await this.adb.install(deviceId, binaryPath);
+		await this.adb.install(deviceId, this.getTestApkPath(binaryPath));
+	}
 
-  getTestApkPath(originalApkPath) {
-    const originalApkPathObj = path.parse(originalApkPath);
-    let splitPath = originalApkPathObj.dir.split(path.sep);
-    splitPath.splice(splitPath.length-1 , 0, 'androidTest');
-    const testApkPath = path.join(splitPath.join(path.sep), `${originalApkPathObj.name}-androidTest${originalApkPathObj.ext}`);
+	getTestApkPath(originalApkPath) {
+		const originalApkPathObj = path.parse(originalApkPath);
+		const splitPath = originalApkPathObj.dir.split(path.sep);
+		splitPath.splice(splitPath.length - 1, 0, "androidTest");
+		const testApkPath = path.join(
+			splitPath.join(path.sep),
+			`${originalApkPathObj.name}-androidTest${originalApkPathObj.ext}`
+		);
 
-    if (!fs.existsSync(testApkPath)) {
-      throw new Error(`'${testApkPath}' could not be found, did you run './gradlew assembleAndroidTest' ?`);
-    }
+		if (!fs.existsSync(testApkPath)) {
+			throw new Error(
+				`'${testApkPath}' could not be found, did you run './gradlew assembleAndroidTest' ?`
+			);
+		}
 
-    return testApkPath;
-  }
+		return testApkPath;
+	}
 
-  async uninstallApp(deviceId, bundleId) {
-    try {
-      await this.adb.uninstall(deviceId, bundleId);
-    } catch (ex) {
-      //this is fine
-    }
+	async uninstallApp(deviceId, bundleId) {
+		try {
+			await this.adb.uninstall(deviceId, bundleId);
+		} catch (ex) {
+			//this is fine
+		}
 
-    try {
-      await this.adb.uninstall(deviceId, `${bundleId}.test`);
-    } catch (ex) {
-      //this is fine
-    }
-  }
+		try {
+			await this.adb.uninstall(deviceId, `${bundleId}.test`);
+		} catch (ex) {
+			//this is fine
+		}
+	}
 
-  async launch(deviceId, bundleId, launchArgs) {
-    const args = [];
-    _.forEach(launchArgs, (value, key) => {
-      args.push(`${key} ${value}`);
-    });
+	async launch(deviceId, bundleId, launchArgs) {
+		const args = [];
+		_.forEach(launchArgs, (value, key) => {
+			args.push(`${key} ${value}`);
+		});
 
-    if (this.instrumentationProcess) {
-      const call = invoke.call(invoke.Android.Class("com.wix.detox.Detox"), 'launchMainActivity');
-      await this.invocationManager.execute(call);
-      return this.instrumentationProcess.pid;
-    }
+		if (this.instrumentationProcess) {
+			const call = invoke.call(
+				invoke.Android.Class("com.wix.detox.Detox"),
+				"launchMainActivity"
+			);
+			await this.invocationManager.execute(call);
+			return this.instrumentationProcess.pid;
+		}
 
-    this.instrumentationProcess = spawn(`adb`, [`-s`, `${deviceId}`, `shell`, `am`, `instrument`, `-w`, `-r`, `${args.join(' ')}`, `-e`, `debug`,
-      `false`, `${bundleId}.test/android.support.test.runner.AndroidJUnitRunner`]);
-    log.verbose(this.instrumentationProcess.spawnargs.join(" "));
-    log.verbose('Instrumentation spawned, childProcess.pid: ', this.instrumentationProcess.pid);
-    this.instrumentationProcess.stdout.on('data', function(data) {
-      log.verbose('Instrumentation stdout: ', data.toString());
-    });
-    this.instrumentationProcess.stderr.on('data', function(data) {
-      log.verbose('Instrumentation stderr: ', data.toString());
-    });
+		this.instrumentationProcess = spawn(`adb`, [
+			`-s`,
+			`${deviceId}`,
+			`shell`,
+			`am`,
+			`instrument`,
+			`-w`,
+			`-r`,
+			`${args.join(" ")}`,
+			`-e`,
+			`debug`,
+			`false`,
+			`${bundleId}.test/android.support.test.runner.AndroidJUnitRunner`
+		]);
+		log.verbose(this.instrumentationProcess.spawnargs.join(" "));
+		log.verbose(
+			"Instrumentation spawned, childProcess.pid: ",
+			this.instrumentationProcess.pid
+		);
+		this.instrumentationProcess.stdout.on("data", function(data) {
+			log.verbose("Instrumentation stdout: ", data.toString());
+		});
+		this.instrumentationProcess.stderr.on("data", function(data) {
+			log.verbose("Instrumentation stderr: ", data.toString());
+		});
 
-    this.instrumentationProcess.on('close', (code, signal) => {
-      log.verbose(`instrumentationProcess terminated due to receipt of signal ${signal}`);
-    });
+		this.instrumentationProcess.on("close", (code, signal) => {
+			log.verbose(
+				`instrumentationProcess terminated due to receipt of signal ${signal}`
+			);
+		});
 
-    return this.instrumentationProcess.pid;
-  }
+		return this.instrumentationProcess.pid;
+	}
 
-  async openURL(deviceId, params) {
-    const call = invoke.call(invoke.Android.Class("com.wix.detox.Detox"), 'startActivityFromUrl', invoke.Android.String(params.url));
-    await this.invocationManager.execute(call);
-  }
+	async openURL(deviceId, params) {
+		const call = invoke.call(
+			invoke.Android.Class("com.wix.detox.Detox"),
+			"startActivityFromUrl",
+			invoke.Android.String(params.url)
+		);
+		await this.invocationManager.execute(call);
+	}
 
-  async sendToHome(deviceId, params) {
-    const uiDevice = invoke.call(invoke.Android.Class("com.wix.detox.uiautomator.UiAutomator"), 'uiDevice');
-    const call = invoke.call(uiDevice, 'pressHome');
-    await this.invocationManager.execute(call);
-  }
+	async sendToHome(deviceId, params) {
+		const uiDevice = invoke.call(
+			invoke.Android.Class("com.wix.detox.uiautomator.UiAutomator"),
+			"uiDevice"
+		);
+		const call = invoke.call(uiDevice, "pressHome");
+		await this.invocationManager.execute(call);
+	}
 
-  async terminate(deviceId, bundleId) {
-    this.terminateInstrumentation();
-    await this.adb.terminate(deviceId, bundleId);
-  }
+	async terminate(deviceId, bundleId) {
+		this.terminateInstrumentation();
+		await this.adb.terminate(deviceId, bundleId);
+	}
 
-  terminateInstrumentation() {
-    if (this.instrumentationProcess) {
-      this.instrumentationProcess.kill();
-      this.instrumentationProcess = null;
-    }
-  }
+	terminateInstrumentation() {
+		if (this.instrumentationProcess) {
+			this.instrumentationProcess.kill();
+			this.instrumentationProcess = null;
+		}
+	}
 
-  async cleanup(deviceId, bundleId) {
-    this.terminateInstrumentation();
-  }
+	async cleanup(deviceId, bundleId) {
+		this.terminateInstrumentation();
+	}
 
-  defaultLaunchArgsPrefix() {
-    return '-e ';
-  }
+	defaultLaunchArgsPrefix() {
+		return "-e ";
+	}
 
-  getPlatform() {
-    return 'android';
-  }
+	getPlatform() {
+		return "android";
+	}
 
-  async findDeviceId(filter) {
-    const adbDevices = await this.adb.devices();
-    const filteredDevices = _.filter(adbDevices, filter);
+	async findDeviceId(filter) {
+		const adbDevices = await this.adb.devices();
+		const filteredDevices = _.filter(adbDevices, filter);
 
-    let adbName;
-    switch (filteredDevices.length) {
-      case 1:
-        const adbDevice = filteredDevices[0];
-        adbName = adbDevice.adbName;
-        break;
-      case 0:
-        throw new Error(`Could not find '${name}' on the currently ADB attached devices, 
+		let adbName;
+		switch (filteredDevices.length) {
+			case 1:
+				const adbDevice = filteredDevices[0];
+				adbName = adbDevice.adbName;
+				break;
+			case 0:
+				throw new Error(`Could not find '${name}' on the currently ADB attached devices, 
       try restarting adb 'adb kill-server && adb start-server'`);
-        break;
-      default:
-        throw new Error(`Got more than one device corresponding to the name: ${name}`);
-    }
+				break;
+			default:
+				throw new Error(
+					`Got more than one device corresponding to the name: ${name}`
+				);
+		}
 
-    return adbName;
-  }
+		return adbName;
+	}
 
-  async setURLBlacklist(urlList) {
-    const call = invoke.call(invoke.Android.Class(EspressoDetox), 'setURLBlacklist', urlList);
-    await this.invocationManager.execute(call);
-  }
+	async setURLBlacklist(urlList) {
+		const call = invoke.call(
+			invoke.Android.Class(EspressoDetox),
+			"setURLBlacklist",
+			urlList
+		);
+		await this.invocationManager.execute(call);
+	}
 
-  async enableSynchronization() {
-    const call = invoke.call(invoke.Android.Class(EspressoDetox), 'setSynchronization', invoke.Android.Boolean(true));
-    await this.invocationManager.execute(call);
-  }
+	async enableSynchronization() {
+		const call = invoke.call(
+			invoke.Android.Class(EspressoDetox),
+			"setSynchronization",
+			invoke.Android.Boolean(true)
+		);
+		await this.invocationManager.execute(call);
+	}
 
-  async disableSynchronization() {
-    const call = invoke.call(invoke.Android.Class(EspressoDetox), 'setSynchronization', invoke.Android.Boolean(false));
-    await this.invocationManager.execute(call);
-  }
+	async disableSynchronization() {
+		const call = invoke.call(
+			invoke.Android.Class(EspressoDetox),
+			"setSynchronization",
+			invoke.Android.Boolean(false)
+		);
+		await this.invocationManager.execute(call);
+	}
 
-  async setOrientation(deviceId, orientation) {
-    const orientationMapping = {
-      landscape: 1, // top at left side landscape
-      portrait: 0 // non-reversed portrait.
-    };
-    
-    const call = invoke.call(invoke.Android.Class(EspressoDetox), 'changeOrientation', invoke.Android.Integer(orientationMapping[orientation]));
-    await this.invocationManager.execute(call);
-  }
+	async setOrientation(deviceId, orientation) {
+		const orientationMapping = {
+			landscape: 1, // top at left side landscape
+			portrait: 0 // non-reversed portrait.
+		};
+
+		const call = invoke.call(
+			invoke.Android.Class(EspressoDetox),
+			"changeOrientation",
+			invoke.Android.Integer(orientationMapping[orientation])
+		);
+		await this.invocationManager.execute(call);
+	}
 }
 
 module.exports = AndroidDriver;

--- a/detox/src/devices/AppleSimUtils.js
+++ b/detox/src/devices/AppleSimUtils.js
@@ -1,248 +1,324 @@
-const _ = require('lodash');
-const exec = require('../utils/exec');
-const retry = require('../utils/retry');
-const environment = require('../utils/environment');
+const _ = require("lodash");
+const exec = require("../utils/exec");
+const retry = require("../utils/retry");
+const environment = require("../utils/environment");
 
 class AppleSimUtils {
+	async setPermissions(udid, bundleId, permissionsObj) {
+		const statusLogs = {
+			trying: `Trying to set permissions...`,
+			successful: "Permissions are set"
+		};
+		const permissions = [];
+		_.forEach(permissionsObj, function(shouldAllow, permission) {
+			permissions.push(permission + "=" + shouldAllow);
+		});
+		await this._execAppleSimUtils(
+			{
+				args: `--simulator ${udid} --bundle ${bundleId} --setPermissions ${_.join(
+					permissions,
+					","
+				)}`
+			},
+			statusLogs,
+			1
+		);
+	}
 
-  async setPermissions(udid, bundleId, permissionsObj) {
-    const statusLogs = {
-      trying: `Trying to set permissions...`,
-      successful: 'Permissions are set'
-    };
-    let permissions = [];
-    _.forEach(permissionsObj, function (shouldAllow, permission) {
-      permissions.push(permission + '=' + shouldAllow);
-    });
-    await this._execAppleSimUtils({
-      args: `--simulator ${udid} --bundle ${bundleId} --setPermissions ${_.join(permissions, ',')}`
-    }, statusLogs, 1);
-  }
-
-  async findDeviceUDID(query) {
-    const statusLogs = {
-      trying: `Searching for device matching ${query}...`
-    };
-    let correctQuery = this._correctQueryWithOS(query);
-    const response = await this._execAppleSimUtils({ args: `--list "${correctQuery}" --maxResults=1` }, statusLogs, 1);
-    const parsed = this._parseResponseFromAppleSimUtils(response);
-    const udid = _.get(parsed, [0, 'udid']);
-    if (!udid) {
-      throw new Error(`Can't find a simulator to match with "${query}", run 'xcrun simctl list' to list your supported devices.
+	async findDeviceUDID(query) {
+		const statusLogs = {
+			trying: `Searching for device matching ${query}...`
+		};
+		const correctQuery = this._correctQueryWithOS(query);
+		const response = await this._execAppleSimUtils(
+			{ args: `--list "${correctQuery}" --maxResults=1` },
+			statusLogs,
+			1
+		);
+		const parsed = this._parseResponseFromAppleSimUtils(response);
+		const udid = _.get(parsed, [0, "udid"]);
+		if (!udid) {
+			throw new Error(`Can't find a simulator to match with "${query}", run 'xcrun simctl list' to list your supported devices.
       It is advised to only state a device type, and not to state iOS version, e.g. "iPhone 7"`);
-    }
-    return udid;
-  }
+		}
+		return udid;
+	}
 
-  async findDeviceByUDID(udid) {
-    const response = await this._execAppleSimUtils({ args: `--list` }, undefined, 1);
-    const parsed = this._parseResponseFromAppleSimUtils(response);
-    const device = _.find(parsed, (device) => _.isEqual(device.udid, udid));
-    if (!device) {
-      throw new Error(`Can't find device ${udid}`);
-    }
-    return device;
-  }
+	async findDeviceByUDID(udid) {
+		const response = await this._execAppleSimUtils(
+			{ args: `--list` },
+			undefined,
+			1
+		);
+		const parsed = this._parseResponseFromAppleSimUtils(response);
+		const device = _.find(parsed, device => _.isEqual(device.udid, udid));
+		if (!device) {
+			throw new Error(`Can't find device ${udid}`);
+		}
+		return device;
+	}
 
-  async waitForDeviceState(udid, state) {
-    let device;
-    await retry({ retries: 10, interval: 1000 }, async () => {
-      device = await this.findDeviceByUDID(udid);
-      if (!_.isEqual(device.state, state)) {
-        throw new Error(`device is in state '${device.state}'`);
-      }
-    });
-    return device;
-  }
+	async waitForDeviceState(udid, state) {
+		let device;
+		await retry({ retries: 10, interval: 1000 }, async () => {
+			device = await this.findDeviceByUDID(udid);
+			if (!_.isEqual(device.state, state)) {
+				throw new Error(`device is in state '${device.state}'`);
+			}
+		});
+		return device;
+	}
 
-  async boot(udid) {
-    const device = await this.findDeviceByUDID(udid);
-    if (_.isEqual(device.state, 'Booted') || _.isEqual(device.state, 'Booting')) {
-      return false;
-    }
-    await this.waitForDeviceState(udid, 'Shutdown');
-    await this._bootDeviceByXcodeVersion(udid);
-    await this.waitForDeviceState(udid, 'Booted');
-  }
+	async boot(udid) {
+		const device = await this.findDeviceByUDID(udid);
+		if (
+			_.isEqual(device.state, "Booted") ||
+			_.isEqual(device.state, "Booting")
+		) {
+			return false;
+		}
+		await this.waitForDeviceState(udid, "Shutdown");
+		await this._bootDeviceByXcodeVersion(udid);
+		await this.waitForDeviceState(udid, "Booted");
+	}
 
-  async install(udid, absPath) {
-    const statusLogs = {
-      trying: `Installing ${absPath}...`,
-      successful: `${absPath} installed`
-    };
-    await this._execSimctl({ cmd: `install ${udid} ${absPath}`, statusLogs });
-  }
+	async install(udid, absPath) {
+		const statusLogs = {
+			trying: `Installing ${absPath}...`,
+			successful: `${absPath} installed`
+		};
+		await this._execSimctl({ cmd: `install ${udid} ${absPath}`, statusLogs });
+	}
 
-  async uninstall(udid, bundleId) {
-    const statusLogs = {
-      trying: `Uninstalling ${bundleId}...`,
-      successful: `${bundleId} uninstalled`
-    };
-    try {
-      await this._execSimctl({ cmd: `uninstall ${udid} ${bundleId}`, statusLogs });
-    } catch (e) {
-      // that's fine
-    }
-  }
+	async uninstall(udid, bundleId) {
+		const statusLogs = {
+			trying: `Uninstalling ${bundleId}...`,
+			successful: `${bundleId} uninstalled`
+		};
+		try {
+			await this._execSimctl({
+				cmd: `uninstall ${udid} ${bundleId}`,
+				statusLogs
+			});
+		} catch (e) {
+			// that's fine
+		}
+	}
 
-  async launch(udid, bundleId, launchArgs) {
-    const frameworkPath = await environment.getFrameworkPath();
-    const logsInfo = new LogsInfo(udid);
-    const args = this._joinLaunchArgs(launchArgs);
+	async launch(udid, bundleId, launchArgs) {
+		const frameworkPath = await environment.getFrameworkPath();
+		const logsInfo = new LogsInfo(udid);
+		const args = this._joinLaunchArgs(launchArgs);
 
-    const result = await this._launchMagically(frameworkPath, logsInfo, udid, bundleId, args);
-    return this._parseLaunchId(result);
-  }
+		const result = await this._launchMagically(
+			frameworkPath,
+			logsInfo,
+			udid,
+			bundleId,
+			args
+		);
+		return this._parseLaunchId(result);
+	}
 
-  async sendToHome(udid) {
-    await this._execSimctl({ cmd: `launch ${udid} com.apple.springboard`, retries: 10 });
-  }
+	async sendToHome(udid) {
+		await this._execSimctl({
+			cmd: `launch ${udid} com.apple.springboard`,
+			retries: 10
+		});
+	}
 
-  getLogsPaths(udid) {
-    const logsInfo = new LogsInfo(udid);
-    return {
-      stdout: logsInfo.absStdout,
-      stderr: logsInfo.absStderr
-    }
-  }
+	getLogsPaths(udid) {
+		const logsInfo = new LogsInfo(udid);
+		return {
+			stdout: logsInfo.absStdout,
+			stderr: logsInfo.absStderr
+		};
+	}
 
-  async terminate(udid, bundleId) {
-    const statusLogs = {
-      trying: `Terminating ${bundleId}...`,
-      successful: `${bundleId} terminated`
-    };
-    await this._execSimctl({ cmd: `terminate ${udid} ${bundleId}`, statusLogs });
-  }
+	async terminate(udid, bundleId) {
+		const statusLogs = {
+			trying: `Terminating ${bundleId}...`,
+			successful: `${bundleId} terminated`
+		};
+		await this._execSimctl({
+			cmd: `terminate ${udid} ${bundleId}`,
+			statusLogs
+		});
+	}
 
-  async shutdown(udid) {
-    const statusLogs = {
-      trying: `Shutting down ${udid}...`,
-      successful: `${udid} shut down`
-    };
-    await this._execSimctl({ cmd: `shutdown ${udid}`, statusLogs });
-  }
+	async shutdown(udid) {
+		const statusLogs = {
+			trying: `Shutting down ${udid}...`,
+			successful: `${udid} shut down`
+		};
+		await this._execSimctl({ cmd: `shutdown ${udid}`, statusLogs });
+	}
 
-  async openUrl(udid, url) {
-    await this._execSimctl({ cmd: `openurl ${udid} ${url}` });
-  }
+	async openUrl(udid, url) {
+		await this._execSimctl({ cmd: `openurl ${udid} ${url}` });
+	}
 
-  async setLocation(udid, lat, lon) {
-    const result = await exec.execWithRetriesAndLogs(`which fbsimctl`, undefined, undefined, 1);
-    if (_.get(result, 'stdout')) {
-      await exec.execWithRetriesAndLogs(`fbsimctl ${udid} set_location ${lat} ${lon}`, undefined, undefined, 1);
-    } else {
-      throw new Error(`setLocation currently supported only through fbsimctl.
+	async setLocation(udid, lat, lon) {
+		const result = await exec.execWithRetriesAndLogs(
+			`which fbsimctl`,
+			undefined,
+			undefined,
+			1
+		);
+		if (_.get(result, "stdout")) {
+			await exec.execWithRetriesAndLogs(
+				`fbsimctl ${udid} set_location ${lat} ${lon}`,
+				undefined,
+				undefined,
+				1
+			);
+		} else {
+			throw new Error(`setLocation currently supported only through fbsimctl.
       Install fbsimctl using:
       "brew tap facebook/fb && export CODE_SIGNING_REQUIRED=NO && brew install fbsimctl"`);
-    }
-  }
+		}
+	}
 
-  async resetContentAndSettings(udid) {
-    await this.shutdown(udid);
-    await this._execSimctl({ cmd: `erase ${udid}` });
-    await this.boot(udid);
-  }
+	async resetContentAndSettings(udid) {
+		await this.shutdown(udid);
+		await this._execSimctl({ cmd: `erase ${udid}` });
+		await this.boot(udid);
+	}
 
-  async getXcodeVersion() {
-    const raw = await exec.execWithRetriesAndLogs(`xcodebuild -version`, undefined, undefined, 1);
-    const stdout = _.get(raw, 'stdout', 'undefined');
-    const match = /^Xcode (\S+)\.*\S*\s*/.exec(stdout);
-    const majorVersion = parseInt(_.get(match, '[1]'));
-    if (!_.isInteger(majorVersion) || majorVersion < 1) {
-      throw new Error(`Can't read Xcode version, got: '${stdout}'`);
-    }
-    return majorVersion;
-  }
+	async getXcodeVersion() {
+		const raw = await exec.execWithRetriesAndLogs(
+			`xcodebuild -version`,
+			undefined,
+			undefined,
+			1
+		);
+		const stdout = _.get(raw, "stdout", "undefined");
+		const match = /^Xcode (\S+)\.*\S*\s*/.exec(stdout);
+		const majorVersion = parseInt(_.get(match, "[1]"));
+		if (!_.isInteger(majorVersion) || majorVersion < 1) {
+			throw new Error(`Can't read Xcode version, got: '${stdout}'`);
+		}
+		return majorVersion;
+	}
 
-  async _execAppleSimUtils(options, statusLogs, retries, interval) {
-    const bin = `applesimutils`;
-    return await exec.execWithRetriesAndLogs(bin, options, statusLogs, retries, interval);
-  }
+	async _execAppleSimUtils(options, statusLogs, retries, interval) {
+		const bin = `applesimutils`;
+		return await exec.execWithRetriesAndLogs(
+			bin,
+			options,
+			statusLogs,
+			retries,
+			interval
+		);
+	}
 
-  async _execSimctl({ cmd, statusLogs = {}, retries = 1 }) {
-    return await exec.execWithRetriesAndLogs(`/usr/bin/xcrun simctl ${cmd}`, undefined, statusLogs, retries);
-  }
+	async _execSimctl({ cmd, statusLogs = {}, retries = 1 }) {
+		return await exec.execWithRetriesAndLogs(
+			`/usr/bin/xcrun simctl ${cmd}`,
+			undefined,
+			statusLogs,
+			retries
+		);
+	}
 
-  _correctQueryWithOS(query) {
-    let correctQuery = query;
-    if (_.includes(query, ',')) {
-      const parts = _.split(query, ',');
-      correctQuery = `${parts[0].trim()}, OS=${parts[1].trim()}`;
-    }
-    return correctQuery;
-  }
+	_correctQueryWithOS(query) {
+		let correctQuery = query;
+		if (_.includes(query, ",")) {
+			const parts = _.split(query, ",");
+			correctQuery = `${parts[0].trim()}, OS=${parts[1].trim()}`;
+		}
+		return correctQuery;
+	}
 
-  _parseResponseFromAppleSimUtils(response) {
-    let out = _.get(response, 'stdout');
-    if (_.isEmpty(out)) {
-      out = _.get(response, 'stderr');
-    }
-    if (_.isEmpty(out)) {
-      return undefined;
-    }
+	_parseResponseFromAppleSimUtils(response) {
+		let out = _.get(response, "stdout");
+		if (_.isEmpty(out)) {
+			out = _.get(response, "stderr");
+		}
+		if (_.isEmpty(out)) {
+			return undefined;
+		}
 
-    let parsed;
-    try {
-      parsed = JSON.parse(out);
-
-    } catch (ex) {
-      throw new Error(`Could not parse response from applesimutils, please update applesimutils and try again.
+		let parsed;
+		try {
+			parsed = JSON.parse(out);
+		} catch (ex) {
+			throw new Error(`Could not parse response from applesimutils, please update applesimutils and try again.
       'brew uninstall applesimutils && brew tap wix/brew && brew install --HEAD applesimutils'`);
-    }
-    return parsed;
-  }
+		}
+		return parsed;
+	}
 
-  async _bootDeviceByXcodeVersion(udid) {
-    const xcodeVersion = await this.getXcodeVersion();
-    if (xcodeVersion >= 9) {
-      const statusLogs = { trying: `Booting device ${udid}` };
-      await this._execSimctl({ cmd: `boot ${udid}`, statusLogs, retries: 10 });
-    } else {
-      await this._bootDeviceMagically(udid);
-    }
-  }
+	async _bootDeviceByXcodeVersion(udid) {
+		const xcodeVersion = await this.getXcodeVersion();
+		if (xcodeVersion >= 9) {
+			const statusLogs = { trying: `Booting device ${udid}` };
+			await this._execSimctl({ cmd: `boot ${udid}`, statusLogs, retries: 10 });
+		} else {
+			await this._bootDeviceMagically(udid);
+		}
+	}
 
-  async _bootDeviceMagically(udid) {
-    const cmd = "/bin/bash -c '`xcode-select -p`/Applications/Simulator.app/Contents/MacOS/Simulator " +
-      `--args -CurrentDeviceUDID ${udid} -ConnectHardwareKeyboard 0 ` +
-      "-DeviceSetPath $HOME/Library/Developer/CoreSimulator/Devices > /dev/null 2>&1 < /dev/null &'";
-    await exec.execWithRetriesAndLogs(cmd, undefined, { trying: `Launching device ${udid}...` }, 1);
-  }
+	async _bootDeviceMagically(udid) {
+		const cmd =
+			"/bin/bash -c '`xcode-select -p`/Applications/Simulator.app/Contents/MacOS/Simulator " +
+			`--args -CurrentDeviceUDID ${udid} -ConnectHardwareKeyboard 0 ` +
+			"-DeviceSetPath $HOME/Library/Developer/CoreSimulator/Devices > /dev/null 2>&1 < /dev/null &'";
+		await exec.execWithRetriesAndLogs(
+			cmd,
+			undefined,
+			{ trying: `Launching device ${udid}...` },
+			1
+		);
+	}
 
-  _joinLaunchArgs(launchArgs) {
-    return _.map(launchArgs, (v, k) => `${k} ${v}`).join(' ').trim();
-  }
+	_joinLaunchArgs(launchArgs) {
+		return _.map(launchArgs, (v, k) => `${k} ${v}`)
+			.join(" ")
+			.trim();
+	}
 
-  async _launchMagically(frameworkPath, logsInfo, udid, bundleId, args) {
-    const statusLogs = {
-      trying: `Launching ${bundleId}...`,
-      successful: `${bundleId} launched. The stdout and stderr logs were recreated, you can watch them with:\n` +
-      `        tail -F ${logsInfo.absJoined}`
-    };
+	async _launchMagically(frameworkPath, logsInfo, udid, bundleId, args) {
+		const statusLogs = {
+			trying: `Launching ${bundleId}...`,
+			successful:
+				`${bundleId} launched. The stdout and stderr logs were recreated, you can watch them with:\n` +
+				`        tail -F ${logsInfo.absJoined}`
+		};
 
-    const launchBin = `/bin/cat /dev/null >${logsInfo.absStdout} 2>${logsInfo.absStderr} && ` +
-      `SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="${frameworkPath}/Detox" ` +
-      `/usr/bin/xcrun simctl launch --stdout=${logsInfo.simStdout} --stderr=${logsInfo.simStderr} ` +
-      `${udid} ${bundleId} --args ${args}`;
+		const launchBin =
+			`/bin/cat /dev/null >${logsInfo.absStdout} 2>${logsInfo.absStderr} && ` +
+			`SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="${frameworkPath}/Detox" ` +
+			`/usr/bin/xcrun simctl launch --stdout=${logsInfo.simStdout} --stderr=${logsInfo.simStderr} ` +
+			`${udid} ${bundleId} --args ${args}`;
 
-    return await exec.execWithRetriesAndLogs(launchBin, undefined, statusLogs, 1);
-  }
+		return await exec.execWithRetriesAndLogs(
+			launchBin,
+			undefined,
+			statusLogs,
+			1
+		);
+	}
 
-  _parseLaunchId(result) {
-    return parseInt(_.get(result, 'stdout', ':').trim().split(':')[1]);
-  }
+	_parseLaunchId(result) {
+		return parseInt(
+			_.get(result, "stdout", ":")
+				.trim()
+				.split(":")[1]
+		);
+	}
 }
 
 class LogsInfo {
-  constructor(udid) {
-    const logPrefix = '/tmp/detox.last_launch_app_log.';
-    this.simStdout = logPrefix + 'out';
-    this.simStderr = logPrefix + 'err';
-    const simDataRoot = `$HOME/Library/Developer/CoreSimulator/Devices/${udid}/data`;
-    this.absStdout = simDataRoot + this.simStdout;
-    this.absStderr = simDataRoot + this.simStderr;
-    this.absJoined = `${simDataRoot}${logPrefix}{out,err}`
-  }
+	constructor(udid) {
+		const logPrefix = "/tmp/detox.last_launch_app_log.";
+		this.simStdout = logPrefix + "out";
+		this.simStderr = logPrefix + "err";
+		const simDataRoot = `$HOME/Library/Developer/CoreSimulator/Devices/${udid}/data`;
+		this.absStdout = simDataRoot + this.simStdout;
+		this.absStderr = simDataRoot + this.simStderr;
+		this.absJoined = `${simDataRoot}${logPrefix}{out,err}`;
+	}
 }
 
 module.exports = AppleSimUtils;

--- a/detox/src/devices/AppleSimUtils.js
+++ b/detox/src/devices/AppleSimUtils.js
@@ -193,7 +193,7 @@ class AppleSimUtils {
 			1
 		);
 		const stdout = _.get(raw, "stdout", "undefined");
-		const match = /^Xcode (\S+)\.*\S*\s*/.exec(stdout);
+		const match = /^Xcode·(\S+)\.*\S*\s*/.exec(stdout);
 		const majorVersion = parseInt(_.get(match, "[1]"));
 		if (!_.isInteger(majorVersion) || majorVersion < 1) {
 			throw new Error(`Can't read Xcode version, got: '${stdout}'`);

--- a/detox/src/devices/AppleSimUtils.test.js
+++ b/detox/src/devices/AppleSimUtils.test.js
@@ -1,424 +1,515 @@
-describe('AppleSimUtils', () => {
-  let AppleSimUtils;
-  let uut;
-  let exec;
-  let retry;
-  let environment;
+describe("AppleSimUtils", () => {
+	let AppleSimUtils;
+	let uut;
+	let exec;
+	let retry;
+	let environment;
 
-  const simUdid = `9C9ABE4D-70C7-49DC-A396-3CB1D0E82846`;
-  const bundleId = 'bundle.id';
+	const simUdid = `9C9ABE4D-70C7-49DC-A396-3CB1D0E82846`;
+	const bundleId = "bundle.id";
 
-  beforeEach(() => {
-    jest.mock('npmlog');
-    jest.mock('../utils/exec');
-    exec = require('../utils/exec');
-    jest.mock('../utils/retry');
-    retry = require('../utils/retry');
-    jest.mock('../utils/environment');
-    environment = require('../utils/environment');
+	beforeEach(() => {
+		jest.mock("npmlog");
+		jest.mock("../utils/exec");
+		exec = require("../utils/exec");
+		jest.mock("../utils/retry");
+		retry = require("../utils/retry");
+		jest.mock("../utils/environment");
+		environment = require("../utils/environment");
 
-    AppleSimUtils = require('./AppleSimUtils');
-    uut = new AppleSimUtils();
-  });
+		AppleSimUtils = require("./AppleSimUtils");
+		uut = new AppleSimUtils();
+	});
 
-  it(`appleSimUtils setPermissions`, async () => {
-    uut.setPermissions(bundleId, simUdid, {
-      permissions:
-      { calendar: "YES" }
-    });
-    expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-  });
+	it(`appleSimUtils setPermissions`, async () => {
+		uut.setPermissions(bundleId, simUdid, {
+			permissions: { calendar: "YES" }
+		});
+		expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+	});
 
-  describe('findDeviceUDID', () => {
-    it('correct params', async () => {
-      expect(exec.execWithRetriesAndLogs).not.toHaveBeenCalled();
-      try {
-        await uut.findDeviceUDID('iPhone 6');
-      } catch (e) { }
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith('applesimutils', {
-        args: `--list "iPhone 6" --maxResults=1`
-      }, expect.anything(), 1, undefined);
-    });
+	describe("findDeviceUDID", () => {
+		it("correct params", async () => {
+			expect(exec.execWithRetriesAndLogs).not.toHaveBeenCalled();
+			try {
+				await uut.findDeviceUDID("iPhone 6");
+			} catch (e) {}
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				"applesimutils",
+				{
+					args: `--list "iPhone 6" --maxResults=1`
+				},
+				expect.anything(),
+				1,
+				undefined
+			);
+		});
 
-    it('adapted to new api with optional OS', async () => {
-      try {
-        await uut.findDeviceUDID('iPhone 6 , iOS 10.3');
-      } catch (e) { }
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith('applesimutils', {
-        args: `--list "iPhone 6, OS=iOS 10.3" --maxResults=1`
-      }, expect.anything(), 1, undefined);
-    });
+		it("adapted to new api with optional OS", async () => {
+			try {
+				await uut.findDeviceUDID("iPhone 6 , iOS 10.3");
+			} catch (e) {}
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				"applesimutils",
+				{
+					args: `--list "iPhone 6, OS=iOS 10.3" --maxResults=1`
+				},
+				expect.anything(),
+				1,
+				undefined
+			);
+		});
 
-    it('returns udid from found device', async () => {
-      exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve({
-        stdout: JSON.stringify([
-          {
-            "state": "Shutdown",
-            "availability": "(available)",
-            "name": "iPhone 6",
-            "udid": "the uuid",
-            "os": {
-              "version": "10.3.1",
-              "availability": "(available)",
-              "name": "iOS 10.3",
-              "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-10-3",
-              "buildversion": "14E8301"
-            }
-          }
-        ])
-      }));
-      const result = await uut.findDeviceUDID('iPhone 7');
-      expect(result).toEqual('the uuid');
-    });
+		it("returns udid from found device", async () => {
+			exec.execWithRetriesAndLogs.mockReturnValueOnce(
+				Promise.resolve({
+					stdout: JSON.stringify([
+						{
+							state: "Shutdown",
+							availability: "(available)",
+							name: "iPhone 6",
+							udid: "the uuid",
+							os: {
+								version: "10.3.1",
+								availability: "(available)",
+								name: "iOS 10.3",
+								identifier: "com.apple.CoreSimulator.SimRuntime.iOS-10-3",
+								buildversion: "14E8301"
+							}
+						}
+					])
+				})
+			);
+			const result = await uut.findDeviceUDID("iPhone 7");
+			expect(result).toEqual("the uuid");
+		});
 
-    it('handles stderr as if stdout', async () => {
-      exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve({
-        stderr: JSON.stringify([
-          {
-            "state": "Shutdown",
-            "availability": "(available)",
-            "name": "iPhone 6",
-            "udid": "the uuid",
-            "os": {
-              "version": "10.3.1",
-              "availability": "(available)",
-              "name": "iOS 10.3",
-              "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-10-3",
-              "buildversion": "14E8301"
-            }
-          }
-        ])
-      }));
-      const result = await uut.findDeviceUDID('iPhone 7');
-      expect(result).toEqual('the uuid');
-    });
+		it("handles stderr as if stdout", async () => {
+			exec.execWithRetriesAndLogs.mockReturnValueOnce(
+				Promise.resolve({
+					stderr: JSON.stringify([
+						{
+							state: "Shutdown",
+							availability: "(available)",
+							name: "iPhone 6",
+							udid: "the uuid",
+							os: {
+								version: "10.3.1",
+								availability: "(available)",
+								name: "iOS 10.3",
+								identifier: "com.apple.CoreSimulator.SimRuntime.iOS-10-3",
+								buildversion: "14E8301"
+							}
+						}
+					])
+				})
+			);
+			const result = await uut.findDeviceUDID("iPhone 7");
+			expect(result).toEqual("the uuid");
+		});
 
-    describe('throws on bad response', () => {
-      const args = [
-        null,
-        {},
-        { stdout: '' },
-        { stdout: '[]' },
-        { stdout: '[{}]' },
-        { stdout: '[{ "udid": "" }]' }
-      ];
-      args.forEach((arg) => {
-        it(`invalid input ${JSON.stringify(arg)}`, async () => {
-          exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve(arg));
-          try {
-            await uut.findDeviceUDID('iPhone 6, iOS 10');
-            fail('should throw');
-          } catch (e) {
-            expect(e.message).toMatch(`Can't find a simulator to match with "iPhone 6, iOS 10"`);
-          }
-        });
-      });
+		describe("throws on bad response", () => {
+			const args = [
+				null,
+				{},
+				{ stdout: "" },
+				{ stdout: "[]" },
+				{ stdout: "[{}]" },
+				{ stdout: '[{ "udid": "" }]' }
+			];
+			args.forEach(arg => {
+				it(`invalid input ${JSON.stringify(arg)}`, async () => {
+					exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve(arg));
+					try {
+						await uut.findDeviceUDID("iPhone 6, iOS 10");
+						fail("should throw");
+					} catch (e) {
+						expect(e.message).toMatch(
+							`Can't find a simulator to match with "iPhone 6, iOS 10"`
+						);
+					}
+				});
+			});
 
-      it('invalid input, not parseable', async () => {
-        exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve({ stdout: '/' }));
-        try {
-          await uut.findDeviceUDID('iPhone 6, iOS 10');
-          fail('should throw');
-        } catch (e) {
-          expect(e.message).toMatch(`Could not parse response from applesimutils, please update applesimutils and try again.
+			it("invalid input, not parseable", async () => {
+				exec.execWithRetriesAndLogs.mockReturnValueOnce(
+					Promise.resolve({ stdout: "/" })
+				);
+				try {
+					await uut.findDeviceUDID("iPhone 6, iOS 10");
+					fail("should throw");
+				} catch (e) {
+					expect(e.message)
+						.toMatch(`Could not parse response from applesimutils, please update applesimutils and try again.
       'brew uninstall applesimutils && brew tap wix/brew && brew install --HEAD applesimutils'`);
-        }
-      });
-    });
-  });
+				}
+			});
+		});
+	});
 
-  describe('findDeviceByUDID', () => {
-    it('throws when cant find device by udid', async () => {
-      try {
-        await uut.findDeviceByUDID('someUdid');
-        fail('should throw');
-      } catch (e) {
-        expect(e).toEqual(new Error(`Can't find device someUdid`));
-      }
-    });
+	describe("findDeviceByUDID", () => {
+		it("throws when cant find device by udid", async () => {
+			try {
+				await uut.findDeviceByUDID("someUdid");
+				fail("should throw");
+			} catch (e) {
+				expect(e).toEqual(new Error(`Can't find device someUdid`));
+			}
+		});
 
-    it('lists devices, finds by udid', async () => {
-      const device = { udid: 'someUdid' };
-      exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve({ stdout: JSON.stringify([device, { udid: 'other' }]) }));
-      const result = await uut.findDeviceByUDID('someUdid');
-      expect(result).toEqual(device);
-    });
-  });
+		it("lists devices, finds by udid", async () => {
+			const device = { udid: "someUdid" };
+			exec.execWithRetriesAndLogs.mockReturnValueOnce(
+				Promise.resolve({ stdout: JSON.stringify([device, { udid: "other" }]) })
+			);
+			const result = await uut.findDeviceByUDID("someUdid");
+			expect(result).toEqual(device);
+		});
+	});
 
-  describe('waitForDeviceState', () => {
-    it('findsDeviceByUdid', async () => {
-      uut.findDeviceByUDID = jest.fn(() => Promise.resolve({ udid: 'the udid', state: 'the state' }));
-      retry.mockImplementation((opts, fn) => Promise.resolve(fn()));
-      const result = await uut.waitForDeviceState(`the udid`, `the state`);
-      expect(uut.findDeviceByUDID).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({ udid: 'the udid', state: 'the state' });
-    });
+	describe("waitForDeviceState", () => {
+		it("findsDeviceByUdid", async () => {
+			uut.findDeviceByUDID = jest.fn(() =>
+				Promise.resolve({ udid: "the udid", state: "the state" })
+			);
+			retry.mockImplementation((opts, fn) => Promise.resolve(fn()));
+			const result = await uut.waitForDeviceState(`the udid`, `the state`);
+			expect(uut.findDeviceByUDID).toHaveBeenCalledTimes(1);
+			expect(result).toEqual({ udid: "the udid", state: "the state" });
+		});
 
-    it('waits for state to be equal', async () => {
-      uut.findDeviceByUDID = jest.fn(() => Promise.resolve({ udid: 'the udid', state: 'different state' }));
-      retry.mockImplementation((opts, fn) => Promise.resolve(fn()));
-      try {
-        await uut.waitForDeviceState(`the udid`, `the state`);
-        fail(`should throw`);
-      } catch (e) {
-        expect(e).toEqual(new Error(`device is in state 'different state'`));
-      }
-      expect(uut.findDeviceByUDID).toHaveBeenCalledTimes(1);
-      expect(retry).toHaveBeenCalledTimes(1);
-      expect(retry).toHaveBeenCalledWith({ retries: 10, interval: 1000 }, expect.any(Function));
-    });
-  });
+		it("waits for state to be equal", async () => {
+			uut.findDeviceByUDID = jest.fn(() =>
+				Promise.resolve({ udid: "the udid", state: "different state" })
+			);
+			retry.mockImplementation((opts, fn) => Promise.resolve(fn()));
+			try {
+				await uut.waitForDeviceState(`the udid`, `the state`);
+				fail(`should throw`);
+			} catch (e) {
+				expect(e).toEqual(new Error(`device is in state 'different state'`));
+			}
+			expect(uut.findDeviceByUDID).toHaveBeenCalledTimes(1);
+			expect(retry).toHaveBeenCalledTimes(1);
+			expect(retry).toHaveBeenCalledWith(
+				{ retries: 10, interval: 1000 },
+				expect.any(Function)
+			);
+		});
+	});
 
-  describe('getXcodeVersion', () => {
-    it('returns xcode major version', async () => {
-      exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve({ stdout: 'Xcode 123.456\nBuild version 123abc123\n' }));
-      const result = await uut.getXcodeVersion();
-      expect(result).toEqual(123);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toBeCalledWith(`xcodebuild -version`, undefined, undefined, 1);
-    });
+	describe("getXcodeVersion", () => {
+		it("returns xcode major version", async () => {
+			exec.execWithRetriesAndLogs.mockReturnValueOnce(
+				Promise.resolve({ stdout: "Xcode 123.456\nBuild version 123abc123\n" })
+			);
+			const result = await uut.getXcodeVersion();
+			expect(result).toEqual(123);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toBeCalledWith(
+				`xcodebuild -version`,
+				undefined,
+				undefined,
+				1
+			);
+		});
 
-    it('handles all sorts of results', async () => {
-      exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve({ stdout: 'Xcode 999' }));
-      const result = await uut.getXcodeVersion();
-      expect(result).toEqual(999);
-    });
+		it("handles all sorts of results", async () => {
+			exec.execWithRetriesAndLogs.mockReturnValueOnce(
+				Promise.resolve({ stdout: "Xcode 999" })
+			);
+			const result = await uut.getXcodeVersion();
+			expect(result).toEqual(999);
+		});
 
-    it('throws when cant read version', async () => {
-      try {
-        await uut.getXcodeVersion();
-        fail(`should throw`);
-      } catch (e) {
-        expect(e).toEqual(new Error(`Can't read Xcode version, got: 'undefined'`));
-      }
-    });
+		it("throws when cant read version", async () => {
+			try {
+				await uut.getXcodeVersion();
+				fail(`should throw`);
+			} catch (e) {
+				expect(e).toEqual(
+					new Error(`Can't read Xcode version, got: 'undefined'`)
+				);
+			}
+		});
 
-    it('throws when invalid version', async () => {
-      exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve({ stdout: 'Xcode bla' }));
-      try {
-        await uut.getXcodeVersion();
-        fail(`should throw`);
-      } catch (e) {
-        expect(e).toEqual(new Error(`Can't read Xcode version, got: 'Xcode bla'`));
-      }
-    });
-  });
+		it("throws when invalid version", async () => {
+			exec.execWithRetriesAndLogs.mockReturnValueOnce(
+				Promise.resolve({ stdout: "Xcode bla" })
+			);
+			try {
+				await uut.getXcodeVersion();
+				fail(`should throw`);
+			} catch (e) {
+				expect(e).toEqual(
+					new Error(`Can't read Xcode version, got: 'Xcode bla'`)
+				);
+			}
+		});
+	});
 
-  describe('boot', () => {
-    it('waits for device by udid to be Shutdown, boots magically, then waits for state to be Booted', async () => {
-      uut.findDeviceByUDID = jest.fn(() => Promise.resolve({ state: 'unknown' }));
-      uut.waitForDeviceState = jest.fn(() => Promise.resolve(true));
-      uut.getXcodeVersion = jest.fn(() => Promise.resolve(1));
-      expect(exec.execWithRetriesAndLogs).not.toHaveBeenCalled();
-      await uut.boot('some udid');
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(expect.stringMatching('xcode-select -p'), undefined, expect.anything(), 1);
-      expect(uut.waitForDeviceState).toHaveBeenCalledTimes(2);
-      expect(uut.waitForDeviceState.mock.calls[0]).toEqual([`some udid`, `Shutdown`]);
-      expect(uut.waitForDeviceState.mock.calls[1]).toEqual([`some udid`, `Booted`]);
-    });
+	describe("boot", () => {
+		it("waits for device by udid to be Shutdown, boots magically, then waits for state to be Booted", async () => {
+			uut.findDeviceByUDID = jest.fn(() =>
+				Promise.resolve({ state: "unknown" })
+			);
+			uut.waitForDeviceState = jest.fn(() => Promise.resolve(true));
+			uut.getXcodeVersion = jest.fn(() => Promise.resolve(1));
+			expect(exec.execWithRetriesAndLogs).not.toHaveBeenCalled();
+			await uut.boot("some udid");
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				expect.stringMatching("xcode-select -p"),
+				undefined,
+				expect.anything(),
+				1
+			);
+			expect(uut.waitForDeviceState).toHaveBeenCalledTimes(2);
+			expect(uut.waitForDeviceState.mock.calls[0]).toEqual([
+				`some udid`,
+				`Shutdown`
+			]);
+			expect(uut.waitForDeviceState.mock.calls[1]).toEqual([
+				`some udid`,
+				`Booted`
+			]);
+		});
 
-    it('skips if device state was already Booted', async () => {
-      uut.findDeviceByUDID = jest.fn(() => Promise.resolve({ state: 'Booted' }));
-      uut.getXcodeVersion = jest.fn(() => Promise.resolve(1));
-      await uut.boot('udid');
-      expect(uut.findDeviceByUDID).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).not.toHaveBeenCalled();
-    });
+		it("skips if device state was already Booted", async () => {
+			uut.findDeviceByUDID = jest.fn(() =>
+				Promise.resolve({ state: "Booted" })
+			);
+			uut.getXcodeVersion = jest.fn(() => Promise.resolve(1));
+			await uut.boot("udid");
+			expect(uut.findDeviceByUDID).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).not.toHaveBeenCalled();
+		});
 
-    it('skips if device state was already Booting', async () => {
-      uut.findDeviceByUDID = jest.fn(() => Promise.resolve({ state: 'Booting' }));
-      uut.getXcodeVersion = jest.fn(() => Promise.resolve(1));
-      await uut.boot('udid');
-      expect(uut.findDeviceByUDID).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).not.toHaveBeenCalled();
-    });
+		it("skips if device state was already Booting", async () => {
+			uut.findDeviceByUDID = jest.fn(() =>
+				Promise.resolve({ state: "Booting" })
+			);
+			uut.getXcodeVersion = jest.fn(() => Promise.resolve(1));
+			await uut.boot("udid");
+			expect(uut.findDeviceByUDID).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).not.toHaveBeenCalled();
+		});
 
-    it('boots with xcrun simctl boot when xcode version >= 9', async () => {
-      uut.findDeviceByUDID = jest.fn(() => Promise.resolve({ state: 'unknown' }));
-      uut.getXcodeVersion = jest.fn(() => Promise.resolve(9));
-      await uut.boot('udid');
-      expect(uut.getXcodeVersion).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(expect.stringMatching('xcrun simctl boot udid'), undefined, expect.anything(), 10);
+		it("boots with xcrun simctl boot when xcode version >= 9", async () => {
+			uut.findDeviceByUDID = jest.fn(() =>
+				Promise.resolve({ state: "unknown" })
+			);
+			uut.getXcodeVersion = jest.fn(() => Promise.resolve(9));
+			await uut.boot("udid");
+			expect(uut.getXcodeVersion).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				expect.stringMatching("xcrun simctl boot udid"),
+				undefined,
+				expect.anything(),
+				10
+			);
+		});
+	});
 
-    });
-  });
+	describe("install", () => {
+		it("calls xcrun", async () => {
+			await uut.install("udid", "somePath");
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				`/usr/bin/xcrun simctl install udid somePath`,
+				undefined,
+				expect.anything(),
+				1
+			);
+		});
+	});
 
-  describe('install', () => {
-    it('calls xcrun', async () => {
-      await uut.install('udid', 'somePath');
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
-        `/usr/bin/xcrun simctl install udid somePath`,
-        undefined,
-        expect.anything(),
-        1);
-    });
-  });
+	describe("uninstall", () => {
+		it("calls xcrun", async () => {
+			await uut.uninstall("udid", "theBundleId");
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				`/usr/bin/xcrun simctl uninstall udid theBundleId`,
+				undefined,
+				expect.anything(),
+				1
+			);
+		});
 
-  describe('uninstall', () => {
-    it('calls xcrun', async () => {
-      await uut.uninstall('udid', 'theBundleId');
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
-        `/usr/bin/xcrun simctl uninstall udid theBundleId`,
-        undefined,
-        expect.anything(),
-        1);
-    });
+		it("does not throw", async () => {
+			exec.execWithRetriesAndLogs.mockImplementation(() =>
+				Promise.reject("some reason")
+			);
+			await uut.uninstall("udid", "theBundleId");
+		});
+	});
 
-    it('does not throw', async () => {
-      exec.execWithRetriesAndLogs.mockImplementation(() => Promise.reject('some reason'));
-      await uut.uninstall('udid', 'theBundleId');
-    });
-  });
+	describe("launch", () => {
+		it("launches magically", async () => {
+			await uut.launch("udid", "theBundleId");
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				expect.stringMatching(/^.*xcrun simctl launch.*$/),
+				undefined,
+				expect.anything(),
+				1
+			);
+		});
 
-  describe('launch', () => {
-    it('launches magically', async () => {
-      await uut.launch('udid', 'theBundleId');
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
-        expect.stringMatching(/^.*xcrun simctl launch.*$/),
-        undefined,
-        expect.anything(),
-        1);
-    });
+		it("concats args", async () => {
+			await uut.launch("udid", "theBundleId", { foo: "bar", bob: "yourUncle" });
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/^.*xcrun simctl launch.* --args foo bar bob yourUncle$/
+				),
+				undefined,
+				expect.anything(),
+				1
+			);
+		});
 
-    it('concats args', async () => {
-      await uut.launch('udid', 'theBundleId', { 'foo': 'bar', 'bob': 'yourUncle' });
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
-        expect.stringMatching(/^.*xcrun simctl launch.* --args foo bar bob yourUncle$/),
-        undefined,
-        expect.anything(),
-        1);
-    });
+		it("asks environment for frameworkPath", async () => {
+			environment.getFrameworkPath.mockReturnValueOnce(
+				Promise.resolve("thePathToFrameworks")
+			);
+			await uut.launch("udid", "theBundleId");
+			expect(environment.getFrameworkPath).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/^.*thePathToFrameworks\/Detox.*xcrun simctl launch.*$/
+				),
+				undefined,
+				expect.anything(),
+				1
+			);
+		});
 
-    it('asks environment for frameworkPath', async () => {
-      environment.getFrameworkPath.mockReturnValueOnce(Promise.resolve('thePathToFrameworks'));
-      await uut.launch('udid', 'theBundleId');
-      expect(environment.getFrameworkPath).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
-        expect.stringMatching(/^.*thePathToFrameworks\/Detox.*xcrun simctl launch.*$/),
-        undefined,
-        expect.anything(),
-        1);
-    });
+		it("should fail when cant locate framework path", async () => {
+			environment.getFrameworkPath.mockReturnValueOnce(
+				Promise.reject("cant find anything")
+			);
+			try {
+				await uut.launch("udid", "theBundleId");
+				fail(`should throw`);
+			} catch (e) {
+				expect(e).toBeDefined();
+			}
+		});
 
-    it('should fail when cant locate framework path', async () => {
-      environment.getFrameworkPath.mockReturnValueOnce(Promise.reject('cant find anything'));
-      try {
-        await uut.launch('udid', 'theBundleId');
-        fail(`should throw`);
-      } catch (e) {
-        expect(e).toBeDefined();
-      }
-    });
+		it("returns the parsed id", async () => {
+			exec.execWithRetriesAndLogs.mockReturnValueOnce(
+				Promise.resolve({ stdout: "appId: 12345 \n" })
+			);
+			const result = await uut.launch("udid", "theBundleId");
+			expect(result).toEqual(12345);
+		});
+	});
 
-    it('returns the parsed id', async () => {
-      exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve({ stdout: 'appId: 12345 \n' }));
-      const result = await uut.launch('udid', 'theBundleId');
-      expect(result).toEqual(12345);
-    });
-  });
+	describe("sendToHome", () => {
+		it("calls xcrun", async () => {
+			await uut.sendToHome("theUdid");
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				expect.stringMatching(/.*xcrun simctl launch theUdid.*/),
+				undefined,
+				expect.anything(),
+				10
+			);
+		});
+	});
 
-  describe('sendToHome', () => {
-    it('calls xcrun', async () => {
-      await uut.sendToHome('theUdid');
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
-        expect.stringMatching(/.*xcrun simctl launch theUdid.*/),
-        undefined,
-        expect.anything(),
-        10
-      );
-    });
-  });
+	describe("getLogsPaths", () => {
+		it("returns correct paths", () => {
+			expect(uut.getLogsPaths("123")).toEqual({
+				stdout:
+					"$HOME/Library/Developer/CoreSimulator/Devices/123/data/tmp/detox.last_launch_app_log.out",
+				stderr:
+					"$HOME/Library/Developer/CoreSimulator/Devices/123/data/tmp/detox.last_launch_app_log.err"
+			});
+		});
+	});
 
-  describe('getLogsPaths', () => {
-    it('returns correct paths', () => {
-      expect(uut.getLogsPaths('123')).toEqual({
-        stdout: '$HOME/Library/Developer/CoreSimulator/Devices/123/data/tmp/detox.last_launch_app_log.out',
-        stderr: '$HOME/Library/Developer/CoreSimulator/Devices/123/data/tmp/detox.last_launch_app_log.err'
-      })
-    });
-  });
+	describe("terminate", () => {
+		it("calls xcrun simctl", async () => {
+			await uut.terminate("theUdid", "thebundleId");
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				expect.stringMatching(/.*xcrun simctl terminate theUdid thebundleId.*/),
+				undefined,
+				expect.anything(),
+				1
+			);
+		});
+	});
 
-  describe('terminate', () => {
-    it('calls xcrun simctl', async () => {
-      await uut.terminate('theUdid', 'thebundleId');
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
-        expect.stringMatching(/.*xcrun simctl terminate theUdid thebundleId.*/),
-        undefined,
-        expect.anything(),
-        1);
-    });
-  });
+	describe("shutdown", () => {
+		it("calls xcrun simctl", async () => {
+			await uut.shutdown("theUdid");
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				expect.stringMatching(/.*xcrun simctl shutdown theUdid.*/),
+				undefined,
+				expect.anything(),
+				1
+			);
+		});
+	});
 
-  describe('shutdown', () => {
-    it('calls xcrun simctl', async () => {
-      await uut.shutdown('theUdid');
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
-        expect.stringMatching(/.*xcrun simctl shutdown theUdid.*/),
-        undefined,
-        expect.anything(),
-        1);
-    });
-  });
+	describe("openUrl", () => {
+		it("calls xcrun simctl", async () => {
+			await uut.openUrl("theUdid", "someUrl");
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				expect.stringMatching(/.*xcrun simctl openurl theUdid someUrl.*/),
+				undefined,
+				expect.anything(),
+				1
+			);
+		});
+	});
 
-  describe('openUrl', () => {
-    it('calls xcrun simctl', async () => {
-      await uut.openUrl('theUdid', 'someUrl');
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
-        expect.stringMatching(/.*xcrun simctl openurl theUdid someUrl.*/),
-        undefined,
-        expect.anything(),
-        1);
-    });
-  });
+	describe("setLocation", () => {
+		it("throws when no fbsimctl installed", async () => {
+			try {
+				await uut.setLocation("theUdid", 123.456, 789.123);
+				fail(`should throw`);
+			} catch (e) {
+				expect(e.message).toMatch(/.*Install fbsimctl using.*/);
+				expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			}
+		});
 
-  describe('setLocation', () => {
-    it('throws when no fbsimctl installed', async () => {
-      try {
-        await uut.setLocation('theUdid', 123.456, 789.123);
-        fail(`should throw`);
-      } catch (e) {
-        expect(e.message).toMatch(/.*Install fbsimctl using.*/);
-        expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      }
-    });
+		it("calls fbsimctl set_location", async () => {
+			exec.execWithRetriesAndLogs.mockReturnValueOnce(
+				Promise.resolve({ stdout: `true` })
+			);
+			await uut.setLocation("theUdid", 123.456, 789.123);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(2);
+			expect(exec.execWithRetriesAndLogs.mock.calls[1][0]).toMatch(
+				/.*fbsimctl theUdid set_location 123.456 789.123.*/
+			);
+		});
+	});
 
-    it('calls fbsimctl set_location', async () => {
-      exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve({ stdout: `true` }));
-      await uut.setLocation('theUdid', 123.456, 789.123);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(2);
-      expect(exec.execWithRetriesAndLogs.mock.calls[1][0])
-        .toMatch(/.*fbsimctl theUdid set_location 123.456 789.123.*/);
-    });
-  });
-
-  describe('resetContentAndSettings', () => {
-    it('shutdown, simctl erase, then boot', async () => {
-      uut.shutdown = jest.fn();
-      uut.boot = jest.fn();
-      expect(uut.shutdown).not.toHaveBeenCalled();
-      expect(uut.boot).not.toHaveBeenCalled();
-      await uut.resetContentAndSettings('theUdid');
-      expect(uut.shutdown).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
-      expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
-        expect.stringMatching(/.*xcrun simctl erase theUdid.*/),
-        undefined,
-        expect.anything(),
-        1);
-      expect(uut.boot).toHaveBeenCalledTimes(1);
-    });
-  });
-
+	describe("resetContentAndSettings", () => {
+		it("shutdown, simctl erase, then boot", async () => {
+			uut.shutdown = jest.fn();
+			uut.boot = jest.fn();
+			expect(uut.shutdown).not.toHaveBeenCalled();
+			expect(uut.boot).not.toHaveBeenCalled();
+			await uut.resetContentAndSettings("theUdid");
+			expect(uut.shutdown).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
+				expect.stringMatching(/.*xcrun simctl erase theUdid.*/),
+				undefined,
+				expect.anything(),
+				1
+			);
+			expect(uut.boot).toHaveBeenCalledTimes(1);
+		});
+	});
 });
-

--- a/detox/src/devices/AppleSimUtils.test.js
+++ b/detox/src/devices/AppleSimUtils.test.js
@@ -33,7 +33,7 @@ describe("AppleSimUtils", () => {
 			expect(exec.execWithRetriesAndLogs).not.toHaveBeenCalled();
 			try {
 				await uut.findDeviceUDID("iPhone 6");
-			} catch (e) {}
+			} catch (e) {} // eslint-disable-line no-empty
 			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
 			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
 				"applesimutils",
@@ -49,7 +49,7 @@ describe("AppleSimUtils", () => {
 		it("adapted to new api with optional OS", async () => {
 			try {
 				await uut.findDeviceUDID("iPhone 6 , iOS 10.3");
-			} catch (e) {}
+			} catch (e) {} // eslint-disable-line no-empty
 			expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
 				"applesimutils",
 				{
@@ -119,6 +119,7 @@ describe("AppleSimUtils", () => {
 				{ stdout: '[{ "udid": "" }]' }
 			];
 			args.forEach(arg => {
+				// eslint-disable-next-line max-nested-callbacks
 				it(`invalid input ${JSON.stringify(arg)}`, async () => {
 					exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve(arg));
 					try {

--- a/detox/src/devices/AttachedAndroidDriver.js
+++ b/detox/src/devices/AttachedAndroidDriver.js
@@ -1,19 +1,18 @@
-const Emulator = require('./android/Emulator');
-const AndroidDriver = require('./AndroidDriver');
+const Emulator = require("./android/Emulator");
+const AndroidDriver = require("./AndroidDriver");
 
 class AttachedAndroidDriver extends AndroidDriver {
+	constructor(client) {
+		super(client);
 
-  constructor(client) {
-    super(client);
+		this.emulator = new Emulator();
+	}
 
-    this.emulator = new Emulator();
-  }
-
-  async acquireFreeDevice(name) {
-    const deviceId = await this.findDeviceId({name: name});
-    await this.adb.unlockScreen(deviceId);
-    return deviceId;
-  }
+	async acquireFreeDevice(name) {
+		const deviceId = await this.findDeviceId({ name: name });
+		await this.adb.unlockScreen(deviceId);
+		return deviceId;
+	}
 }
 
 module.exports = AttachedAndroidDriver;

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -1,211 +1,234 @@
-const fs = require('fs');
-const path = require('path');
-const _ = require('lodash');
-const argparse = require('../utils/argparse');
-const ArtifactsCopier = require('../artifacts/ArtifactsCopier');
+const fs = require("fs");
+const path = require("path");
+const _ = require("lodash");
+const argparse = require("../utils/argparse");
+const ArtifactsCopier = require("../artifacts/ArtifactsCopier");
 
 class Device {
+	constructor(deviceConfig, sessionConfig, deviceDriver) {
+		this._deviceConfig = deviceConfig;
+		this._sessionConfig = sessionConfig;
+		this.deviceDriver = deviceDriver;
+		this._processes = {};
+		this._artifactsCopier = new ArtifactsCopier(deviceDriver);
+		this.deviceDriver.validateDeviceConfig(deviceConfig);
+	}
 
-  constructor(deviceConfig, sessionConfig, deviceDriver) {
-    this._deviceConfig = deviceConfig;
-    this._sessionConfig = sessionConfig;
-    this.deviceDriver = deviceDriver;
-    this._processes = {};
-    this._artifactsCopier = new ArtifactsCopier(deviceDriver);
-    this.deviceDriver.validateDeviceConfig(deviceConfig);
-  }
+	async prepare(params = {}) {
+		this._binaryPath = this._getAbsolutePath(this._deviceConfig.binaryPath);
+		this._deviceId = await this.deviceDriver.acquireFreeDevice(
+			this._deviceConfig.name
+		);
+		this._bundleId = await this.deviceDriver.getBundleIdFromBinary(
+			this._binaryPath
+		);
+		this._artifactsCopier.prepare(this._deviceId);
 
-  async prepare(params = {}) {
-    this._binaryPath = this._getAbsolutePath(this._deviceConfig.binaryPath);
-    this._deviceId = await this.deviceDriver.acquireFreeDevice(this._deviceConfig.name);
-    this._bundleId = await this.deviceDriver.getBundleIdFromBinary(this._binaryPath);
-    this._artifactsCopier.prepare(this._deviceId);
+		await this.deviceDriver.prepare();
 
-    await this.deviceDriver.prepare();
+		if (!argparse.getArgValue("reuse")) {
+			await this.deviceDriver.uninstallApp(this._deviceId, this._bundleId);
+			await this.deviceDriver.installApp(this._deviceId, this._binaryPath);
+		}
 
-    if (!argparse.getArgValue('reuse')) {
-      await this.deviceDriver.uninstallApp(this._deviceId, this._bundleId);
-      await this.deviceDriver.installApp(this._deviceId, this._binaryPath);
-    }
+		if (params.launchApp) {
+			await this.launchApp({ newInstance: true });
+		}
+	}
 
-    if (params.launchApp) {
-      await this.launchApp({newInstance: true});
-    }
-  }
+	setArtifactsDestination(testArtifactsPath) {
+		this._artifactsCopier.setArtifactsDestination(testArtifactsPath);
+	}
 
-  setArtifactsDestination(testArtifactsPath) {
-    this._artifactsCopier.setArtifactsDestination(testArtifactsPath);
-  }
+	async finalizeArtifacts() {
+		await this._artifactsCopier.finalizeArtifacts();
+	}
 
-  async finalizeArtifacts() {
-    await this._artifactsCopier.finalizeArtifacts();
-  }
+	async launchApp(params = { newInstance: false }, bundleId) {
+		await this._artifactsCopier.handleAppRelaunch();
 
-  async launchApp(params = {newInstance: false}, bundleId) {
-    await this._artifactsCopier.handleAppRelaunch();
+		if (params.url && params.userNotification) {
+			throw new Error(
+				`detox can't understand this 'relaunchApp(${JSON.stringify(
+					params
+				)})' request, either request to launch with url or with userNotification, not both`
+			);
+		}
 
-    if (params.url && params.userNotification) {
-      throw new Error(`detox can't understand this 'relaunchApp(${JSON.stringify(params)})' request, either request to launch with url or with userNotification, not both`);
-    }
+		if (params.delete) {
+			await this.deviceDriver.terminate(this._deviceId, this._bundleId);
+			await this.deviceDriver.uninstallApp(this._deviceId, this._bundleId);
+			await this.deviceDriver.installApp(this._deviceId, this._binaryPath);
+		} else if (params.newInstance) {
+			await this.deviceDriver.terminate(this._deviceId, this._bundleId);
+		}
 
-    if (params.delete) {
-      await this.deviceDriver.terminate(this._deviceId, this._bundleId);
-      await this.deviceDriver.uninstallApp(this._deviceId, this._bundleId);
-      await this.deviceDriver.installApp(this._deviceId, this._binaryPath);
-    } else if (params.newInstance) {
-      await this.deviceDriver.terminate(this._deviceId, this._bundleId);
-    }
+		let baseLaunchArgs = {};
+		if (params.launchArgs) {
+			baseLaunchArgs = params.launchArgs;
+		}
 
-    let baseLaunchArgs = {};
-    if (params.launchArgs) {
-      baseLaunchArgs = params.launchArgs;
-    }
+		if (params.url) {
+			baseLaunchArgs.detoxURLOverride = params.url;
+			if (params.sourceApp) {
+				baseLaunchArgs.detoxSourceAppOverride = params.sourceApp;
+			}
+		} else if (params.userNotification) {
+			baseLaunchArgs = {
+				detoxUserNotificationDataURL: this.deviceDriver.createPushNotificationJson(
+					params.userNotification
+				)
+			};
+		}
 
-    if (params.url) {
-      baseLaunchArgs['detoxURLOverride'] = params.url;
-      if(params.sourceApp) {
-        baseLaunchArgs['detoxSourceAppOverride'] = params.sourceApp;
-      }
-    } else if (params.userNotification) {
-      baseLaunchArgs = {'detoxUserNotificationDataURL': this.deviceDriver.createPushNotificationJson(params.userNotification)};
-    }
+		if (params.permissions) {
+			await this.deviceDriver.setPermissions(
+				this._deviceId,
+				this._bundleId,
+				params.permissions
+			);
+		}
 
-    if (params.permissions) {
-      await this.deviceDriver.setPermissions(this._deviceId, this._bundleId, params.permissions);
-    }
+		this._addPrefixToDefaultLaunchArgs(baseLaunchArgs);
 
-    this._addPrefixToDefaultLaunchArgs(baseLaunchArgs);
+		const _bundleId = bundleId || this._bundleId;
+		const processId = await this.deviceDriver.launch(
+			this._deviceId,
+			_bundleId,
+			this._prepareLaunchArgs(baseLaunchArgs)
+		);
 
-    const _bundleId = bundleId || this._bundleId;
-    const processId = await this.deviceDriver.launch(this._deviceId, _bundleId, this._prepareLaunchArgs(baseLaunchArgs));
+		if (this._processes[_bundleId] === processId) {
+			if (params.url) {
+				await this.openURL(params);
+			} else if (params.userNotification) {
+				await this.sendUserNotification(params.userNotification);
+			}
+		}
 
-    if (this._processes[_bundleId] === processId) {
-      if (params.url) {
-        await this.openURL(params);
-      } else if (params.userNotification) {
-        await this.sendUserNotification(params.userNotification);
-      }
-    }
+		this._processes[_bundleId] = processId;
 
-    this._processes[_bundleId] = processId;
+		await this.deviceDriver.waitUntilReady();
+	}
 
-    await this.deviceDriver.waitUntilReady();
-  }
+	/**deprecated */
+	async relaunchApp(params = {}, bundleId) {
+		if (params.newInstance === undefined) {
+			params.newInstance = true;
+		}
+		await this.launchApp(params, bundleId);
+	}
 
-  /**deprecated */
-  async relaunchApp(params = {}, bundleId) {
-    if (params.newInstance === undefined) {
-      params['newInstance'] = true;
-    }
-    await this.launchApp(params, bundleId);
-  }
+	async sendToHome() {
+		await this.deviceDriver.sendToHome(this._deviceId);
+	}
 
-  async sendToHome() {
-    await this.deviceDriver.sendToHome(this._deviceId);
-  }
+	async terminateApp(bundleId) {
+		const _bundleId = bundleId || this._bundleId;
+		await this.deviceDriver.terminate(this._deviceId, _bundleId);
+	}
 
-  async terminateApp(bundleId) {
-    const _bundleId = bundleId || this._bundleId;
-    await this.deviceDriver.terminate(this._deviceId, _bundleId);
-  }
+	async installApp(binaryPath) {
+		const _binaryPath = binaryPath || this._binaryPath;
+		await this.deviceDriver.installApp(this._deviceId, _binaryPath);
+	}
 
-  async installApp(binaryPath) {
-    const _binaryPath = binaryPath || this._binaryPath;
-    await this.deviceDriver.installApp(this._deviceId, _binaryPath);
-  }
+	async uninstallApp(bundleId) {
+		const _bundleId = bundleId || this._bundleId;
+		await this.deviceDriver.uninstallApp(this._deviceId, _bundleId);
+	}
 
-  async uninstallApp(bundleId) {
-    const _bundleId = bundleId || this._bundleId;
-    await this.deviceDriver.uninstallApp(this._deviceId, _bundleId);
-  }
+	async reloadReactNative() {
+		await this.deviceDriver.reloadReactNative();
+	}
 
-  async reloadReactNative() {
-    await this.deviceDriver.reloadReactNative();
-  }
+	async openURL(params) {
+		if (typeof params !== "object" || !params.url) {
+			throw new Error(
+				`openURL must be called with JSON params, and a value for 'url' key must be provided. example: await device.openURL({url: "url", sourceApp[optional]: "sourceAppBundleID"}`
+			);
+		}
 
-  async openURL(params) {
-    if (typeof params !== 'object' || !params.url) {
-      throw new Error(`openURL must be called with JSON params, and a value for 'url' key must be provided. example: await device.openURL({url: "url", sourceApp[optional]: "sourceAppBundleID"}`);
-    }
+		await this.deviceDriver.openURL(this._deviceId, params);
+	}
 
-    await this.deviceDriver.openURL(this._deviceId, params);
-  }
+	async shutdown() {
+		await this.deviceDriver.shutdown(this._deviceId);
+	}
 
-  async shutdown() {
-    await this.deviceDriver.shutdown(this._deviceId);
-  }
+	async setOrientation(orientation) {
+		await this.deviceDriver.setOrientation(this._deviceId, orientation);
+	}
 
-  async setOrientation(orientation) {
-    await this.deviceDriver.setOrientation(this._deviceId, orientation);
-  }
+	async setLocation(lat, lon) {
+		lat = String(lat).replace(".", ",");
+		lon = String(lon).replace(".", ",");
+		await this.deviceDriver.setLocation(this._deviceId, lat, lon);
+	}
 
-  async setLocation(lat, lon) {
-    lat = String(lat).replace('.', ',');
-    lon = String(lon).replace('.', ',');
-    await this.deviceDriver.setLocation(this._deviceId, lat, lon);
-  }
+	async sendUserNotification(params) {
+		await this.deviceDriver.sendUserNotification(params);
+	}
 
-  async sendUserNotification(params) {
-    await this.deviceDriver.sendUserNotification(params);
-  }
+	async setURLBlacklist(urlList) {
+		await this.deviceDriver.setURLBlacklist(urlList);
+	}
 
-  async setURLBlacklist(urlList) {
-    await this.deviceDriver.setURLBlacklist(urlList);
-  }
+	async enableSynchronization() {
+		await this.deviceDriver.enableSynchronization();
+	}
 
-  async enableSynchronization() {
-    await this.deviceDriver.enableSynchronization();
-  }
+	async disableSynchronization() {
+		await this.deviceDriver.disableSynchronization();
+	}
 
-  async disableSynchronization() {
-    await this.deviceDriver.disableSynchronization();
-  }
+	async resetContentAndSettings() {
+		await this.deviceDriver.resetContentAndSettings(this._deviceId);
+	}
 
-  async resetContentAndSettings() {
-    await this.deviceDriver.resetContentAndSettings(this._deviceId);
-  }
+	getPlatform() {
+		return this.deviceDriver.getPlatform(this._deviceId);
+	}
 
-  getPlatform() {
-    return this.deviceDriver.getPlatform(this._deviceId);
-  }
+	async _cleanup() {
+		await this.deviceDriver.cleanup(this._deviceId, this._bundleId);
+	}
 
-  async _cleanup() {
-    await this.deviceDriver.cleanup(this._deviceId, this._bundleId);
-  }
+	_defaultLaunchArgs() {
+		return {
+			detoxServer: this._sessionConfig.server,
+			detoxSessionId: this._sessionConfig.sessionId
+		};
+	}
 
-  _defaultLaunchArgs() {
-    return {
-      'detoxServer': this._sessionConfig.server,
-      'detoxSessionId': this._sessionConfig.sessionId
-    };
-  }
+	_addPrefixToDefaultLaunchArgs(args) {
+		const newArgs = {};
+		_.forEach(args, (value, key) => {
+			newArgs[`${this.deviceDriver.defaultLaunchArgsPrefix()}${key}`] = value;
+		});
+		return newArgs;
+	}
 
-  _addPrefixToDefaultLaunchArgs(args) {
-    let newArgs = {};
-    _.forEach(args, (value, key) => {
-      newArgs[`${this.deviceDriver.defaultLaunchArgsPrefix()}${key}`] = value;
-    });
-    return newArgs;
-  }
+	_prepareLaunchArgs(additionalLaunchArgs) {
+		const merged = _.merge(this._defaultLaunchArgs(), additionalLaunchArgs);
+		const launchArgs = this._addPrefixToDefaultLaunchArgs(merged);
+		return launchArgs;
+	}
 
-  _prepareLaunchArgs(additionalLaunchArgs) {
-    const merged = _.merge(this._defaultLaunchArgs(), additionalLaunchArgs);
-    const launchArgs = this._addPrefixToDefaultLaunchArgs(merged);
-    return launchArgs;
-  }
+	_getAbsolutePath(appPath) {
+		if (path.isAbsolute(appPath)) {
+			return appPath;
+		}
 
-  _getAbsolutePath(appPath) {
-    if(path.isAbsolute(appPath)) {
-      return appPath;
-    }
-    
-    const absPath = path.join(process.cwd(), appPath);
-    if (fs.existsSync(absPath)) {
-      return absPath;
-    } else {
-      throw new Error(`app binary not found at '${absPath}', did you build it?`);
-    }
-  }
+		const absPath = path.join(process.cwd(), appPath);
+		if (fs.existsSync(absPath)) {
+			return absPath;
+		} else {
+			throw new Error(
+				`app binary not found at '${absPath}', did you build it?`
+			);
+		}
+	}
 }
 
 module.exports = Device;

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -161,9 +161,9 @@ class Device {
 	}
 
 	async setLocation(lat, lon) {
-		lat = String(lat).replace(".", ",");
-		lon = String(lon).replace(".", ",");
-		await this.deviceDriver.setLocation(this._deviceId, lat, lon);
+		const latitude = String(lat).replace(".", ",");
+		const longitude = String(lon).replace(".", ",");
+		await this.deviceDriver.setLocation(this._deviceId, latitude, longitude);
 	}
 
 	async sendUserNotification(params) {

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -481,6 +481,7 @@ describe("Device", () => {
 
 	it(`new Device() with invalid device config (no binary) should throw`, async () => {
 		try {
+			// eslint-disable-next-line no-new
 			new Device(
 				invalidDeviceNoBinary.configurations["ios.sim.release"],
 				validScheme.session,
@@ -494,6 +495,7 @@ describe("Device", () => {
 
 	it(`new Device() with invalid device config (no device name) should throw`, async () => {
 		try {
+			// eslint-disable-next-line no-new
 			new Device(
 				invalidDeviceNoDeviceName.configurations["ios.sim.release"],
 				validScheme.session,
@@ -519,7 +521,7 @@ describe("Device", () => {
 		device.setArtifactsDestination("/tmp");
 		await device.relaunchApp();
 		sh.cp = jest.fn(() => {
-			throw "exception sent by mocked cp";
+			throw "exception sent by mocked cp"; // eslint-disable-line no-throw-literal
 		});
 		await device.finalizeArtifacts();
 	});

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -1,5 +1,5 @@
-const _ = require('lodash');
-const configurationsMock = require('../configurations.mock');
+const _ = require("lodash");
+const configurationsMock = require("../configurations.mock");
 
 const validScheme = configurationsMock.validOneDeviceAndSession;
 const validIosNoneScheme = configurationsMock.validOneIosNoneDeviceNoSession;
@@ -7,534 +7,635 @@ const validIosNoneScheme = configurationsMock.validOneIosNoneDeviceNoSession;
 const invalidDeviceNoBinary = configurationsMock.invalidDeviceNoBinary;
 const invalidDeviceNoDeviceName = configurationsMock.invalidDeviceNoDeviceName;
 
-describe('Device', () => {
-  let fs;
-  let ws;
-  let cpp;
-  let DeviceDriverBase;
-  let SimulatorDriver;
-  let IosDriver;
-  let Device;
-  let device;
-  let argparse;
-  let sh;
-
-  let Client;
-  let client;
-
-  beforeEach(async () => {
-    Device = require('./Device');
-    jest.mock('npmlog');
-
-    jest.mock('../utils/sh');
-    sh = require('../utils/sh');
-    sh.cp = jest.fn();
-
-    jest.mock('fs');
-    fs = require('fs');
-    jest.mock('../ios/expect');
-    jest.mock('child-process-promise');
-    cpp = require('child-process-promise');
-
-    jest.mock('../utils/environment');
-
-    jest.mock('./AppleSimUtils');
-
-    jest.mock('../client/Client');
-    jest.mock('../utils/argparse');
-    argparse = require('../utils/argparse');
-
-    jest.mock('./DeviceDriverBase');
-    DeviceDriverBase = require('./DeviceDriverBase');
-    SimulatorDriver = require('./SimulatorDriver');
-    IosDriver = require('./IosDriver');
-    Client = require('../client/Client');
-
-    client = new Client(validScheme.session);
-    await client.connect();
-
-  });
-
-  function validDevice() {
-    const device = new Device(validScheme.configurations['ios.sim.release'], validScheme.session, new DeviceDriverBase(client));
-    fs.existsSync.mockReturnValue(true);
-    device.deviceDriver.defaultLaunchArgsPrefix.mockReturnValue('-');
-    device.deviceDriver.acquireFreeDevice.mockReturnValue('mockDeviceId');
-
-    return device;
-  }
-
-  function validSimulator() {
-    const device = new Device(validScheme.configurations['ios.sim.release'], validScheme.session, new SimulatorDriver(client));
-    fs.existsSync.mockReturnValue(true);
-    device.deviceDriver.acquireFreeDevice.mockReturnValue('mockDeviceId');
-
-    return device;
-  }
-
-  function validIosNone() {
-    const device = new Device(validIosNoneScheme.configurations['ios.none'], validScheme.session, new IosDriver(client));
-    fs.existsSync.mockReturnValue(true);
-    device.deviceDriver.acquireFreeDevice.mockReturnValue('mockDeviceId');
-
-    return device;
-  }
-
-  it(`valid scheme, no binary, should throw`, async () => {
-    device = validDevice();
-    fs.existsSync.mockReturnValue(false);
-    try {
-      await device.prepare();
-      fail('should throw')
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
-
-  it(`valid scheme, no binary, should not throw`, async () => {
-    device = validDevice();
-    await device.prepare();
-  });
-
-  it(`prepare() with when reuse is enabled should not uninstall and install`, async () => {
-    device = validDevice();
-    cpp.exec.mockReturnValue(() => Promise.resolve());
-    fs.existsSync.mockReturnValue(true);
-    argparse.getArgValue.mockReturnValue(true);
-
-    await device.prepare();
-
-    expect(device.deviceDriver.uninstallApp).not.toHaveBeenCalled();
-    expect(device.deviceDriver.installApp).not.toHaveBeenCalled();
-  });
-
-  it(`launchApp() should launch app with default launch args`, async () => {
-    device = validDevice();
-
-    await device.launchApp();
-
-    expect(device.deviceDriver.launch).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test"});
-  });
-
-  it(`relaunchApp()`, async () => {
-    device = validDevice();
-
-    await device.relaunchApp();
-
-    expect(device.deviceDriver.terminate).toHaveBeenCalled();
-    expect(device.deviceDriver.launch).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test"});
-  });
-
-  it(`relaunchApp({newInstance: false}) should not terminate the app before launch`, async () => {
-    device = validDevice();
-
-    await device.relaunchApp({newInstance: false});
-
-    expect(device.deviceDriver.terminate).not.toHaveBeenCalled();
-  });
-
-  it(`relaunchApp({newInstance: true}) should terminate the app before launch`, async () => {
-    device = validDevice();
-
-    await device.relaunchApp({newInstance: true});
-
-    expect(device.deviceDriver.terminate).toHaveBeenCalled();
-  });
-
-  it(`relaunchApp() (no params) should terminate the app before launch - backwards compat`, async () => {
-    device = validDevice();
-
-    await device.relaunchApp();
-
-    expect(device.deviceDriver.terminate).toHaveBeenCalled();
-  });
-
-  it(`relaunchApp() with delete=true`, async () => {
-    device = validDevice();
-    fs.existsSync.mockReturnValue(true);
-
-    await device.relaunchApp({delete: true});
-
-    expect(device.deviceDriver.uninstallApp).toHaveBeenCalled();
-    expect(device.deviceDriver.installApp).toHaveBeenCalled();
-    expect(device.deviceDriver.launch).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test"});
-  });
-
-  it(`relaunchApp() without delete when reuse is enabled should not uninstall and install`, async () => {
-    device = validDevice();
-    argparse.getArgValue.mockReturnValue(true);
-    fs.existsSync.mockReturnValue(true);
-
-    await device.relaunchApp();
-
-    expect(device.deviceDriver.uninstallApp).not.toHaveBeenCalled();
-    expect(device.deviceDriver.installApp).not.toHaveBeenCalled();
-    expect(device.deviceDriver.launch).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test"});
-  });
-
-  it(`relaunchApp() without delete when reuse is enabled should not uninstall and install`, async () => {
-    device = validSimulator();
-    argparse.getArgValue.mockReturnValue(true);
-    fs.existsSync.mockReturnValue(true);
-
-    await device.relaunchApp();
-
-    expect(device.deviceDriver.uninstallApp).not.toHaveBeenCalled();
-    expect(device.deviceDriver.installApp).not.toHaveBeenCalled();
-    expect(device.deviceDriver.launch).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test"});
-  });
-
-  it(`relaunchApp() with url should send the url as a param in launchParams`, async () => {
-    device = await  validDevice();
-    await device.relaunchApp({url: `scheme://some.url`});
-
-    expect(device.deviceDriver.launch).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test", "-detoxURLOverride": "scheme://some.url"});
-  });
-
-  it(`relaunchApp() with url should send the url as a param in launchParams`, async () => {
-    device = await  validDevice();
-    await device.relaunchApp({url: `scheme://some.url`, sourceApp: 'sourceAppBundleId'});
-
-    expect(device.deviceDriver.launch).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test", "-detoxURLOverride": "scheme://some.url", "-detoxSourceAppOverride":
-        "sourceAppBundleId"});
-  });
-
-  it(`relaunchApp() with userNofitication should send the userNotification as a param in launchParams`, async () => {
-    device = validDevice();
-    fs.existsSync.mockReturnValue(true);
-    device.deviceDriver.createPushNotificationJson = jest.fn(() => 'url');
-
-    await device.relaunchApp({userNotification: 'json'});
-
-    expect(device.deviceDriver.launch).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test", "-detoxUserNotificationDataURL": "url"});
-  });
-
-  it(`relaunchApp() with url and userNofitication should throw`, async () => {
-    device = validDevice();
-    try {
-      await device.relaunchApp({url: "scheme://some.url", userNotification: 'notif'});
-      fail('should fail');
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
-
-  it(`relaunchApp() with permissions should send trigger setpermissions before app starts`, async () => {
-    device = await validDevice();
-    await device.relaunchApp({permissions: {calendar: "YES"}});
-
-    expect(device.deviceDriver.setPermissions).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId, {calendar: "YES"});
-  });
-
-  it(`launchApp({launchArgs: }) should pass to native as launch args`, async () => {
-    device = validDevice();
-
-    await device.launchApp({launchArgs: {arg1: "1", arg2: 2}});
-
-    expect(device.deviceDriver.launch).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test", "-arg1": "1", "-arg2": 2});
-  });
-
-  it(`sendToHome() should pass to device driver`, async () => {
-    device = validDevice();
-    await device.sendToHome();
-
-    expect(device.deviceDriver.sendToHome).toHaveBeenCalledTimes(1);
-  });
-
-  it(`terminateApp() should pass to device driver`, async () => {
-    device = validDevice();
-    await device.terminateApp();
-
-    expect(device.deviceDriver.terminate).toHaveBeenCalledTimes(1);
-  });
-
-  it(`installApp() with a custom app path should use custom app path`, async () => {
-    device = validDevice();
-    fs.existsSync.mockReturnValue(true);
-
-    await device.installApp('newAppPath');
-
-    expect(device.deviceDriver.installApp).toHaveBeenCalledWith(device._deviceId, 'newAppPath');
-  });
-
-  it(`installApp() with no params should use the default path given in configuration`, async () => {
-    device = validDevice();
-
-    await device.installApp();
-
-    expect(device.deviceDriver.installApp).toHaveBeenCalledWith(device._deviceId, device._binaryPath);
-  });
-
-  it(`uninstallApp() with a custom app path should use custom app path`, async () => {
-    device = validDevice();
-    fs.existsSync.mockReturnValue(true);
-
-    await device.uninstallApp('newBundleId');
-
-    expect(device.deviceDriver.uninstallApp).toHaveBeenCalledWith(device._deviceId, 'newBundleId');
-  });
-
-  it(`uninstallApp() with no params should use the default path given in configuration`, async () => {
-    device = validDevice();
-
-    await device.uninstallApp();
-
-    expect(device.deviceDriver.uninstallApp).toHaveBeenCalledWith(device._deviceId, device._binaryPath);
-  });
-
-  it(`shutdown() should pass to device driver`, async () => {
-    device = validDevice();
-    await device.shutdown();
-
-    expect(device.deviceDriver.shutdown).toHaveBeenCalledTimes(1);
-  });
-
-  it(`openURL({url:url}) should pass to device driver`, async () => {
-    device = validDevice();
-    await device.openURL({url: 'url'});
-
-    expect(device.deviceDriver.openURL).toHaveBeenCalledWith(device._deviceId, {url: 'url'});
-  });
-
-  it(`openURL(notAnObject) should pass to device driver`, async () => {
-    device = validDevice();
-    try {
-      await device.openURL('url');
-      fail('should throw');
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
-
-  it(`reloadReactNative() should pass to device driver`, async () => {
-    device = validDevice();
-    await device.reloadReactNative();
-
-    expect(device.deviceDriver.reloadReactNative).toHaveBeenCalledTimes(1);
-  });
-
-  it(`setOrientation() should pass to device driver`, async () => {
-    device = validDevice();
-    await device.setOrientation('param');
-
-    expect(device.deviceDriver.setOrientation).toHaveBeenCalledWith(device._deviceId, 'param');
-  });
-
-  it(`sendUserNotification() should pass to device driver`, async () => {
-    device = validDevice();
-    await device.sendUserNotification('notif');
-
-    expect(device.deviceDriver.sendUserNotification).toHaveBeenCalledWith('notif');
-  });
-
-  it(`setLocation() should pass to device driver`, async () => {
-    device = validDevice();
-    await device.setLocation(30, 30);
-
-    expect(device.deviceDriver.setLocation).toHaveBeenCalledWith(device._deviceId, '30', '30');
-  });
-
-  it(`setURLBlacklist() should pass to device driver`, async () => {
-    device = validDevice();
-    await device.setURLBlacklist();
-
-    expect(device.deviceDriver.setURLBlacklist).toHaveBeenCalledTimes(1);
-  });
-
-  it(`enableSynchronization() should pass to device driver`, async () => {
-    device = validDevice();
-    await device.enableSynchronization();
-
-    expect(device.deviceDriver.enableSynchronization).toHaveBeenCalledTimes(1);
-  });
-
-  it(`disableSynchronization() should pass to device driver`, async () => {
-    device = validDevice();
-    await device.disableSynchronization();
-
-    expect(device.deviceDriver.disableSynchronization).toHaveBeenCalledTimes(1);
-  });
-
-  it(`resetContentAndSettings() should pass to device driver`, async () => {
-    device = validDevice();
-    await device.resetContentAndSettings();
-
-    expect(device.deviceDriver.resetContentAndSettings).toHaveBeenCalledTimes(1);
-  });
-
-  it(`getPlatform() should pass to device driver`, async () => {
-    device = validDevice();
-    device.getPlatform();
-
-    expect(device.deviceDriver.getPlatform).toHaveBeenCalledTimes(1);
-  });
-
-  it(`getPlatform() should pass to device driver`, async () => {
-    device = validSimulator();
-    device.getPlatform();
-
-    expect(device.deviceDriver.getPlatform).toHaveBeenCalledTimes(1);
-  });
-
-  it(`_cleanup() should pass to device driver`, async () => {
-    device = validDevice();
-    await device._cleanup();
-
-    expect(device.deviceDriver.cleanup).toHaveBeenCalledTimes(1);
-  });
-
-  it(`new Device() with invalid device config (no binary) should throw`, async () => {
-    try {
-      new Device(invalidDeviceNoBinary.configurations['ios.sim.release'], validScheme.session, new SimulatorDriver(client));
-      fail('should throw');
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
-
-  it(`new Device() with invalid device config (no device name) should throw`, async () => {
-    try {
-      new Device(invalidDeviceNoDeviceName.configurations['ios.sim.release'], validScheme.session, new SimulatorDriver(client));
-      fail('should throw');
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
-
-  it(`finalizeArtifacts() should call cp`, async () => {
-    device = validDevice();
-    device.deviceDriver.getLogsPaths = () => ({stdout: '/t1', stderr: '/t2'});
-    device.setArtifactsDestination('/tmp');
-    await device.finalizeArtifacts();
-    expect(sh.cp).toHaveBeenCalledTimes(2);
-  });
-
-  it(`finalizeArtifacts() should catch cp exception`, async () => {
-    device = validDevice();
-    device.deviceDriver.getLogsPaths = () => ({stdout: '/t1', stderr: '/t2'});
-    device.setArtifactsDestination('/tmp');
-    await device.relaunchApp();
-    sh.cp = jest.fn(() => {throw 'exception sent by mocked cp'});
-    await device.finalizeArtifacts();
-  });
-
-  it(`finalizeArtifacts() should not cp if setArtifactsDestination wasn't called`, async () => {
-    device = validDevice();
-    device.deviceDriver.getLogsPaths = () => ({stdout: '/t1', stderr: '/t2'});
-    await device.relaunchApp();
-    await device.finalizeArtifacts();
-    expect(sh.cp).toHaveBeenCalledTimes(0);
-  });
-
-  it(`launchApp({url:url}) should check if process is in background and use openURL() instead of launch args`, async () => {
-    const processId = 1;
-    device = validDevice();
-    device.deviceDriver.getBundleIdFromBinary.mockReturnValue('test.bundle');
-    device.deviceDriver.launch.mockReturnValueOnce(processId).mockReturnValueOnce(processId);
-
-    await device.prepare({launchApp: true});
-    await device.launchApp({url: 'url://me'});
-
-    expect(device.deviceDriver.openURL).toHaveBeenCalledTimes(1);
-  });
-
-  it(`launchApp({url:url}) should check if process is in background and if not use launch args`, async () => {
-    const launchParams = {url: 'url://me'};
-    const processId = 1;
-    const newProcessId = 2;
-
-    device = validDevice();
-    device.deviceDriver.getBundleIdFromBinary.mockReturnValue('test.bundle');
-    device.deviceDriver.launch.mockReturnValueOnce(processId).mockReturnValueOnce(newProcessId);
-
-    await device.prepare();
-    await device.launchApp(launchParams);
-
-    expect(device.deviceDriver.openURL).toHaveBeenCalledTimes(0);
-  });
-
-  it(`launchApp({url:url}) should check if process is in background and use openURL() instead of launch args`, async () => {
-    const launchParams = {url: 'url://me'};
-    const processId = 1;
-
-    device = validDevice();
-    device.deviceDriver.getBundleIdFromBinary.mockReturnValue('test.bundle');
-    device.deviceDriver.launch.mockReturnValue(processId);
-
-    await device.prepare({launchApp: true});
-    await device.launchApp(launchParams);
-
-    expect(device.deviceDriver.openURL).toHaveBeenCalledTimes(1);
-  });
-
-  it(`launchApp({userNotification:userNotification}) should check if process is in background and if it is use sendUserNotification`, async () => {
-    const launchParams = {userNotification: 'notification'};
-    const processId = 1;
-
-    device = validDevice();
-    device.deviceDriver.getBundleIdFromBinary.mockReturnValue('test.bundle');
-    device.deviceDriver.launch.mockReturnValueOnce(processId).mockReturnValueOnce(processId);
-
-    await device.prepare({launchApp: true});
-    await device.launchApp(launchParams);
-
-    expect(device.deviceDriver.sendUserNotification).toHaveBeenCalledWith(launchParams.userNotification);
-  });
-
-  it(`launchApp({userNotification:userNotification}) should check if process is in background and if not use launch args`, async () => {
-    const launchParams = {userNotification: 'notification'};
-    const processId = 1;
-    const newProcessId = 2;
-
-    device = validDevice();
-    device.deviceDriver.getBundleIdFromBinary.mockReturnValue('test.bundle');
-    device.deviceDriver.launch.mockReturnValueOnce(processId).mockReturnValueOnce(newProcessId);
-
-    await device.prepare();
-    await device.launchApp(launchParams);
-
-    expect(device.deviceDriver.sendUserNotification).toHaveBeenCalledTimes(0);
-  });
-
-  async function launchAndTestBinaryPath(configuration) {
-    const scheme = configurationsMock.pathsTests;
-    const device = new Device(scheme.configurations[configuration], scheme.session, new DeviceDriverBase(client));
-    fs.existsSync.mockReturnValue(true);
-    device.deviceDriver.defaultLaunchArgsPrefix.mockReturnValue('-');
-    device.deviceDriver.acquireFreeDevice.mockReturnValue('mockDeviceId');
-
-    await device.prepare();
-    await device.launchApp();
-
-    return device.deviceDriver.installApp.mock.calls[0][1];
-  }
-
-  it(`should accept absolute path for binary`, async () => {
-    const actualPath = await launchAndTestBinaryPath('absolutePath');
-    expect(actualPath).toEqual('/tmp/abcdef/123');
-  });
-
-  it(`should accept relative path for binary`, async () => {
-    const actualPath = await launchAndTestBinaryPath('relativePath');
-    expect(actualPath).toEqual(`${process.cwd()}/abcdef/123`);
-  });
+describe("Device", () => {
+	let fs;
+	let ws;
+	let cpp;
+	let DeviceDriverBase;
+	let SimulatorDriver;
+	let IosDriver;
+	let Device;
+	let device;
+	let argparse;
+	let sh;
+
+	let Client;
+	let client;
+
+	beforeEach(async () => {
+		Device = require("./Device");
+		jest.mock("npmlog");
+
+		jest.mock("../utils/sh");
+		sh = require("../utils/sh");
+		sh.cp = jest.fn();
+
+		jest.mock("fs");
+		fs = require("fs");
+		jest.mock("../ios/expect");
+		jest.mock("child-process-promise");
+		cpp = require("child-process-promise");
+
+		jest.mock("../utils/environment");
+
+		jest.mock("./AppleSimUtils");
+
+		jest.mock("../client/Client");
+		jest.mock("../utils/argparse");
+		argparse = require("../utils/argparse");
+
+		jest.mock("./DeviceDriverBase");
+		DeviceDriverBase = require("./DeviceDriverBase");
+		SimulatorDriver = require("./SimulatorDriver");
+		IosDriver = require("./IosDriver");
+		Client = require("../client/Client");
+
+		client = new Client(validScheme.session);
+		await client.connect();
+	});
+
+	function validDevice() {
+		const device = new Device(
+			validScheme.configurations["ios.sim.release"],
+			validScheme.session,
+			new DeviceDriverBase(client)
+		);
+		fs.existsSync.mockReturnValue(true);
+		device.deviceDriver.defaultLaunchArgsPrefix.mockReturnValue("-");
+		device.deviceDriver.acquireFreeDevice.mockReturnValue("mockDeviceId");
+
+		return device;
+	}
+
+	function validSimulator() {
+		const device = new Device(
+			validScheme.configurations["ios.sim.release"],
+			validScheme.session,
+			new SimulatorDriver(client)
+		);
+		fs.existsSync.mockReturnValue(true);
+		device.deviceDriver.acquireFreeDevice.mockReturnValue("mockDeviceId");
+
+		return device;
+	}
+
+	function validIosNone() {
+		const device = new Device(
+			validIosNoneScheme.configurations["ios.none"],
+			validScheme.session,
+			new IosDriver(client)
+		);
+		fs.existsSync.mockReturnValue(true);
+		device.deviceDriver.acquireFreeDevice.mockReturnValue("mockDeviceId");
+
+		return device;
+	}
+
+	it(`valid scheme, no binary, should throw`, async () => {
+		device = validDevice();
+		fs.existsSync.mockReturnValue(false);
+		try {
+			await device.prepare();
+			fail("should throw");
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
+
+	it(`valid scheme, no binary, should not throw`, async () => {
+		device = validDevice();
+		await device.prepare();
+	});
+
+	it(`prepare() with when reuse is enabled should not uninstall and install`, async () => {
+		device = validDevice();
+		cpp.exec.mockReturnValue(() => Promise.resolve());
+		fs.existsSync.mockReturnValue(true);
+		argparse.getArgValue.mockReturnValue(true);
+
+		await device.prepare();
+
+		expect(device.deviceDriver.uninstallApp).not.toHaveBeenCalled();
+		expect(device.deviceDriver.installApp).not.toHaveBeenCalled();
+	});
+
+	it(`launchApp() should launch app with default launch args`, async () => {
+		device = validDevice();
+
+		await device.launchApp();
+
+		expect(
+			device.deviceDriver.launch
+		).toHaveBeenCalledWith(device._deviceId, device._bundleId, {
+			"-detoxServer": "ws://localhost:8099",
+			"-detoxSessionId": "test"
+		});
+	});
+
+	it(`relaunchApp()`, async () => {
+		device = validDevice();
+
+		await device.relaunchApp();
+
+		expect(device.deviceDriver.terminate).toHaveBeenCalled();
+		expect(
+			device.deviceDriver.launch
+		).toHaveBeenCalledWith(device._deviceId, device._bundleId, {
+			"-detoxServer": "ws://localhost:8099",
+			"-detoxSessionId": "test"
+		});
+	});
+
+	it(`relaunchApp({newInstance: false}) should not terminate the app before launch`, async () => {
+		device = validDevice();
+
+		await device.relaunchApp({ newInstance: false });
+
+		expect(device.deviceDriver.terminate).not.toHaveBeenCalled();
+	});
+
+	it(`relaunchApp({newInstance: true}) should terminate the app before launch`, async () => {
+		device = validDevice();
+
+		await device.relaunchApp({ newInstance: true });
+
+		expect(device.deviceDriver.terminate).toHaveBeenCalled();
+	});
+
+	it(`relaunchApp() (no params) should terminate the app before launch - backwards compat`, async () => {
+		device = validDevice();
+
+		await device.relaunchApp();
+
+		expect(device.deviceDriver.terminate).toHaveBeenCalled();
+	});
+
+	it(`relaunchApp() with delete=true`, async () => {
+		device = validDevice();
+		fs.existsSync.mockReturnValue(true);
+
+		await device.relaunchApp({ delete: true });
+
+		expect(device.deviceDriver.uninstallApp).toHaveBeenCalled();
+		expect(device.deviceDriver.installApp).toHaveBeenCalled();
+		expect(
+			device.deviceDriver.launch
+		).toHaveBeenCalledWith(device._deviceId, device._bundleId, {
+			"-detoxServer": "ws://localhost:8099",
+			"-detoxSessionId": "test"
+		});
+	});
+
+	it(`relaunchApp() without delete when reuse is enabled should not uninstall and install`, async () => {
+		device = validDevice();
+		argparse.getArgValue.mockReturnValue(true);
+		fs.existsSync.mockReturnValue(true);
+
+		await device.relaunchApp();
+
+		expect(device.deviceDriver.uninstallApp).not.toHaveBeenCalled();
+		expect(device.deviceDriver.installApp).not.toHaveBeenCalled();
+		expect(
+			device.deviceDriver.launch
+		).toHaveBeenCalledWith(device._deviceId, device._bundleId, {
+			"-detoxServer": "ws://localhost:8099",
+			"-detoxSessionId": "test"
+		});
+	});
+
+	it(`relaunchApp() without delete when reuse is enabled should not uninstall and install`, async () => {
+		device = validSimulator();
+		argparse.getArgValue.mockReturnValue(true);
+		fs.existsSync.mockReturnValue(true);
+
+		await device.relaunchApp();
+
+		expect(device.deviceDriver.uninstallApp).not.toHaveBeenCalled();
+		expect(device.deviceDriver.installApp).not.toHaveBeenCalled();
+		expect(
+			device.deviceDriver.launch
+		).toHaveBeenCalledWith(device._deviceId, device._bundleId, {
+			"-detoxServer": "ws://localhost:8099",
+			"-detoxSessionId": "test"
+		});
+	});
+
+	it(`relaunchApp() with url should send the url as a param in launchParams`, async () => {
+		device = await validDevice();
+		await device.relaunchApp({ url: `scheme://some.url` });
+
+		expect(
+			device.deviceDriver.launch
+		).toHaveBeenCalledWith(device._deviceId, device._bundleId, {
+			"-detoxServer": "ws://localhost:8099",
+			"-detoxSessionId": "test",
+			"-detoxURLOverride": "scheme://some.url"
+		});
+	});
+
+	it(`relaunchApp() with url should send the url as a param in launchParams`, async () => {
+		device = await validDevice();
+		await device.relaunchApp({
+			url: `scheme://some.url`,
+			sourceApp: "sourceAppBundleId"
+		});
+
+		expect(
+			device.deviceDriver.launch
+		).toHaveBeenCalledWith(device._deviceId, device._bundleId, {
+			"-detoxServer": "ws://localhost:8099",
+			"-detoxSessionId": "test",
+			"-detoxURLOverride": "scheme://some.url",
+			"-detoxSourceAppOverride": "sourceAppBundleId"
+		});
+	});
+
+	it(`relaunchApp() with userNofitication should send the userNotification as a param in launchParams`, async () => {
+		device = validDevice();
+		fs.existsSync.mockReturnValue(true);
+		device.deviceDriver.createPushNotificationJson = jest.fn(() => "url");
+
+		await device.relaunchApp({ userNotification: "json" });
+
+		expect(
+			device.deviceDriver.launch
+		).toHaveBeenCalledWith(device._deviceId, device._bundleId, {
+			"-detoxServer": "ws://localhost:8099",
+			"-detoxSessionId": "test",
+			"-detoxUserNotificationDataURL": "url"
+		});
+	});
+
+	it(`relaunchApp() with url and userNofitication should throw`, async () => {
+		device = validDevice();
+		try {
+			await device.relaunchApp({
+				url: "scheme://some.url",
+				userNotification: "notif"
+			});
+			fail("should fail");
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
+
+	it(`relaunchApp() with permissions should send trigger setpermissions before app starts`, async () => {
+		device = await validDevice();
+		await device.relaunchApp({ permissions: { calendar: "YES" } });
+
+		expect(
+			device.deviceDriver.setPermissions
+		).toHaveBeenCalledWith(device._deviceId, device._bundleId, {
+			calendar: "YES"
+		});
+	});
+
+	it(`launchApp({launchArgs: }) should pass to native as launch args`, async () => {
+		device = validDevice();
+
+		await device.launchApp({ launchArgs: { arg1: "1", arg2: 2 } });
+
+		expect(
+			device.deviceDriver.launch
+		).toHaveBeenCalledWith(device._deviceId, device._bundleId, {
+			"-detoxServer": "ws://localhost:8099",
+			"-detoxSessionId": "test",
+			"-arg1": "1",
+			"-arg2": 2
+		});
+	});
+
+	it(`sendToHome() should pass to device driver`, async () => {
+		device = validDevice();
+		await device.sendToHome();
+
+		expect(device.deviceDriver.sendToHome).toHaveBeenCalledTimes(1);
+	});
+
+	it(`terminateApp() should pass to device driver`, async () => {
+		device = validDevice();
+		await device.terminateApp();
+
+		expect(device.deviceDriver.terminate).toHaveBeenCalledTimes(1);
+	});
+
+	it(`installApp() with a custom app path should use custom app path`, async () => {
+		device = validDevice();
+		fs.existsSync.mockReturnValue(true);
+
+		await device.installApp("newAppPath");
+
+		expect(device.deviceDriver.installApp).toHaveBeenCalledWith(
+			device._deviceId,
+			"newAppPath"
+		);
+	});
+
+	it(`installApp() with no params should use the default path given in configuration`, async () => {
+		device = validDevice();
+
+		await device.installApp();
+
+		expect(device.deviceDriver.installApp).toHaveBeenCalledWith(
+			device._deviceId,
+			device._binaryPath
+		);
+	});
+
+	it(`uninstallApp() with a custom app path should use custom app path`, async () => {
+		device = validDevice();
+		fs.existsSync.mockReturnValue(true);
+
+		await device.uninstallApp("newBundleId");
+
+		expect(device.deviceDriver.uninstallApp).toHaveBeenCalledWith(
+			device._deviceId,
+			"newBundleId"
+		);
+	});
+
+	it(`uninstallApp() with no params should use the default path given in configuration`, async () => {
+		device = validDevice();
+
+		await device.uninstallApp();
+
+		expect(device.deviceDriver.uninstallApp).toHaveBeenCalledWith(
+			device._deviceId,
+			device._binaryPath
+		);
+	});
+
+	it(`shutdown() should pass to device driver`, async () => {
+		device = validDevice();
+		await device.shutdown();
+
+		expect(device.deviceDriver.shutdown).toHaveBeenCalledTimes(1);
+	});
+
+	it(`openURL({url:url}) should pass to device driver`, async () => {
+		device = validDevice();
+		await device.openURL({ url: "url" });
+
+		expect(device.deviceDriver.openURL).toHaveBeenCalledWith(device._deviceId, {
+			url: "url"
+		});
+	});
+
+	it(`openURL(notAnObject) should pass to device driver`, async () => {
+		device = validDevice();
+		try {
+			await device.openURL("url");
+			fail("should throw");
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
+
+	it(`reloadReactNative() should pass to device driver`, async () => {
+		device = validDevice();
+		await device.reloadReactNative();
+
+		expect(device.deviceDriver.reloadReactNative).toHaveBeenCalledTimes(1);
+	});
+
+	it(`setOrientation() should pass to device driver`, async () => {
+		device = validDevice();
+		await device.setOrientation("param");
+
+		expect(device.deviceDriver.setOrientation).toHaveBeenCalledWith(
+			device._deviceId,
+			"param"
+		);
+	});
+
+	it(`sendUserNotification() should pass to device driver`, async () => {
+		device = validDevice();
+		await device.sendUserNotification("notif");
+
+		expect(device.deviceDriver.sendUserNotification).toHaveBeenCalledWith(
+			"notif"
+		);
+	});
+
+	it(`setLocation() should pass to device driver`, async () => {
+		device = validDevice();
+		await device.setLocation(30, 30);
+
+		expect(device.deviceDriver.setLocation).toHaveBeenCalledWith(
+			device._deviceId,
+			"30",
+			"30"
+		);
+	});
+
+	it(`setURLBlacklist() should pass to device driver`, async () => {
+		device = validDevice();
+		await device.setURLBlacklist();
+
+		expect(device.deviceDriver.setURLBlacklist).toHaveBeenCalledTimes(1);
+	});
+
+	it(`enableSynchronization() should pass to device driver`, async () => {
+		device = validDevice();
+		await device.enableSynchronization();
+
+		expect(device.deviceDriver.enableSynchronization).toHaveBeenCalledTimes(1);
+	});
+
+	it(`disableSynchronization() should pass to device driver`, async () => {
+		device = validDevice();
+		await device.disableSynchronization();
+
+		expect(device.deviceDriver.disableSynchronization).toHaveBeenCalledTimes(1);
+	});
+
+	it(`resetContentAndSettings() should pass to device driver`, async () => {
+		device = validDevice();
+		await device.resetContentAndSettings();
+
+		expect(device.deviceDriver.resetContentAndSettings).toHaveBeenCalledTimes(
+			1
+		);
+	});
+
+	it(`getPlatform() should pass to device driver`, async () => {
+		device = validDevice();
+		device.getPlatform();
+
+		expect(device.deviceDriver.getPlatform).toHaveBeenCalledTimes(1);
+	});
+
+	it(`getPlatform() should pass to device driver`, async () => {
+		device = validSimulator();
+		device.getPlatform();
+
+		expect(device.deviceDriver.getPlatform).toHaveBeenCalledTimes(1);
+	});
+
+	it(`_cleanup() should pass to device driver`, async () => {
+		device = validDevice();
+		await device._cleanup();
+
+		expect(device.deviceDriver.cleanup).toHaveBeenCalledTimes(1);
+	});
+
+	it(`new Device() with invalid device config (no binary) should throw`, async () => {
+		try {
+			new Device(
+				invalidDeviceNoBinary.configurations["ios.sim.release"],
+				validScheme.session,
+				new SimulatorDriver(client)
+			);
+			fail("should throw");
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
+
+	it(`new Device() with invalid device config (no device name) should throw`, async () => {
+		try {
+			new Device(
+				invalidDeviceNoDeviceName.configurations["ios.sim.release"],
+				validScheme.session,
+				new SimulatorDriver(client)
+			);
+			fail("should throw");
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
+
+	it(`finalizeArtifacts() should call cp`, async () => {
+		device = validDevice();
+		device.deviceDriver.getLogsPaths = () => ({ stdout: "/t1", stderr: "/t2" });
+		device.setArtifactsDestination("/tmp");
+		await device.finalizeArtifacts();
+		expect(sh.cp).toHaveBeenCalledTimes(2);
+	});
+
+	it(`finalizeArtifacts() should catch cp exception`, async () => {
+		device = validDevice();
+		device.deviceDriver.getLogsPaths = () => ({ stdout: "/t1", stderr: "/t2" });
+		device.setArtifactsDestination("/tmp");
+		await device.relaunchApp();
+		sh.cp = jest.fn(() => {
+			throw "exception sent by mocked cp";
+		});
+		await device.finalizeArtifacts();
+	});
+
+	it(`finalizeArtifacts() should not cp if setArtifactsDestination wasn't called`, async () => {
+		device = validDevice();
+		device.deviceDriver.getLogsPaths = () => ({ stdout: "/t1", stderr: "/t2" });
+		await device.relaunchApp();
+		await device.finalizeArtifacts();
+		expect(sh.cp).toHaveBeenCalledTimes(0);
+	});
+
+	it(`launchApp({url:url}) should check if process is in background and use openURL() instead of launch args`, async () => {
+		const processId = 1;
+		device = validDevice();
+		device.deviceDriver.getBundleIdFromBinary.mockReturnValue("test.bundle");
+		device.deviceDriver.launch
+			.mockReturnValueOnce(processId)
+			.mockReturnValueOnce(processId);
+
+		await device.prepare({ launchApp: true });
+		await device.launchApp({ url: "url://me" });
+
+		expect(device.deviceDriver.openURL).toHaveBeenCalledTimes(1);
+	});
+
+	it(`launchApp({url:url}) should check if process is in background and if not use launch args`, async () => {
+		const launchParams = { url: "url://me" };
+		const processId = 1;
+		const newProcessId = 2;
+
+		device = validDevice();
+		device.deviceDriver.getBundleIdFromBinary.mockReturnValue("test.bundle");
+		device.deviceDriver.launch
+			.mockReturnValueOnce(processId)
+			.mockReturnValueOnce(newProcessId);
+
+		await device.prepare();
+		await device.launchApp(launchParams);
+
+		expect(device.deviceDriver.openURL).toHaveBeenCalledTimes(0);
+	});
+
+	it(`launchApp({url:url}) should check if process is in background and use openURL() instead of launch args`, async () => {
+		const launchParams = { url: "url://me" };
+		const processId = 1;
+
+		device = validDevice();
+		device.deviceDriver.getBundleIdFromBinary.mockReturnValue("test.bundle");
+		device.deviceDriver.launch.mockReturnValue(processId);
+
+		await device.prepare({ launchApp: true });
+		await device.launchApp(launchParams);
+
+		expect(device.deviceDriver.openURL).toHaveBeenCalledTimes(1);
+	});
+
+	it(`launchApp({userNotification:userNotification}) should check if process is in background and if it is use sendUserNotification`, async () => {
+		const launchParams = { userNotification: "notification" };
+		const processId = 1;
+
+		device = validDevice();
+		device.deviceDriver.getBundleIdFromBinary.mockReturnValue("test.bundle");
+		device.deviceDriver.launch
+			.mockReturnValueOnce(processId)
+			.mockReturnValueOnce(processId);
+
+		await device.prepare({ launchApp: true });
+		await device.launchApp(launchParams);
+
+		expect(device.deviceDriver.sendUserNotification).toHaveBeenCalledWith(
+			launchParams.userNotification
+		);
+	});
+
+	it(`launchApp({userNotification:userNotification}) should check if process is in background and if not use launch args`, async () => {
+		const launchParams = { userNotification: "notification" };
+		const processId = 1;
+		const newProcessId = 2;
+
+		device = validDevice();
+		device.deviceDriver.getBundleIdFromBinary.mockReturnValue("test.bundle");
+		device.deviceDriver.launch
+			.mockReturnValueOnce(processId)
+			.mockReturnValueOnce(newProcessId);
+
+		await device.prepare();
+		await device.launchApp(launchParams);
+
+		expect(device.deviceDriver.sendUserNotification).toHaveBeenCalledTimes(0);
+	});
+
+	async function launchAndTestBinaryPath(configuration) {
+		const scheme = configurationsMock.pathsTests;
+		const device = new Device(
+			scheme.configurations[configuration],
+			scheme.session,
+			new DeviceDriverBase(client)
+		);
+		fs.existsSync.mockReturnValue(true);
+		device.deviceDriver.defaultLaunchArgsPrefix.mockReturnValue("-");
+		device.deviceDriver.acquireFreeDevice.mockReturnValue("mockDeviceId");
+
+		await device.prepare();
+		await device.launchApp();
+
+		return device.deviceDriver.installApp.mock.calls[0][1];
+	}
+
+	it(`should accept absolute path for binary`, async () => {
+		const actualPath = await launchAndTestBinaryPath("absolutePath");
+		expect(actualPath).toEqual("/tmp/abcdef/123");
+	});
+
+	it(`should accept relative path for binary`, async () => {
+		const actualPath = await launchAndTestBinaryPath("relativePath");
+		expect(actualPath).toEqual(`${process.cwd()}/abcdef/123`);
+	});
 });

--- a/detox/src/devices/DeviceDriverBase.js
+++ b/detox/src/devices/DeviceDriverBase.js
@@ -1,137 +1,129 @@
-const _ = require('lodash');
-const fs = require('fs');
-const path = require('path');
+const _ = require("lodash");
+const fs = require("fs");
+const path = require("path");
 
 class DeviceDriverBase {
-  constructor(client) {
-    this.client = client;
-  }
+	constructor(client) {
+		this.client = client;
+	}
 
-  async acquireFreeDevice(name) {
-    await Promise.resolve('');
-  }
+	async acquireFreeDevice(name) {
+		await Promise.resolve("");
+	}
 
-  async prepare() {
-    return await Promise.resolve('');
-  }
+	async prepare() {
+		return await Promise.resolve("");
+	}
 
-  async boot() {
-    return await Promise.resolve('');
-  }
+	async boot() {
+		return await Promise.resolve("");
+	}
 
-  async launch() {
-    return await Promise.resolve('');
-  }
+	async launch() {
+		return await Promise.resolve("");
+	}
 
-  async sendToHome() {
-    return await Promise.resolve('');
-  }
+	async sendToHome() {
+		return await Promise.resolve("");
+	}
 
-  async relaunchApp() {
-    return await Promise.resolve('');
-  }
+	async relaunchApp() {
+		return await Promise.resolve("");
+	}
 
-  async installApp() {
-    return await Promise.resolve('');
-  }
+	async installApp() {
+		return await Promise.resolve("");
+	}
 
-  async uninstallApp() {
-    return await Promise.resolve('');
-  }
+	async uninstallApp() {
+		return await Promise.resolve("");
+	}
 
-  async openURL(params) {
-    return await Promise.resolve('');
-  }
+	async openURL(params) {
+		return await Promise.resolve("");
+	}
 
-  async setLocation(lat, lon) {
-    return await Promise.resolve('');
-  }
+	async setLocation(lat, lon) {
+		return await Promise.resolve("");
+	}
 
-  async waitUntilReady() {
-    return await this.client.waitUntilReady();
-  }
+	async waitUntilReady() {
+		return await this.client.waitUntilReady();
+	}
 
-  async reloadReactNative() {
-    return await this.client.reloadReactNative();
-  }
+	async reloadReactNative() {
+		return await this.client.reloadReactNative();
+	}
 
-  async sendUserNotification(params) {
-    await this.client.sendUserNotification(params);
-  }
+	async sendUserNotification(params) {
+		await this.client.sendUserNotification(params);
+	}
 
-  createPushNotificationJson(notification) {
+	createPushNotificationJson(notification) {}
 
-  }
+	async setPermissions(deviceId, bundleId, permissions) {
+		return await Promise.resolve("");
+	}
 
-  async setPermissions(deviceId, bundleId, permissions) {
-    return await Promise.resolve('');
-  }
+	async terminate(deviceId, bundleId) {
+		return await Promise.resolve("");
+	}
 
-  async terminate(deviceId, bundleId) {
-    return await Promise.resolve('');
-  }
+	async shutdown() {
+		return await Promise.resolve("");
+	}
 
-  async shutdown() {
-    return await Promise.resolve('');
-  }
+	async setOrientation(deviceId, orientation) {
+		return await Promise.resolve("");
+	}
 
-  async setOrientation(deviceId, orientation) {
-    return await Promise.resolve('');
-  }
+	async setURLBlacklist(urlList) {
+		return await Promise.resolve("");
+	}
 
-  async setURLBlacklist(urlList) {
-    return await Promise.resolve('');
-  }
+	async enableSynchronization() {
+		return await Promise.resolve("");
+	}
 
-  async enableSynchronization() {
-    return await Promise.resolve('');
-  }
+	async disableSynchronization() {
+		return await Promise.resolve("");
+	}
 
-  async disableSynchronization() {
-    return await Promise.resolve('');
-  }
+	async resetContentAndSettings() {
+		return await Promise.resolve("");
+	}
 
-  async resetContentAndSettings() {
-    return await Promise.resolve('');
-  }
+	defaultLaunchArgsPrefix() {
+		return "";
+	}
 
-  defaultLaunchArgsPrefix() {
-    return '';
-  }
+	ensureDirectoryExistence(filePath) {
+		const dirname = path.dirname(filePath);
+		if (fs.existsSync(dirname)) {
+			return true;
+		}
 
-  ensureDirectoryExistence(filePath) {
-    const dirname = path.dirname(filePath);
-    if (fs.existsSync(dirname)) {
-      return true;
-    }
+		this.ensureDirectoryExistence(dirname);
+		fs.mkdirSync(dirname);
+		return true;
+	}
 
-    this.ensureDirectoryExistence(dirname);
-    fs.mkdirSync(dirname);
-    return true;
-  }
+	getBundleIdFromBinary(appPath) {}
 
-  getBundleIdFromBinary(appPath) {
+	validateDeviceConfig(deviceConfig) {}
 
-  }
+	getPlatform() {}
 
-  validateDeviceConfig(deviceConfig) {
+	async cleanup(deviceId, bundleId) {
+		return await Promise.resolve("");
+	}
 
-  }
-
-  getPlatform() {
-
-  }
-
-  async cleanup(deviceId, bundleId) {
-    return await Promise.resolve('');
-  }
-
-  getLogsPaths(deviceId) {
-    return {
-      stdout: undefined,
-      stderr: undefined
-    };
-  }
+	getLogsPaths(deviceId) {
+		return {
+			stdout: undefined,
+			stderr: undefined
+		};
+	}
 }
 
 module.exports = DeviceDriverBase;

--- a/detox/src/devices/DeviceDriverBase.js
+++ b/detox/src/devices/DeviceDriverBase.js
@@ -59,6 +59,7 @@ class DeviceDriverBase {
 		await this.client.sendUserNotification(params);
 	}
 
+	// eslint-disable-next-line no-empty-function
 	createPushNotificationJson(notification) {}
 
 	async setPermissions(deviceId, bundleId, permissions) {
@@ -108,10 +109,13 @@ class DeviceDriverBase {
 		return true;
 	}
 
+	// eslint-disable-next-line no-empty-function
 	getBundleIdFromBinary(appPath) {}
 
+	// eslint-disable-next-line no-empty-function
 	validateDeviceConfig(deviceConfig) {}
 
+	// eslint-disable-next-line no-empty-function
 	getPlatform() {}
 
 	async cleanup(deviceId, bundleId) {

--- a/detox/src/devices/EmulatorDriver.js
+++ b/detox/src/devices/EmulatorDriver.js
@@ -73,8 +73,7 @@ class EmulatorDriver extends AndroidDriver {
 				throw new Error(`Could not find '${name}' on the currently ADB attached devices, 
       try restarting adb 'adb kill-server && adb start-server'`);
 			case 1:
-				const adbDevice = filteredDevices[0];
-				adbName = adbDevice.adbName;
+				adbName = filteredDevices[0].adbName;
 				break;
 			default:
 				throw new Error(

--- a/detox/src/devices/EmulatorDriver.js
+++ b/detox/src/devices/EmulatorDriver.js
@@ -1,86 +1,98 @@
-const _ = require('lodash');
-const path = require('path');
-const Emulator = require('./android/Emulator');
-const EmulatorTelnet = require('./android/EmulatorTelnet');
-const Environment = require('../utils/environment');
-const AndroidDriver = require('./AndroidDriver');
-const ini = require('ini');
-const fs = require('fs');
-const os = require('os');
+const _ = require("lodash");
+const path = require("path");
+const Emulator = require("./android/Emulator");
+const EmulatorTelnet = require("./android/EmulatorTelnet");
+const Environment = require("../utils/environment");
+const AndroidDriver = require("./AndroidDriver");
+const ini = require("ini");
+const fs = require("fs");
+const os = require("os");
 
 class EmulatorDriver extends AndroidDriver {
-  constructor(client) {
-    super(client);
+	constructor(client) {
+		super(client);
 
-    this.emulator = new Emulator();
-  }
+		this.emulator = new Emulator();
+	}
 
-  async _fixEmulatorConfigIniSkinName(name) {
-    const configFile = `${os.homedir()}/.android/avd/${name}.avd/config.ini`;
-    const config = ini.parse(fs.readFileSync(configFile, 'utf-8'));
+	async _fixEmulatorConfigIniSkinName(name) {
+		const configFile = `${os.homedir()}/.android/avd/${name}.avd/config.ini`;
+		const config = ini.parse(fs.readFileSync(configFile, "utf-8"));
 
-    if (!config['skin.name']) {
-      const width = config['hw.lcd.width'];
-      const height = config['hw.lcd.height'];
+		if (!config["skin.name"]) {
+			const width = config["hw.lcd.width"];
+			const height = config["hw.lcd.height"];
 
-      if (width === undefined || height === undefined) {
-        throw new Error(`Emulator with name ${name} has a corrupt config.ini file (${configFile}), try fixing it by recreating an emulator.`);
-      }
+			if (width === undefined || height === undefined) {
+				throw new Error(
+					`Emulator with name ${name} has a corrupt config.ini file (${configFile}), try fixing it by recreating an emulator.`
+				);
+			}
 
-      config['skin.name'] = `${width}x${height}`;
-      fs.writeFileSync(configFile, ini.stringify(config));
-    }
-    return config;
-  }
+			config["skin.name"] = `${width}x${height}`;
+			fs.writeFileSync(configFile, ini.stringify(config));
+		}
+		return config;
+	}
 
-  async boot(deviceId) {
-    await this.emulator.boot(deviceId);
-    await this.adb.waitForBootComplete(deviceId);
-  }
+	async boot(deviceId) {
+		await this.emulator.boot(deviceId);
+		await this.adb.waitForBootComplete(deviceId);
+	}
 
-  async acquireFreeDevice(name) {
-    const avds = await this.emulator.listAvds();
-    if (!avds) {
-      const avdmanagerPath = path.join(Environment.getAndroidSDKPath(), 'tools', 'bin', 'avdmanager');
-      throw new Error(`Could not find any configured Android Emulator. 
+	async acquireFreeDevice(name) {
+		const avds = await this.emulator.listAvds();
+		if (!avds) {
+			const avdmanagerPath = path.join(
+				Environment.getAndroidSDKPath(),
+				"tools",
+				"bin",
+				"avdmanager"
+			);
+			throw new Error(`Could not find any configured Android Emulator. 
       Try creating a device first, example: ${avdmanagerPath} create avd --force --name Nexus_5X_API_24 --abi x86 --package 'system-images;android-24;google_apis_playstore;x86' --device "Nexus 5X"
       or go to https://developer.android.com/studio/run/managing-avds.html for details on how to create an Emulator.`);
-    }
-    if (_.indexOf(avds, name) === -1) {
-      throw new Error(`Can not boot Android Emulator with the name: '${name}', 
+		}
+		if (_.indexOf(avds, name) === -1) {
+			throw new Error(`Can not boot Android Emulator with the name: '${name}', 
       make sure you choose one of the available emulators: ${avds.toString()}`);
-    }
+		}
 
-    await this._fixEmulatorConfigIniSkinName(name);
-    await this.emulator.boot(name);
+		await this._fixEmulatorConfigIniSkinName(name);
+		await this.emulator.boot(name);
 
-    const adbDevices = await this.adb.devices();
-    const filteredDevices = _.filter(adbDevices, {type: 'emulator', name: name});
+		const adbDevices = await this.adb.devices();
+		const filteredDevices = _.filter(adbDevices, {
+			type: "emulator",
+			name: name
+		});
 
-    let adbName;
-    switch (filteredDevices.length) {
-      case 0:
-        throw new Error(`Could not find '${name}' on the currently ADB attached devices, 
+		let adbName;
+		switch (filteredDevices.length) {
+			case 0:
+				throw new Error(`Could not find '${name}' on the currently ADB attached devices, 
       try restarting adb 'adb kill-server && adb start-server'`);
-      case 1:
-        const adbDevice = filteredDevices[0];
-        adbName = adbDevice.adbName;
-        break;
-      default:
-        throw new Error(`Got more than one device corresponding to the name: ${name}`);
-    }
+			case 1:
+				const adbDevice = filteredDevices[0];
+				adbName = adbDevice.adbName;
+				break;
+			default:
+				throw new Error(
+					`Got more than one device corresponding to the name: ${name}`
+				);
+		}
 
-    await this.adb.waitForBootComplete(adbName);
-    await this.adb.unlockScreen(adbName);
-    return adbName;
-  }
+		await this.adb.waitForBootComplete(adbName);
+		await this.adb.unlockScreen(adbName);
+		return adbName;
+	}
 
-  async shutdown(deviceId) {
-    const port = _.split(deviceId, '-')[1];
-    const telnet = new EmulatorTelnet();
-    await telnet.connect(port);
-    await telnet.kill();
-  }
+	async shutdown(deviceId) {
+		const port = _.split(deviceId, "-")[1];
+		const telnet = new EmulatorTelnet();
+		await telnet.connect(port);
+		await telnet.kill();
+	}
 }
 
 module.exports = EmulatorDriver;

--- a/detox/src/devices/IosDriver.js
+++ b/detox/src/devices/IosDriver.js
@@ -1,76 +1,90 @@
-const path = require('path');
-const fs = require('fs');
-const DeviceDriverBase = require('./DeviceDriverBase');
-const InvocationManager = require('../invoke').InvocationManager;
-const invoke = require('../invoke');
-const GREYConfiguration = require('./../ios/earlgreyapi/GREYConfiguration');
+const path = require("path");
+const fs = require("fs");
+const DeviceDriverBase = require("./DeviceDriverBase");
+const InvocationManager = require("../invoke").InvocationManager;
+const invoke = require("../invoke");
+const GREYConfiguration = require("./../ios/earlgreyapi/GREYConfiguration");
 
 class IosDriver extends DeviceDriverBase {
+	constructor(client) {
+		super(client);
 
-  constructor(client) {
-    super(client);
+		const expect = require("../ios/expect");
+		expect.exportGlobals();
+		expect.setInvocationManager(new InvocationManager(client));
+	}
 
-    const expect = require('../ios/expect');
-    expect.exportGlobals();
-    expect.setInvocationManager(new InvocationManager(client));
-  }
+	createPushNotificationJson(notification) {
+		const notificationFilePath = path.join(
+			__dirname,
+			`detox`,
+			`notifications`,
+			`notification.json`
+		);
+		this.ensureDirectoryExistence(notificationFilePath);
+		fs.writeFileSync(
+			notificationFilePath,
+			JSON.stringify(notification, null, 2)
+		);
+		return notificationFilePath;
+	}
 
-  createPushNotificationJson(notification) {
-    const notificationFilePath = path.join(__dirname, `detox`, `notifications`, `notification.json`);
-    this.ensureDirectoryExistence(notificationFilePath);
-    fs.writeFileSync(notificationFilePath, JSON.stringify(notification, null, 2));
-    return notificationFilePath;
-  }
+	async sendUserNotification(notification) {
+		const notificationFilePath = this.createPushNotificationJson(notification);
+		await super.sendUserNotification({
+			detoxUserNotificationDataURL: notificationFilePath
+		});
+	}
 
-  async sendUserNotification(notification) {
-    const notificationFilePath = this.createPushNotificationJson(notification);
-    await super.sendUserNotification({detoxUserNotificationDataURL: notificationFilePath});
-  }
+	async openURL(deviceId, params) {
+		this.client.openURL(params);
+	}
 
-  async openURL(deviceId, params) {
-    this.client.openURL(params);
-  }
+	async setURLBlacklist(urlList) {
+		await this.client.execute(GREYConfiguration.setURLBlacklist(urlList));
+	}
 
-  async setURLBlacklist(urlList) {
-    await this.client.execute(GREYConfiguration.setURLBlacklist(urlList));
-  }
+	async enableSynchronization() {
+		await this.client.execute(GREYConfiguration.enableSynchronization());
+	}
 
-  async enableSynchronization() {
-    await this.client.execute(GREYConfiguration.enableSynchronization());
-  }
+	async disableSynchronization() {
+		await this.client.execute(GREYConfiguration.disableSynchronization());
+	}
 
-  async disableSynchronization() {
-    await this.client.execute(GREYConfiguration.disableSynchronization());
-  }
+	async setOrientation(deviceId, orientation) {
+		// keys are possible orientations
+		const orientationMapping = {
+			landscape: 3, // top at left side landscape
+			portrait: 1 // non-reversed portrait
+		};
+		if (!Object.keys(orientationMapping).includes(orientation)) {
+			throw new Error(
+				`setOrientation failed: provided orientation ${orientation} is not part of supported orientations: ${Object.keys(
+					orientationMapping
+				)}`
+			);
+		}
 
-  async setOrientation(deviceId, orientation) {
-    // keys are possible orientations
-    const orientationMapping = {
-      landscape: 3, // top at left side landscape
-      portrait: 1  // non-reversed portrait
-    };
-    if (!Object.keys(orientationMapping).includes(orientation)) {
-      throw new Error(`setOrientation failed: provided orientation ${orientation} is not part of supported orientations: ${Object.keys(orientationMapping)}`)
-    }
+		const call = invoke.call(
+			invoke.EarlGrey.instance,
+			"rotateDeviceToOrientation:errorOrNil:",
+			invoke.IOS.NSInteger(orientationMapping[orientation])
+		);
+		await this.client.execute(call);
+	}
 
-    const call = invoke.call(invoke.EarlGrey.instance,
-      'rotateDeviceToOrientation:errorOrNil:',
-      invoke.IOS.NSInteger(orientationMapping[orientation])
-    );
-    await this.client.execute(call);
-  }
+	defaultLaunchArgsPrefix() {
+		return "-";
+	}
 
-  defaultLaunchArgsPrefix() {
-    return '-';
-  }
+	validateDeviceConfig(config) {
+		//no validation
+	}
 
-  validateDeviceConfig(config) {
-    //no validation
-  }
-
-  getPlatform() {
-    return 'ios';
-  }
+	getPlatform() {
+		return "ios";
+	}
 }
 
 module.exports = IosDriver;

--- a/detox/src/devices/SimulatorDriver.js
+++ b/detox/src/devices/SimulatorDriver.js
@@ -1,100 +1,106 @@
-const exec = require('child-process-promise').exec;
-const path = require('path');
-const fs = require('fs');
-const _ = require('lodash');
-const IosDriver = require('./IosDriver');
-const AppleSimUtils = require('./AppleSimUtils');
-const configuration = require('../configuration');
-const environment = require('../utils/environment');
+const exec = require("child-process-promise").exec;
+const path = require("path");
+const fs = require("fs");
+const _ = require("lodash");
+const IosDriver = require("./IosDriver");
+const AppleSimUtils = require("./AppleSimUtils");
+const configuration = require("../configuration");
+const environment = require("../utils/environment");
 
 class SimulatorDriver extends IosDriver {
+	constructor(client) {
+		super(client);
+		this._applesimutils = new AppleSimUtils();
+	}
 
-  constructor(client) {
-    super(client);
-    this._applesimutils = new AppleSimUtils();
-  }
+	async prepare() {
+		const detoxFrameworkPath = await environment.getFrameworkPath();
 
-  async prepare() {
-    const detoxFrameworkPath = await environment.getFrameworkPath();
-
-    if (!fs.existsSync(detoxFrameworkPath)) {
-      throw new Error(`${detoxFrameworkPath} could not be found, this means either you changed a version of Xcode or Detox postinstall script was unsuccessful. 
+		if (!fs.existsSync(detoxFrameworkPath)) {
+			throw new Error(`${detoxFrameworkPath} could not be found, this means either you changed a version of Xcode or Detox postinstall script was unsuccessful. 
       To attempt a fix try running 'detox clean-framework-cache && detox build-framework-cache'`);
-    }
-  }
+		}
+	}
 
-  async acquireFreeDevice(name) {
-    const deviceId = await this._applesimutils.findDeviceUDID(name);
-    await this.boot(deviceId);
-    return deviceId;
-  }
+	async acquireFreeDevice(name) {
+		const deviceId = await this._applesimutils.findDeviceUDID(name);
+		await this.boot(deviceId);
+		return deviceId;
+	}
 
-  async getBundleIdFromBinary(appPath) {
-    try {
-      const result = await exec(`/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" ${path.join(appPath, 'Info.plist')}`);
-      const bundleId = _.trim(result.stdout);
-      if (_.isEmpty(bundleId)) {
-        throw new Error();
-      }
-      return bundleId;
-    } catch (ex) {
-      throw new Error(`field CFBundleIdentifier not found inside Info.plist of app binary at ${appPath}`);
-    }
-  }
+	async getBundleIdFromBinary(appPath) {
+		try {
+			const result = await exec(
+				`/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" ${path.join(
+					appPath,
+					"Info.plist"
+				)}`
+			);
+			const bundleId = _.trim(result.stdout);
+			if (_.isEmpty(bundleId)) {
+				throw new Error();
+			}
+			return bundleId;
+		} catch (ex) {
+			throw new Error(
+				`field CFBundleIdentifier not found inside Info.plist of app binary at ${appPath}`
+			);
+		}
+	}
 
-  async boot(deviceId) {
-    await this._applesimutils.boot(deviceId);
-  }
+	async boot(deviceId) {
+		await this._applesimutils.boot(deviceId);
+	}
 
-  async installApp(deviceId, binaryPath) {
-    await this._applesimutils.install(deviceId, binaryPath);
-  }
+	async installApp(deviceId, binaryPath) {
+		await this._applesimutils.install(deviceId, binaryPath);
+	}
 
-  async uninstallApp(deviceId, bundleId) {
-    await this._applesimutils.uninstall(deviceId, bundleId);
-  }
+	async uninstallApp(deviceId, bundleId) {
+		await this._applesimutils.uninstall(deviceId, bundleId);
+	}
 
-  async launch(deviceId, bundleId, launchArgs) {
-    return await this._applesimutils.launch(deviceId, bundleId, launchArgs);
-  }
+	async launch(deviceId, bundleId, launchArgs) {
+		return await this._applesimutils.launch(deviceId, bundleId, launchArgs);
+	}
 
-  async terminate(deviceId, bundleId) {
-    await this._applesimutils.terminate(deviceId, bundleId);
-  }
+	async terminate(deviceId, bundleId) {
+		await this._applesimutils.terminate(deviceId, bundleId);
+	}
 
-  async sendToHome(deviceId) {
-    return await this._applesimutils.sendToHome(deviceId);
-  }
+	async sendToHome(deviceId) {
+		return await this._applesimutils.sendToHome(deviceId);
+	}
 
-  async shutdown(deviceId) {
-    await this._applesimutils.shutdown(deviceId);
-  }
+	async shutdown(deviceId) {
+		await this._applesimutils.shutdown(deviceId);
+	}
 
-  async setLocation(deviceId, lat, lon) {
-    await this._applesimutils.setLocation(deviceId, lat, lon);
-  }
+	async setLocation(deviceId, lat, lon) {
+		await this._applesimutils.setLocation(deviceId, lat, lon);
+	}
 
-  async setPermissions(deviceId, bundleId, permissions) {
-    await this._applesimutils.setPermissions(deviceId, bundleId, permissions);
-  }
+	async setPermissions(deviceId, bundleId, permissions) {
+		await this._applesimutils.setPermissions(deviceId, bundleId, permissions);
+	}
 
-  async resetContentAndSettings(deviceId) {
-    return await this._applesimutils.resetContentAndSettings(deviceId);
-  }
+	async resetContentAndSettings(deviceId) {
+		return await this._applesimutils.resetContentAndSettings(deviceId);
+	}
 
-  validateDeviceConfig(deviceConfig) {
-    if (!deviceConfig.binaryPath) {
-      configuration.throwOnEmptyBinaryPath();
-    }
+	validateDeviceConfig(deviceConfig) {
+		if (!deviceConfig.binaryPath) {
+			configuration.throwOnEmptyBinaryPath();
+		}
 
-    if (!deviceConfig.name) {
-      configuration.throwOnEmptyName();
-    }
-  }
+		if (!deviceConfig.name) {
+			configuration.throwOnEmptyName();
+		}
+	}
 
-  getLogsPaths(deviceId) {
-    return this._applesimutils.getLogsPaths(deviceId);
-  }
+	getLogsPaths(deviceId) {
+		return this._applesimutils.getLogsPaths(deviceId);
+	}
 }
 
 module.exports = SimulatorDriver;

--- a/detox/src/devices/android/AAPT.js
+++ b/detox/src/devices/android/AAPT.js
@@ -1,30 +1,38 @@
-const _ = require('lodash');
-const exec = require('child-process-promise').exec;
-const Environment = require('../../utils/environment');
-const path = require('path');
-const fsext = require('../../utils/fsext');
+const _ = require("lodash");
+const exec = require("child-process-promise").exec;
+const Environment = require("../../utils/environment");
+const path = require("path");
+const fsext = require("../../utils/fsext");
 
 class AAPT {
+	constructor() {
+		this.aaptBin = null;
+	}
 
-  constructor() {
-    this.aaptBin = null;
-  }
+	async _prepare() {
+		if (!this.aaptBin) {
+			const sdkPath = Environment.getAndroidSDKPath();
+			const buildToolsDirs = await fsext.getDirectories(
+				path.join(sdkPath, "build-tools")
+			);
+			const latestBuildToolsVersion = _.last(buildToolsDirs);
+			this.aaptBin = path.join(
+				sdkPath,
+				"build-tools",
+				latestBuildToolsVersion,
+				"aapt"
+			);
+		}
+	}
 
-  async _prepare() {
-    if (!this.aaptBin) {
-      const sdkPath = Environment.getAndroidSDKPath();
-      const buildToolsDirs = await fsext.getDirectories(path.join(sdkPath, 'build-tools'));
-      const latestBuildToolsVersion = _.last(buildToolsDirs);
-      this.aaptBin = path.join(sdkPath, 'build-tools', latestBuildToolsVersion, 'aapt');
-    }
-  }
-
-  async getPackageName(apkPath) {
-    await this._prepare();
-    const process = await exec(`${this.aaptBin} dump badging "${apkPath}"`);
-    const packageName = new RegExp(/package: name='([^']+)'/g).exec(process.stdout);
-    return packageName[1];
-  }
+	async getPackageName(apkPath) {
+		await this._prepare();
+		const process = await exec(`${this.aaptBin} dump badging "${apkPath}"`);
+		const packageName = new RegExp(/package: name='([^']+)'/g).exec(
+			process.stdout
+		);
+		return packageName[1];
+	}
 }
 
 module.exports = AAPT;

--- a/detox/src/devices/android/AAPT.test.js
+++ b/detox/src/devices/android/AAPT.test.js
@@ -1,29 +1,29 @@
 //Disabled until we can create a build environment for Android in CI
-xdescribe('AAPT', () => {
-  let AAPT;
-  let aapt;
-  let exec;
+xdescribe("AAPT", () => {
+	let AAPT;
+	let aapt;
+	let exec;
 
-  beforeEach(() => {
-    jest.mock('npmlog');
-    jest.mock('child-process-promise');
-    exec = require('child-process-promise').exec;
+	beforeEach(() => {
+		jest.mock("npmlog");
+		jest.mock("child-process-promise");
+		exec = require("child-process-promise").exec;
 
-    AAPT = require('./AAPT');
-    aapt = new AAPT();
-  });
+		AAPT = require("./AAPT");
+		aapt = new AAPT();
+	});
 
-  it(`Parse 'aapt dump badging' output`, async () => {
-    exec.mockReturnValueOnce(Promise.resolve({stdout: AAPTOutputMock}));
-    const pacakageName = await aapt.getPackageName('path/to/file.apk');
-    expect(pacakageName).toEqual('com.wix.detox.test');
-  });
+	it(`Parse 'aapt dump badging' output`, async () => {
+		exec.mockReturnValueOnce(Promise.resolve({ stdout: AAPTOutputMock }));
+		const pacakageName = await aapt.getPackageName("path/to/file.apk");
+		expect(pacakageName).toEqual("com.wix.detox.test");
+	});
 
-  it(`Configure aaptBin only once`, async () => {
-    exec.mockReturnValue(Promise.resolve({stdout: AAPTOutputMock}));
-    await aapt.getPackageName('path/to/file.apk');
-    await aapt.getPackageName('path/to/file.apk');
-  });
+	it(`Configure aaptBin only once`, async () => {
+		exec.mockReturnValue(Promise.resolve({ stdout: AAPTOutputMock }));
+		await aapt.getPackageName("path/to/file.apk");
+		await aapt.getPackageName("path/to/file.apk");
+	});
 });
 
 const AAPTOutputMock = `package: name='com.wix.detox.test' versionCode='1' versionName='1.0' platformBuildVersionName='7.1.1'

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -1,97 +1,116 @@
-const path = require('path');
-const exec = require('../../utils/exec').execWithRetriesAndLogs;
-const _ = require('lodash');
-const EmulatorTelnet = require('./EmulatorTelnet');
-const Environment = require('../../utils/environment');
+const path = require("path");
+const exec = require("../../utils/exec").execWithRetriesAndLogs;
+const _ = require("lodash");
+const EmulatorTelnet = require("./EmulatorTelnet");
+const Environment = require("../../utils/environment");
 
 class ADB {
+	constructor() {
+		this.adbBin = path.join(
+			Environment.getAndroidSDKPath(),
+			"platform-tools",
+			"adb"
+		);
+	}
 
-  constructor() {
-    this.adbBin = path.join(Environment.getAndroidSDKPath(), 'platform-tools', 'adb');
-  }
+	async devices() {
+		const output = (await this.adbCmd("", "devices")).stdout;
+		return await this.parseAdbDevicesConsoleOutput(output);
+	}
 
-  async devices() {
-    const output = (await this.adbCmd('', 'devices')).stdout;
-    return await this.parseAdbDevicesConsoleOutput(output);
-  }
+	async parseAdbDevicesConsoleOutput(input) {
+		const outputToList = input.trim().split("\n");
+		const devicesList = _.takeRight(outputToList, outputToList.length - 1);
+		const devices = [];
+		for (const deviceString of devicesList) {
+			const deviceParams = deviceString.split("\t");
+			const deviceAdbName = deviceParams[0];
+			let device;
+			if (this.isEmulator(deviceAdbName)) {
+				const port = _.split(deviceAdbName, "-")[1];
+				const telnet = new EmulatorTelnet();
+				await telnet.connect(port);
+				const name = await telnet.avdName();
+				device = {
+					type: "emulator",
+					name: name,
+					adbName: deviceAdbName,
+					port: port
+				};
+				await telnet.quit();
+			} else if (this.isGenymotion(deviceAdbName)) {
+				device = {
+					type: "genymotion",
+					name: deviceAdbName,
+					adbName: deviceAdbName
+				};
+			} else {
+				device = {
+					type: "device",
+					name: deviceAdbName,
+					adbName: deviceAdbName
+				};
+			}
+			devices.push(device);
+		}
+		return devices;
+	}
 
-  async parseAdbDevicesConsoleOutput(input) {
-    const outputToList = input.trim().split('\n');
-    const devicesList = _.takeRight(outputToList, outputToList.length - 1);
-    const devices = [];
-    for (const deviceString of devicesList) {
-      const deviceParams = deviceString.split('\t');
-      const deviceAdbName = deviceParams[0];
-      let device;
-      if (this.isEmulator(deviceAdbName)) {
-        const port = _.split(deviceAdbName, '-')[1];
-        const telnet = new EmulatorTelnet();
-        await telnet.connect(port);
-        const name = await telnet.avdName();
-        device = {type: 'emulator', name: name, adbName: deviceAdbName, port: port};
-        await telnet.quit();
-      } else if (this.isGenymotion(deviceAdbName)) {
-        device = {type: 'genymotion', name: deviceAdbName, adbName: deviceAdbName};
-      } else {
-        device = {type: 'device', name: deviceAdbName, adbName: deviceAdbName};
-      }
-      devices.push(device);
-    }
-    return devices;
-  }
+	isEmulator(deviceAdbName) {
+		return _.includes(deviceAdbName, "emulator-");
+	}
 
-  isEmulator(deviceAdbName) {
-    return _.includes(deviceAdbName, 'emulator-');
-  }
+	isGenymotion(string) {
+		return (/^((1?\d?\d|25[0-5]|2[0-4]\d)(\.|:)){4}[0-9]{4}/).test(string);
+	}
 
-  isGenymotion(string) {
-    return (/^((1?\d?\d|25[0-5]|2[0-4]\d)(\.|:)){4}[0-9]{4}/.test(string));
-  }
+	async install(deviceId, apkPath) {
+		await this.adbCmd(deviceId, `install -r -g ${apkPath}`);
+	}
 
-  async install(deviceId, apkPath) {
-    await this.adbCmd(deviceId, `install -r -g ${apkPath}`);
-  }
+	async uninstall(deviceId, appId) {
+		await this.adbCmd(deviceId, `uninstall ${appId}`);
+	}
 
-  async uninstall(deviceId, appId) {
-    await this.adbCmd(deviceId, `uninstall ${appId}`);
-  }
+	async terminate(deviceId, appId) {
+		await this.shell(deviceId, `am force-stop ${appId}`);
+	}
 
-  async terminate(deviceId, appId) {
-    await this.shell(deviceId, `am force-stop ${appId}`);
-  }
+	async unlockScreen(deviceId) {
+		await this.shell(deviceId, `input keyevent 82`);
+	}
 
-  async unlockScreen(deviceId) {
-    await this.shell(deviceId, `input keyevent 82`);
-  }
+	async shell(deviceId, cmd) {
+		return (await this.adbCmd(deviceId, `shell ${cmd}`)).stdout.trim();
+	}
 
-  async shell(deviceId, cmd) {
-    return (await this.adbCmd(deviceId, `shell ${cmd}`)).stdout.trim();
-  }
+	async waitForBootComplete(deviceId) {
+		try {
+			const bootComplete = await this.shell(
+				deviceId,
+				`getprop dev.bootcomplete`
+			);
+			if (bootComplete === "1") {
+				return true;
+			} else {
+				await this.sleep(2000);
+				return await this.waitForBootComplete(deviceId);
+			}
+		} catch (ex) {
+			await this.sleep(2000);
+			return await this.waitForBootComplete(deviceId);
+		}
+	}
 
-  async waitForBootComplete(deviceId) {
-    try {
-      const bootComplete = await this.shell(deviceId, `getprop dev.bootcomplete`);
-      if (bootComplete === '1') {
-        return true;
-      } else {
-        await this.sleep(2000);
-        return await this.waitForBootComplete(deviceId);
-      }
-    } catch (ex) {
-      await this.sleep(2000);
-      return await this.waitForBootComplete(deviceId);
-    }
-  }
+	async adbCmd(deviceId, params) {
+		const serial = `${deviceId ? `-s ${deviceId}` : ""}`;
+		const cmd = `${this.adbBin} ${serial} ${params}`;
+		return await exec(cmd, undefined, undefined, 1);
+	}
 
-  async adbCmd(deviceId, params) {
-    const serial = `${deviceId ? `-s ${deviceId}` : ''}`;
-    const cmd = `${this.adbBin} ${serial} ${params}`;
-    return await exec(cmd, undefined, undefined, 1);
-  }
-
-  async sleep(ms = 0) {
-    return new Promise((resolve, reject) => setTimeout(resolve, ms));
-  }
+	async sleep(ms = 0) {
+		return new Promise((resolve, reject) => setTimeout(resolve, ms));
+	}
 }
 
 module.exports = ADB;

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -61,7 +61,7 @@ class ADB {
 	}
 
 	isGenymotion(string) {
-		return (/^((1?\d?\d|25[0-5]|2[0-4]\d)(\.|:)){4}[0-9]{4}/).test(string);
+		return /^((1?\d?\d|25[0-5]|2[0-4]\d)(\.|:)){4}[0-9]{4}/.test(string);
 	}
 
 	async install(deviceId, apkPath) {

--- a/detox/src/devices/android/ADB.test.js
+++ b/detox/src/devices/android/ADB.test.js
@@ -1,59 +1,74 @@
 //Disabled until we can create a build environment for Android in CI
-xdescribe('ADB', () => {
-  let ADB;
-  let adb;
-  let EmulatorTelnet;
-  let exec;
+xdescribe("ADB", () => {
+	let ADB;
+	let adb;
+	let EmulatorTelnet;
+	let exec;
 
-  beforeEach(() => {
-    jest.mock('npmlog');
-    ADB = require('./ADB');
+	beforeEach(() => {
+		jest.mock("npmlog");
+		ADB = require("./ADB");
 
-    jest.mock('./EmulatorTelnet');
-    EmulatorTelnet = require('./EmulatorTelnet');
+		jest.mock("./EmulatorTelnet");
+		EmulatorTelnet = require("./EmulatorTelnet");
 
-    jest.mock('../../utils/exec');
-    exec = require('../../utils/exec').execWithRetriesAndLogs;
-    adb = new ADB();
-  });
+		jest.mock("../../utils/exec");
+		exec = require("../../utils/exec").execWithRetriesAndLogs;
+		adb = new ADB();
+	});
 
-  it(`Parse 'adb device' output`, async () => {
-    const adbDevicesConsoleOutput = "List of devices attached\n"
-                                    + "192.168.60.101:5555\tdevice\n"
-                                    + "emulator-5556\tdevice\n"
-                                    + "emulator-5554\tdevice\n"
-                                    + "sx432wsds\tdevice\n"
-                                    + "\n";
-    exec.mockReturnValue(Promise.resolve({stdout: adbDevicesConsoleOutput}));
+	it(`Parse 'adb device' output`, async () => {
+		const adbDevicesConsoleOutput =
+			"List of devices attached\n" +
+			"192.168.60.101:5555\tdevice\n" +
+			"emulator-5556\tdevice\n" +
+			"emulator-5554\tdevice\n" +
+			"sx432wsds\tdevice\n" +
+			"\n";
+		exec.mockReturnValue(Promise.resolve({ stdout: adbDevicesConsoleOutput }));
 
-    const parsedDevices = [
-      {"adbName": "192.168.60.101:5555", "name": "192.168.60.101:5555", "type": "genymotion"},
-      {"adbName": "emulator-5556", "name": undefined, "port": "5556", "type": "emulator"},
-      {"adbName": "emulator-5554", "name": undefined, "port": "5554", "type": "emulator"},
-      {"adbName": "sx432wsds", "name": "sx432wsds", "type": "device"}];
+		const parsedDevices = [
+			{
+				adbName: "192.168.60.101:5555",
+				name: "192.168.60.101:5555",
+				type: "genymotion"
+			},
+			{
+				adbName: "emulator-5556",
+				name: undefined,
+				port: "5556",
+				type: "emulator"
+			},
+			{
+				adbName: "emulator-5554",
+				name: undefined,
+				port: "5554",
+				type: "emulator"
+			},
+			{ adbName: "sx432wsds", name: "sx432wsds", type: "device" }
+		];
 
-    const devices = await adb.devices();
-    expect(devices).toEqual(parsedDevices);
-  });
+		const devices = await adb.devices();
+		expect(devices).toEqual(parsedDevices);
+	});
 
-  it(`install`, async () => {
-    await adb.install('path/to/app');
-    expect(exec).toHaveBeenCalledTimes(1);
-  });
+	it(`install`, async () => {
+		await adb.install("path/to/app");
+		expect(exec).toHaveBeenCalledTimes(1);
+	});
 
-  it(`uninstall`, async () => {
-    await adb.uninstall('com.package');
-    expect(exec).toHaveBeenCalledTimes(1);
-  });
+	it(`uninstall`, async () => {
+		await adb.uninstall("com.package");
+		expect(exec).toHaveBeenCalledTimes(1);
+	});
 
-  it(`terminate`, async () => {
-    await adb.terminate('com.package');
-    expect(exec).toHaveBeenCalledTimes(1);
-  });
+	it(`terminate`, async () => {
+		await adb.terminate("com.package");
+		expect(exec).toHaveBeenCalledTimes(1);
+	});
 
-  it(`unlockScreen`, async () => {
-    await adb.unlockScreen('deviceId');
-    expect(exec).toHaveBeenCalledTimes(1);
-  });
+	it(`unlockScreen`, async () => {
+		await adb.unlockScreen("deviceId");
+		expect(exec).toHaveBeenCalledTimes(1);
+	});
 });
-

--- a/detox/src/devices/android/Emulator.js
+++ b/detox/src/devices/android/Emulator.js
@@ -67,7 +67,7 @@ class Emulator {
 			tail.unwatch();
 			fs.closeSync(stdout);
 			fs.closeSync(stderr);
-			fs.unlink(tempLog, () => {});
+			fs.unlink(tempLog, () => {}); // eslint-disable-line no-empty-function
 			promise._cpResolve();
 		}
 

--- a/detox/src/devices/android/Emulator.js
+++ b/detox/src/devices/android/Emulator.js
@@ -1,67 +1,78 @@
-const path = require('path');
-const exec = require('../../utils/exec').execWithRetriesAndLogs;
-const spawn = require('child-process-promise').spawn;
-const _ = require('lodash');
-const log = require('npmlog');
-const fs = require('fs');
-const Environment = require('../../utils/environment');
-const Tail = require('tail').Tail;
+const path = require("path");
+const exec = require("../../utils/exec").execWithRetriesAndLogs;
+const spawn = require("child-process-promise").spawn;
+const _ = require("lodash");
+const log = require("npmlog");
+const fs = require("fs");
+const Environment = require("../../utils/environment");
+const Tail = require("tail").Tail;
 
 class Emulator {
-  constructor() {
-    this.emulatorBin = path.join(Environment.getAndroidSDKPath(), 'tools', 'emulator');
-  }
+	constructor() {
+		this.emulatorBin = path.join(
+			Environment.getAndroidSDKPath(),
+			"tools",
+			"emulator"
+		);
+	}
 
-  async listAvds() {
-    const output = await this.exec(`-list-avds --verbose`);
-    const avds = output.trim().split('\n');
-    return avds;
-  }
+	async listAvds() {
+		const output = await this.exec(`-list-avds --verbose`);
+		const avds = output.trim().split("\n");
+		return avds;
+	}
 
-  async exec(cmd) {
-    return (await exec(`${this.emulatorBin} ${cmd}`)).stdout;
-  }
+	async exec(cmd) {
+		return (await exec(`${this.emulatorBin} ${cmd}`)).stdout;
+	}
 
-  async boot(emulatorName) {
-    const cmd = `-verbose -gpu host -no-audio @${emulatorName}`;
-    log.verbose(this.emulatorBin, cmd);
-    const tempLog = `./${emulatorName}.log`;
-    const stdout = fs.openSync(tempLog, 'a');
-    const stderr = fs.openSync(tempLog, 'a');
-    const tail = new Tail(tempLog);
-    const promise = spawn(this.emulatorBin, _.split(cmd, ' '), {detached: true, stdio: ['ignore', stdout, stderr]});
+	async boot(emulatorName) {
+		const cmd = `-verbose -gpu host -no-audio @${emulatorName}`;
+		log.verbose(this.emulatorBin, cmd);
+		const tempLog = `./${emulatorName}.log`;
+		const stdout = fs.openSync(tempLog, "a");
+		const stderr = fs.openSync(tempLog, "a");
+		const tail = new Tail(tempLog);
+		const promise = spawn(this.emulatorBin, _.split(cmd, " "), {
+			detached: true,
+			stdio: ["ignore", stdout, stderr]
+		});
 
-    const childProcess = promise.childProcess;
-    childProcess.unref();
+		const childProcess = promise.childProcess;
+		childProcess.unref();
 
-    tail.on("line", function(data) {
-      if (data.includes('Adb connected, start proxing data')) {
-        detach();
-      }
-      if (data.includes(`There's another emulator instance running with the current AVD`)) {
-        detach();
-      }
-    });
+		tail.on("line", function(data) {
+			if (data.includes("Adb connected, start proxing data")) {
+				detach();
+			}
+			if (
+				data.includes(
+					`There's another emulator instance running with the current AVD`
+				)
+			) {
+				detach();
+			}
+		});
 
-    tail.on("error", function(error) {
-      detach();
-      log.verbose('Emulator stderr: ', error);
-    });
+		tail.on("error", function(error) {
+			detach();
+			log.verbose("Emulator stderr: ", error);
+		});
 
-    promise.catch(function(err) {
-      log.error('Emulator ERROR: ', err);
-    });
+		promise.catch(function(err) {
+			log.error("Emulator ERROR: ", err);
+		});
 
-    function detach() {
-      tail.unwatch();
-      fs.closeSync(stdout);
-      fs.closeSync(stderr);
-      fs.unlink(tempLog, () => {});
-      promise._cpResolve();
-    }
+		function detach() {
+			tail.unwatch();
+			fs.closeSync(stdout);
+			fs.closeSync(stderr);
+			fs.unlink(tempLog, () => {});
+			promise._cpResolve();
+		}
 
-    return promise;
-  }
+		return promise;
+	}
 }
 
 module.exports = Emulator;

--- a/detox/src/devices/android/EmulatorTelnet.js
+++ b/detox/src/devices/android/EmulatorTelnet.js
@@ -1,68 +1,70 @@
-const Telnet = require('telnet-client');
-const path = require('path');
-const os = require('os');
-const fs = require('fs-extra');
+const Telnet = require("telnet-client");
+const path = require("path");
+const os = require("os");
+const fs = require("fs-extra");
 
 class EmulatorTelnet {
-  constructor() {
-    this.connection = new Telnet();
-  }
+	constructor() {
+		this.connection = new Telnet();
+	}
 
-  async connect(port) {
-    const params = {
-      host: 'localhost',
-      port: port,
-      shellPrompt: /^OK$/m,
-      timeout: 1500,
-      execTimeout: 1500,
-      sendTimeout: 1500,
-      echoLines: -2,
-      stripShellPrompt: true
-    };
+	async connect(port) {
+		const params = {
+			host: "localhost",
+			port: port,
+			shellPrompt: /^OK$/m,
+			timeout: 1500,
+			execTimeout: 1500,
+			sendTimeout: 1500,
+			echoLines: -2,
+			stripShellPrompt: true
+		};
 
-    await this.connection.connect(params);
-    const auth = await fs.readFile(path.join(os.homedir(), '.emulator_console_auth_token'), 'utf8');
-    await this.exec(`auth ${auth}`);
-  }
+		await this.connection.connect(params);
+		const auth = await fs.readFile(
+			path.join(os.homedir(), ".emulator_console_auth_token"),
+			"utf8"
+		);
+		await this.exec(`auth ${auth}`);
+	}
 
-  async exec(command) {
-    let res = await this.connection.exec(`${command}`);
-    res = res.split('\n')[0];
-    return res;
-  }
+	async exec(command) {
+		let res = await this.connection.exec(`${command}`);
+		res = res.split("\n")[0];
+		return res;
+	}
 
-  async shell(command) {
-    return new Promise((resolve, reject) => {
-      this.connection.shell((error, stream) => {
-        stream.write(`${command}\n`);
-        stream.on('data', (data) => {
-          const result = data.toString();
-          if (result.includes('\n')) {
-            resolve(result);
-          }
-        }
-        );
-      });
-    });
-  }
+	async shell(command) {
+		return new Promise((resolve, reject) => {
+			this.connection.shell((error, stream) => {
+				stream.write(`${command}\n`);
+				stream.on("data", data => {
+					const result = data.toString();
+					if (result.includes("\n")) {
+						resolve(result);
+					}
+				});
+			});
+		});
+	}
 
-  async avdName() {
-    return await this.exec('avd name');
-  }
+	async avdName() {
+		return await this.exec("avd name");
+	}
 
-  async kill() {
-    await this.shell('kill');
-    await this.quit();
-  }
+	async kill() {
+		await this.shell("kill");
+		await this.quit();
+	}
 
-  async quit() {
-    await this.connection.end();
-    await this.connection.destroy();
-  }
+	async quit() {
+		await this.connection.end();
+		await this.connection.destroy();
+	}
 
-  async rotate() {
-    return await this.shell('rotate');
-  }
+	async rotate() {
+		return await this.shell("rotate");
+	}
 }
 
 module.exports = EmulatorTelnet;

--- a/detox/src/errors/CustomError.js
+++ b/detox/src/errors/CustomError.js
@@ -1,12 +1,11 @@
-
 class CustomError extends Error {
-  constructor(...args) {
-    super(...args);
-    Object.defineProperty(this, "name", {
-      value: this.constructor.name
-    });
-    Error.captureStackTrace(this, this.constructor);
-  }
+	constructor(...args) {
+		super(...args);
+		Object.defineProperty(this, "name", {
+			value: this.constructor.name
+		});
+		Error.captureStackTrace(this, this.constructor);
+	}
 }
 
 module.exports = CustomError;

--- a/detox/src/errors/CustomError.test.js
+++ b/detox/src/errors/CustomError.test.js
@@ -1,10 +1,10 @@
-describe('CustomError', () => {
-  let CustomError;
-  beforeEach(() => {
-    CustomError = require('./CustomError');
-  });
+describe("CustomError", () => {
+	let CustomError;
+	beforeEach(() => {
+		CustomError = require("./CustomError");
+	});
 
-  it(`new CustomError should be defined`, () => {
-    expect(new CustomError()).toBeDefined();
-  });
+	it(`new CustomError should be defined`, () => {
+		expect(new CustomError()).toBeDefined();
+	});
 });

--- a/detox/src/index.js
+++ b/detox/src/index.js
@@ -1,28 +1,28 @@
-const Detox = require('./Detox');
+const Detox = require("./Detox");
 
 let detox;
 
 async function init(config, params) {
-  detox = new Detox(config);
-  await detox.init(params);
+	detox = new Detox(config);
+	await detox.init(params);
 }
 
 async function cleanup() {
-  if (detox) {
-    await detox.cleanup();
-  }
+	if (detox) {
+		await detox.cleanup();
+	}
 }
 
 async function beforeEach() {
-  if (detox) {
-    await detox.beforeEach.apply(detox, arguments);
-  }
+	if (detox) {
+		await detox.beforeEach(...arguments);
+	}
 }
 
 async function afterEach() {
-  if (detox) {
-    await detox.afterEach.apply(detox, arguments);
-  }
+	if (detox) {
+		await detox.afterEach(...arguments);
+	}
 }
 
 //process.on('uncaughtException', (err) => {
@@ -36,8 +36,8 @@ async function afterEach() {
 //});
 
 module.exports = {
-  init,
-  cleanup,
-  beforeEach,
-  afterEach
+	init,
+	cleanup,
+	beforeEach,
+	afterEach
 };

--- a/detox/src/index.js
+++ b/detox/src/index.js
@@ -13,15 +13,15 @@ async function cleanup() {
 	}
 }
 
-async function beforeEach() {
+async function beforeEach(...args) {
 	if (detox) {
-		await detox.beforeEach(...arguments);
+		await detox.beforeEach(...args);
 	}
 }
 
-async function afterEach() {
+async function afterEach(...args) {
 	if (detox) {
-		await detox.afterEach(...arguments);
+		await detox.afterEach(...args);
 	}
 }
 

--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -1,37 +1,37 @@
-const schemes = require('./configurations.mock');
-describe('index', () => {
-  let detox;
-  beforeEach(() => {
-    jest.mock('detox-server');
-    jest.mock('./devices/Device');
-    jest.mock('./client/Client');
-    detox = require('./index');
-  });
+const schemes = require("./configurations.mock");
+describe("index", () => {
+	let detox;
+	beforeEach(() => {
+		jest.mock("detox-server");
+		jest.mock("./devices/Device");
+		jest.mock("./client/Client");
+		detox = require("./index");
+	});
 
-  it(`Basic usage`, async() => {
-    await detox.init(schemes.validOneDeviceNoSession);
-    await detox.cleanup();
-  });
+	it(`Basic usage`, async () => {
+		await detox.init(schemes.validOneDeviceNoSession);
+		await detox.cleanup();
+	});
 
-  it(`Basic usage, if detox is undefined, do not throw an error`, async() => {
-    await detox.cleanup();
-  });
+	it(`Basic usage, if detox is undefined, do not throw an error`, async () => {
+		await detox.cleanup();
+	});
 
-  it(`beforeEach() should be covered - with detox initialized`, async() => {
-    await detox.init(schemes.validOneDeviceNoSession);
-    await detox.beforeEach();
-  });
+	it(`beforeEach() should be covered - with detox initialized`, async () => {
+		await detox.init(schemes.validOneDeviceNoSession);
+		await detox.beforeEach();
+	});
 
-  it(`beforeEach() should be covered - with detox not initialized`, async() => {
-    await detox.beforeEach();
-  });
+	it(`beforeEach() should be covered - with detox not initialized`, async () => {
+		await detox.beforeEach();
+	});
 
-  it(`afterEach() should be covered - with detox initialized`, async() => {
-    await detox.init(schemes.validOneDeviceNoSession);
-    await detox.afterEach();
-  });
+	it(`afterEach() should be covered - with detox initialized`, async () => {
+		await detox.init(schemes.validOneDeviceNoSession);
+		await detox.afterEach();
+	});
 
-  it(`afterEach() should be covered - with detox not initialized`, async() => {
-    await detox.afterEach();
-  });
+	it(`afterEach() should be covered - with detox not initialized`, async () => {
+		await detox.afterEach();
+	});
 });

--- a/detox/src/invoke.js
+++ b/detox/src/invoke.js
@@ -1,23 +1,23 @@
-const Invoke = require('./invoke/Invoke');
-const EarlGrey = require('./invoke/EarlGrey');
-const Espresso = require('./invoke/Espresso');
+const Invoke = require("./invoke/Invoke");
+const EarlGrey = require("./invoke/EarlGrey");
+const Espresso = require("./invoke/Espresso");
 
 class InvocationManager {
-  constructor(excutionHandler) {
-    this.executionHandler = excutionHandler;
-  }
+	constructor(excutionHandler) {
+		this.executionHandler = excutionHandler;
+	}
 
-  async execute(invocation) {
-    await this.executionHandler.execute(invocation);
-  }
+	async execute(invocation) {
+		await this.executionHandler.execute(invocation);
+	}
 }
 
 module.exports = {
-  InvocationManager,
-  EarlGrey,
-  Espresso: Espresso.target,
-  IOS: Invoke.genericInvokeObject,
-  Android: Invoke.genericInvokeObject,
-  call: Invoke.call,
-  callDirectly: Invoke.callDirectly
+	InvocationManager,
+	EarlGrey,
+	Espresso: Espresso.target,
+	IOS: Invoke.genericInvokeObject,
+	Android: Invoke.genericInvokeObject,
+	call: Invoke.call,
+	callDirectly: Invoke.callDirectly
 };

--- a/detox/src/invoke.test.js
+++ b/detox/src/invoke.test.js
@@ -1,23 +1,29 @@
-const invoke = require('./invoke');
+const invoke = require("./invoke");
 
-describe('invoke', () => {
-  let Client;
+describe("invoke", () => {
+	let Client;
 
-  beforeEach(() => {
-    jest.mock('./client/Client');
-    jest.mock('./invoke/Invoke');
-    Client = require('./client/Client');
-  });
+	beforeEach(() => {
+		jest.mock("./client/Client");
+		jest.mock("./invoke/Invoke");
+		Client = require("./client/Client");
+	});
 
-  it(`execute() should trigger executionHandler.execute()`, () => {
-    const invocationManager = new invoke.InvocationManager(new Client(""));
-    invocationManager.execute();
-    expect(invocationManager.executionHandler.execute).toHaveBeenCalled();
-  });
+	it(`execute() should trigger executionHandler.execute()`, () => {
+		const invocationManager = new invoke.InvocationManager(new Client(""));
+		invocationManager.execute();
+		expect(invocationManager.executionHandler.execute).toHaveBeenCalled();
+	});
 
-  it(`invoke.IOS.{anything} will create an instance of {generic} invoke object`, () => {
-    expect(invoke.IOS.CGPoint({x: 2, y: 1})).toEqual({type: 'CGPoint', value: {x: 2, y: 1}});
-    expect(invoke.IOS.CGRect({x: 12, y: 11})).toEqual({type: 'CGRect', value: {x: 12, y: 11}});
-    expect(invoke.IOS.Anything(1)).toEqual({type: 'Anything', value: 1});
-  });
+	it(`invoke.IOS.{anything} will create an instance of {generic} invoke object`, () => {
+		expect(invoke.IOS.CGPoint({ x: 2, y: 1 })).toEqual({
+			type: "CGPoint",
+			value: { x: 2, y: 1 }
+		});
+		expect(invoke.IOS.CGRect({ x: 12, y: 11 })).toEqual({
+			type: "CGRect",
+			value: { x: 12, y: 11 }
+		});
+		expect(invoke.IOS.Anything(1)).toEqual({ type: "Anything", value: 1 });
+	});
 });

--- a/detox/src/invoke/EarlGrey.js
+++ b/detox/src/invoke/EarlGrey.js
@@ -1,8 +1,8 @@
 const instance = {
-  type: 'EarlGrey',
-  value: 'instance'
+	type: "EarlGrey",
+	value: "instance"
 };
 
 module.exports = {
-  instance
+	instance
 };

--- a/detox/src/invoke/Espresso.js
+++ b/detox/src/invoke/Espresso.js
@@ -1,8 +1,8 @@
 const target = {
-  type: 'Class',
-  value: 'android.support.test.espresso.Espresso'
+	type: "Class",
+	value: "android.support.test.espresso.Espresso"
 };
 
 module.exports = {
-  target
+	target
 };

--- a/detox/src/invoke/Invoke.js
+++ b/detox/src/invoke/Invoke.js
@@ -1,7 +1,8 @@
 function call(target, method, ...args) {
 	return function() {
+		let targetResult = target;
 		if (typeof target === "function") {
-			target = {
+			targetResult = {
 				type: "Invocation",
 				value: target()
 			};
@@ -15,7 +16,7 @@ function call(target, method, ...args) {
 			}
 		}
 		return {
-			target: target,
+			target: targetResult,
 			method: method,
 			args: args
 		};

--- a/detox/src/invoke/Invoke.js
+++ b/detox/src/invoke/Invoke.js
@@ -1,48 +1,50 @@
 function call(target, method, ...args) {
-  return function() {
-    if (typeof target === 'function') {
-      target = {
-        type: 'Invocation',
-        value: target()
-      };
-    }
-    for (let i = 0; i < args.length; i++) {
-      if (typeof args[i] === 'function') {
-        args[i] = {
-          type: 'Invocation',
-          value: args[i]()
-        };
-      }
-    }
-    return {
-      target: target,
-      method: method,
-      args: args
-    };
-  };
+	return function() {
+		if (typeof target === "function") {
+			target = {
+				type: "Invocation",
+				value: target()
+			};
+		}
+		for (let i = 0; i < args.length; i++) {
+			if (typeof args[i] === "function") {
+				args[i] = {
+					type: "Invocation",
+					value: args[i]()
+				};
+			}
+		}
+		return {
+			target: target,
+			method: method,
+			args: args
+		};
+	};
 }
 
 function callDirectly(json) {
-  return {
-    type: 'Invocation',
-    value: json
-  };
+	return {
+		type: "Invocation",
+		value: json
+	};
 }
 
-const genericInvokeObject = new Proxy({},
-  {
-    get: (target, prop) => {
-      return (p) => {
-        return {
-          type: prop,
-          value: p
-        };
-      };
-    }
-  });
+const genericInvokeObject = new Proxy(
+	{},
+	{
+		get: (target, prop) => {
+			return p => {
+				return {
+					type: prop,
+					value: p
+				};
+			};
+		}
+	}
+);
 
 module.exports = {
-  call,
-  callDirectly,
-  genericInvokeObject
+	call,
+	callDirectly,
+	genericInvokeObject
 };

--- a/detox/src/ios/earlgreyapi/GREYActions.js
+++ b/detox/src/ios/earlgreyapi/GREYActions.js
@@ -4,119 +4,173 @@
 	For more information see generation/README.md.
 */
 
-
 function sanitize_greyDirection(action) {
-  switch (action) {
-    case "left":
-      return 1;
-    case "right":
-      return 2;
-    case "up":
-      return 3;
-    case "down":
-      return 4;
-      
-    default:
-      throw new Error(`GREYAction.GREYDirection must be a 'left'/'right'/'up'/'down', got ${action}`);
-  }
+	switch (action) {
+		case "left":
+			return 1;
+		case "right":
+			return 2;
+		case "up":
+			return 3;
+		case "down":
+			return 4;
+
+		default:
+			throw new Error(
+				`GREYAction.GREYDirection must be a 'left'/'right'/'up'/'down', got ${action}`
+			);
+	}
 }
 function sanitize_greyContentEdge(action) {
-  switch (action) {
-    case "left":
-      return 0;
-    case "right":
-      return 1;
-    case "top":
-      return 2;
-    case "bottom":
-      return 3;
+	switch (action) {
+		case "left":
+			return 0;
+		case "right":
+			return 1;
+		case "top":
+			return 2;
+		case "bottom":
+			return 3;
 
-    default:
-      throw new Error(`GREYAction.GREYContentEdge must be a 'left'/'right'/'top'/'bottom', got ${action}`);
-  }
+		default:
+			throw new Error(
+				`GREYAction.GREYContentEdge must be a 'left'/'right'/'top'/'bottom', got ${action}`
+			);
+	}
 }
 class GREYActions {
-  /*@return A GREYAction that performs multiple taps of a specified @c count.
-*/static actionForMultipleTapsWithCount(count) {
-    if (typeof count !== "number") throw new Error("count should be a number, but got " + (count + (" (" + (typeof count + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForMultipleTapsWithCount:",
-      args: [{
-        type: "NSInteger",
-        value: count
-      }]
-    };
-  }
+	/*@return A GREYAction that performs multiple taps of a specified @c count.
+*/ static actionForMultipleTapsWithCount(
+		count
+	) {
+		if (typeof count !== "number") {
+			throw new Error(
+				"count should be a number, but got " +
+					(count + (" (" + (typeof count + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForMultipleTapsWithCount:",
+			args: [
+				{
+					type: "NSInteger",
+					value: count
+				}
+			]
+		};
+	}
 
-  /*@return A GREYAction that performs multiple taps of a specified @c count at a specified
+	/*@return A GREYAction that performs multiple taps of a specified @c count at a specified
 @c point.
-*/static actionForMultipleTapsWithCountAtPoint(count, point) {
-    if (typeof count !== "number") throw new Error("count should be a number, but got " + (count + (" (" + (typeof count + ")"))));
-    if (typeof point !== "object") throw new Error("point should be a object, but got " + (point + (" (" + (typeof point + ")"))));
-    if (typeof point.x !== "number") throw new Error("point.x should be a number, but got " + (point.x + (" (" + (typeof point.x + ")"))));
-    if (typeof point.y !== "number") throw new Error("point.y should be a number, but got " + (point.y + (" (" + (typeof point.y + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForMultipleTapsWithCount:atPoint:",
-      args: [{
-        type: "NSInteger",
-        value: count
-      }, {
-        type: "CGPoint",
-        value: point
-      }]
-    };
-  }
+*/ static actionForMultipleTapsWithCountAtPoint(
+		count,
+		point
+	) {
+		if (typeof count !== "number") {
+			throw new Error(
+				"count should be a number, but got " +
+					(count + (" (" + (typeof count + ")")))
+			);
+		}
+		if (typeof point !== "object") {
+			throw new Error(
+				"point should be a object, but got " +
+					(point + (" (" + (typeof point + ")")))
+			);
+		}
+		if (typeof point.x !== "number") {
+			throw new Error(
+				"point.x should be a number, but got " +
+					(point.x + (" (" + (typeof point.x + ")")))
+			);
+		}
+		if (typeof point.y !== "number") {
+			throw new Error(
+				"point.y should be a number, but got " +
+					(point.y + (" (" + (typeof point.y + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForMultipleTapsWithCount:atPoint:",
+			args: [
+				{
+					type: "NSInteger",
+					value: count
+				},
+				{
+					type: "CGPoint",
+					value: point
+				}
+			]
+		};
+	}
 
-  /*Returns an action that holds down finger for 1.0 second (@c kGREYLongPressDefaultDuration) to
+	/*Returns an action that holds down finger for 1.0 second (@c kGREYLongPressDefaultDuration) to
 simulate a long press.
 
 @return A GREYAction that performs a long press on an element.
-*/static actionForLongPress() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForLongPress",
-      args: []
-    };
-  }
+*/ static actionForLongPress() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForLongPress",
+			args: []
+		};
+	}
 
-  /*Returns an action that scrolls a @c UIScrollView by @c amount (in points) in the specified
+	/*Returns an action that scrolls a @c UIScrollView by @c amount (in points) in the specified
 @c direction.
 
 @param direction The direction of the swipe.
 @param amount    The amount of points in CGPoints to scroll.
 
 @return A GREYAction that scrolls a scroll view in a given @c direction for a given @c amount.
-*/static actionForScrollInDirectionAmount(direction, amount) {
-    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
-    if (typeof amount !== "number") throw new Error("amount should be a number, but got " + (amount + (" (" + (typeof amount + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForScrollInDirection:amount:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyDirection(direction)
-      }, {
-        type: "CGFloat",
-        value: amount
-      }]
-    };
-  }
+*/ static actionForScrollInDirectionAmount(
+		direction,
+		amount
+	) {
+		if (!["left", "right", "up", "down"].some(option => option === direction)) {
+			throw new Error(
+				"direction should be one of [left, right, up, down], but got " +
+					direction
+			);
+		}
+		if (typeof amount !== "number") {
+			throw new Error(
+				"amount should be a number, but got " +
+					(amount + (" (" + (typeof amount + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForScrollInDirection:amount:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyDirection(direction)
+				},
+				{
+					type: "CGFloat",
+					value: amount
+				}
+			]
+		};
+	}
 
-  /*Returns a scroll action that scrolls in a @c direction for an @c amount of points starting from
+	/*Returns a scroll action that scrolls in a @c direction for an @c amount of points starting from
 the given start point specified as percentages. @c xOriginStartPercentage is the x start
 position as a percentage of the total width of the scrollable visible area,
 @c yOriginStartPercentage is the y start position as a percentage of the total height of the
@@ -132,50 +186,91 @@ exclusive, of the total height of the scrollable visible area.
 
 @return A GREYAction that scrolls a scroll view in a given @c direction for a given @c amount
 starting from the given start points.
-*/static actionForScrollInDirectionAmountXOriginStartPercentageYOriginStartPercentage(direction, amount, xOriginStartPercentage, yOriginStartPercentage) {
-    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
-    if (typeof amount !== "number") throw new Error("amount should be a number, but got " + (amount + (" (" + (typeof amount + ")"))));
-    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
-    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForScrollInDirection:amount:xOriginStartPercentage:yOriginStartPercentage:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyDirection(direction)
-      }, {
-        type: "CGFloat",
-        value: amount
-      }, {
-        type: "CGFloat",
-        value: xOriginStartPercentage
-      }, {
-        type: "CGFloat",
-        value: yOriginStartPercentage
-      }]
-    };
-  }
+*/ static actionForScrollInDirectionAmountXOriginStartPercentageYOriginStartPercentage(
+		direction,
+		amount,
+		xOriginStartPercentage,
+		yOriginStartPercentage
+	) {
+		if (!["left", "right", "up", "down"].some(option => option === direction)) {
+			throw new Error(
+				"direction should be one of [left, right, up, down], but got " +
+					direction
+			);
+		}
+		if (typeof amount !== "number") {
+			throw new Error(
+				"amount should be a number, but got " +
+					(amount + (" (" + (typeof amount + ")")))
+			);
+		}
+		if (typeof xOriginStartPercentage !== "number") {
+			throw new Error(
+				"xOriginStartPercentage should be a number, but got " +
+					(xOriginStartPercentage +
+						(" (" + (typeof xOriginStartPercentage + ")")))
+			);
+		}
+		if (typeof yOriginStartPercentage !== "number") {
+			throw new Error(
+				"yOriginStartPercentage should be a number, but got " +
+					(yOriginStartPercentage +
+						(" (" + (typeof yOriginStartPercentage + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method:
+				"actionForScrollInDirection:amount:xOriginStartPercentage:yOriginStartPercentage:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyDirection(direction)
+				},
+				{
+					type: "CGFloat",
+					value: amount
+				},
+				{
+					type: "CGFloat",
+					value: xOriginStartPercentage
+				},
+				{
+					type: "CGFloat",
+					value: yOriginStartPercentage
+				}
+			]
+		};
+	}
 
-  /*@return A GREYAction that scrolls to the given content @c edge of a scroll view.
-*/static actionForScrollToContentEdge(edge) {
-    if (!["left", "right", "top", "bottom"].some(option => option === edge)) throw new Error("edge should be one of [left, right, top, bottom], but got " + edge);
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForScrollToContentEdge:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyContentEdge(edge)
-      }]
-    };
-  }
+	/*@return A GREYAction that scrolls to the given content @c edge of a scroll view.
+*/ static actionForScrollToContentEdge(
+		edge
+	) {
+		if (!["left", "right", "top", "bottom"].some(option => option === edge)) {
+			throw new Error(
+				"edge should be one of [left, right, top, bottom], but got " + edge
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForScrollToContentEdge:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyContentEdge(edge)
+				}
+			]
+		};
+	}
 
-  /*A GREYAction that scrolls to the given content @c edge of a scroll view with the scroll action
+	/*A GREYAction that scrolls to the given content @c edge of a scroll view with the scroll action
 starting from the given start point specified as percentages. @c xOriginStartPercentage is the x
 start position as a percentage of the total width of the scrollable visible area,
 @c yOriginStartPercentage is the y start position as a percentage of the total height of the
@@ -190,72 +285,115 @@ exclusive, of the total height of the scrollable visible area.
 
 @return A GREYAction that scrolls to the given content @c edge of a scroll view with the scroll
 action starting from the given start point.
-*/static actionForScrollToContentEdgeXOriginStartPercentageYOriginStartPercentage(edge, xOriginStartPercentage, yOriginStartPercentage) {
-    if (!["left", "right", "top", "bottom"].some(option => option === edge)) throw new Error("edge should be one of [left, right, top, bottom], but got " + edge);
-    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
-    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForScrollToContentEdge:xOriginStartPercentage:yOriginStartPercentage:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyContentEdge(edge)
-      }, {
-        type: "CGFloat",
-        value: xOriginStartPercentage
-      }, {
-        type: "CGFloat",
-        value: yOriginStartPercentage
-      }]
-    };
-  }
+*/ static actionForScrollToContentEdgeXOriginStartPercentageYOriginStartPercentage(
+		edge,
+		xOriginStartPercentage,
+		yOriginStartPercentage
+	) {
+		if (!["left", "right", "top", "bottom"].some(option => option === edge)) {
+			throw new Error(
+				"edge should be one of [left, right, top, bottom], but got " + edge
+			);
+		}
+		if (typeof xOriginStartPercentage !== "number") {
+			throw new Error(
+				"xOriginStartPercentage should be a number, but got " +
+					(xOriginStartPercentage +
+						(" (" + (typeof xOriginStartPercentage + ")")))
+			);
+		}
+		if (typeof yOriginStartPercentage !== "number") {
+			throw new Error(
+				"yOriginStartPercentage should be a number, but got " +
+					(yOriginStartPercentage +
+						(" (" + (typeof yOriginStartPercentage + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method:
+				"actionForScrollToContentEdge:xOriginStartPercentage:yOriginStartPercentage:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyContentEdge(edge)
+				},
+				{
+					type: "CGFloat",
+					value: xOriginStartPercentage
+				},
+				{
+					type: "CGFloat",
+					value: yOriginStartPercentage
+				}
+			]
+		};
+	}
 
-  /*Returns an action that fast swipes through the view. The start point of the swipe is chosen to
+	/*Returns an action that fast swipes through the view. The start point of the swipe is chosen to
 achieve the maximum the swipe possible to the other edge.
 
 @param direction The direction of the swipe.
 
 @return A GREYAction that performs a fast swipe in the given direction.
-*/static actionForSwipeFastInDirection(direction) {
-    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForSwipeFastInDirection:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyDirection(direction)
-      }]
-    };
-  }
+*/ static actionForSwipeFastInDirection(
+		direction
+	) {
+		if (!["left", "right", "up", "down"].some(option => option === direction)) {
+			throw new Error(
+				"direction should be one of [left, right, up, down], but got " +
+					direction
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForSwipeFastInDirection:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyDirection(direction)
+				}
+			]
+		};
+	}
 
-  /*Returns an action that slow swipes through the view. The start point of the swipe is chosen to
+	/*Returns an action that slow swipes through the view. The start point of the swipe is chosen to
 achieve maximum the swipe possible to the other edge.
 
 @param direction The direction of the swipe.
 
 @return A GREYAction that performs a slow swipe in the given direction.
-*/static actionForSwipeSlowInDirection(direction) {
-    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForSwipeSlowInDirection:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyDirection(direction)
-      }]
-    };
-  }
+*/ static actionForSwipeSlowInDirection(
+		direction
+	) {
+		if (!["left", "right", "up", "down"].some(option => option === direction)) {
+			throw new Error(
+				"direction should be one of [left, right, up, down], but got " +
+					direction
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForSwipeSlowInDirection:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyDirection(direction)
+				}
+			]
+		};
+	}
 
-  /*Returns an action that swipes through the view quickly in the given @c direction from a specific
+	/*Returns an action that swipes through the view quickly in the given @c direction from a specific
 origin.
 
 @param direction              The direction of the swipe.
@@ -266,30 +404,56 @@ of the view. This must be between 0 and 1.
 
 @return A GREYAction that performs a fast swipe through a view in a specific direction from
 the specified point.
-*/static actionForSwipeFastInDirectionXOriginStartPercentageYOriginStartPercentage(direction, xOriginStartPercentage, yOriginStartPercentage) {
-    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
-    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
-    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForSwipeFastInDirection:xOriginStartPercentage:yOriginStartPercentage:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyDirection(direction)
-      }, {
-        type: "CGFloat",
-        value: xOriginStartPercentage
-      }, {
-        type: "CGFloat",
-        value: yOriginStartPercentage
-      }]
-    };
-  }
+*/ static actionForSwipeFastInDirectionXOriginStartPercentageYOriginStartPercentage(
+		direction,
+		xOriginStartPercentage,
+		yOriginStartPercentage
+	) {
+		if (!["left", "right", "up", "down"].some(option => option === direction)) {
+			throw new Error(
+				"direction should be one of [left, right, up, down], but got " +
+					direction
+			);
+		}
+		if (typeof xOriginStartPercentage !== "number") {
+			throw new Error(
+				"xOriginStartPercentage should be a number, but got " +
+					(xOriginStartPercentage +
+						(" (" + (typeof xOriginStartPercentage + ")")))
+			);
+		}
+		if (typeof yOriginStartPercentage !== "number") {
+			throw new Error(
+				"yOriginStartPercentage should be a number, but got " +
+					(yOriginStartPercentage +
+						(" (" + (typeof yOriginStartPercentage + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method:
+				"actionForSwipeFastInDirection:xOriginStartPercentage:yOriginStartPercentage:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyDirection(direction)
+				},
+				{
+					type: "CGFloat",
+					value: xOriginStartPercentage
+				},
+				{
+					type: "CGFloat",
+					value: yOriginStartPercentage
+				}
+			]
+		};
+	}
 
-  /*Returns an action that swipes through the view quickly in the given @c direction from a
+	/*Returns an action that swipes through the view quickly in the given @c direction from a
 specific origin.
 
 @param direction              The direction of the swipe.
@@ -300,30 +464,56 @@ of the view. This must be between 0 and 1.
 
 @return A GREYAction that performs a slow swipe through a view in a specific direction from
 the specified point.
-*/static actionForSwipeSlowInDirectionXOriginStartPercentageYOriginStartPercentage(direction, xOriginStartPercentage, yOriginStartPercentage) {
-    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
-    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
-    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForSwipeSlowInDirection:xOriginStartPercentage:yOriginStartPercentage:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyDirection(direction)
-      }, {
-        type: "CGFloat",
-        value: xOriginStartPercentage
-      }, {
-        type: "CGFloat",
-        value: yOriginStartPercentage
-      }]
-    };
-  }
+*/ static actionForSwipeSlowInDirectionXOriginStartPercentageYOriginStartPercentage(
+		direction,
+		xOriginStartPercentage,
+		yOriginStartPercentage
+	) {
+		if (!["left", "right", "up", "down"].some(option => option === direction)) {
+			throw new Error(
+				"direction should be one of [left, right, up, down], but got " +
+					direction
+			);
+		}
+		if (typeof xOriginStartPercentage !== "number") {
+			throw new Error(
+				"xOriginStartPercentage should be a number, but got " +
+					(xOriginStartPercentage +
+						(" (" + (typeof xOriginStartPercentage + ")")))
+			);
+		}
+		if (typeof yOriginStartPercentage !== "number") {
+			throw new Error(
+				"yOriginStartPercentage should be a number, but got " +
+					(yOriginStartPercentage +
+						(" (" + (typeof yOriginStartPercentage + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method:
+				"actionForSwipeSlowInDirection:xOriginStartPercentage:yOriginStartPercentage:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyDirection(direction)
+				},
+				{
+					type: "CGFloat",
+					value: xOriginStartPercentage
+				},
+				{
+					type: "CGFloat",
+					value: yOriginStartPercentage
+				}
+			]
+		};
+	}
 
-  /*Returns an action that performs a multi-finger slow swipe through the view in the given
+	/*Returns an action that performs a multi-finger slow swipe through the view in the given
 @c direction.
 
 @param direction       The direction of the swipe.
@@ -331,26 +521,42 @@ the specified point.
 
 @return A GREYAction that performs a multi-finger slow swipe through a view in a specific
 direction from the specified point.
-*/static actionForMultiFingerSwipeSlowInDirectionNumberOfFingers(direction, numberOfFingers) {
-    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
-    if (typeof numberOfFingers !== "number") throw new Error("numberOfFingers should be a number, but got " + (numberOfFingers + (" (" + (typeof numberOfFingers + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForMultiFingerSwipeSlowInDirection:numberOfFingers:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyDirection(direction)
-      }, {
-        type: "NSInteger",
-        value: numberOfFingers
-      }]
-    };
-  }
+*/ static actionForMultiFingerSwipeSlowInDirectionNumberOfFingers(
+		direction,
+		numberOfFingers
+	) {
+		if (!["left", "right", "up", "down"].some(option => option === direction)) {
+			throw new Error(
+				"direction should be one of [left, right, up, down], but got " +
+					direction
+			);
+		}
+		if (typeof numberOfFingers !== "number") {
+			throw new Error(
+				"numberOfFingers should be a number, but got " +
+					(numberOfFingers + (" (" + (typeof numberOfFingers + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForMultiFingerSwipeSlowInDirection:numberOfFingers:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyDirection(direction)
+				},
+				{
+					type: "NSInteger",
+					value: numberOfFingers
+				}
+			]
+		};
+	}
 
-  /*Returns an action that performs a multi-finger fast swipe through the view in the given
+	/*Returns an action that performs a multi-finger fast swipe through the view in the given
 @c direction.
 
 @param direction       The direction of the swipe.
@@ -358,26 +564,42 @@ direction from the specified point.
 
 @return A GREYAction that performs a multi-finger fast swipe through a view in a specific
 direction from the specified point.
-*/static actionForMultiFingerSwipeFastInDirectionNumberOfFingers(direction, numberOfFingers) {
-    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
-    if (typeof numberOfFingers !== "number") throw new Error("numberOfFingers should be a number, but got " + (numberOfFingers + (" (" + (typeof numberOfFingers + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForMultiFingerSwipeFastInDirection:numberOfFingers:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyDirection(direction)
-      }, {
-        type: "NSInteger",
-        value: numberOfFingers
-      }]
-    };
-  }
+*/ static actionForMultiFingerSwipeFastInDirectionNumberOfFingers(
+		direction,
+		numberOfFingers
+	) {
+		if (!["left", "right", "up", "down"].some(option => option === direction)) {
+			throw new Error(
+				"direction should be one of [left, right, up, down], but got " +
+					direction
+			);
+		}
+		if (typeof numberOfFingers !== "number") {
+			throw new Error(
+				"numberOfFingers should be a number, but got " +
+					(numberOfFingers + (" (" + (typeof numberOfFingers + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForMultiFingerSwipeFastInDirection:numberOfFingers:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyDirection(direction)
+				},
+				{
+					type: "NSInteger",
+					value: numberOfFingers
+				}
+			]
+		};
+	}
 
-  /*Returns an action that performs a multi-finger slow swipe through the view in the given
+	/*Returns an action that performs a multi-finger slow swipe through the view in the given
 @c direction.
 
 @param direction       The direction of the swipe.
@@ -385,34 +607,67 @@ direction from the specified point.
 
 @return A GREYAction that performs a multi-finger slow swipe through a view in a specific
 direction from the specified point.
-*/static actionForMultiFingerSwipeSlowInDirectionNumberOfFingersXOriginStartPercentageYOriginStartPercentage(direction, numberOfFingers, xOriginStartPercentage, yOriginStartPercentage) {
-    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
-    if (typeof numberOfFingers !== "number") throw new Error("numberOfFingers should be a number, but got " + (numberOfFingers + (" (" + (typeof numberOfFingers + ")"))));
-    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
-    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForMultiFingerSwipeSlowInDirection:numberOfFingers:xOriginStartPercentage:yOriginStartPercentage:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyDirection(direction)
-      }, {
-        type: "NSInteger",
-        value: numberOfFingers
-      }, {
-        type: "CGFloat",
-        value: xOriginStartPercentage
-      }, {
-        type: "CGFloat",
-        value: yOriginStartPercentage
-      }]
-    };
-  }
+*/ static actionForMultiFingerSwipeSlowInDirectionNumberOfFingersXOriginStartPercentageYOriginStartPercentage(
+		direction,
+		numberOfFingers,
+		xOriginStartPercentage,
+		yOriginStartPercentage
+	) {
+		if (!["left", "right", "up", "down"].some(option => option === direction)) {
+			throw new Error(
+				"direction should be one of [left, right, up, down], but got " +
+					direction
+			);
+		}
+		if (typeof numberOfFingers !== "number") {
+			throw new Error(
+				"numberOfFingers should be a number, but got " +
+					(numberOfFingers + (" (" + (typeof numberOfFingers + ")")))
+			);
+		}
+		if (typeof xOriginStartPercentage !== "number") {
+			throw new Error(
+				"xOriginStartPercentage should be a number, but got " +
+					(xOriginStartPercentage +
+						(" (" + (typeof xOriginStartPercentage + ")")))
+			);
+		}
+		if (typeof yOriginStartPercentage !== "number") {
+			throw new Error(
+				"yOriginStartPercentage should be a number, but got " +
+					(yOriginStartPercentage +
+						(" (" + (typeof yOriginStartPercentage + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method:
+				"actionForMultiFingerSwipeSlowInDirection:numberOfFingers:xOriginStartPercentage:yOriginStartPercentage:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyDirection(direction)
+				},
+				{
+					type: "NSInteger",
+					value: numberOfFingers
+				},
+				{
+					type: "CGFloat",
+					value: xOriginStartPercentage
+				},
+				{
+					type: "CGFloat",
+					value: yOriginStartPercentage
+				}
+			]
+		};
+	}
 
-  /*Returns an action that performs a multi-finger fast swipe through the view in the given
+	/*Returns an action that performs a multi-finger fast swipe through the view in the given
 @c direction.
 
 @param direction       The direction of the swipe.
@@ -420,72 +675,124 @@ direction from the specified point.
 
 @return A GREYAction that performs a multi-finger fast swipe through a view in a specific
 direction from the specified point.
-*/static actionForMultiFingerSwipeFastInDirectionNumberOfFingersXOriginStartPercentageYOriginStartPercentage(direction, numberOfFingers, xOriginStartPercentage, yOriginStartPercentage) {
-    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
-    if (typeof numberOfFingers !== "number") throw new Error("numberOfFingers should be a number, but got " + (numberOfFingers + (" (" + (typeof numberOfFingers + ")"))));
-    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
-    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForMultiFingerSwipeFastInDirection:numberOfFingers:xOriginStartPercentage:yOriginStartPercentage:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyDirection(direction)
-      }, {
-        type: "NSInteger",
-        value: numberOfFingers
-      }, {
-        type: "CGFloat",
-        value: xOriginStartPercentage
-      }, {
-        type: "CGFloat",
-        value: yOriginStartPercentage
-      }]
-    };
-  }
+*/ static actionForMultiFingerSwipeFastInDirectionNumberOfFingersXOriginStartPercentageYOriginStartPercentage(
+		direction,
+		numberOfFingers,
+		xOriginStartPercentage,
+		yOriginStartPercentage
+	) {
+		if (!["left", "right", "up", "down"].some(option => option === direction)) {
+			throw new Error(
+				"direction should be one of [left, right, up, down], but got " +
+					direction
+			);
+		}
+		if (typeof numberOfFingers !== "number") {
+			throw new Error(
+				"numberOfFingers should be a number, but got " +
+					(numberOfFingers + (" (" + (typeof numberOfFingers + ")")))
+			);
+		}
+		if (typeof xOriginStartPercentage !== "number") {
+			throw new Error(
+				"xOriginStartPercentage should be a number, but got " +
+					(xOriginStartPercentage +
+						(" (" + (typeof xOriginStartPercentage + ")")))
+			);
+		}
+		if (typeof yOriginStartPercentage !== "number") {
+			throw new Error(
+				"yOriginStartPercentage should be a number, but got " +
+					(yOriginStartPercentage +
+						(" (" + (typeof yOriginStartPercentage + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method:
+				"actionForMultiFingerSwipeFastInDirection:numberOfFingers:xOriginStartPercentage:yOriginStartPercentage:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyDirection(direction)
+				},
+				{
+					type: "NSInteger",
+					value: numberOfFingers
+				},
+				{
+					type: "CGFloat",
+					value: xOriginStartPercentage
+				},
+				{
+					type: "CGFloat",
+					value: yOriginStartPercentage
+				}
+			]
+		};
+	}
 
-  /*Returns an action that taps on an element at the activation point of the element.
+	/*Returns an action that taps on an element at the activation point of the element.
 
 @return A GREYAction to tap on an element.
-*/static actionForTap() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForTap",
-      args: []
-    };
-  }
+*/ static actionForTap() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForTap",
+			args: []
+		};
+	}
 
-  /*Returns an action that taps on an element at the specified @c point.
+	/*Returns an action that taps on an element at the specified @c point.
 
 @param point The point that should be tapped. It must be in the coordinate system of the
 element and it's position is relative to the origin of the element, as in
 (element_width/2, element_height/2) will tap at the center of element.
 
 @return A GREYAction to tap on an element at a specific point.
-*/static actionForTapAtPoint(point) {
-    if (typeof point !== "object") throw new Error("point should be a object, but got " + (point + (" (" + (typeof point + ")"))));
-    if (typeof point.x !== "number") throw new Error("point.x should be a number, but got " + (point.x + (" (" + (typeof point.x + ")"))));
-    if (typeof point.y !== "number") throw new Error("point.y should be a number, but got " + (point.y + (" (" + (typeof point.y + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForTapAtPoint:",
-      args: [{
-        type: "CGPoint",
-        value: point
-      }]
-    };
-  }
+*/ static actionForTapAtPoint(
+		point
+	) {
+		if (typeof point !== "object") {
+			throw new Error(
+				"point should be a object, but got " +
+					(point + (" (" + (typeof point + ")")))
+			);
+		}
+		if (typeof point.x !== "number") {
+			throw new Error(
+				"point.x should be a number, but got " +
+					(point.x + (" (" + (typeof point.x + ")")))
+			);
+		}
+		if (typeof point.y !== "number") {
+			throw new Error(
+				"point.y should be a number, but got " +
+					(point.y + (" (" + (typeof point.y + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForTapAtPoint:",
+			args: [
+				{
+					type: "CGPoint",
+					value: point
+				}
+			]
+		};
+	}
 
-  /*Returns an action that uses the iOS keyboard to input a string.
+	/*Returns an action that uses the iOS keyboard to input a string.
 
 @param text The text to be typed. For Objective-C, backspace is supported by using "\b" in the
 string and "\u{8}" in Swift strings. Return key is supported with "\n".
@@ -493,78 +800,111 @@ For Example: @"Helpo\b\bloWorld" will type HelloWorld in Objective-C.
 "Helpo\u{8}\u{8}loWorld" will type HelloWorld in Swift.
 
 @return A GREYAction to type a specific text string in a text field.
-*/static actionForTypeText(text) {
-    if (typeof text !== "string") throw new Error("text should be a string, but got " + (text + (" (" + (typeof text + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForTypeText:",
-      args: [{
-        type: "NSString",
-        value: text
-      }]
-    };
-  }
+*/ static actionForTypeText(
+		text
+	) {
+		if (typeof text !== "string") {
+			throw new Error(
+				"text should be a string, but got " +
+					(text + (" (" + (typeof text + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForTypeText:",
+			args: [
+				{
+					type: "NSString",
+					value: text
+				}
+			]
+		};
+	}
 
-  /*Returns an action that sets text on a UITextField or webview input directly.
+	/*Returns an action that sets text on a UITextField or webview input directly.
 
 @param text The text to be typed.
 
 @return A GREYAction to type a specific text string in a text field.
-*/static actionForReplaceText(text) {
-    if (typeof text !== "string") throw new Error("text should be a string, but got " + (text + (" (" + (typeof text + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForReplaceText:",
-      args: [{
-        type: "NSString",
-        value: text
-      }]
-    };
-  }
+*/ static actionForReplaceText(
+		text
+	) {
+		if (typeof text !== "string") {
+			throw new Error(
+				"text should be a string, but got " +
+					(text + (" (" + (typeof text + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForReplaceText:",
+			args: [
+				{
+					type: "NSString",
+					value: text
+				}
+			]
+		};
+	}
 
-  /*@return A GREYAction that clears a text field by injecting back-spaces.
-*/static actionForClearText() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForClearText",
-      args: []
-    };
-  }
+	/*@return A GREYAction that clears a text field by injecting back-spaces.
+*/ static actionForClearText() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForClearText",
+			args: []
+		};
+	}
 
-  /*Returns an action that selects @c value on the given @c column of a UIPickerView.
+	/*Returns an action that selects @c value on the given @c column of a UIPickerView.
 
 @param column The UIPickerView column being set.
 @param value  The value to set the UIPickerView.
 
 @return A GREYAction to set the value of a specified column of a UIPickerView.
-*/static actionForSetPickerColumnToValue(column, value) {
-    if (typeof column !== "number") throw new Error("column should be a number, but got " + (column + (" (" + (typeof column + ")"))));
-    if (typeof value !== "string") throw new Error("value should be a string, but got " + (value + (" (" + (typeof value + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYActions"
-      },
-      method: "actionForSetPickerColumn:toValue:",
-      args: [{
-        type: "NSInteger",
-        value: column
-      }, {
-        type: "NSString",
-        value: value
-      }]
-    };
-  }
-
+*/ static actionForSetPickerColumnToValue(
+		column,
+		value
+	) {
+		if (typeof column !== "number") {
+			throw new Error(
+				"column should be a number, but got " +
+					(column + (" (" + (typeof column + ")")))
+			);
+		}
+		if (typeof value !== "string") {
+			throw new Error(
+				"value should be a string, but got " +
+					(value + (" (" + (typeof value + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYActions"
+			},
+			method: "actionForSetPickerColumn:toValue:",
+			args: [
+				{
+					type: "NSInteger",
+					value: column
+				},
+				{
+					type: "NSString",
+					value: value
+				}
+			]
+		};
+	}
 }
 
 module.exports = GREYActions;

--- a/detox/src/ios/earlgreyapi/GREYActions.js
+++ b/detox/src/ios/earlgreyapi/GREYActions.js
@@ -1,8 +1,10 @@
+/* eslint-disable */
 /**
 
 	This code is generated.
 	For more information see generation/README.md.
 */
+
 
 function sanitize_greyDirection(action) {
 	switch (action) {
@@ -20,7 +22,7 @@ function sanitize_greyDirection(action) {
 				`GREYAction.GREYDirection must be a 'left'/'right'/'up'/'down', got ${action}`
 			);
 	}
-}
+} 
 function sanitize_greyContentEdge(action) {
 	switch (action) {
 		case "left":
@@ -37,140 +39,89 @@ function sanitize_greyContentEdge(action) {
 				`GREYAction.GREYContentEdge must be a 'left'/'right'/'top'/'bottom', got ${action}`
 			);
 	}
-}
+} 
 class GREYActions {
-	/*@return A GREYAction that performs multiple taps of a specified @c count.
-*/ static actionForMultipleTapsWithCount(
-		count
-	) {
-		if (typeof count !== "number") {
-			throw new Error(
-				"count should be a number, but got " +
-					(count + (" (" + (typeof count + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForMultipleTapsWithCount:",
-			args: [
-				{
-					type: "NSInteger",
-					value: count
-				}
-			]
-		};
-	}
+  /*@return A GREYAction that performs multiple taps of a specified @c count.
+*/static actionForMultipleTapsWithCount(count) {
+    if (typeof count !== "number") throw new Error("count should be a number, but got " + (count + (" (" + (typeof count + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForMultipleTapsWithCount:",
+      args: [{
+        type: "NSInteger",
+        value: count
+      }]
+    };
+  }
 
-	/*@return A GREYAction that performs multiple taps of a specified @c count at a specified
+  /*@return A GREYAction that performs multiple taps of a specified @c count at a specified
 @c point.
-*/ static actionForMultipleTapsWithCountAtPoint(
-		count,
-		point
-	) {
-		if (typeof count !== "number") {
-			throw new Error(
-				"count should be a number, but got " +
-					(count + (" (" + (typeof count + ")")))
-			);
-		}
-		if (typeof point !== "object") {
-			throw new Error(
-				"point should be a object, but got " +
-					(point + (" (" + (typeof point + ")")))
-			);
-		}
-		if (typeof point.x !== "number") {
-			throw new Error(
-				"point.x should be a number, but got " +
-					(point.x + (" (" + (typeof point.x + ")")))
-			);
-		}
-		if (typeof point.y !== "number") {
-			throw new Error(
-				"point.y should be a number, but got " +
-					(point.y + (" (" + (typeof point.y + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForMultipleTapsWithCount:atPoint:",
-			args: [
-				{
-					type: "NSInteger",
-					value: count
-				},
-				{
-					type: "CGPoint",
-					value: point
-				}
-			]
-		};
-	}
+*/static actionForMultipleTapsWithCountAtPoint(count, point) {
+    if (typeof count !== "number") throw new Error("count should be a number, but got " + (count + (" (" + (typeof count + ")"))));
+    if (typeof point !== "object") throw new Error("point should be a object, but got " + (point + (" (" + (typeof point + ")"))));
+    if (typeof point.x !== "number") throw new Error("point.x should be a number, but got " + (point.x + (" (" + (typeof point.x + ")"))));
+    if (typeof point.y !== "number") throw new Error("point.y should be a number, but got " + (point.y + (" (" + (typeof point.y + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForMultipleTapsWithCount:atPoint:",
+      args: [{
+        type: "NSInteger",
+        value: count
+      }, {
+        type: "CGPoint",
+        value: point
+      }]
+    };
+  }
 
-	/*Returns an action that holds down finger for 1.0 second (@c kGREYLongPressDefaultDuration) to
+  /*Returns an action that holds down finger for 1.0 second (@c kGREYLongPressDefaultDuration) to
 simulate a long press.
 
 @return A GREYAction that performs a long press on an element.
-*/ static actionForLongPress() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForLongPress",
-			args: []
-		};
-	}
+*/static actionForLongPress() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForLongPress",
+      args: []
+    };
+  }
 
-	/*Returns an action that scrolls a @c UIScrollView by @c amount (in points) in the specified
+  /*Returns an action that scrolls a @c UIScrollView by @c amount (in points) in the specified
 @c direction.
 
 @param direction The direction of the swipe.
 @param amount    The amount of points in CGPoints to scroll.
 
 @return A GREYAction that scrolls a scroll view in a given @c direction for a given @c amount.
-*/ static actionForScrollInDirectionAmount(
-		direction,
-		amount
-	) {
-		if (!["left", "right", "up", "down"].some(option => option === direction)) {
-			throw new Error(
-				"direction should be one of [left, right, up, down], but got " +
-					direction
-			);
-		}
-		if (typeof amount !== "number") {
-			throw new Error(
-				"amount should be a number, but got " +
-					(amount + (" (" + (typeof amount + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForScrollInDirection:amount:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyDirection(direction)
-				},
-				{
-					type: "CGFloat",
-					value: amount
-				}
-			]
-		};
-	}
+*/static actionForScrollInDirectionAmount(direction, amount) {
+    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
+    if (typeof amount !== "number") throw new Error("amount should be a number, but got " + (amount + (" (" + (typeof amount + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForScrollInDirection:amount:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyDirection(direction)
+      }, {
+        type: "CGFloat",
+        value: amount
+      }]
+    };
+  }
 
-	/*Returns a scroll action that scrolls in a @c direction for an @c amount of points starting from
+  /*Returns a scroll action that scrolls in a @c direction for an @c amount of points starting from
 the given start point specified as percentages. @c xOriginStartPercentage is the x start
 position as a percentage of the total width of the scrollable visible area,
 @c yOriginStartPercentage is the y start position as a percentage of the total height of the
@@ -186,91 +137,50 @@ exclusive, of the total height of the scrollable visible area.
 
 @return A GREYAction that scrolls a scroll view in a given @c direction for a given @c amount
 starting from the given start points.
-*/ static actionForScrollInDirectionAmountXOriginStartPercentageYOriginStartPercentage(
-		direction,
-		amount,
-		xOriginStartPercentage,
-		yOriginStartPercentage
-	) {
-		if (!["left", "right", "up", "down"].some(option => option === direction)) {
-			throw new Error(
-				"direction should be one of [left, right, up, down], but got " +
-					direction
-			);
-		}
-		if (typeof amount !== "number") {
-			throw new Error(
-				"amount should be a number, but got " +
-					(amount + (" (" + (typeof amount + ")")))
-			);
-		}
-		if (typeof xOriginStartPercentage !== "number") {
-			throw new Error(
-				"xOriginStartPercentage should be a number, but got " +
-					(xOriginStartPercentage +
-						(" (" + (typeof xOriginStartPercentage + ")")))
-			);
-		}
-		if (typeof yOriginStartPercentage !== "number") {
-			throw new Error(
-				"yOriginStartPercentage should be a number, but got " +
-					(yOriginStartPercentage +
-						(" (" + (typeof yOriginStartPercentage + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method:
-				"actionForScrollInDirection:amount:xOriginStartPercentage:yOriginStartPercentage:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyDirection(direction)
-				},
-				{
-					type: "CGFloat",
-					value: amount
-				},
-				{
-					type: "CGFloat",
-					value: xOriginStartPercentage
-				},
-				{
-					type: "CGFloat",
-					value: yOriginStartPercentage
-				}
-			]
-		};
-	}
+*/static actionForScrollInDirectionAmountXOriginStartPercentageYOriginStartPercentage(direction, amount, xOriginStartPercentage, yOriginStartPercentage) {
+    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
+    if (typeof amount !== "number") throw new Error("amount should be a number, but got " + (amount + (" (" + (typeof amount + ")"))));
+    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
+    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForScrollInDirection:amount:xOriginStartPercentage:yOriginStartPercentage:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyDirection(direction)
+      }, {
+        type: "CGFloat",
+        value: amount
+      }, {
+        type: "CGFloat",
+        value: xOriginStartPercentage
+      }, {
+        type: "CGFloat",
+        value: yOriginStartPercentage
+      }]
+    };
+  }
 
-	/*@return A GREYAction that scrolls to the given content @c edge of a scroll view.
-*/ static actionForScrollToContentEdge(
-		edge
-	) {
-		if (!["left", "right", "top", "bottom"].some(option => option === edge)) {
-			throw new Error(
-				"edge should be one of [left, right, top, bottom], but got " + edge
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForScrollToContentEdge:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyContentEdge(edge)
-				}
-			]
-		};
-	}
+  /*@return A GREYAction that scrolls to the given content @c edge of a scroll view.
+*/static actionForScrollToContentEdge(edge) {
+    if (!["left", "right", "top", "bottom"].some(option => option === edge)) throw new Error("edge should be one of [left, right, top, bottom], but got " + edge);
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForScrollToContentEdge:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyContentEdge(edge)
+      }]
+    };
+  }
 
-	/*A GREYAction that scrolls to the given content @c edge of a scroll view with the scroll action
+  /*A GREYAction that scrolls to the given content @c edge of a scroll view with the scroll action
 starting from the given start point specified as percentages. @c xOriginStartPercentage is the x
 start position as a percentage of the total width of the scrollable visible area,
 @c yOriginStartPercentage is the y start position as a percentage of the total height of the
@@ -285,115 +195,72 @@ exclusive, of the total height of the scrollable visible area.
 
 @return A GREYAction that scrolls to the given content @c edge of a scroll view with the scroll
 action starting from the given start point.
-*/ static actionForScrollToContentEdgeXOriginStartPercentageYOriginStartPercentage(
-		edge,
-		xOriginStartPercentage,
-		yOriginStartPercentage
-	) {
-		if (!["left", "right", "top", "bottom"].some(option => option === edge)) {
-			throw new Error(
-				"edge should be one of [left, right, top, bottom], but got " + edge
-			);
-		}
-		if (typeof xOriginStartPercentage !== "number") {
-			throw new Error(
-				"xOriginStartPercentage should be a number, but got " +
-					(xOriginStartPercentage +
-						(" (" + (typeof xOriginStartPercentage + ")")))
-			);
-		}
-		if (typeof yOriginStartPercentage !== "number") {
-			throw new Error(
-				"yOriginStartPercentage should be a number, but got " +
-					(yOriginStartPercentage +
-						(" (" + (typeof yOriginStartPercentage + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method:
-				"actionForScrollToContentEdge:xOriginStartPercentage:yOriginStartPercentage:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyContentEdge(edge)
-				},
-				{
-					type: "CGFloat",
-					value: xOriginStartPercentage
-				},
-				{
-					type: "CGFloat",
-					value: yOriginStartPercentage
-				}
-			]
-		};
-	}
+*/static actionForScrollToContentEdgeXOriginStartPercentageYOriginStartPercentage(edge, xOriginStartPercentage, yOriginStartPercentage) {
+    if (!["left", "right", "top", "bottom"].some(option => option === edge)) throw new Error("edge should be one of [left, right, top, bottom], but got " + edge);
+    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
+    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForScrollToContentEdge:xOriginStartPercentage:yOriginStartPercentage:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyContentEdge(edge)
+      }, {
+        type: "CGFloat",
+        value: xOriginStartPercentage
+      }, {
+        type: "CGFloat",
+        value: yOriginStartPercentage
+      }]
+    };
+  }
 
-	/*Returns an action that fast swipes through the view. The start point of the swipe is chosen to
+  /*Returns an action that fast swipes through the view. The start point of the swipe is chosen to
 achieve the maximum the swipe possible to the other edge.
 
 @param direction The direction of the swipe.
 
 @return A GREYAction that performs a fast swipe in the given direction.
-*/ static actionForSwipeFastInDirection(
-		direction
-	) {
-		if (!["left", "right", "up", "down"].some(option => option === direction)) {
-			throw new Error(
-				"direction should be one of [left, right, up, down], but got " +
-					direction
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForSwipeFastInDirection:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyDirection(direction)
-				}
-			]
-		};
-	}
+*/static actionForSwipeFastInDirection(direction) {
+    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForSwipeFastInDirection:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyDirection(direction)
+      }]
+    };
+  }
 
-	/*Returns an action that slow swipes through the view. The start point of the swipe is chosen to
+  /*Returns an action that slow swipes through the view. The start point of the swipe is chosen to
 achieve maximum the swipe possible to the other edge.
 
 @param direction The direction of the swipe.
 
 @return A GREYAction that performs a slow swipe in the given direction.
-*/ static actionForSwipeSlowInDirection(
-		direction
-	) {
-		if (!["left", "right", "up", "down"].some(option => option === direction)) {
-			throw new Error(
-				"direction should be one of [left, right, up, down], but got " +
-					direction
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForSwipeSlowInDirection:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyDirection(direction)
-				}
-			]
-		};
-	}
+*/static actionForSwipeSlowInDirection(direction) {
+    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForSwipeSlowInDirection:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyDirection(direction)
+      }]
+    };
+  }
 
-	/*Returns an action that swipes through the view quickly in the given @c direction from a specific
+  /*Returns an action that swipes through the view quickly in the given @c direction from a specific
 origin.
 
 @param direction              The direction of the swipe.
@@ -404,56 +271,30 @@ of the view. This must be between 0 and 1.
 
 @return A GREYAction that performs a fast swipe through a view in a specific direction from
 the specified point.
-*/ static actionForSwipeFastInDirectionXOriginStartPercentageYOriginStartPercentage(
-		direction,
-		xOriginStartPercentage,
-		yOriginStartPercentage
-	) {
-		if (!["left", "right", "up", "down"].some(option => option === direction)) {
-			throw new Error(
-				"direction should be one of [left, right, up, down], but got " +
-					direction
-			);
-		}
-		if (typeof xOriginStartPercentage !== "number") {
-			throw new Error(
-				"xOriginStartPercentage should be a number, but got " +
-					(xOriginStartPercentage +
-						(" (" + (typeof xOriginStartPercentage + ")")))
-			);
-		}
-		if (typeof yOriginStartPercentage !== "number") {
-			throw new Error(
-				"yOriginStartPercentage should be a number, but got " +
-					(yOriginStartPercentage +
-						(" (" + (typeof yOriginStartPercentage + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method:
-				"actionForSwipeFastInDirection:xOriginStartPercentage:yOriginStartPercentage:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyDirection(direction)
-				},
-				{
-					type: "CGFloat",
-					value: xOriginStartPercentage
-				},
-				{
-					type: "CGFloat",
-					value: yOriginStartPercentage
-				}
-			]
-		};
-	}
+*/static actionForSwipeFastInDirectionXOriginStartPercentageYOriginStartPercentage(direction, xOriginStartPercentage, yOriginStartPercentage) {
+    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
+    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
+    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForSwipeFastInDirection:xOriginStartPercentage:yOriginStartPercentage:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyDirection(direction)
+      }, {
+        type: "CGFloat",
+        value: xOriginStartPercentage
+      }, {
+        type: "CGFloat",
+        value: yOriginStartPercentage
+      }]
+    };
+  }
 
-	/*Returns an action that swipes through the view quickly in the given @c direction from a
+  /*Returns an action that swipes through the view quickly in the given @c direction from a
 specific origin.
 
 @param direction              The direction of the swipe.
@@ -464,56 +305,30 @@ of the view. This must be between 0 and 1.
 
 @return A GREYAction that performs a slow swipe through a view in a specific direction from
 the specified point.
-*/ static actionForSwipeSlowInDirectionXOriginStartPercentageYOriginStartPercentage(
-		direction,
-		xOriginStartPercentage,
-		yOriginStartPercentage
-	) {
-		if (!["left", "right", "up", "down"].some(option => option === direction)) {
-			throw new Error(
-				"direction should be one of [left, right, up, down], but got " +
-					direction
-			);
-		}
-		if (typeof xOriginStartPercentage !== "number") {
-			throw new Error(
-				"xOriginStartPercentage should be a number, but got " +
-					(xOriginStartPercentage +
-						(" (" + (typeof xOriginStartPercentage + ")")))
-			);
-		}
-		if (typeof yOriginStartPercentage !== "number") {
-			throw new Error(
-				"yOriginStartPercentage should be a number, but got " +
-					(yOriginStartPercentage +
-						(" (" + (typeof yOriginStartPercentage + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method:
-				"actionForSwipeSlowInDirection:xOriginStartPercentage:yOriginStartPercentage:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyDirection(direction)
-				},
-				{
-					type: "CGFloat",
-					value: xOriginStartPercentage
-				},
-				{
-					type: "CGFloat",
-					value: yOriginStartPercentage
-				}
-			]
-		};
-	}
+*/static actionForSwipeSlowInDirectionXOriginStartPercentageYOriginStartPercentage(direction, xOriginStartPercentage, yOriginStartPercentage) {
+    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
+    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
+    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForSwipeSlowInDirection:xOriginStartPercentage:yOriginStartPercentage:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyDirection(direction)
+      }, {
+        type: "CGFloat",
+        value: xOriginStartPercentage
+      }, {
+        type: "CGFloat",
+        value: yOriginStartPercentage
+      }]
+    };
+  }
 
-	/*Returns an action that performs a multi-finger slow swipe through the view in the given
+  /*Returns an action that performs a multi-finger slow swipe through the view in the given
 @c direction.
 
 @param direction       The direction of the swipe.
@@ -521,42 +336,26 @@ the specified point.
 
 @return A GREYAction that performs a multi-finger slow swipe through a view in a specific
 direction from the specified point.
-*/ static actionForMultiFingerSwipeSlowInDirectionNumberOfFingers(
-		direction,
-		numberOfFingers
-	) {
-		if (!["left", "right", "up", "down"].some(option => option === direction)) {
-			throw new Error(
-				"direction should be one of [left, right, up, down], but got " +
-					direction
-			);
-		}
-		if (typeof numberOfFingers !== "number") {
-			throw new Error(
-				"numberOfFingers should be a number, but got " +
-					(numberOfFingers + (" (" + (typeof numberOfFingers + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForMultiFingerSwipeSlowInDirection:numberOfFingers:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyDirection(direction)
-				},
-				{
-					type: "NSInteger",
-					value: numberOfFingers
-				}
-			]
-		};
-	}
+*/static actionForMultiFingerSwipeSlowInDirectionNumberOfFingers(direction, numberOfFingers) {
+    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
+    if (typeof numberOfFingers !== "number") throw new Error("numberOfFingers should be a number, but got " + (numberOfFingers + (" (" + (typeof numberOfFingers + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForMultiFingerSwipeSlowInDirection:numberOfFingers:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyDirection(direction)
+      }, {
+        type: "NSInteger",
+        value: numberOfFingers
+      }]
+    };
+  }
 
-	/*Returns an action that performs a multi-finger fast swipe through the view in the given
+  /*Returns an action that performs a multi-finger fast swipe through the view in the given
 @c direction.
 
 @param direction       The direction of the swipe.
@@ -564,42 +363,26 @@ direction from the specified point.
 
 @return A GREYAction that performs a multi-finger fast swipe through a view in a specific
 direction from the specified point.
-*/ static actionForMultiFingerSwipeFastInDirectionNumberOfFingers(
-		direction,
-		numberOfFingers
-	) {
-		if (!["left", "right", "up", "down"].some(option => option === direction)) {
-			throw new Error(
-				"direction should be one of [left, right, up, down], but got " +
-					direction
-			);
-		}
-		if (typeof numberOfFingers !== "number") {
-			throw new Error(
-				"numberOfFingers should be a number, but got " +
-					(numberOfFingers + (" (" + (typeof numberOfFingers + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForMultiFingerSwipeFastInDirection:numberOfFingers:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyDirection(direction)
-				},
-				{
-					type: "NSInteger",
-					value: numberOfFingers
-				}
-			]
-		};
-	}
+*/static actionForMultiFingerSwipeFastInDirectionNumberOfFingers(direction, numberOfFingers) {
+    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
+    if (typeof numberOfFingers !== "number") throw new Error("numberOfFingers should be a number, but got " + (numberOfFingers + (" (" + (typeof numberOfFingers + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForMultiFingerSwipeFastInDirection:numberOfFingers:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyDirection(direction)
+      }, {
+        type: "NSInteger",
+        value: numberOfFingers
+      }]
+    };
+  }
 
-	/*Returns an action that performs a multi-finger slow swipe through the view in the given
+  /*Returns an action that performs a multi-finger slow swipe through the view in the given
 @c direction.
 
 @param direction       The direction of the swipe.
@@ -607,67 +390,34 @@ direction from the specified point.
 
 @return A GREYAction that performs a multi-finger slow swipe through a view in a specific
 direction from the specified point.
-*/ static actionForMultiFingerSwipeSlowInDirectionNumberOfFingersXOriginStartPercentageYOriginStartPercentage(
-		direction,
-		numberOfFingers,
-		xOriginStartPercentage,
-		yOriginStartPercentage
-	) {
-		if (!["left", "right", "up", "down"].some(option => option === direction)) {
-			throw new Error(
-				"direction should be one of [left, right, up, down], but got " +
-					direction
-			);
-		}
-		if (typeof numberOfFingers !== "number") {
-			throw new Error(
-				"numberOfFingers should be a number, but got " +
-					(numberOfFingers + (" (" + (typeof numberOfFingers + ")")))
-			);
-		}
-		if (typeof xOriginStartPercentage !== "number") {
-			throw new Error(
-				"xOriginStartPercentage should be a number, but got " +
-					(xOriginStartPercentage +
-						(" (" + (typeof xOriginStartPercentage + ")")))
-			);
-		}
-		if (typeof yOriginStartPercentage !== "number") {
-			throw new Error(
-				"yOriginStartPercentage should be a number, but got " +
-					(yOriginStartPercentage +
-						(" (" + (typeof yOriginStartPercentage + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method:
-				"actionForMultiFingerSwipeSlowInDirection:numberOfFingers:xOriginStartPercentage:yOriginStartPercentage:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyDirection(direction)
-				},
-				{
-					type: "NSInteger",
-					value: numberOfFingers
-				},
-				{
-					type: "CGFloat",
-					value: xOriginStartPercentage
-				},
-				{
-					type: "CGFloat",
-					value: yOriginStartPercentage
-				}
-			]
-		};
-	}
+*/static actionForMultiFingerSwipeSlowInDirectionNumberOfFingersXOriginStartPercentageYOriginStartPercentage(direction, numberOfFingers, xOriginStartPercentage, yOriginStartPercentage) {
+    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
+    if (typeof numberOfFingers !== "number") throw new Error("numberOfFingers should be a number, but got " + (numberOfFingers + (" (" + (typeof numberOfFingers + ")"))));
+    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
+    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForMultiFingerSwipeSlowInDirection:numberOfFingers:xOriginStartPercentage:yOriginStartPercentage:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyDirection(direction)
+      }, {
+        type: "NSInteger",
+        value: numberOfFingers
+      }, {
+        type: "CGFloat",
+        value: xOriginStartPercentage
+      }, {
+        type: "CGFloat",
+        value: yOriginStartPercentage
+      }]
+    };
+  }
 
-	/*Returns an action that performs a multi-finger fast swipe through the view in the given
+  /*Returns an action that performs a multi-finger fast swipe through the view in the given
 @c direction.
 
 @param direction       The direction of the swipe.
@@ -675,124 +425,72 @@ direction from the specified point.
 
 @return A GREYAction that performs a multi-finger fast swipe through a view in a specific
 direction from the specified point.
-*/ static actionForMultiFingerSwipeFastInDirectionNumberOfFingersXOriginStartPercentageYOriginStartPercentage(
-		direction,
-		numberOfFingers,
-		xOriginStartPercentage,
-		yOriginStartPercentage
-	) {
-		if (!["left", "right", "up", "down"].some(option => option === direction)) {
-			throw new Error(
-				"direction should be one of [left, right, up, down], but got " +
-					direction
-			);
-		}
-		if (typeof numberOfFingers !== "number") {
-			throw new Error(
-				"numberOfFingers should be a number, but got " +
-					(numberOfFingers + (" (" + (typeof numberOfFingers + ")")))
-			);
-		}
-		if (typeof xOriginStartPercentage !== "number") {
-			throw new Error(
-				"xOriginStartPercentage should be a number, but got " +
-					(xOriginStartPercentage +
-						(" (" + (typeof xOriginStartPercentage + ")")))
-			);
-		}
-		if (typeof yOriginStartPercentage !== "number") {
-			throw new Error(
-				"yOriginStartPercentage should be a number, but got " +
-					(yOriginStartPercentage +
-						(" (" + (typeof yOriginStartPercentage + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method:
-				"actionForMultiFingerSwipeFastInDirection:numberOfFingers:xOriginStartPercentage:yOriginStartPercentage:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyDirection(direction)
-				},
-				{
-					type: "NSInteger",
-					value: numberOfFingers
-				},
-				{
-					type: "CGFloat",
-					value: xOriginStartPercentage
-				},
-				{
-					type: "CGFloat",
-					value: yOriginStartPercentage
-				}
-			]
-		};
-	}
+*/static actionForMultiFingerSwipeFastInDirectionNumberOfFingersXOriginStartPercentageYOriginStartPercentage(direction, numberOfFingers, xOriginStartPercentage, yOriginStartPercentage) {
+    if (!["left", "right", "up", "down"].some(option => option === direction)) throw new Error("direction should be one of [left, right, up, down], but got " + direction);
+    if (typeof numberOfFingers !== "number") throw new Error("numberOfFingers should be a number, but got " + (numberOfFingers + (" (" + (typeof numberOfFingers + ")"))));
+    if (typeof xOriginStartPercentage !== "number") throw new Error("xOriginStartPercentage should be a number, but got " + (xOriginStartPercentage + (" (" + (typeof xOriginStartPercentage + ")"))));
+    if (typeof yOriginStartPercentage !== "number") throw new Error("yOriginStartPercentage should be a number, but got " + (yOriginStartPercentage + (" (" + (typeof yOriginStartPercentage + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForMultiFingerSwipeFastInDirection:numberOfFingers:xOriginStartPercentage:yOriginStartPercentage:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyDirection(direction)
+      }, {
+        type: "NSInteger",
+        value: numberOfFingers
+      }, {
+        type: "CGFloat",
+        value: xOriginStartPercentage
+      }, {
+        type: "CGFloat",
+        value: yOriginStartPercentage
+      }]
+    };
+  }
 
-	/*Returns an action that taps on an element at the activation point of the element.
+  /*Returns an action that taps on an element at the activation point of the element.
 
 @return A GREYAction to tap on an element.
-*/ static actionForTap() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForTap",
-			args: []
-		};
-	}
+*/static actionForTap() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForTap",
+      args: []
+    };
+  }
 
-	/*Returns an action that taps on an element at the specified @c point.
+  /*Returns an action that taps on an element at the specified @c point.
 
 @param point The point that should be tapped. It must be in the coordinate system of the
 element and it's position is relative to the origin of the element, as in
 (element_width/2, element_height/2) will tap at the center of element.
 
 @return A GREYAction to tap on an element at a specific point.
-*/ static actionForTapAtPoint(
-		point
-	) {
-		if (typeof point !== "object") {
-			throw new Error(
-				"point should be a object, but got " +
-					(point + (" (" + (typeof point + ")")))
-			);
-		}
-		if (typeof point.x !== "number") {
-			throw new Error(
-				"point.x should be a number, but got " +
-					(point.x + (" (" + (typeof point.x + ")")))
-			);
-		}
-		if (typeof point.y !== "number") {
-			throw new Error(
-				"point.y should be a number, but got " +
-					(point.y + (" (" + (typeof point.y + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForTapAtPoint:",
-			args: [
-				{
-					type: "CGPoint",
-					value: point
-				}
-			]
-		};
-	}
+*/static actionForTapAtPoint(point) {
+    if (typeof point !== "object") throw new Error("point should be a object, but got " + (point + (" (" + (typeof point + ")"))));
+    if (typeof point.x !== "number") throw new Error("point.x should be a number, but got " + (point.x + (" (" + (typeof point.x + ")"))));
+    if (typeof point.y !== "number") throw new Error("point.y should be a number, but got " + (point.y + (" (" + (typeof point.y + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForTapAtPoint:",
+      args: [{
+        type: "CGPoint",
+        value: point
+      }]
+    };
+  }
 
-	/*Returns an action that uses the iOS keyboard to input a string.
+  /*Returns an action that uses the iOS keyboard to input a string.
 
 @param text The text to be typed. For Objective-C, backspace is supported by using "\b" in the
 string and "\u{8}" in Swift strings. Return key is supported with "\n".
@@ -800,111 +498,78 @@ For Example: @"Helpo\b\bloWorld" will type HelloWorld in Objective-C.
 "Helpo\u{8}\u{8}loWorld" will type HelloWorld in Swift.
 
 @return A GREYAction to type a specific text string in a text field.
-*/ static actionForTypeText(
-		text
-	) {
-		if (typeof text !== "string") {
-			throw new Error(
-				"text should be a string, but got " +
-					(text + (" (" + (typeof text + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForTypeText:",
-			args: [
-				{
-					type: "NSString",
-					value: text
-				}
-			]
-		};
-	}
+*/static actionForTypeText(text) {
+    if (typeof text !== "string") throw new Error("text should be a string, but got " + (text + (" (" + (typeof text + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForTypeText:",
+      args: [{
+        type: "NSString",
+        value: text
+      }]
+    };
+  }
 
-	/*Returns an action that sets text on a UITextField or webview input directly.
+  /*Returns an action that sets text on a UITextField or webview input directly.
 
 @param text The text to be typed.
 
 @return A GREYAction to type a specific text string in a text field.
-*/ static actionForReplaceText(
-		text
-	) {
-		if (typeof text !== "string") {
-			throw new Error(
-				"text should be a string, but got " +
-					(text + (" (" + (typeof text + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForReplaceText:",
-			args: [
-				{
-					type: "NSString",
-					value: text
-				}
-			]
-		};
-	}
+*/static actionForReplaceText(text) {
+    if (typeof text !== "string") throw new Error("text should be a string, but got " + (text + (" (" + (typeof text + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForReplaceText:",
+      args: [{
+        type: "NSString",
+        value: text
+      }]
+    };
+  }
 
-	/*@return A GREYAction that clears a text field by injecting back-spaces.
-*/ static actionForClearText() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForClearText",
-			args: []
-		};
-	}
+  /*@return A GREYAction that clears a text field by injecting back-spaces.
+*/static actionForClearText() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForClearText",
+      args: []
+    };
+  }
 
-	/*Returns an action that selects @c value on the given @c column of a UIPickerView.
+  /*Returns an action that selects @c value on the given @c column of a UIPickerView.
 
 @param column The UIPickerView column being set.
 @param value  The value to set the UIPickerView.
 
 @return A GREYAction to set the value of a specified column of a UIPickerView.
-*/ static actionForSetPickerColumnToValue(
-		column,
-		value
-	) {
-		if (typeof column !== "number") {
-			throw new Error(
-				"column should be a number, but got " +
-					(column + (" (" + (typeof column + ")")))
-			);
-		}
-		if (typeof value !== "string") {
-			throw new Error(
-				"value should be a string, but got " +
-					(value + (" (" + (typeof value + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYActions"
-			},
-			method: "actionForSetPickerColumn:toValue:",
-			args: [
-				{
-					type: "NSInteger",
-					value: column
-				},
-				{
-					type: "NSString",
-					value: value
-				}
-			]
-		};
-	}
+*/static actionForSetPickerColumnToValue(column, value) {
+    if (typeof column !== "number") throw new Error("column should be a number, but got " + (column + (" (" + (typeof column + ")"))));
+    if (typeof value !== "string") throw new Error("value should be a string, but got " + (value + (" (" + (typeof value + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForSetPickerColumn:toValue:",
+      args: [{
+        type: "NSInteger",
+        value: column
+      }, {
+        type: "NSString",
+        value: value
+      }]
+    };
+  }
+
 }
 
 module.exports = GREYActions;

--- a/detox/src/ios/earlgreyapi/GREYConfiguration.js
+++ b/detox/src/ios/earlgreyapi/GREYConfiguration.js
@@ -1,5 +1,4 @@
-
-const invoke = require('../../invoke');
+const invoke = require("../../invoke");
 
 /**
  * An 'invoke' wrapper for https://github.com/google/EarlGrey/blob/master/EarlGrey/Common/GREYConfiguration.h
@@ -11,29 +10,34 @@ const invoke = require('../../invoke');
  * @returns {*}
  */
 function setURLBlacklist(blacklist) {
-  return setValueForConfigKey(blacklist, 'GREYConfigKeyURLBlacklistRegex');
+	return setValueForConfigKey(blacklist, "GREYConfigKeyURLBlacklistRegex");
 }
 
 function enableSynchronization() {
-  //return setValueForConfigKey(invoke.IOS.Boolean(true), 'kGREYConfigKeySynchronizationEnabled');
-  return invoke.call(GREYConfigurationInstance(), 'enableSynchronization');
+	//return setValueForConfigKey(invoke.IOS.Boolean(true), 'kGREYConfigKeySynchronizationEnabled');
+	return invoke.call(GREYConfigurationInstance(), "enableSynchronization");
 }
 
 function disableSynchronization() {
-  //return setValueForConfigKey(invoke.IOS.Boolean(false), 'kGREYConfigKeySynchronizationEnabled');
-  return invoke.call(GREYConfigurationInstance(), 'disableSynchronization');
+	//return setValueForConfigKey(invoke.IOS.Boolean(false), 'kGREYConfigKeySynchronizationEnabled');
+	return invoke.call(GREYConfigurationInstance(), "disableSynchronization");
 }
 
 function setValueForConfigKey(value, configKey) {
-  return invoke.call(GREYConfigurationInstance(), 'setValue:forConfigKey:', value, configKey);
+	return invoke.call(
+		GREYConfigurationInstance(),
+		"setValue:forConfigKey:",
+		value,
+		configKey
+	);
 }
 
 function GREYConfigurationInstance() {
-  return invoke.call(invoke.IOS.Class('GREYConfiguration'), 'sharedInstance');
+	return invoke.call(invoke.IOS.Class("GREYConfiguration"), "sharedInstance");
 }
 
 module.exports = {
-  setURLBlacklist,
-  enableSynchronization,
-  disableSynchronization
+	setURLBlacklist,
+	enableSynchronization,
+	disableSynchronization
 };

--- a/detox/src/ios/earlgreyapi/GREYMatchers+Detox.js
+++ b/detox/src/ios/earlgreyapi/GREYMatchers+Detox.js
@@ -1,258 +1,160 @@
+/* eslint-disable */
 /**
 
 	This code is generated.
 	For more information see generation/README.md.
 */
 
+
+
 class GREYMatchers {
-	static detoxMatcherForText(text) {
-		if (typeof text !== "string") {
-			throw new Error(
-				"text should be a string, but got " +
-					(text + (" (" + (typeof text + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "detoxMatcherForText:",
-			args: [
-				{
-					type: "NSString",
-					value: text
-				}
-			]
-		};
-	}
+  static detoxMatcherForText(text) {
+    if (typeof text !== "string") throw new Error("text should be a string, but got " + (text + (" (" + (typeof text + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "detoxMatcherForText:",
+      args: [{
+        type: "NSString",
+        value: text
+      }]
+    };
+  }
 
-	static detox_matcherForAccessibilityLabel(label) {
-		if (typeof label !== "string") {
-			throw new Error(
-				"label should be a string, but got " +
-					(label + (" (" + (typeof label + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "detox_matcherForAccessibilityLabel:",
-			args: [
-				{
-					type: "NSString",
-					value: label
-				}
-			]
-		};
-	}
+  static detox_matcherForAccessibilityLabel(label) {
+    if (typeof label !== "string") throw new Error("label should be a string, but got " + (label + (" (" + (typeof label + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "detox_matcherForAccessibilityLabel:",
+      args: [{
+        type: "NSString",
+        value: label
+      }]
+    };
+  }
 
-	static detoxMatcherForScrollChildOfMatcher(matcher) {
-		if (
-			typeof matcher !== "object" ||
-			matcher.type !== "Invocation" ||
-			typeof matcher.value !== "object" ||
-			typeof matcher.value.target !== "object" ||
-			matcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"matcher should be a GREYMatcher, but got " + JSON.stringify(matcher)
-			);
-		}
+  static detoxMatcherForScrollChildOfMatcher(matcher) {
+    if (typeof matcher !== "object" || matcher.type !== "Invocation" || typeof matcher.value !== "object" || typeof matcher.value.target !== "object" || matcher.value.target.value !== "GREYMatchers") {
+      throw new Error('matcher should be a GREYMatcher, but got ' + JSON.stringify(matcher));
+    }
 
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "detoxMatcherForScrollChildOfMatcher:",
-			args: [matcher]
-		};
-	}
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "detoxMatcherForScrollChildOfMatcher:",
+      args: [matcher]
+    };
+  }
 
-	static detoxMatcherAvoidingProblematicReactNativeElements(matcher) {
-		if (
-			typeof matcher !== "object" ||
-			matcher.type !== "Invocation" ||
-			typeof matcher.value !== "object" ||
-			typeof matcher.value.target !== "object" ||
-			matcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"matcher should be a GREYMatcher, but got " + JSON.stringify(matcher)
-			);
-		}
+  static detoxMatcherAvoidingProblematicReactNativeElements(matcher) {
+    if (typeof matcher !== "object" || matcher.type !== "Invocation" || typeof matcher.value !== "object" || typeof matcher.value.target !== "object" || matcher.value.target.value !== "GREYMatchers") {
+      throw new Error('matcher should be a GREYMatcher, but got ' + JSON.stringify(matcher));
+    }
 
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "detoxMatcherAvoidingProblematicReactNativeElements:",
-			args: [matcher]
-		};
-	}
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "detoxMatcherAvoidingProblematicReactNativeElements:",
+      args: [matcher]
+    };
+  }
 
-	static detoxMatcherForBothAnd(firstMatcher, secondMatcher) {
-		if (
-			typeof firstMatcher !== "object" ||
-			firstMatcher.type !== "Invocation" ||
-			typeof firstMatcher.value !== "object" ||
-			typeof firstMatcher.value.target !== "object" ||
-			firstMatcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"firstMatcher should be a GREYMatcher, but got " +
-					JSON.stringify(firstMatcher)
-			);
-		}
+  static detoxMatcherForBothAnd(firstMatcher, secondMatcher) {
+    if (typeof firstMatcher !== "object" || firstMatcher.type !== "Invocation" || typeof firstMatcher.value !== "object" || typeof firstMatcher.value.target !== "object" || firstMatcher.value.target.value !== "GREYMatchers") {
+      throw new Error('firstMatcher should be a GREYMatcher, but got ' + JSON.stringify(firstMatcher));
+    }
 
-		if (
-			typeof secondMatcher !== "object" ||
-			secondMatcher.type !== "Invocation" ||
-			typeof secondMatcher.value !== "object" ||
-			typeof secondMatcher.value.target !== "object" ||
-			secondMatcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"secondMatcher should be a GREYMatcher, but got " +
-					JSON.stringify(secondMatcher)
-			);
-		}
+    if (typeof secondMatcher !== "object" || secondMatcher.type !== "Invocation" || typeof secondMatcher.value !== "object" || typeof secondMatcher.value.target !== "object" || secondMatcher.value.target.value !== "GREYMatchers") {
+      throw new Error('secondMatcher should be a GREYMatcher, but got ' + JSON.stringify(secondMatcher));
+    }
 
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "detoxMatcherForBoth:and:",
-			args: [firstMatcher, secondMatcher]
-		};
-	}
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "detoxMatcherForBoth:and:",
+      args: [firstMatcher, secondMatcher]
+    };
+  }
 
-	static detoxMatcherForBothAndAncestorMatcher(firstMatcher, ancestorMatcher) {
-		if (
-			typeof firstMatcher !== "object" ||
-			firstMatcher.type !== "Invocation" ||
-			typeof firstMatcher.value !== "object" ||
-			typeof firstMatcher.value.target !== "object" ||
-			firstMatcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"firstMatcher should be a GREYMatcher, but got " +
-					JSON.stringify(firstMatcher)
-			);
-		}
+  static detoxMatcherForBothAndAncestorMatcher(firstMatcher, ancestorMatcher) {
+    if (typeof firstMatcher !== "object" || firstMatcher.type !== "Invocation" || typeof firstMatcher.value !== "object" || typeof firstMatcher.value.target !== "object" || firstMatcher.value.target.value !== "GREYMatchers") {
+      throw new Error('firstMatcher should be a GREYMatcher, but got ' + JSON.stringify(firstMatcher));
+    }
 
-		if (
-			typeof ancestorMatcher !== "object" ||
-			ancestorMatcher.type !== "Invocation" ||
-			typeof ancestorMatcher.value !== "object" ||
-			typeof ancestorMatcher.value.target !== "object" ||
-			ancestorMatcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"ancestorMatcher should be a GREYMatcher, but got " +
-					JSON.stringify(ancestorMatcher)
-			);
-		}
+    if (typeof ancestorMatcher !== "object" || ancestorMatcher.type !== "Invocation" || typeof ancestorMatcher.value !== "object" || typeof ancestorMatcher.value.target !== "object" || ancestorMatcher.value.target.value !== "GREYMatchers") {
+      throw new Error('ancestorMatcher should be a GREYMatcher, but got ' + JSON.stringify(ancestorMatcher));
+    }
 
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "detoxMatcherForBoth:andAncestorMatcher:",
-			args: [firstMatcher, ancestorMatcher]
-		};
-	}
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "detoxMatcherForBoth:andAncestorMatcher:",
+      args: [firstMatcher, ancestorMatcher]
+    };
+  }
 
-	static detoxMatcherForBothAndDescendantMatcher(
-		firstMatcher,
-		descendantMatcher
-	) {
-		if (
-			typeof firstMatcher !== "object" ||
-			firstMatcher.type !== "Invocation" ||
-			typeof firstMatcher.value !== "object" ||
-			typeof firstMatcher.value.target !== "object" ||
-			firstMatcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"firstMatcher should be a GREYMatcher, but got " +
-					JSON.stringify(firstMatcher)
-			);
-		}
+  static detoxMatcherForBothAndDescendantMatcher(firstMatcher, descendantMatcher) {
+    if (typeof firstMatcher !== "object" || firstMatcher.type !== "Invocation" || typeof firstMatcher.value !== "object" || typeof firstMatcher.value.target !== "object" || firstMatcher.value.target.value !== "GREYMatchers") {
+      throw new Error('firstMatcher should be a GREYMatcher, but got ' + JSON.stringify(firstMatcher));
+    }
 
-		if (
-			typeof descendantMatcher !== "object" ||
-			descendantMatcher.type !== "Invocation" ||
-			typeof descendantMatcher.value !== "object" ||
-			typeof descendantMatcher.value.target !== "object" ||
-			descendantMatcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"descendantMatcher should be a GREYMatcher, but got " +
-					JSON.stringify(descendantMatcher)
-			);
-		}
+    if (typeof descendantMatcher !== "object" || descendantMatcher.type !== "Invocation" || typeof descendantMatcher.value !== "object" || typeof descendantMatcher.value.target !== "object" || descendantMatcher.value.target.value !== "GREYMatchers") {
+      throw new Error('descendantMatcher should be a GREYMatcher, but got ' + JSON.stringify(descendantMatcher));
+    }
 
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "detoxMatcherForBoth:andDescendantMatcher:",
-			args: [firstMatcher, descendantMatcher]
-		};
-	}
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "detoxMatcherForBoth:andDescendantMatcher:",
+      args: [firstMatcher, descendantMatcher]
+    };
+  }
 
-	static detoxMatcherForNot(matcher) {
-		if (
-			typeof matcher !== "object" ||
-			matcher.type !== "Invocation" ||
-			typeof matcher.value !== "object" ||
-			typeof matcher.value.target !== "object" ||
-			matcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"matcher should be a GREYMatcher, but got " + JSON.stringify(matcher)
-			);
-		}
+  static detoxMatcherForNot(matcher) {
+    if (typeof matcher !== "object" || matcher.type !== "Invocation" || typeof matcher.value !== "object" || typeof matcher.value.target !== "object" || matcher.value.target.value !== "GREYMatchers") {
+      throw new Error('matcher should be a GREYMatcher, but got ' + JSON.stringify(matcher));
+    }
 
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "detoxMatcherForNot:",
-			args: [matcher]
-		};
-	}
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "detoxMatcherForNot:",
+      args: [matcher]
+    };
+  }
 
-	static detoxMatcherForClass(aClassName) {
-		if (typeof aClassName !== "string") {
-			throw new Error(
-				"aClassName should be a string, but got " +
-					(aClassName + (" (" + (typeof aClassName + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "detoxMatcherForClass:",
-			args: [
-				{
-					type: "NSString",
-					value: aClassName
-				}
-			]
-		};
-	}
+  static detoxMatcherForClass(aClassName) {
+    if (typeof aClassName !== "string") throw new Error("aClassName should be a string, but got " + (aClassName + (" (" + (typeof aClassName + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "detoxMatcherForClass:",
+      args: [{
+        type: "NSString",
+        value: aClassName
+      }]
+    };
+  }
+
 }
 
 module.exports = GREYMatchers;

--- a/detox/src/ios/earlgreyapi/GREYMatchers+Detox.js
+++ b/detox/src/ios/earlgreyapi/GREYMatchers+Detox.js
@@ -4,156 +4,255 @@
 	For more information see generation/README.md.
 */
 
-
-
 class GREYMatchers {
-  static detoxMatcherForText(text) {
-    if (typeof text !== "string") throw new Error("text should be a string, but got " + (text + (" (" + (typeof text + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "detoxMatcherForText:",
-      args: [{
-        type: "NSString",
-        value: text
-      }]
-    };
-  }
+	static detoxMatcherForText(text) {
+		if (typeof text !== "string") {
+			throw new Error(
+				"text should be a string, but got " +
+					(text + (" (" + (typeof text + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "detoxMatcherForText:",
+			args: [
+				{
+					type: "NSString",
+					value: text
+				}
+			]
+		};
+	}
 
-  static detox_matcherForAccessibilityLabel(label) {
-    if (typeof label !== "string") throw new Error("label should be a string, but got " + (label + (" (" + (typeof label + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "detox_matcherForAccessibilityLabel:",
-      args: [{
-        type: "NSString",
-        value: label
-      }]
-    };
-  }
+	static detox_matcherForAccessibilityLabel(label) {
+		if (typeof label !== "string") {
+			throw new Error(
+				"label should be a string, but got " +
+					(label + (" (" + (typeof label + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "detox_matcherForAccessibilityLabel:",
+			args: [
+				{
+					type: "NSString",
+					value: label
+				}
+			]
+		};
+	}
 
-  static detoxMatcherForScrollChildOfMatcher(matcher) {
-    if (typeof matcher !== "object" || matcher.type !== "Invocation" || typeof matcher.value !== "object" || typeof matcher.value.target !== "object" || matcher.value.target.value !== "GREYMatchers") {
-      throw new Error('matcher should be a GREYMatcher, but got ' + JSON.stringify(matcher));
-    }
+	static detoxMatcherForScrollChildOfMatcher(matcher) {
+		if (
+			typeof matcher !== "object" ||
+			matcher.type !== "Invocation" ||
+			typeof matcher.value !== "object" ||
+			typeof matcher.value.target !== "object" ||
+			matcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"matcher should be a GREYMatcher, but got " + JSON.stringify(matcher)
+			);
+		}
 
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "detoxMatcherForScrollChildOfMatcher:",
-      args: [matcher]
-    };
-  }
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "detoxMatcherForScrollChildOfMatcher:",
+			args: [matcher]
+		};
+	}
 
-  static detoxMatcherAvoidingProblematicReactNativeElements(matcher) {
-    if (typeof matcher !== "object" || matcher.type !== "Invocation" || typeof matcher.value !== "object" || typeof matcher.value.target !== "object" || matcher.value.target.value !== "GREYMatchers") {
-      throw new Error('matcher should be a GREYMatcher, but got ' + JSON.stringify(matcher));
-    }
+	static detoxMatcherAvoidingProblematicReactNativeElements(matcher) {
+		if (
+			typeof matcher !== "object" ||
+			matcher.type !== "Invocation" ||
+			typeof matcher.value !== "object" ||
+			typeof matcher.value.target !== "object" ||
+			matcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"matcher should be a GREYMatcher, but got " + JSON.stringify(matcher)
+			);
+		}
 
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "detoxMatcherAvoidingProblematicReactNativeElements:",
-      args: [matcher]
-    };
-  }
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "detoxMatcherAvoidingProblematicReactNativeElements:",
+			args: [matcher]
+		};
+	}
 
-  static detoxMatcherForBothAnd(firstMatcher, secondMatcher) {
-    if (typeof firstMatcher !== "object" || firstMatcher.type !== "Invocation" || typeof firstMatcher.value !== "object" || typeof firstMatcher.value.target !== "object" || firstMatcher.value.target.value !== "GREYMatchers") {
-      throw new Error('firstMatcher should be a GREYMatcher, but got ' + JSON.stringify(firstMatcher));
-    }
+	static detoxMatcherForBothAnd(firstMatcher, secondMatcher) {
+		if (
+			typeof firstMatcher !== "object" ||
+			firstMatcher.type !== "Invocation" ||
+			typeof firstMatcher.value !== "object" ||
+			typeof firstMatcher.value.target !== "object" ||
+			firstMatcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"firstMatcher should be a GREYMatcher, but got " +
+					JSON.stringify(firstMatcher)
+			);
+		}
 
-    if (typeof secondMatcher !== "object" || secondMatcher.type !== "Invocation" || typeof secondMatcher.value !== "object" || typeof secondMatcher.value.target !== "object" || secondMatcher.value.target.value !== "GREYMatchers") {
-      throw new Error('secondMatcher should be a GREYMatcher, but got ' + JSON.stringify(secondMatcher));
-    }
+		if (
+			typeof secondMatcher !== "object" ||
+			secondMatcher.type !== "Invocation" ||
+			typeof secondMatcher.value !== "object" ||
+			typeof secondMatcher.value.target !== "object" ||
+			secondMatcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"secondMatcher should be a GREYMatcher, but got " +
+					JSON.stringify(secondMatcher)
+			);
+		}
 
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "detoxMatcherForBoth:and:",
-      args: [firstMatcher, secondMatcher]
-    };
-  }
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "detoxMatcherForBoth:and:",
+			args: [firstMatcher, secondMatcher]
+		};
+	}
 
-  static detoxMatcherForBothAndAncestorMatcher(firstMatcher, ancestorMatcher) {
-    if (typeof firstMatcher !== "object" || firstMatcher.type !== "Invocation" || typeof firstMatcher.value !== "object" || typeof firstMatcher.value.target !== "object" || firstMatcher.value.target.value !== "GREYMatchers") {
-      throw new Error('firstMatcher should be a GREYMatcher, but got ' + JSON.stringify(firstMatcher));
-    }
+	static detoxMatcherForBothAndAncestorMatcher(firstMatcher, ancestorMatcher) {
+		if (
+			typeof firstMatcher !== "object" ||
+			firstMatcher.type !== "Invocation" ||
+			typeof firstMatcher.value !== "object" ||
+			typeof firstMatcher.value.target !== "object" ||
+			firstMatcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"firstMatcher should be a GREYMatcher, but got " +
+					JSON.stringify(firstMatcher)
+			);
+		}
 
-    if (typeof ancestorMatcher !== "object" || ancestorMatcher.type !== "Invocation" || typeof ancestorMatcher.value !== "object" || typeof ancestorMatcher.value.target !== "object" || ancestorMatcher.value.target.value !== "GREYMatchers") {
-      throw new Error('ancestorMatcher should be a GREYMatcher, but got ' + JSON.stringify(ancestorMatcher));
-    }
+		if (
+			typeof ancestorMatcher !== "object" ||
+			ancestorMatcher.type !== "Invocation" ||
+			typeof ancestorMatcher.value !== "object" ||
+			typeof ancestorMatcher.value.target !== "object" ||
+			ancestorMatcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"ancestorMatcher should be a GREYMatcher, but got " +
+					JSON.stringify(ancestorMatcher)
+			);
+		}
 
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "detoxMatcherForBoth:andAncestorMatcher:",
-      args: [firstMatcher, ancestorMatcher]
-    };
-  }
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "detoxMatcherForBoth:andAncestorMatcher:",
+			args: [firstMatcher, ancestorMatcher]
+		};
+	}
 
-  static detoxMatcherForBothAndDescendantMatcher(firstMatcher, descendantMatcher) {
-    if (typeof firstMatcher !== "object" || firstMatcher.type !== "Invocation" || typeof firstMatcher.value !== "object" || typeof firstMatcher.value.target !== "object" || firstMatcher.value.target.value !== "GREYMatchers") {
-      throw new Error('firstMatcher should be a GREYMatcher, but got ' + JSON.stringify(firstMatcher));
-    }
+	static detoxMatcherForBothAndDescendantMatcher(
+		firstMatcher,
+		descendantMatcher
+	) {
+		if (
+			typeof firstMatcher !== "object" ||
+			firstMatcher.type !== "Invocation" ||
+			typeof firstMatcher.value !== "object" ||
+			typeof firstMatcher.value.target !== "object" ||
+			firstMatcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"firstMatcher should be a GREYMatcher, but got " +
+					JSON.stringify(firstMatcher)
+			);
+		}
 
-    if (typeof descendantMatcher !== "object" || descendantMatcher.type !== "Invocation" || typeof descendantMatcher.value !== "object" || typeof descendantMatcher.value.target !== "object" || descendantMatcher.value.target.value !== "GREYMatchers") {
-      throw new Error('descendantMatcher should be a GREYMatcher, but got ' + JSON.stringify(descendantMatcher));
-    }
+		if (
+			typeof descendantMatcher !== "object" ||
+			descendantMatcher.type !== "Invocation" ||
+			typeof descendantMatcher.value !== "object" ||
+			typeof descendantMatcher.value.target !== "object" ||
+			descendantMatcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"descendantMatcher should be a GREYMatcher, but got " +
+					JSON.stringify(descendantMatcher)
+			);
+		}
 
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "detoxMatcherForBoth:andDescendantMatcher:",
-      args: [firstMatcher, descendantMatcher]
-    };
-  }
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "detoxMatcherForBoth:andDescendantMatcher:",
+			args: [firstMatcher, descendantMatcher]
+		};
+	}
 
-  static detoxMatcherForNot(matcher) {
-    if (typeof matcher !== "object" || matcher.type !== "Invocation" || typeof matcher.value !== "object" || typeof matcher.value.target !== "object" || matcher.value.target.value !== "GREYMatchers") {
-      throw new Error('matcher should be a GREYMatcher, but got ' + JSON.stringify(matcher));
-    }
+	static detoxMatcherForNot(matcher) {
+		if (
+			typeof matcher !== "object" ||
+			matcher.type !== "Invocation" ||
+			typeof matcher.value !== "object" ||
+			typeof matcher.value.target !== "object" ||
+			matcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"matcher should be a GREYMatcher, but got " + JSON.stringify(matcher)
+			);
+		}
 
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "detoxMatcherForNot:",
-      args: [matcher]
-    };
-  }
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "detoxMatcherForNot:",
+			args: [matcher]
+		};
+	}
 
-  static detoxMatcherForClass(aClassName) {
-    if (typeof aClassName !== "string") throw new Error("aClassName should be a string, but got " + (aClassName + (" (" + (typeof aClassName + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "detoxMatcherForClass:",
-      args: [{
-        type: "NSString",
-        value: aClassName
-      }]
-    };
-  }
-
+	static detoxMatcherForClass(aClassName) {
+		if (typeof aClassName !== "string") {
+			throw new Error(
+				"aClassName should be a string, but got " +
+					(aClassName + (" (" + (typeof aClassName + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "detoxMatcherForClass:",
+			args: [
+				{
+					type: "NSString",
+					value: aClassName
+				}
+			]
+		};
+	}
 }
 
 module.exports = GREYMatchers;

--- a/detox/src/ios/earlgreyapi/GREYMatchers.js
+++ b/detox/src/ios/earlgreyapi/GREYMatchers.js
@@ -1,8 +1,10 @@
+/* eslint-disable */
 /**
 
 	This code is generated.
 	For more information see generation/README.md.
 */
+
 
 function sanitize_uiAccessibilityTraits(value) {
 	let traits = 0;
@@ -58,15 +60,15 @@ function sanitize_uiAccessibilityTraits(value) {
 				break;
 			default:
 				throw new Error(
-					`Unknown trait '${value[
-						i
-					]}', see list in https://facebook.github.io/react-native/docs/accessibility.html#accessibilitytraits-ios`
+					`Unknown trait '${
+						value[i]
+					}', see list in https://facebook.github.io/react-native/docs/accessibility.html#accessibilitytraits-ios`
 				);
 		}
 	}
 
 	return traits;
-}
+} 
 function sanitize_greyContentEdge(action) {
 	switch (action) {
 		case "left":
@@ -83,241 +85,190 @@ function sanitize_greyContentEdge(action) {
 				`GREYAction.GREYContentEdge must be a 'left'/'right'/'top'/'bottom', got ${action}`
 			);
 	}
-}
+} 
 class GREYMatchers {
-	/*Matcher for application's key window.
+  /*Matcher for application's key window.
 
 @return A matcher for the application's key window.
-*/ static matcherForKeyWindow() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForKeyWindow",
-			args: []
-		};
-	}
+*/static matcherForKeyWindow() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForKeyWindow",
+      args: []
+    };
+  }
 
-	/*Matcher for UI element with the provided accessibility @c label.
+  /*Matcher for UI element with the provided accessibility @c label.
 
 @param label The accessibility label to be matched.
 
 @return A matcher for the accessibility label of an accessible element.
-*/ static matcherForAccessibilityLabel(
-		label
-	) {
-		if (typeof label !== "string") {
-			throw new Error(
-				"label should be a string, but got " +
-					(label + (" (" + (typeof label + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForAccessibilityLabel:",
-			args: [
-				{
-					type: "NSString",
-					value: label
-				}
-			]
-		};
-	}
+*/static matcherForAccessibilityLabel(label) {
+    if (typeof label !== "string") throw new Error("label should be a string, but got " + (label + (" (" + (typeof label + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForAccessibilityLabel:",
+      args: [{
+        type: "NSString",
+        value: label
+      }]
+    };
+  }
 
-	/*Matcher for UI element with the provided accessibility ID @c accessibilityID.
+  /*Matcher for UI element with the provided accessibility ID @c accessibilityID.
 
 @param accessibilityID The accessibility ID to be matched.
 
 @return A matcher for the accessibility ID of an accessible element.
-*/ static matcherForAccessibilityID(
-		accessibilityID
-	) {
-		if (typeof accessibilityID !== "string") {
-			throw new Error(
-				"accessibilityID should be a string, but got " +
-					(accessibilityID + (" (" + (typeof accessibilityID + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForAccessibilityID:",
-			args: [
-				{
-					type: "NSString",
-					value: accessibilityID
-				}
-			]
-		};
-	}
+*/static matcherForAccessibilityID(accessibilityID) {
+    if (typeof accessibilityID !== "string") throw new Error("accessibilityID should be a string, but got " + (accessibilityID + (" (" + (typeof accessibilityID + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForAccessibilityID:",
+      args: [{
+        type: "NSString",
+        value: accessibilityID
+      }]
+    };
+  }
 
-	/*Matcher for UI element with the provided accessibility @c value.
+  /*Matcher for UI element with the provided accessibility @c value.
 
 @param value The accessibility value to be matched.
 
 @return A matcher for the accessibility value of an accessible element.
-*/ static matcherForAccessibilityValue(
-		value
-	) {
-		if (typeof value !== "string") {
-			throw new Error(
-				"value should be a string, but got " +
-					(value + (" (" + (typeof value + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForAccessibilityValue:",
-			args: [
-				{
-					type: "NSString",
-					value: value
-				}
-			]
-		};
-	}
+*/static matcherForAccessibilityValue(value) {
+    if (typeof value !== "string") throw new Error("value should be a string, but got " + (value + (" (" + (typeof value + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForAccessibilityValue:",
+      args: [{
+        type: "NSString",
+        value: value
+      }]
+    };
+  }
 
-	/*Matcher for UI element with the provided accessibility @c traits.
+  /*Matcher for UI element with the provided accessibility @c traits.
 
 @param traits The accessibility traits to be matched.
 
 @return A matcher for the accessibility traits of an accessible element.
 
-*/ static matcherForAccessibilityTraits(
-		traits
-	) {
-		if (typeof traits !== "object" || !traits instanceof Array) {
-			throw new Error(
-				"TraitsMatcher ctor argument must be an array, got " + typeof traits
-			);
-		}
+*/static matcherForAccessibilityTraits(traits) {
+    if (typeof traits !== 'object' || !traits instanceof Array) {
+      throw new Error('TraitsMatcher ctor argument must be an array, got ' + typeof traits);
+    }
 
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForAccessibilityTraits:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_uiAccessibilityTraits(traits)
-				}
-			]
-		};
-	}
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForAccessibilityTraits:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_uiAccessibilityTraits(traits)
+      }]
+    };
+  }
 
-	/*Matcher for UI element with the provided accessiblity @c hint.
+  /*Matcher for UI element with the provided accessiblity @c hint.
 
 @param hint The accessibility hint to be matched.
 
 @return A matcher for the accessibility hint of an accessible element.
-*/ static matcherForAccessibilityHint(
-		hint
-	) {
-		if (typeof hint !== "string") {
-			throw new Error(
-				"hint should be a string, but got " +
-					(hint + (" (" + (typeof hint + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForAccessibilityHint:",
-			args: [
-				{
-					type: "NSString",
-					value: hint
-				}
-			]
-		};
-	}
+*/static matcherForAccessibilityHint(hint) {
+    if (typeof hint !== "string") throw new Error("hint should be a string, but got " + (hint + (" (" + (typeof hint + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForAccessibilityHint:",
+      args: [{
+        type: "NSString",
+        value: hint
+      }]
+    };
+  }
 
-	/*Matcher for UI element with accessiblity focus.
+  /*Matcher for UI element with accessiblity focus.
 
 @return A matcher for the accessibility focus of an accessible element.
-*/ static matcherForAccessibilityElementIsFocused() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForAccessibilityElementIsFocused",
-			args: []
-		};
-	}
+*/static matcherForAccessibilityElementIsFocused() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForAccessibilityElementIsFocused",
+      args: []
+    };
+  }
 
-	/*Matcher for UI elements of type UIButton, UILabel, UITextField or UITextView displaying the
+  /*Matcher for UI elements of type UIButton, UILabel, UITextField or UITextView displaying the
 provided @c inputText.
 
 @param text The text to be matched in the UI elements.
 
 @return A matcher to check for any UI elements with a text field containing the given text.
-*/ static matcherForText(
-		text
-	) {
-		if (typeof text !== "string") {
-			throw new Error(
-				"text should be a string, but got " +
-					(text + (" (" + (typeof text + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForText:",
-			args: [
-				{
-					type: "NSString",
-					value: text
-				}
-			]
-		};
-	}
+*/static matcherForText(text) {
+    if (typeof text !== "string") throw new Error("text should be a string, but got " + (text + (" (" + (typeof text + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForText:",
+      args: [{
+        type: "NSString",
+        value: text
+      }]
+    };
+  }
 
-	/*Matcher for element that is the first responder.
+  /*Matcher for element that is the first responder.
 
 @return A matcher that verifies if a UI element is the first responder.
-*/ static matcherForFirstResponder() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForFirstResponder",
-			args: []
-		};
-	}
+*/static matcherForFirstResponder() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForFirstResponder",
+      args: []
+    };
+  }
 
-	/*Matcher to check if system alert view is shown.
+  /*Matcher to check if system alert view is shown.
 
 @return A matcher to check if a system alert view is being shown.
-*/ static matcherForSystemAlertViewShown() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForSystemAlertViewShown",
-			args: []
-		};
-	}
+*/static matcherForSystemAlertViewShown() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForSystemAlertViewShown",
+      args: []
+    };
+  }
 
-	/*Matcher for UI element whose percent visible area (of its accessibility frame) exceeds the
+  /*Matcher for UI element whose percent visible area (of its accessibility frame) exceeds the
 given @c percent.
 
 @param percent The percent visible area that the UI element being matched has to be visible.
@@ -325,94 +276,85 @@ Allowed values for @c percent are [0,1] inclusive.
 
 @return A matcher that checks if a UI element has a visible area at least equal
 to a minimum value.
-*/ static matcherForMinimumVisiblePercent(
-		percent
-	) {
-		if (typeof percent !== "number") {
-			throw new Error(
-				"percent should be a number, but got " +
-					(percent + (" (" + (typeof percent + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForMinimumVisiblePercent:",
-			args: [
-				{
-					type: "CGFloat",
-					value: percent
-				}
-			]
-		};
-	}
+*/static matcherForMinimumVisiblePercent(percent) {
+    if (typeof percent !== "number") throw new Error("percent should be a number, but got " + (percent + (" (" + (typeof percent + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForMinimumVisiblePercent:",
+      args: [{
+        type: "CGFloat",
+        value: percent
+      }]
+    };
+  }
 
-	/*Matcher for UI element that is sufficiently visible to the user. EarlGrey considers elements
+  /*Matcher for UI element that is sufficiently visible to the user. EarlGrey considers elements
 that are more than @c kElementSufficientlyVisiblePercentage (75 %) visible areawise to be
 sufficiently visible.
 
 @return A matcher intialized with a visibility percentage that confirms an element is
 sufficiently visible.
-*/ static matcherForSufficientlyVisible() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForSufficientlyVisible",
-			args: []
-		};
-	}
+*/static matcherForSufficientlyVisible() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForSufficientlyVisible",
+      args: []
+    };
+  }
 
-	/*Matcher for UI element that is not visible to the user at all i.e. it has a zero visible area.
+  /*Matcher for UI element that is not visible to the user at all i.e. it has a zero visible area.
 
 @return A matcher for verifying if an element is not visible.
-*/ static matcherForNotVisible() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForNotVisible",
-			args: []
-		};
-	}
+*/static matcherForNotVisible() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForNotVisible",
+      args: []
+    };
+  }
 
-	/*Matcher for UI element that matches EarlGrey's criteria for user interaction. Currently it must
+  /*Matcher for UI element that matches EarlGrey's criteria for user interaction. Currently it must
 satisfy at least the following criteria:
 1) At least a few pixels of the element are visible to the user.
 2) The element's accessibility activation point OR the center of the element's visible area
 is completely visible.
 
 @return A matcher that checks if a UI element is interactable.
-*/ static matcherForInteractable() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForInteractable",
-			args: []
-		};
-	}
+*/static matcherForInteractable() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForInteractable",
+      args: []
+    };
+  }
 
-	/*Matcher to check if a UI element is accessible.
+  /*Matcher to check if a UI element is accessible.
 
 @return A matcher that checks if a UI element is accessible.
-*/ static matcherForAccessibilityElement() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForAccessibilityElement",
-			args: []
-		};
-	}
+*/static matcherForAccessibilityElement() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForAccessibilityElement",
+      args: []
+    };
+  }
 
-	/*Matcher for matching UIProgressView's values. Use greaterThan, greaterThanOrEqualTo,
+  /*Matcher for matching UIProgressView's values. Use greaterThan, greaterThanOrEqualTo,
 lessThan etc to create @c comparisonMatcher. For example, to match the UIProgressView
 elements that have progress value greater than 50.2, use
 @code [GREYMatchers matcherForProgress:grey_greaterThan(@(50.2))] @endcode. In case if an
@@ -421,168 +363,107 @@ unimplemented matcher is required, please implement it similar to @c grey_closeT
 @param comparisonMatcher The matcher with the value to check the progress against.
 
 @return A matcher for checking a UIProgessView's value.
-*/ static matcherForProgress(
-		comparisonMatcher
-	) {
-		if (
-			typeof comparisonMatcher !== "object" ||
-			comparisonMatcher.type !== "Invocation" ||
-			typeof comparisonMatcher.value !== "object" ||
-			typeof comparisonMatcher.value.target !== "object" ||
-			comparisonMatcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"comparisonMatcher should be a GREYMatcher, but got " +
-					JSON.stringify(comparisonMatcher)
-			);
-		}
+*/static matcherForProgress(comparisonMatcher) {
+    if (typeof comparisonMatcher !== "object" || comparisonMatcher.type !== "Invocation" || typeof comparisonMatcher.value !== "object" || typeof comparisonMatcher.value.target !== "object" || comparisonMatcher.value.target.value !== "GREYMatchers") {
+      throw new Error('comparisonMatcher should be a GREYMatcher, but got ' + JSON.stringify(comparisonMatcher));
+    }
 
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForProgress:",
-			args: [comparisonMatcher]
-		};
-	}
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForProgress:",
+      args: [comparisonMatcher]
+    };
+  }
 
-	/*Matcher that matches UI element based on the presence of an ancestor in its hierarchy.
+  /*Matcher that matches UI element based on the presence of an ancestor in its hierarchy.
 The given matcher is used to match decendants.
 
 @param ancestorMatcher The ancestor UI element whose descendants are to be matched.
 
 @return A matcher to check if a UI element is the descendant of another.
-*/ static matcherForAncestor(
-		ancestorMatcher
-	) {
-		if (
-			typeof ancestorMatcher !== "object" ||
-			ancestorMatcher.type !== "Invocation" ||
-			typeof ancestorMatcher.value !== "object" ||
-			typeof ancestorMatcher.value.target !== "object" ||
-			ancestorMatcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"ancestorMatcher should be a GREYMatcher, but got " +
-					JSON.stringify(ancestorMatcher)
-			);
-		}
+*/static matcherForAncestor(ancestorMatcher) {
+    if (typeof ancestorMatcher !== "object" || ancestorMatcher.type !== "Invocation" || typeof ancestorMatcher.value !== "object" || typeof ancestorMatcher.value.target !== "object" || ancestorMatcher.value.target.value !== "GREYMatchers") {
+      throw new Error('ancestorMatcher should be a GREYMatcher, but got ' + JSON.stringify(ancestorMatcher));
+    }
 
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForAncestor:",
-			args: [ancestorMatcher]
-		};
-	}
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForAncestor:",
+      args: [ancestorMatcher]
+    };
+  }
 
-	/*Matcher that matches any UI element with a descendant matching the given matcher.
+  /*Matcher that matches any UI element with a descendant matching the given matcher.
 
 @param descendantMatcher A matcher being checked to be a descendant
 of the UI element being checked.
 
 @return A matcher to check if a the specified element is in a descendant of another UI element.
-*/ static matcherForDescendant(
-		descendantMatcher
-	) {
-		if (
-			typeof descendantMatcher !== "object" ||
-			descendantMatcher.type !== "Invocation" ||
-			typeof descendantMatcher.value !== "object" ||
-			typeof descendantMatcher.value.target !== "object" ||
-			descendantMatcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"descendantMatcher should be a GREYMatcher, but got " +
-					JSON.stringify(descendantMatcher)
-			);
-		}
+*/static matcherForDescendant(descendantMatcher) {
+    if (typeof descendantMatcher !== "object" || descendantMatcher.type !== "Invocation" || typeof descendantMatcher.value !== "object" || typeof descendantMatcher.value.target !== "object" || descendantMatcher.value.target.value !== "GREYMatchers") {
+      throw new Error('descendantMatcher should be a GREYMatcher, but got ' + JSON.stringify(descendantMatcher));
+    }
 
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForDescendant:",
-			args: [descendantMatcher]
-		};
-	}
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForDescendant:",
+      args: [descendantMatcher]
+    };
+  }
 
-	/*Matcher that matches UIButton that has title label as @c text.
+  /*Matcher that matches UIButton that has title label as @c text.
 
 @param title The title to be checked on the UIButtons being matched.
 
 @return A matcher to confirm UIButton titles.
-*/ static matcherForButtonTitle(
-		title
-	) {
-		if (typeof title !== "string") {
-			throw new Error(
-				"title should be a string, but got " +
-					(title + (" (" + (typeof title + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForButtonTitle:",
-			args: [
-				{
-					type: "NSString",
-					value: title
-				}
-			]
-		};
-	}
+*/static matcherForButtonTitle(title) {
+    if (typeof title !== "string") throw new Error("title should be a string, but got " + (title + (" (" + (typeof title + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForButtonTitle:",
+      args: [{
+        type: "NSString",
+        value: title
+      }]
+    };
+  }
 
-	/*Matcher that matches UIScrollView that has contentOffset as @c offset.
+  /*Matcher that matches UIScrollView that has contentOffset as @c offset.
 
 @param offset The content offset to be checked on the UIScrollView being
 matched.
 
 @return A matcher to confirm UIScrollView content offset.
-*/ static matcherForScrollViewContentOffset(
-		offset
-	) {
-		if (typeof offset !== "object") {
-			throw new Error(
-				"offset should be a object, but got " +
-					(offset + (" (" + (typeof offset + ")")))
-			);
-		}
-		if (typeof offset.x !== "number") {
-			throw new Error(
-				"offset.x should be a number, but got " +
-					(offset.x + (" (" + (typeof offset.x + ")")))
-			);
-		}
-		if (typeof offset.y !== "number") {
-			throw new Error(
-				"offset.y should be a number, but got " +
-					(offset.y + (" (" + (typeof offset.y + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForScrollViewContentOffset:",
-			args: [
-				{
-					type: "CGPoint",
-					value: offset
-				}
-			]
-		};
-	}
+*/static matcherForScrollViewContentOffset(offset) {
+    if (typeof offset !== "object") throw new Error("offset should be a object, but got " + (offset + (" (" + (typeof offset + ")"))));
+    if (typeof offset.x !== "number") throw new Error("offset.x should be a number, but got " + (offset.x + (" (" + (typeof offset.x + ")"))));
+    if (typeof offset.y !== "number") throw new Error("offset.y should be a number, but got " + (offset.y + (" (" + (typeof offset.y + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForScrollViewContentOffset:",
+      args: [{
+        type: "CGPoint",
+        value: offset
+      }]
+    };
+  }
 
-	/*Matcher that matches a UISlider's value.
+  /*Matcher that matches a UISlider's value.
 
 @param valueMatcher A matcher for the UISlider's value. You must provide a valid
 @c valueMatcher for the floating point value comparison. The
@@ -594,213 +475,170 @@ floating point value. If you are using @c grey_closeTo, use delta diff as
 is required, please implement it similar to @c grey_closeTo.
 
 @return A matcher for checking a UISlider's value.
-*/ static matcherForSliderValueMatcher(
-		valueMatcher
-	) {
-		if (
-			typeof valueMatcher !== "object" ||
-			valueMatcher.type !== "Invocation" ||
-			typeof valueMatcher.value !== "object" ||
-			typeof valueMatcher.value.target !== "object" ||
-			valueMatcher.value.target.value !== "GREYMatchers"
-		) {
-			throw new Error(
-				"valueMatcher should be a GREYMatcher, but got " +
-					JSON.stringify(valueMatcher)
-			);
-		}
+*/static matcherForSliderValueMatcher(valueMatcher) {
+    if (typeof valueMatcher !== "object" || valueMatcher.type !== "Invocation" || typeof valueMatcher.value !== "object" || typeof valueMatcher.value.target !== "object" || valueMatcher.value.target.value !== "GREYMatchers") {
+      throw new Error('valueMatcher should be a GREYMatcher, but got ' + JSON.stringify(valueMatcher));
+    }
 
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForSliderValueMatcher:",
-			args: [valueMatcher]
-		};
-	}
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForSliderValueMatcher:",
+      args: [valueMatcher]
+    };
+  }
 
-	/*Matcher that matches UIPickerView that has a column set to @c value.
+  /*Matcher that matches UIPickerView that has a column set to @c value.
 
 @param column The column of the UIPickerView to be matched.
 @param value  The value that should be set in the column of the UIPickerView.
 
 @return A matcher to check the value in a particular column of a UIPickerView.
-*/ static matcherForPickerColumnSetToValue(
-		column,
-		value
-	) {
-		if (typeof column !== "number") {
-			throw new Error(
-				"column should be a number, but got " +
-					(column + (" (" + (typeof column + ")")))
-			);
-		}
-		if (typeof value !== "string") {
-			throw new Error(
-				"value should be a string, but got " +
-					(value + (" (" + (typeof value + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForPickerColumn:setToValue:",
-			args: [
-				{
-					type: "NSInteger",
-					value: column
-				},
-				{
-					type: "NSString",
-					value: value
-				}
-			]
-		};
-	}
+*/static matcherForPickerColumnSetToValue(column, value) {
+    if (typeof column !== "number") throw new Error("column should be a number, but got " + (column + (" (" + (typeof column + ")"))));
+    if (typeof value !== "string") throw new Error("value should be a string, but got " + (value + (" (" + (typeof value + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForPickerColumn:setToValue:",
+      args: [{
+        type: "NSInteger",
+        value: column
+      }, {
+        type: "NSString",
+        value: value
+      }]
+    };
+  }
 
-	/*Matcher that verifies whether an element, that is a UIControl, is enabled.
+  /*Matcher that verifies whether an element, that is a UIControl, is enabled.
 
 @return A matcher for checking whether a UI element is an enabled UIControl.
-*/ static matcherForEnabledElement() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForEnabledElement",
-			args: []
-		};
-	}
+*/static matcherForEnabledElement() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForEnabledElement",
+      args: []
+    };
+  }
 
-	/*Matcher that verifies whether an element, that is a UIControl, is selected.
+  /*Matcher that verifies whether an element, that is a UIControl, is selected.
 
 @return A matcher for checking whether a UI element is a selected UIControl.
-*/ static matcherForSelectedElement() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForSelectedElement",
-			args: []
-		};
-	}
+*/static matcherForSelectedElement() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForSelectedElement",
+      args: []
+    };
+  }
 
-	/*Matcher that verifies whether a view has its userInteractionEnabled property set to @c YES.
+  /*Matcher that verifies whether a view has its userInteractionEnabled property set to @c YES.
 
 @return A matcher for checking whether a view' userInteractionEnabled property is set to @c YES.
-*/ static matcherForUserInteractionEnabled() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForUserInteractionEnabled",
-			args: []
-		};
-	}
+*/static matcherForUserInteractionEnabled() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForUserInteractionEnabled",
+      args: []
+    };
+  }
 
-	/*Matcher primarily for asserting that the element is @c nil or not found.
+  /*Matcher primarily for asserting that the element is @c nil or not found.
 
 @return A matcher to check if a specified element is @c nil or not found.
-*/ static matcherForNil() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForNil",
-			args: []
-		};
-	}
+*/static matcherForNil() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForNil",
+      args: []
+    };
+  }
 
-	/*Matcher for asserting that the element exists in the UI hierarchy (i.e. not @c nil).
+  /*Matcher for asserting that the element exists in the UI hierarchy (i.e. not @c nil).
 
 @return A matcher to check if a specified element is not @c nil.
-*/ static matcherForNotNil() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForNotNil",
-			args: []
-		};
-	}
+*/static matcherForNotNil() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForNotNil",
+      args: []
+    };
+  }
 
-	/*A Matcher that matches against any object, including @c nils.
+  /*A Matcher that matches against any object, including @c nils.
 
 @return A matcher that matches any object.
-*/ static matcherForAnything() {
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForAnything",
-			args: []
-		};
-	}
+*/static matcherForAnything() {
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForAnything",
+      args: []
+    };
+  }
 
-	/*Matcher that matches a UIScrollView scrolled to content @c edge.
+  /*Matcher that matches a UIScrollView scrolled to content @c edge.
 
 @param edge The content edge UIScrollView should be scrolled to.
 
 @return A matcher that matches a UIScrollView scrolled to content @c edge.
-*/ static matcherForScrolledToContentEdge(
-		edge
-	) {
-		if (!["left", "right", "top", "bottom"].some(option => option === edge)) {
-			throw new Error(
-				"edge should be one of [left, right, top, bottom], but got " + edge
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForScrolledToContentEdge:",
-			args: [
-				{
-					type: "NSInteger",
-					value: sanitize_greyContentEdge(edge)
-				}
-			]
-		};
-	}
+*/static matcherForScrolledToContentEdge(edge) {
+    if (!["left", "right", "top", "bottom"].some(option => option === edge)) throw new Error("edge should be one of [left, right, top, bottom], but got " + edge);
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForScrolledToContentEdge:",
+      args: [{
+        type: "NSInteger",
+        value: sanitize_greyContentEdge(edge)
+      }]
+    };
+  }
 
-	/*Matcher that matches a UITextField's content.
+  /*Matcher that matches a UITextField's content.
 
 @param value The text string contained inside the UITextField.
 
 @return A matcher that matches the value inside a UITextField.
-*/ static matcherForTextFieldValue(
-		value
-	) {
-		if (typeof value !== "string") {
-			throw new Error(
-				"value should be a string, but got " +
-					(value + (" (" + (typeof value + ")")))
-			);
-		}
-		return {
-			target: {
-				type: "Class",
-				value: "GREYMatchers"
-			},
-			method: "matcherForTextFieldValue:",
-			args: [
-				{
-					type: "NSString",
-					value: value
-				}
-			]
-		};
-	}
+*/static matcherForTextFieldValue(value) {
+    if (typeof value !== "string") throw new Error("value should be a string, but got " + (value + (" (" + (typeof value + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYMatchers"
+      },
+      method: "matcherForTextFieldValue:",
+      args: [{
+        type: "NSString",
+        value: value
+      }]
+    };
+  }
+
 }
 
 module.exports = GREYMatchers;

--- a/detox/src/ios/earlgreyapi/GREYMatchers.js
+++ b/detox/src/ios/earlgreyapi/GREYMatchers.js
@@ -4,231 +4,320 @@
 	For more information see generation/README.md.
 */
 
-
 function sanitize_uiAccessibilityTraits(value) {
-  let traits = 0;
-  for (let i = 0; i < value.length; i++) {
-    switch (value[i]) {
-      case 'button': traits |= 1; break;
-      case 'link': traits |= 2; break;
-      case 'header': traits |= 4; break;
-      case 'search': traits |= 8; break;
-      case 'image': traits |= 16; break;
-      case 'selected': traits |= 32; break;
-      case 'plays': traits |= 64; break;
-      case 'key': traits |= 128; break;
-      case 'text': traits |= 256; break;
-      case 'summary': traits |= 512; break;
-      case 'disabled': traits |= 1024; break;
-      case 'frequentUpdates': traits |= 2048; break;
-      case 'startsMedia': traits |= 4096; break;
-      case 'adjustable': traits |= 8192; break;
-      case 'allowsDirectInteraction': traits |= 16384; break;
-      case 'pageTurn': traits |= 32768; break;
-      default: throw new Error(`Unknown trait '${value[i]}', see list in https://facebook.github.io/react-native/docs/accessibility.html#accessibilitytraits-ios`);
-    }
-  }
+	let traits = 0;
+	for (let i = 0; i < value.length; i++) {
+		switch (value[i]) {
+			case "button":
+				traits |= 1;
+				break;
+			case "link":
+				traits |= 2;
+				break;
+			case "header":
+				traits |= 4;
+				break;
+			case "search":
+				traits |= 8;
+				break;
+			case "image":
+				traits |= 16;
+				break;
+			case "selected":
+				traits |= 32;
+				break;
+			case "plays":
+				traits |= 64;
+				break;
+			case "key":
+				traits |= 128;
+				break;
+			case "text":
+				traits |= 256;
+				break;
+			case "summary":
+				traits |= 512;
+				break;
+			case "disabled":
+				traits |= 1024;
+				break;
+			case "frequentUpdates":
+				traits |= 2048;
+				break;
+			case "startsMedia":
+				traits |= 4096;
+				break;
+			case "adjustable":
+				traits |= 8192;
+				break;
+			case "allowsDirectInteraction":
+				traits |= 16384;
+				break;
+			case "pageTurn":
+				traits |= 32768;
+				break;
+			default:
+				throw new Error(
+					`Unknown trait '${value[
+						i
+					]}', see list in https://facebook.github.io/react-native/docs/accessibility.html#accessibilitytraits-ios`
+				);
+		}
+	}
 
-  return traits;
+	return traits;
 }
 function sanitize_greyContentEdge(action) {
-  switch (action) {
-    case "left":
-      return 0;
-    case "right":
-      return 1;
-    case "top":
-      return 2;
-    case "bottom":
-      return 3;
+	switch (action) {
+		case "left":
+			return 0;
+		case "right":
+			return 1;
+		case "top":
+			return 2;
+		case "bottom":
+			return 3;
 
-    default:
-      throw new Error(`GREYAction.GREYContentEdge must be a 'left'/'right'/'top'/'bottom', got ${action}`);
-  }
+		default:
+			throw new Error(
+				`GREYAction.GREYContentEdge must be a 'left'/'right'/'top'/'bottom', got ${action}`
+			);
+	}
 }
 class GREYMatchers {
-  /*Matcher for application's key window.
+	/*Matcher for application's key window.
 
 @return A matcher for the application's key window.
-*/static matcherForKeyWindow() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForKeyWindow",
-      args: []
-    };
-  }
+*/ static matcherForKeyWindow() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForKeyWindow",
+			args: []
+		};
+	}
 
-  /*Matcher for UI element with the provided accessibility @c label.
+	/*Matcher for UI element with the provided accessibility @c label.
 
 @param label The accessibility label to be matched.
 
 @return A matcher for the accessibility label of an accessible element.
-*/static matcherForAccessibilityLabel(label) {
-    if (typeof label !== "string") throw new Error("label should be a string, but got " + (label + (" (" + (typeof label + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForAccessibilityLabel:",
-      args: [{
-        type: "NSString",
-        value: label
-      }]
-    };
-  }
+*/ static matcherForAccessibilityLabel(
+		label
+	) {
+		if (typeof label !== "string") {
+			throw new Error(
+				"label should be a string, but got " +
+					(label + (" (" + (typeof label + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForAccessibilityLabel:",
+			args: [
+				{
+					type: "NSString",
+					value: label
+				}
+			]
+		};
+	}
 
-  /*Matcher for UI element with the provided accessibility ID @c accessibilityID.
+	/*Matcher for UI element with the provided accessibility ID @c accessibilityID.
 
 @param accessibilityID The accessibility ID to be matched.
 
 @return A matcher for the accessibility ID of an accessible element.
-*/static matcherForAccessibilityID(accessibilityID) {
-    if (typeof accessibilityID !== "string") throw new Error("accessibilityID should be a string, but got " + (accessibilityID + (" (" + (typeof accessibilityID + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForAccessibilityID:",
-      args: [{
-        type: "NSString",
-        value: accessibilityID
-      }]
-    };
-  }
+*/ static matcherForAccessibilityID(
+		accessibilityID
+	) {
+		if (typeof accessibilityID !== "string") {
+			throw new Error(
+				"accessibilityID should be a string, but got " +
+					(accessibilityID + (" (" + (typeof accessibilityID + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForAccessibilityID:",
+			args: [
+				{
+					type: "NSString",
+					value: accessibilityID
+				}
+			]
+		};
+	}
 
-  /*Matcher for UI element with the provided accessibility @c value.
+	/*Matcher for UI element with the provided accessibility @c value.
 
 @param value The accessibility value to be matched.
 
 @return A matcher for the accessibility value of an accessible element.
-*/static matcherForAccessibilityValue(value) {
-    if (typeof value !== "string") throw new Error("value should be a string, but got " + (value + (" (" + (typeof value + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForAccessibilityValue:",
-      args: [{
-        type: "NSString",
-        value: value
-      }]
-    };
-  }
+*/ static matcherForAccessibilityValue(
+		value
+	) {
+		if (typeof value !== "string") {
+			throw new Error(
+				"value should be a string, but got " +
+					(value + (" (" + (typeof value + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForAccessibilityValue:",
+			args: [
+				{
+					type: "NSString",
+					value: value
+				}
+			]
+		};
+	}
 
-  /*Matcher for UI element with the provided accessibility @c traits.
+	/*Matcher for UI element with the provided accessibility @c traits.
 
 @param traits The accessibility traits to be matched.
 
 @return A matcher for the accessibility traits of an accessible element.
 
-*/static matcherForAccessibilityTraits(traits) {
-    if (typeof traits !== 'object' || !traits instanceof Array) {
-      throw new Error('TraitsMatcher ctor argument must be an array, got ' + typeof traits);
-    }
+*/ static matcherForAccessibilityTraits(
+		traits
+	) {
+		if (typeof traits !== "object" || !traits instanceof Array) {
+			throw new Error(
+				"TraitsMatcher ctor argument must be an array, got " + typeof traits
+			);
+		}
 
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForAccessibilityTraits:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_uiAccessibilityTraits(traits)
-      }]
-    };
-  }
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForAccessibilityTraits:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_uiAccessibilityTraits(traits)
+				}
+			]
+		};
+	}
 
-  /*Matcher for UI element with the provided accessiblity @c hint.
+	/*Matcher for UI element with the provided accessiblity @c hint.
 
 @param hint The accessibility hint to be matched.
 
 @return A matcher for the accessibility hint of an accessible element.
-*/static matcherForAccessibilityHint(hint) {
-    if (typeof hint !== "string") throw new Error("hint should be a string, but got " + (hint + (" (" + (typeof hint + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForAccessibilityHint:",
-      args: [{
-        type: "NSString",
-        value: hint
-      }]
-    };
-  }
+*/ static matcherForAccessibilityHint(
+		hint
+	) {
+		if (typeof hint !== "string") {
+			throw new Error(
+				"hint should be a string, but got " +
+					(hint + (" (" + (typeof hint + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForAccessibilityHint:",
+			args: [
+				{
+					type: "NSString",
+					value: hint
+				}
+			]
+		};
+	}
 
-  /*Matcher for UI element with accessiblity focus.
+	/*Matcher for UI element with accessiblity focus.
 
 @return A matcher for the accessibility focus of an accessible element.
-*/static matcherForAccessibilityElementIsFocused() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForAccessibilityElementIsFocused",
-      args: []
-    };
-  }
+*/ static matcherForAccessibilityElementIsFocused() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForAccessibilityElementIsFocused",
+			args: []
+		};
+	}
 
-  /*Matcher for UI elements of type UIButton, UILabel, UITextField or UITextView displaying the
+	/*Matcher for UI elements of type UIButton, UILabel, UITextField or UITextView displaying the
 provided @c inputText.
 
 @param text The text to be matched in the UI elements.
 
 @return A matcher to check for any UI elements with a text field containing the given text.
-*/static matcherForText(text) {
-    if (typeof text !== "string") throw new Error("text should be a string, but got " + (text + (" (" + (typeof text + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForText:",
-      args: [{
-        type: "NSString",
-        value: text
-      }]
-    };
-  }
+*/ static matcherForText(
+		text
+	) {
+		if (typeof text !== "string") {
+			throw new Error(
+				"text should be a string, but got " +
+					(text + (" (" + (typeof text + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForText:",
+			args: [
+				{
+					type: "NSString",
+					value: text
+				}
+			]
+		};
+	}
 
-  /*Matcher for element that is the first responder.
+	/*Matcher for element that is the first responder.
 
 @return A matcher that verifies if a UI element is the first responder.
-*/static matcherForFirstResponder() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForFirstResponder",
-      args: []
-    };
-  }
+*/ static matcherForFirstResponder() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForFirstResponder",
+			args: []
+		};
+	}
 
-  /*Matcher to check if system alert view is shown.
+	/*Matcher to check if system alert view is shown.
 
 @return A matcher to check if a system alert view is being shown.
-*/static matcherForSystemAlertViewShown() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForSystemAlertViewShown",
-      args: []
-    };
-  }
+*/ static matcherForSystemAlertViewShown() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForSystemAlertViewShown",
+			args: []
+		};
+	}
 
-  /*Matcher for UI element whose percent visible area (of its accessibility frame) exceeds the
+	/*Matcher for UI element whose percent visible area (of its accessibility frame) exceeds the
 given @c percent.
 
 @param percent The percent visible area that the UI element being matched has to be visible.
@@ -236,85 +325,94 @@ Allowed values for @c percent are [0,1] inclusive.
 
 @return A matcher that checks if a UI element has a visible area at least equal
 to a minimum value.
-*/static matcherForMinimumVisiblePercent(percent) {
-    if (typeof percent !== "number") throw new Error("percent should be a number, but got " + (percent + (" (" + (typeof percent + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForMinimumVisiblePercent:",
-      args: [{
-        type: "CGFloat",
-        value: percent
-      }]
-    };
-  }
+*/ static matcherForMinimumVisiblePercent(
+		percent
+	) {
+		if (typeof percent !== "number") {
+			throw new Error(
+				"percent should be a number, but got " +
+					(percent + (" (" + (typeof percent + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForMinimumVisiblePercent:",
+			args: [
+				{
+					type: "CGFloat",
+					value: percent
+				}
+			]
+		};
+	}
 
-  /*Matcher for UI element that is sufficiently visible to the user. EarlGrey considers elements
+	/*Matcher for UI element that is sufficiently visible to the user. EarlGrey considers elements
 that are more than @c kElementSufficientlyVisiblePercentage (75 %) visible areawise to be
 sufficiently visible.
 
 @return A matcher intialized with a visibility percentage that confirms an element is
 sufficiently visible.
-*/static matcherForSufficientlyVisible() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForSufficientlyVisible",
-      args: []
-    };
-  }
+*/ static matcherForSufficientlyVisible() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForSufficientlyVisible",
+			args: []
+		};
+	}
 
-  /*Matcher for UI element that is not visible to the user at all i.e. it has a zero visible area.
+	/*Matcher for UI element that is not visible to the user at all i.e. it has a zero visible area.
 
 @return A matcher for verifying if an element is not visible.
-*/static matcherForNotVisible() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForNotVisible",
-      args: []
-    };
-  }
+*/ static matcherForNotVisible() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForNotVisible",
+			args: []
+		};
+	}
 
-  /*Matcher for UI element that matches EarlGrey's criteria for user interaction. Currently it must
+	/*Matcher for UI element that matches EarlGrey's criteria for user interaction. Currently it must
 satisfy at least the following criteria:
 1) At least a few pixels of the element are visible to the user.
 2) The element's accessibility activation point OR the center of the element's visible area
 is completely visible.
 
 @return A matcher that checks if a UI element is interactable.
-*/static matcherForInteractable() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForInteractable",
-      args: []
-    };
-  }
+*/ static matcherForInteractable() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForInteractable",
+			args: []
+		};
+	}
 
-  /*Matcher to check if a UI element is accessible.
+	/*Matcher to check if a UI element is accessible.
 
 @return A matcher that checks if a UI element is accessible.
-*/static matcherForAccessibilityElement() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForAccessibilityElement",
-      args: []
-    };
-  }
+*/ static matcherForAccessibilityElement() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForAccessibilityElement",
+			args: []
+		};
+	}
 
-  /*Matcher for matching UIProgressView's values. Use greaterThan, greaterThanOrEqualTo,
+	/*Matcher for matching UIProgressView's values. Use greaterThan, greaterThanOrEqualTo,
 lessThan etc to create @c comparisonMatcher. For example, to match the UIProgressView
 elements that have progress value greater than 50.2, use
 @code [GREYMatchers matcherForProgress:grey_greaterThan(@(50.2))] @endcode. In case if an
@@ -323,107 +421,168 @@ unimplemented matcher is required, please implement it similar to @c grey_closeT
 @param comparisonMatcher The matcher with the value to check the progress against.
 
 @return A matcher for checking a UIProgessView's value.
-*/static matcherForProgress(comparisonMatcher) {
-    if (typeof comparisonMatcher !== "object" || comparisonMatcher.type !== "Invocation" || typeof comparisonMatcher.value !== "object" || typeof comparisonMatcher.value.target !== "object" || comparisonMatcher.value.target.value !== "GREYMatchers") {
-      throw new Error('comparisonMatcher should be a GREYMatcher, but got ' + JSON.stringify(comparisonMatcher));
-    }
+*/ static matcherForProgress(
+		comparisonMatcher
+	) {
+		if (
+			typeof comparisonMatcher !== "object" ||
+			comparisonMatcher.type !== "Invocation" ||
+			typeof comparisonMatcher.value !== "object" ||
+			typeof comparisonMatcher.value.target !== "object" ||
+			comparisonMatcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"comparisonMatcher should be a GREYMatcher, but got " +
+					JSON.stringify(comparisonMatcher)
+			);
+		}
 
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForProgress:",
-      args: [comparisonMatcher]
-    };
-  }
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForProgress:",
+			args: [comparisonMatcher]
+		};
+	}
 
-  /*Matcher that matches UI element based on the presence of an ancestor in its hierarchy.
+	/*Matcher that matches UI element based on the presence of an ancestor in its hierarchy.
 The given matcher is used to match decendants.
 
 @param ancestorMatcher The ancestor UI element whose descendants are to be matched.
 
 @return A matcher to check if a UI element is the descendant of another.
-*/static matcherForAncestor(ancestorMatcher) {
-    if (typeof ancestorMatcher !== "object" || ancestorMatcher.type !== "Invocation" || typeof ancestorMatcher.value !== "object" || typeof ancestorMatcher.value.target !== "object" || ancestorMatcher.value.target.value !== "GREYMatchers") {
-      throw new Error('ancestorMatcher should be a GREYMatcher, but got ' + JSON.stringify(ancestorMatcher));
-    }
+*/ static matcherForAncestor(
+		ancestorMatcher
+	) {
+		if (
+			typeof ancestorMatcher !== "object" ||
+			ancestorMatcher.type !== "Invocation" ||
+			typeof ancestorMatcher.value !== "object" ||
+			typeof ancestorMatcher.value.target !== "object" ||
+			ancestorMatcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"ancestorMatcher should be a GREYMatcher, but got " +
+					JSON.stringify(ancestorMatcher)
+			);
+		}
 
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForAncestor:",
-      args: [ancestorMatcher]
-    };
-  }
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForAncestor:",
+			args: [ancestorMatcher]
+		};
+	}
 
-  /*Matcher that matches any UI element with a descendant matching the given matcher.
+	/*Matcher that matches any UI element with a descendant matching the given matcher.
 
 @param descendantMatcher A matcher being checked to be a descendant
 of the UI element being checked.
 
 @return A matcher to check if a the specified element is in a descendant of another UI element.
-*/static matcherForDescendant(descendantMatcher) {
-    if (typeof descendantMatcher !== "object" || descendantMatcher.type !== "Invocation" || typeof descendantMatcher.value !== "object" || typeof descendantMatcher.value.target !== "object" || descendantMatcher.value.target.value !== "GREYMatchers") {
-      throw new Error('descendantMatcher should be a GREYMatcher, but got ' + JSON.stringify(descendantMatcher));
-    }
+*/ static matcherForDescendant(
+		descendantMatcher
+	) {
+		if (
+			typeof descendantMatcher !== "object" ||
+			descendantMatcher.type !== "Invocation" ||
+			typeof descendantMatcher.value !== "object" ||
+			typeof descendantMatcher.value.target !== "object" ||
+			descendantMatcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"descendantMatcher should be a GREYMatcher, but got " +
+					JSON.stringify(descendantMatcher)
+			);
+		}
 
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForDescendant:",
-      args: [descendantMatcher]
-    };
-  }
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForDescendant:",
+			args: [descendantMatcher]
+		};
+	}
 
-  /*Matcher that matches UIButton that has title label as @c text.
+	/*Matcher that matches UIButton that has title label as @c text.
 
 @param title The title to be checked on the UIButtons being matched.
 
 @return A matcher to confirm UIButton titles.
-*/static matcherForButtonTitle(title) {
-    if (typeof title !== "string") throw new Error("title should be a string, but got " + (title + (" (" + (typeof title + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForButtonTitle:",
-      args: [{
-        type: "NSString",
-        value: title
-      }]
-    };
-  }
+*/ static matcherForButtonTitle(
+		title
+	) {
+		if (typeof title !== "string") {
+			throw new Error(
+				"title should be a string, but got " +
+					(title + (" (" + (typeof title + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForButtonTitle:",
+			args: [
+				{
+					type: "NSString",
+					value: title
+				}
+			]
+		};
+	}
 
-  /*Matcher that matches UIScrollView that has contentOffset as @c offset.
+	/*Matcher that matches UIScrollView that has contentOffset as @c offset.
 
 @param offset The content offset to be checked on the UIScrollView being
 matched.
 
 @return A matcher to confirm UIScrollView content offset.
-*/static matcherForScrollViewContentOffset(offset) {
-    if (typeof offset !== "object") throw new Error("offset should be a object, but got " + (offset + (" (" + (typeof offset + ")"))));
-    if (typeof offset.x !== "number") throw new Error("offset.x should be a number, but got " + (offset.x + (" (" + (typeof offset.x + ")"))));
-    if (typeof offset.y !== "number") throw new Error("offset.y should be a number, but got " + (offset.y + (" (" + (typeof offset.y + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForScrollViewContentOffset:",
-      args: [{
-        type: "CGPoint",
-        value: offset
-      }]
-    };
-  }
+*/ static matcherForScrollViewContentOffset(
+		offset
+	) {
+		if (typeof offset !== "object") {
+			throw new Error(
+				"offset should be a object, but got " +
+					(offset + (" (" + (typeof offset + ")")))
+			);
+		}
+		if (typeof offset.x !== "number") {
+			throw new Error(
+				"offset.x should be a number, but got " +
+					(offset.x + (" (" + (typeof offset.x + ")")))
+			);
+		}
+		if (typeof offset.y !== "number") {
+			throw new Error(
+				"offset.y should be a number, but got " +
+					(offset.y + (" (" + (typeof offset.y + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForScrollViewContentOffset:",
+			args: [
+				{
+					type: "CGPoint",
+					value: offset
+				}
+			]
+		};
+	}
 
-  /*Matcher that matches a UISlider's value.
+	/*Matcher that matches a UISlider's value.
 
 @param valueMatcher A matcher for the UISlider's value. You must provide a valid
 @c valueMatcher for the floating point value comparison. The
@@ -435,170 +594,213 @@ floating point value. If you are using @c grey_closeTo, use delta diff as
 is required, please implement it similar to @c grey_closeTo.
 
 @return A matcher for checking a UISlider's value.
-*/static matcherForSliderValueMatcher(valueMatcher) {
-    if (typeof valueMatcher !== "object" || valueMatcher.type !== "Invocation" || typeof valueMatcher.value !== "object" || typeof valueMatcher.value.target !== "object" || valueMatcher.value.target.value !== "GREYMatchers") {
-      throw new Error('valueMatcher should be a GREYMatcher, but got ' + JSON.stringify(valueMatcher));
-    }
+*/ static matcherForSliderValueMatcher(
+		valueMatcher
+	) {
+		if (
+			typeof valueMatcher !== "object" ||
+			valueMatcher.type !== "Invocation" ||
+			typeof valueMatcher.value !== "object" ||
+			typeof valueMatcher.value.target !== "object" ||
+			valueMatcher.value.target.value !== "GREYMatchers"
+		) {
+			throw new Error(
+				"valueMatcher should be a GREYMatcher, but got " +
+					JSON.stringify(valueMatcher)
+			);
+		}
 
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForSliderValueMatcher:",
-      args: [valueMatcher]
-    };
-  }
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForSliderValueMatcher:",
+			args: [valueMatcher]
+		};
+	}
 
-  /*Matcher that matches UIPickerView that has a column set to @c value.
+	/*Matcher that matches UIPickerView that has a column set to @c value.
 
 @param column The column of the UIPickerView to be matched.
 @param value  The value that should be set in the column of the UIPickerView.
 
 @return A matcher to check the value in a particular column of a UIPickerView.
-*/static matcherForPickerColumnSetToValue(column, value) {
-    if (typeof column !== "number") throw new Error("column should be a number, but got " + (column + (" (" + (typeof column + ")"))));
-    if (typeof value !== "string") throw new Error("value should be a string, but got " + (value + (" (" + (typeof value + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForPickerColumn:setToValue:",
-      args: [{
-        type: "NSInteger",
-        value: column
-      }, {
-        type: "NSString",
-        value: value
-      }]
-    };
-  }
+*/ static matcherForPickerColumnSetToValue(
+		column,
+		value
+	) {
+		if (typeof column !== "number") {
+			throw new Error(
+				"column should be a number, but got " +
+					(column + (" (" + (typeof column + ")")))
+			);
+		}
+		if (typeof value !== "string") {
+			throw new Error(
+				"value should be a string, but got " +
+					(value + (" (" + (typeof value + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForPickerColumn:setToValue:",
+			args: [
+				{
+					type: "NSInteger",
+					value: column
+				},
+				{
+					type: "NSString",
+					value: value
+				}
+			]
+		};
+	}
 
-  /*Matcher that verifies whether an element, that is a UIControl, is enabled.
+	/*Matcher that verifies whether an element, that is a UIControl, is enabled.
 
 @return A matcher for checking whether a UI element is an enabled UIControl.
-*/static matcherForEnabledElement() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForEnabledElement",
-      args: []
-    };
-  }
+*/ static matcherForEnabledElement() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForEnabledElement",
+			args: []
+		};
+	}
 
-  /*Matcher that verifies whether an element, that is a UIControl, is selected.
+	/*Matcher that verifies whether an element, that is a UIControl, is selected.
 
 @return A matcher for checking whether a UI element is a selected UIControl.
-*/static matcherForSelectedElement() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForSelectedElement",
-      args: []
-    };
-  }
+*/ static matcherForSelectedElement() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForSelectedElement",
+			args: []
+		};
+	}
 
-  /*Matcher that verifies whether a view has its userInteractionEnabled property set to @c YES.
+	/*Matcher that verifies whether a view has its userInteractionEnabled property set to @c YES.
 
 @return A matcher for checking whether a view' userInteractionEnabled property is set to @c YES.
-*/static matcherForUserInteractionEnabled() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForUserInteractionEnabled",
-      args: []
-    };
-  }
+*/ static matcherForUserInteractionEnabled() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForUserInteractionEnabled",
+			args: []
+		};
+	}
 
-  /*Matcher primarily for asserting that the element is @c nil or not found.
+	/*Matcher primarily for asserting that the element is @c nil or not found.
 
 @return A matcher to check if a specified element is @c nil or not found.
-*/static matcherForNil() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForNil",
-      args: []
-    };
-  }
+*/ static matcherForNil() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForNil",
+			args: []
+		};
+	}
 
-  /*Matcher for asserting that the element exists in the UI hierarchy (i.e. not @c nil).
+	/*Matcher for asserting that the element exists in the UI hierarchy (i.e. not @c nil).
 
 @return A matcher to check if a specified element is not @c nil.
-*/static matcherForNotNil() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForNotNil",
-      args: []
-    };
-  }
+*/ static matcherForNotNil() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForNotNil",
+			args: []
+		};
+	}
 
-  /*A Matcher that matches against any object, including @c nils.
+	/*A Matcher that matches against any object, including @c nils.
 
 @return A matcher that matches any object.
-*/static matcherForAnything() {
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForAnything",
-      args: []
-    };
-  }
+*/ static matcherForAnything() {
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForAnything",
+			args: []
+		};
+	}
 
-  /*Matcher that matches a UIScrollView scrolled to content @c edge.
+	/*Matcher that matches a UIScrollView scrolled to content @c edge.
 
 @param edge The content edge UIScrollView should be scrolled to.
 
 @return A matcher that matches a UIScrollView scrolled to content @c edge.
-*/static matcherForScrolledToContentEdge(edge) {
-    if (!["left", "right", "top", "bottom"].some(option => option === edge)) throw new Error("edge should be one of [left, right, top, bottom], but got " + edge);
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForScrolledToContentEdge:",
-      args: [{
-        type: "NSInteger",
-        value: sanitize_greyContentEdge(edge)
-      }]
-    };
-  }
+*/ static matcherForScrolledToContentEdge(
+		edge
+	) {
+		if (!["left", "right", "top", "bottom"].some(option => option === edge)) {
+			throw new Error(
+				"edge should be one of [left, right, top, bottom], but got " + edge
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForScrolledToContentEdge:",
+			args: [
+				{
+					type: "NSInteger",
+					value: sanitize_greyContentEdge(edge)
+				}
+			]
+		};
+	}
 
-  /*Matcher that matches a UITextField's content.
+	/*Matcher that matches a UITextField's content.
 
 @param value The text string contained inside the UITextField.
 
 @return A matcher that matches the value inside a UITextField.
-*/static matcherForTextFieldValue(value) {
-    if (typeof value !== "string") throw new Error("value should be a string, but got " + (value + (" (" + (typeof value + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "GREYMatchers"
-      },
-      method: "matcherForTextFieldValue:",
-      args: [{
-        type: "NSString",
-        value: value
-      }]
-    };
-  }
-
+*/ static matcherForTextFieldValue(
+		value
+	) {
+		if (typeof value !== "string") {
+			throw new Error(
+				"value should be a string, but got " +
+					(value + (" (" + (typeof value + ")")))
+			);
+		}
+		return {
+			target: {
+				type: "Class",
+				value: "GREYMatchers"
+			},
+			method: "matcherForTextFieldValue:",
+			args: [
+				{
+					type: "NSString",
+					value: value
+				}
+			]
+		};
+	}
 }
 
 module.exports = GREYMatchers;

--- a/detox/src/ios/expect.js
+++ b/detox/src/ios/expect.js
@@ -132,20 +132,28 @@ class SwipeAction extends Action {
 			const eps = 10 ** -8;
 			switch (direction) {
 				case "left":
-					(x = percentage), (y = eps);
+					x = percentage;
+					y = eps;
 					break;
 				case "right":
-					(x = percentage), (y = eps);
+					x = percentage;
+					y = eps;
 					break;
 				case "up":
-					(y = percentage), (x = eps);
+					y = percentage;
+					x = eps;
 					break;
 				case "down":
-					(y = percentage), (x = eps);
+					y = percentage;
+					x = eps;
 					break;
+				default:
+					throw new Error(
+						`SwipeAction direction must be a 'left'/'right'/'up'/'down', got ${direction}`
+					);
 			}
 
-			if (speed == "fast") {
+			if (speed === "fast") {
 				this._call = invoke.callDirectly(
 					GreyActions.actionForSwipeFastInDirectionXOriginStartPercentageYOriginStartPercentage(
 						direction,
@@ -153,7 +161,7 @@ class SwipeAction extends Action {
 						y
 					)
 				);
-			} else if (speed == "slow") {
+			} else if (speed === "slow") {
 				this._call = invoke.callDirectly(
 					GreyActions.actionForSwipeSlowInDirectionXOriginStartPercentageYOriginStartPercentage(
 						direction,
@@ -166,11 +174,11 @@ class SwipeAction extends Action {
 					`SwipeAction speed must be a 'fast'/'slow', got ${speed}`
 				);
 			}
-		} else if (speed == "fast") {
+		} else if (speed === "fast") {
 			this._call = invoke.callDirectly(
 				GreyActions.actionForSwipeFastInDirection(direction)
 			);
-		} else if (speed == "slow") {
+		} else if (speed === "slow") {
 			this._call = invoke.callDirectly(
 				GreyActions.actionForSwipeSlowInDirection(direction)
 			);

--- a/detox/src/ios/expect.js
+++ b/detox/src/ios/expect.js
@@ -1,5 +1,5 @@
-const invoke = require('../invoke');
-const matchers = require('./matchers');
+const invoke = require("../invoke");
+const matchers = require("./matchers");
 const Matcher = matchers.Matcher;
 const LabelMatcher = matchers.LabelMatcher;
 const IdMatcher = matchers.IdMatcher;
@@ -11,12 +11,12 @@ const ExistsMatcher = matchers.ExistsMatcher;
 const NotExistsMatcher = matchers.NotExistsMatcher;
 const TextMatcher = matchers.TextMatcher;
 const ValueMatcher = matchers.ValueMatcher;
-const GreyActions = require('./earlgreyapi/GREYActions');
+const GreyActions = require("./earlgreyapi/GREYActions");
 
 let invocationManager;
 
 function setInvocationManager(im) {
-  invocationManager = im;
+	invocationManager = im;
 }
 
 //// examples
@@ -44,348 +44,491 @@ detox.invoke.execute(_getInteraction2);
 class Action {}
 
 class TapAction extends Action {
-  constructor() {
-    super();
-    this._call = invoke.callDirectly(GreyActions.actionForTap());
-  }
+	constructor() {
+		super();
+		this._call = invoke.callDirectly(GreyActions.actionForTap());
+	}
 }
 
 class TapAtPointAction extends Action {
-  constructor(value) {
-    super();
-    this._call = invoke.callDirectly(GreyActions.actionForTapAtPoint(value));
-  }
+	constructor(value) {
+		super();
+		this._call = invoke.callDirectly(GreyActions.actionForTapAtPoint(value));
+	}
 }
 
 class LongPressAction extends Action {
-  constructor() {
-    super();
-    this._call = invoke.callDirectly(GreyActions.actionForLongPress());
-  }
+	constructor() {
+		super();
+		this._call = invoke.callDirectly(GreyActions.actionForLongPress());
+	}
 }
 
 class MultiTapAction extends Action {
-  constructor(value) {
-    super();
-    this._call = invoke.callDirectly(GreyActions.actionForMultipleTapsWithCount(value));
-  }
+	constructor(value) {
+		super();
+		this._call = invoke.callDirectly(
+			GreyActions.actionForMultipleTapsWithCount(value)
+		);
+	}
 }
 
 class TypeTextAction extends Action {
-  constructor(value) {
-    super();
-    this._call = invoke.callDirectly(GreyActions.actionForTypeText(value));
-  }
+	constructor(value) {
+		super();
+		this._call = invoke.callDirectly(GreyActions.actionForTypeText(value));
+	}
 }
 
 class ReplaceTextAction extends Action {
-  constructor(value) {
-    super();
-    this._call = invoke.callDirectly(GreyActions.actionForReplaceText(value));
-  }
+	constructor(value) {
+		super();
+		this._call = invoke.callDirectly(GreyActions.actionForReplaceText(value));
+	}
 }
 
 class ClearTextAction extends Action {
-  constructor() {
-    super();
-    this._call = invoke.callDirectly(GreyActions.actionForClearText());
-  }
+	constructor() {
+		super();
+		this._call = invoke.callDirectly(GreyActions.actionForClearText());
+	}
 }
 
 class ScrollAmountAction extends Action {
-  constructor(direction, amount) {
-    super();
-    this._call = invoke.callDirectly(GreyActions.actionForScrollInDirectionAmount(direction, amount));
-  }
+	constructor(direction, amount) {
+		super();
+		this._call = invoke.callDirectly(
+			GreyActions.actionForScrollInDirectionAmount(direction, amount)
+		);
+	}
 }
 
 class ScrollEdgeAction extends Action {
-  constructor(edge) {
-    super();
+	constructor(edge) {
+		super();
 
-    this._call = invoke.callDirectly(GreyActions.actionForScrollToContentEdge(edge));
-  }
+		this._call = invoke.callDirectly(
+			GreyActions.actionForScrollToContentEdge(edge)
+		);
+	}
 }
 
 class SwipeAction extends Action {
-  constructor(direction, speed, percentage) {
-    super();
-    if (typeof direction !== 'string') throw new Error(`SwipeAction ctor 1st argument must be a string, got ${typeof direction}`);
-    if (typeof speed !== 'string') throw new Error(`SwipeAction ctor 2nd argument must be a string, got ${typeof speed}`);
+	constructor(direction, speed, percentage) {
+		super();
+		if (typeof direction !== "string") {
+			throw new Error(
+				`SwipeAction ctor 1st argument must be a string, got ${typeof direction}`
+			);
+		}
+		if (typeof speed !== "string") {
+			throw new Error(
+				`SwipeAction ctor 2nd argument must be a string, got ${typeof speed}`
+			);
+		}
 
-    if (percentage) {
-      let x, y;
-      const eps = 10 ** -8;
-      switch (direction) {
-        case "left":
-          x = percentage, y = eps;
-          break;
-        case "right":
-          x = percentage, y = eps;
-          break;
-        case "up":
-          y = percentage, x = eps;
-          break;
-        case "down":
-          y = percentage, x = eps;
-          break;
-      }
+		if (percentage) {
+			let x, y;
+			const eps = 10 ** -8;
+			switch (direction) {
+				case "left":
+					(x = percentage), (y = eps);
+					break;
+				case "right":
+					(x = percentage), (y = eps);
+					break;
+				case "up":
+					(y = percentage), (x = eps);
+					break;
+				case "down":
+					(y = percentage), (x = eps);
+					break;
+			}
 
-      if (speed == 'fast') {
-        this._call = invoke.callDirectly(
-          GreyActions.actionForSwipeFastInDirectionXOriginStartPercentageYOriginStartPercentage(direction, x, y)
-        );
-      } else if (speed == 'slow') {
-        this._call = invoke.callDirectly(
-          GreyActions.actionForSwipeSlowInDirectionXOriginStartPercentageYOriginStartPercentage(direction, x, y)
-        );
-      } else {
-        throw new Error(`SwipeAction speed must be a 'fast'/'slow', got ${speed}`);
-      }
-    } else {
-      if (speed == 'fast') {
-        this._call = invoke.callDirectly(GreyActions.actionForSwipeFastInDirection(direction));
-      } else if (speed == 'slow') {
-        this._call = invoke.callDirectly(GreyActions.actionForSwipeSlowInDirection(direction));
-      } else {
-        throw new Error(`SwipeAction speed must be a 'fast'/'slow', got ${speed}`);
-      }
-    }
-  }
+			if (speed == "fast") {
+				this._call = invoke.callDirectly(
+					GreyActions.actionForSwipeFastInDirectionXOriginStartPercentageYOriginStartPercentage(
+						direction,
+						x,
+						y
+					)
+				);
+			} else if (speed == "slow") {
+				this._call = invoke.callDirectly(
+					GreyActions.actionForSwipeSlowInDirectionXOriginStartPercentageYOriginStartPercentage(
+						direction,
+						x,
+						y
+					)
+				);
+			} else {
+				throw new Error(
+					`SwipeAction speed must be a 'fast'/'slow', got ${speed}`
+				);
+			}
+		} else if (speed == "fast") {
+			this._call = invoke.callDirectly(
+				GreyActions.actionForSwipeFastInDirection(direction)
+			);
+		} else if (speed == "slow") {
+			this._call = invoke.callDirectly(
+				GreyActions.actionForSwipeSlowInDirection(direction)
+			);
+		} else {
+			throw new Error(
+				`SwipeAction speed must be a 'fast'/'slow', got ${speed}`
+			);
+		}
+	}
 }
 
 class Interaction {
-  async execute() {
-    //if (!this._call) throw new Error(`Interaction.execute cannot find a valid _call, got ${typeof this._call}`);
-    await invocationManager.execute(this._call);
-  }
+	async execute() {
+		//if (!this._call) throw new Error(`Interaction.execute cannot find a valid _call, got ${typeof this._call}`);
+		await invocationManager.execute(this._call);
+	}
 }
 
 class ActionInteraction extends Interaction {
-  constructor(element, action) {
-    super();
-    //if (!(element instanceof Element)) throw new Error(`ActionInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
-    //if (!(action instanceof Action)) throw new Error(`ActionInteraction ctor 2nd argument must be a valid Action, got ${typeof action}`);
-    this._call = invoke.call(element._call, 'performAction:', action._call);
-    // TODO: move this.execute() here from the caller
-  }
+	constructor(element, action) {
+		super();
+		//if (!(element instanceof Element)) throw new Error(`ActionInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
+		//if (!(action instanceof Action)) throw new Error(`ActionInteraction ctor 2nd argument must be a valid Action, got ${typeof action}`);
+		this._call = invoke.call(element._call, "performAction:", action._call);
+		// TODO: move this.execute() here from the caller
+	}
 }
 
 class MatcherAssertionInteraction extends Interaction {
-  constructor(element, matcher) {
-    super();
-    //if (!(element instanceof Element)) throw new Error(`MatcherAssertionInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
-    //if (!(matcher instanceof Matcher)) throw new Error(`MatcherAssertionInteraction ctor 2nd argument must be a valid Matcher, got ${typeof matcher}`);
-    this._call = invoke.call(element._call, 'assertWithMatcher:', matcher._call);
-    // TODO: move this.execute() here from the caller
-  }
+	constructor(element, matcher) {
+		super();
+		//if (!(element instanceof Element)) throw new Error(`MatcherAssertionInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
+		//if (!(matcher instanceof Matcher)) throw new Error(`MatcherAssertionInteraction ctor 2nd argument must be a valid Matcher, got ${typeof matcher}`);
+		this._call = invoke.call(
+			element._call,
+			"assertWithMatcher:",
+			matcher._call
+		);
+		// TODO: move this.execute() here from the caller
+	}
 }
 
 class WaitForInteraction extends Interaction {
-  constructor(element, matcher) {
-    super();
-    //if (!(element instanceof Element)) throw new Error(`WaitForInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
-    //if (!(matcher instanceof Matcher)) throw new Error(`WaitForInteraction ctor 2nd argument must be a valid Matcher, got ${typeof matcher}`);
-    this._element = element;
-    this._originalMatcher = matcher;
-    // we need to override the original matcher for the element and add matcher to it as well
-    this._element._selectElementWithMatcher(this._element._originalMatcher.and(this._originalMatcher));
-  }
-  _not() {
-    this._notCondition = true;
-    return this;
-  }
-  async withTimeout(timeout) {
-    if (typeof timeout !== 'number') throw new Error(`WaitForInteraction withTimeout argument must be a number, got ${typeof timeout}`);
-    if (timeout < 0) throw new Error('timeout must be larger than 0');
-    let _conditionCall = invoke.call(invoke.IOS.Class('GREYCondition'), 'detoxConditionForElementMatched:', this._element._call);
-    if (this._notCondition) {
-      _conditionCall = invoke.call(invoke.IOS.Class('GREYCondition'), 'detoxConditionForNotElementMatched:', this._element._call);
-    }
-    this._call = invoke.call(_conditionCall, 'waitWithTimeout:', invoke.IOS.CGFloat(timeout/1000));
-    await this.execute();
-  }
-  whileElement(searchMatcher) {
-    return new WaitForActionInteraction(this._element, this._originalMatcher, searchMatcher);
-  }
+	constructor(element, matcher) {
+		super();
+		//if (!(element instanceof Element)) throw new Error(`WaitForInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
+		//if (!(matcher instanceof Matcher)) throw new Error(`WaitForInteraction ctor 2nd argument must be a valid Matcher, got ${typeof matcher}`);
+		this._element = element;
+		this._originalMatcher = matcher;
+		// we need to override the original matcher for the element and add matcher to it as well
+		this._element._selectElementWithMatcher(
+			this._element._originalMatcher.and(this._originalMatcher)
+		);
+	}
+	_not() {
+		this._notCondition = true;
+		return this;
+	}
+	async withTimeout(timeout) {
+		if (typeof timeout !== "number") {
+			throw new Error(
+				`WaitForInteraction withTimeout argument must be a number, got ${typeof timeout}`
+			);
+		}
+		if (timeout < 0) {
+			throw new Error("timeout must be larger than 0");
+		}
+		let _conditionCall = invoke.call(
+			invoke.IOS.Class("GREYCondition"),
+			"detoxConditionForElementMatched:",
+			this._element._call
+		);
+		if (this._notCondition) {
+			_conditionCall = invoke.call(
+				invoke.IOS.Class("GREYCondition"),
+				"detoxConditionForNotElementMatched:",
+				this._element._call
+			);
+		}
+		this._call = invoke.call(
+			_conditionCall,
+			"waitWithTimeout:",
+			invoke.IOS.CGFloat(timeout / 1000)
+		);
+		await this.execute();
+	}
+	whileElement(searchMatcher) {
+		return new WaitForActionInteraction(
+			this._element,
+			this._originalMatcher,
+			searchMatcher
+		);
+	}
 }
 
 class WaitForActionInteraction extends Interaction {
-  constructor(element, matcher, searchMatcher) {
-    super();
-    //if (!(element instanceof Element)) throw new Error(`WaitForActionInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
-    //if (!(matcher instanceof Matcher)) throw new Error(`WaitForActionInteraction ctor 2nd argument must be a valid Matcher, got ${typeof matcher}`);
-    if (!(searchMatcher instanceof Matcher)) throw new Error(`WaitForActionInteraction ctor 3rd argument must be a valid Matcher, got ${typeof searchMatcher}`);
-    this._element = element;
-    this._originalMatcher = matcher;
-    this._searchMatcher = searchMatcher;
-  }
-  async _execute(searchAction) {
-    //if (!searchAction instanceof Action) throw new Error(`WaitForActionInteraction _execute argument must be a valid Action, got ${typeof searchAction}`);
-    const _interactionCall = invoke.call(this._element._call, 'usingSearchAction:onElementWithMatcher:', searchAction._call, this._searchMatcher._call);
-    this._call = invoke.call(_interactionCall, 'assertWithMatcher:', this._originalMatcher._call);
-    await this.execute();
-  }
-  async scroll(amount, direction = 'down') {
-    // override the user's element selection with an extended matcher that looks for UIScrollView children
-    this._searchMatcher = this._searchMatcher._extendToDescendantScrollViews();
-    await this._execute(new ScrollAmountAction(direction, amount));
-  }
+	constructor(element, matcher, searchMatcher) {
+		super();
+		//if (!(element instanceof Element)) throw new Error(`WaitForActionInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
+		//if (!(matcher instanceof Matcher)) throw new Error(`WaitForActionInteraction ctor 2nd argument must be a valid Matcher, got ${typeof matcher}`);
+		if (!(searchMatcher instanceof Matcher)) {
+			throw new Error(
+				`WaitForActionInteraction ctor 3rd argument must be a valid Matcher, got ${typeof searchMatcher}`
+			);
+		}
+		this._element = element;
+		this._originalMatcher = matcher;
+		this._searchMatcher = searchMatcher;
+	}
+	async _execute(searchAction) {
+		//if (!searchAction instanceof Action) throw new Error(`WaitForActionInteraction _execute argument must be a valid Action, got ${typeof searchAction}`);
+		const _interactionCall = invoke.call(
+			this._element._call,
+			"usingSearchAction:onElementWithMatcher:",
+			searchAction._call,
+			this._searchMatcher._call
+		);
+		this._call = invoke.call(
+			_interactionCall,
+			"assertWithMatcher:",
+			this._originalMatcher._call
+		);
+		await this.execute();
+	}
+	async scroll(amount, direction = "down") {
+		// override the user's element selection with an extended matcher that looks for UIScrollView children
+		this._searchMatcher = this._searchMatcher._extendToDescendantScrollViews();
+		await this._execute(new ScrollAmountAction(direction, amount));
+	}
 }
 
 class Element {
-  constructor(matcher) {
-    this._originalMatcher = matcher;
-    this._selectElementWithMatcher(this._originalMatcher);
-  }
-  _selectElementWithMatcher(matcher) {
-    if (!(matcher instanceof Matcher)) throw new Error(`Element _selectElementWithMatcher argument must be a valid Matcher, got ${typeof matcher}`);
-    this._call = invoke.call(invoke.EarlGrey.instance, 'detox_selectElementWithMatcher:', matcher._call);
-  }
-  atIndex(index) {
-    if (typeof index !== 'number') throw new Error(`Element atIndex argument must be a number, got ${typeof index}`);
-    const _originalCall = this._call;
-    this._call = invoke.call(_originalCall, 'atIndex:', invoke.IOS.NSInteger(index));
-    return this;
-  }
-  async tap() {
-    return await new ActionInteraction(this, new TapAction()).execute();
-  }
-  async tapAtPoint(value) {
-    return await new ActionInteraction(this, new TapAtPointAction(value)).execute();
-  }
-  async longPress() {
-    return await new ActionInteraction(this, new LongPressAction()).execute();
-  }
-  async multiTap(value) {
-    return await new ActionInteraction(this, new MultiTapAction(value)).execute();
-  }
-  async typeText(value) {
-    return await new ActionInteraction(this, new TypeTextAction(value)).execute();
-  }
-  async replaceText(value) {
-    return await new ActionInteraction(this, new ReplaceTextAction(value)).execute();
-  }
-  async clearText() {
-    return await new ActionInteraction(this, new ClearTextAction()).execute();
-  }
-  async scroll(amount, direction = 'down') {
-    // override the user's element selection with an extended matcher that looks for UIScrollView children
-    this._selectElementWithMatcher(this._originalMatcher._extendToDescendantScrollViews());
-    return await new ActionInteraction(this, new ScrollAmountAction(direction, amount)).execute();
-  }
-  async scrollTo(edge) {
-    // override the user's element selection with an extended matcher that looks for UIScrollView children
-    this._selectElementWithMatcher(this._originalMatcher._extendToDescendantScrollViews());
-    return await new ActionInteraction(this, new ScrollEdgeAction(edge)).execute();
-  }
-  async swipe(direction, speed = 'fast', percentage = 0) {
-    // override the user's element selection with an extended matcher that avoids RN issues with RCTScrollView
-    this._selectElementWithMatcher(this._originalMatcher._avoidProblematicReactNativeElements());
-    return await new ActionInteraction(this, new SwipeAction(direction, speed, percentage)).execute();
-  }
+	constructor(matcher) {
+		this._originalMatcher = matcher;
+		this._selectElementWithMatcher(this._originalMatcher);
+	}
+	_selectElementWithMatcher(matcher) {
+		if (!(matcher instanceof Matcher)) {
+			throw new Error(
+				`Element _selectElementWithMatcher argument must be a valid Matcher, got ${typeof matcher}`
+			);
+		}
+		this._call = invoke.call(
+			invoke.EarlGrey.instance,
+			"detox_selectElementWithMatcher:",
+			matcher._call
+		);
+	}
+	atIndex(index) {
+		if (typeof index !== "number") {
+			throw new Error(
+				`Element atIndex argument must be a number, got ${typeof index}`
+			);
+		}
+		const _originalCall = this._call;
+		this._call = invoke.call(
+			_originalCall,
+			"atIndex:",
+			invoke.IOS.NSInteger(index)
+		);
+		return this;
+	}
+	async tap() {
+		return await new ActionInteraction(this, new TapAction()).execute();
+	}
+	async tapAtPoint(value) {
+		return await new ActionInteraction(
+			this,
+			new TapAtPointAction(value)
+		).execute();
+	}
+	async longPress() {
+		return await new ActionInteraction(this, new LongPressAction()).execute();
+	}
+	async multiTap(value) {
+		return await new ActionInteraction(
+			this,
+			new MultiTapAction(value)
+		).execute();
+	}
+	async typeText(value) {
+		return await new ActionInteraction(
+			this,
+			new TypeTextAction(value)
+		).execute();
+	}
+	async replaceText(value) {
+		return await new ActionInteraction(
+			this,
+			new ReplaceTextAction(value)
+		).execute();
+	}
+	async clearText() {
+		return await new ActionInteraction(this, new ClearTextAction()).execute();
+	}
+	async scroll(amount, direction = "down") {
+		// override the user's element selection with an extended matcher that looks for UIScrollView children
+		this._selectElementWithMatcher(
+			this._originalMatcher._extendToDescendantScrollViews()
+		);
+		return await new ActionInteraction(
+			this,
+			new ScrollAmountAction(direction, amount)
+		).execute();
+	}
+	async scrollTo(edge) {
+		// override the user's element selection with an extended matcher that looks for UIScrollView children
+		this._selectElementWithMatcher(
+			this._originalMatcher._extendToDescendantScrollViews()
+		);
+		return await new ActionInteraction(
+			this,
+			new ScrollEdgeAction(edge)
+		).execute();
+	}
+	async swipe(direction, speed = "fast", percentage = 0) {
+		// override the user's element selection with an extended matcher that avoids RN issues with RCTScrollView
+		this._selectElementWithMatcher(
+			this._originalMatcher._avoidProblematicReactNativeElements()
+		);
+		return await new ActionInteraction(
+			this,
+			new SwipeAction(direction, speed, percentage)
+		).execute();
+	}
 }
 
 class Expect {}
 
 class ExpectElement extends Expect {
-  constructor(element) {
-    super();
-    this._element = element;
-  }
-  async toBeVisible() {
-    return await new MatcherAssertionInteraction(this._element, new VisibleMatcher()).execute();
-  }
-  async toBeNotVisible() {
-    return await new MatcherAssertionInteraction(this._element, new NotVisibleMatcher()).execute();
-  }
-  async toExist() {
-    return await new MatcherAssertionInteraction(this._element, new ExistsMatcher()).execute();
-  }
-  async toNotExist() {
-    return await new MatcherAssertionInteraction(this._element, new NotExistsMatcher()).execute();
-  }
-  async toHaveText(value) {
-    return await new MatcherAssertionInteraction(this._element, new TextMatcher(value)).execute();
-  }
-  async toHaveLabel(value) {
-    return await new MatcherAssertionInteraction(this._element, new LabelMatcher(value)).execute();
-  }
-  async toHaveId(value) {
-    return await new MatcherAssertionInteraction(this._element, new IdMatcher(value)).execute();
-  }
-  async toHaveValue(value) {
-    return await new MatcherAssertionInteraction(this._element, new ValueMatcher(value)).execute();
-  }
+	constructor(element) {
+		super();
+		this._element = element;
+	}
+	async toBeVisible() {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new VisibleMatcher()
+		).execute();
+	}
+	async toBeNotVisible() {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new NotVisibleMatcher()
+		).execute();
+	}
+	async toExist() {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new ExistsMatcher()
+		).execute();
+	}
+	async toNotExist() {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new NotExistsMatcher()
+		).execute();
+	}
+	async toHaveText(value) {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new TextMatcher(value)
+		).execute();
+	}
+	async toHaveLabel(value) {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new LabelMatcher(value)
+		).execute();
+	}
+	async toHaveId(value) {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new IdMatcher(value)
+		).execute();
+	}
+	async toHaveValue(value) {
+		return await new MatcherAssertionInteraction(
+			this._element,
+			new ValueMatcher(value)
+		).execute();
+	}
 }
 
 class WaitFor {}
 
 class WaitForElement extends WaitFor {
-  constructor(element) {
-    super();
-    //if ((!element instanceof Element)) throw new Error(`WaitForElement ctor argument must be a valid Element, got ${typeof element}`);
-    this._element = element;
-  }
-  toBeVisible() {
-    return new WaitForInteraction(this._element, new VisibleMatcher());
-  }
-  toBeNotVisible() {
-    return new WaitForInteraction(this._element, new VisibleMatcher())._not();
-  }
-  toExist() {
-    return new WaitForInteraction(this._element, new ExistsMatcher());
-  }
-  toNotExist() {
-    return new WaitForInteraction(this._element, new ExistsMatcher())._not();
-  }
-  toHaveText(text) {
-    return new WaitForInteraction(this._element, new TextMatcher(text));
-  }
-  toHaveValue(value) {
-    return new WaitForInteraction(this._element, new ValueMatcher(value));
-  }
-  toNotHaveValue(value) {
-    return new WaitForInteraction(this._element, new ValueMatcher(value))._not();
-  }
+	constructor(element) {
+		super();
+		//if ((!element instanceof Element)) throw new Error(`WaitForElement ctor argument must be a valid Element, got ${typeof element}`);
+		this._element = element;
+	}
+	toBeVisible() {
+		return new WaitForInteraction(this._element, new VisibleMatcher());
+	}
+	toBeNotVisible() {
+		return new WaitForInteraction(this._element, new VisibleMatcher())._not();
+	}
+	toExist() {
+		return new WaitForInteraction(this._element, new ExistsMatcher());
+	}
+	toNotExist() {
+		return new WaitForInteraction(this._element, new ExistsMatcher())._not();
+	}
+	toHaveText(text) {
+		return new WaitForInteraction(this._element, new TextMatcher(text));
+	}
+	toHaveValue(value) {
+		return new WaitForInteraction(this._element, new ValueMatcher(value));
+	}
+	toNotHaveValue(value) {
+		return new WaitForInteraction(
+			this._element,
+			new ValueMatcher(value)
+		)._not();
+	}
 }
 
 function expect(element) {
-  if (element instanceof Element) return new ExpectElement(element);
-  throw new Error(`expect() argument is invalid, got ${typeof element}`);
+	if (element instanceof Element) {
+		return new ExpectElement(element);
+	}
+	throw new Error(`expect() argument is invalid, got ${typeof element}`);
 }
 
 function waitFor(element) {
-  if (element instanceof Element) return new WaitForElement(element);
-  throw new Error(`waitFor() argument is invalid, got ${typeof element}`);
+	if (element instanceof Element) {
+		return new WaitForElement(element);
+	}
+	throw new Error(`waitFor() argument is invalid, got ${typeof element}`);
 }
 
 function element(matcher) {
-  return new Element(matcher);
+	return new Element(matcher);
 }
 
 const by = {
-  accessibilityLabel: (value) => new LabelMatcher(value),
-  label: (value) => new LabelMatcher(value),
-  id: (value) => new IdMatcher(value),
-  type: (value) => new TypeMatcher(value),
-  traits: (value) => new TraitsMatcher(value),
-  value: (value) => new ValueMatcher(value),
-  text: (value) => new TextMatcher(value)
+	accessibilityLabel: value => new LabelMatcher(value),
+	label: value => new LabelMatcher(value),
+	id: value => new IdMatcher(value),
+	type: value => new TypeMatcher(value),
+	traits: value => new TraitsMatcher(value),
+	value: value => new ValueMatcher(value),
+	text: value => new TextMatcher(value)
 };
 
 const exportGlobals = () => {
-  global.element = element;
-  global.expect = expect;
-  global.waitFor = waitFor;
-  global.by = by;
+	global.element = element;
+	global.expect = expect;
+	global.waitFor = waitFor;
+	global.by = by;
 };
 
 module.exports = {
-  setInvocationManager,
-  exportGlobals,
-  expect,
-  waitFor,
-  element,
-  by
+	setInvocationManager,
+	exportGlobals,
+	expect,
+	waitFor,
+	element,
+	by
 };

--- a/detox/src/ios/expect.test.js
+++ b/detox/src/ios/expect.test.js
@@ -254,14 +254,15 @@ async function expectToThrow(func) {
 
 class MockExecutor {
 	async execute(invocation) {
+		let invoke = invocation;
 		if (typeof invocation === "function") {
-			invocation = invocation();
+			invoke = invocation();
 		}
-		expect(invocation.target).toBeDefined();
-		expect(invocation.target.type).toBeDefined();
-		expect(invocation.target.value).toBeDefined();
+		expect(invoke.target).toBeDefined();
+		expect(invoke.target.type).toBeDefined();
+		expect(invoke.target.value).toBeDefined();
 
-		this.recurse(invocation);
+		this.recurse(invoke);
 		await this.timeout(1);
 	}
 

--- a/detox/src/ios/expect.test.js
+++ b/detox/src/ios/expect.test.js
@@ -1,195 +1,286 @@
-describe('expect', async () => {
-  let e;
+describe("expect", async () => {
+	let e;
 
-  beforeEach(() => {
-    e = require('./expect');
-    e.setInvocationManager(new MockExecutor());
-  });
+	beforeEach(() => {
+		e = require("./expect");
+		e.setInvocationManager(new MockExecutor());
+	});
 
-  it(`element by accessibilityLabel`, async () => {
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toBeVisible();
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toBeNotVisible();
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toExist();
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toNotExist();
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveText('text');
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveLabel('label');
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveId('id');
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveValue('value');
-  });
+	it(`element by accessibilityLabel`, async () => {
+		await e.expect(e.element(e.by.accessibilityLabel("test"))).toBeVisible();
+		await e.expect(e.element(e.by.accessibilityLabel("test"))).toBeNotVisible();
+		await e.expect(e.element(e.by.accessibilityLabel("test"))).toExist();
+		await e.expect(e.element(e.by.accessibilityLabel("test"))).toNotExist();
+		await e
+			.expect(e.element(e.by.accessibilityLabel("test")))
+			.toHaveText("text");
+		await e
+			.expect(e.element(e.by.accessibilityLabel("test")))
+			.toHaveLabel("label");
+		await e.expect(e.element(e.by.accessibilityLabel("test"))).toHaveId("id");
+		await e
+			.expect(e.element(e.by.accessibilityLabel("test")))
+			.toHaveValue("value");
+	});
 
-  it(`element by label (for backwards compat)`, async () => {
-    await e.expect(e.element(e.by.label('test'))).toBeVisible();
-    await e.expect(e.element(e.by.label('test'))).toBeNotVisible();
-    await e.expect(e.element(e.by.label('test'))).toExist();
-    await e.expect(e.element(e.by.label('test'))).toNotExist();
-    await e.expect(e.element(e.by.label('test'))).toHaveText('text');
-    await e.expect(e.element(e.by.label('test'))).toHaveLabel('label');
-    await e.expect(e.element(e.by.label('test'))).toHaveId('id');
-    await e.expect(e.element(e.by.label('test'))).toHaveValue('value');
-  });
+	it(`element by label (for backwards compat)`, async () => {
+		await e.expect(e.element(e.by.label("test"))).toBeVisible();
+		await e.expect(e.element(e.by.label("test"))).toBeNotVisible();
+		await e.expect(e.element(e.by.label("test"))).toExist();
+		await e.expect(e.element(e.by.label("test"))).toNotExist();
+		await e.expect(e.element(e.by.label("test"))).toHaveText("text");
+		await e.expect(e.element(e.by.label("test"))).toHaveLabel("label");
+		await e.expect(e.element(e.by.label("test"))).toHaveId("id");
+		await e.expect(e.element(e.by.label("test"))).toHaveValue("value");
+	});
 
-  it(`element by id`, async () => {
-    await e.expect(e.element(e.by.id('test'))).toBeVisible();
-  });
+	it(`element by id`, async () => {
+		await e.expect(e.element(e.by.id("test"))).toBeVisible();
+	});
 
-  it(`element by type`, async () => {
-    await e.expect(e.element(e.by.type('test'))).toBeVisible();
-  });
+	it(`element by type`, async () => {
+		await e.expect(e.element(e.by.type("test"))).toBeVisible();
+	});
 
-  it(`element by traits`, async () => {
-    await e.expect(e.element(e.by.traits(['button', 'link', 'header', 'search']))).toBeVisible();
-    await e.expect(e.element(e.by.traits(['image', 'selected', 'plays', 'key']))).toBeNotVisible();
-    await e.expect(e.element(e.by.traits(['text', 'summary', 'disabled', 'frequentUpdates']))).toBeNotVisible();
-    await e.expect(e.element(e.by.traits(['startsMedia', 'adjustable', 'allowsDirectInteraction', 'pageTurn']))).toBeNotVisible();
-  });
+	it(`element by traits`, async () => {
+		await e
+			.expect(e.element(e.by.traits(["button", "link", "header", "search"])))
+			.toBeVisible();
+		await e
+			.expect(e.element(e.by.traits(["image", "selected", "plays", "key"])))
+			.toBeNotVisible();
+		await e
+			.expect(
+				e.element(
+					e.by.traits(["text", "summary", "disabled", "frequentUpdates"])
+				)
+			)
+			.toBeNotVisible();
+		await e
+			.expect(
+				e.element(
+					e.by.traits([
+						"startsMedia",
+						"adjustable",
+						"allowsDirectInteraction",
+						"pageTurn"
+					])
+				)
+			)
+			.toBeNotVisible();
+	});
 
-  it(`matcher helpers`, async () => {
-    await e.expect(e.element(e.by.id('test').withAncestor(e.by.id('ancestor')))).toBeVisible();
-    await e.expect(e.element(e.by.id('test').withDescendant(e.by.id('descendant')))).toBeVisible();
-    await e.expect(e.element(e.by.id('test').and(e.by.type('type')))).toBeVisible();
-    await e.expect(e.element(e.by.id('test').not())).toBeVisible();
-  });
+	it(`matcher helpers`, async () => {
+		await e
+			.expect(e.element(e.by.id("test").withAncestor(e.by.id("ancestor"))))
+			.toBeVisible();
+		await e
+			.expect(e.element(e.by.id("test").withDescendant(e.by.id("descendant"))))
+			.toBeVisible();
+		await e
+			.expect(e.element(e.by.id("test").and(e.by.type("type"))))
+			.toBeVisible();
+		await e.expect(e.element(e.by.id("test").not())).toBeVisible();
+	});
 
-  it(`expect with wrong parameters should throw`, async () => {
-     await expectToThrow(() => e.expect('notAnElement'));
-     await expectToThrow(() => e.expect(e.element('notAMatcher')));
-  });
+	it(`expect with wrong parameters should throw`, async () => {
+		await expectToThrow(() => e.expect("notAnElement"));
+		await expectToThrow(() => e.expect(e.element("notAMatcher")));
+	});
 
-  it(`matchers with wrong parameters should throw`, async () => {
-    await expectToThrow(() => e.element(e.by.label(5)));
-    await expectToThrow(() => e.element(e.by.id(5)));
-    await expectToThrow(() => e.element(e.by.type(0)));
-    await expectToThrow(() => e.by.traits(1));
-    await expectToThrow(() => e.by.traits(['nonExistentTrait']));
-    await expectToThrow(() => e.element(e.by.value(0)));
-    await expectToThrow(() => e.element(e.by.text(0)));
-    await expectToThrow(() => e.element(e.by.id('test').withAncestor('notAMatcher')));
-    await expectToThrow(() => e.element(e.by.id('test').withDescendant('notAMatcher')));
-    await expectToThrow(() => e.element(e.by.id('test').and('notAMatcher')));
-  });
+	it(`matchers with wrong parameters should throw`, async () => {
+		await expectToThrow(() => e.element(e.by.label(5)));
+		await expectToThrow(() => e.element(e.by.id(5)));
+		await expectToThrow(() => e.element(e.by.type(0)));
+		await expectToThrow(() => e.by.traits(1));
+		await expectToThrow(() => e.by.traits(["nonExistentTrait"]));
+		await expectToThrow(() => e.element(e.by.value(0)));
+		await expectToThrow(() => e.element(e.by.text(0)));
+		await expectToThrow(() =>
+			e.element(e.by.id("test").withAncestor("notAMatcher"))
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("test").withDescendant("notAMatcher"))
+		);
+		await expectToThrow(() => e.element(e.by.id("test").and("notAMatcher")));
+	});
 
-  it(`waitFor (element)`, async () => {
-    await e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout(0);
-    await e.waitFor(e.element(e.by.id('id'))).toBeVisible();
-    await e.waitFor(e.element(e.by.id('id'))).toBeNotVisible();
-    await e.waitFor(e.element(e.by.id('id'))).toExist();
-    await e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout(0);
-    await e.waitFor(e.element(e.by.id('id'))).toNotExist().withTimeout(0);
-    await e.waitFor(e.element(e.by.id('id'))).toHaveText('text');
-    await e.waitFor(e.element(e.by.id('id'))).toHaveValue('value');
-    await e.waitFor(e.element(e.by.id('id'))).toNotHaveValue('value');
+	it(`waitFor (element)`, async () => {
+		await e
+			.waitFor(e.element(e.by.id("id")))
+			.toExist()
+			.withTimeout(0);
+		await e.waitFor(e.element(e.by.id("id"))).toBeVisible();
+		await e.waitFor(e.element(e.by.id("id"))).toBeNotVisible();
+		await e.waitFor(e.element(e.by.id("id"))).toExist();
+		await e
+			.waitFor(e.element(e.by.id("id")))
+			.toExist()
+			.withTimeout(0);
+		await e
+			.waitFor(e.element(e.by.id("id")))
+			.toNotExist()
+			.withTimeout(0);
+		await e.waitFor(e.element(e.by.id("id"))).toHaveText("text");
+		await e.waitFor(e.element(e.by.id("id"))).toHaveValue("value");
+		await e.waitFor(e.element(e.by.id("id"))).toNotHaveValue("value");
 
-    await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).scroll(50, 'down');
-    await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).scroll(50);
-  });
+		await e
+			.waitFor(e.element(e.by.id("id")))
+			.toBeVisible()
+			.whileElement(e.by.id("id2"))
+			.scroll(50, "down");
+		await e
+			.waitFor(e.element(e.by.id("id")))
+			.toBeVisible()
+			.whileElement(e.by.id("id2"))
+			.scroll(50);
+	});
 
-  it(`waitFor (element) with wrong parameters should throw`, async () => {
-     await expectToThrow(() => e.waitFor('notAnElement'));
-     await expectToThrow(() => e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout('notANumber'));
-     await expectToThrow(() => e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout(-1));
-     await expectToThrow(() => e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement('notAnElement'));
-  });
+	it(`waitFor (element) with wrong parameters should throw`, async () => {
+		await expectToThrow(() => e.waitFor("notAnElement"));
+		await expectToThrow(() =>
+			e
+				.waitFor(e.element(e.by.id("id")))
+				.toExist()
+				.withTimeout("notANumber")
+		);
+		await expectToThrow(() =>
+			e
+				.waitFor(e.element(e.by.id("id")))
+				.toExist()
+				.withTimeout(-1)
+		);
+		await expectToThrow(() =>
+			e
+				.waitFor(e.element(e.by.id("id")))
+				.toBeVisible()
+				.whileElement("notAnElement")
+		);
+	});
 
-  it(`waitFor (element) with non-elements should throw`, async () => {
-    await expectToThrow(() => e.waitFor('notAnElement').toBeVisible());
-  });
+	it(`waitFor (element) with non-elements should throw`, async () => {
+		await expectToThrow(() => e.waitFor("notAnElement").toBeVisible());
+	});
 
-  it(`interactions`, async () => {
-    await e.element(e.by.label('Tap Me')).tap();
-    await e.element(e.by.label('Tap Me')).tapAtPoint({x: 10, y:10});
-    await e.element(e.by.label('Tap Me')).longPress();
-    await e.element(e.by.id('UniqueId819')).multiTap(3);
-    await e.element(e.by.id('UniqueId937')).typeText('passcode');
-    await e.element(e.by.id('UniqueId005')).clearText();
-    await e.element(e.by.id('UniqueId005')).replaceText('replaceTo');
-    await e.element(e.by.id('ScrollView161')).scroll(100);
-    await e.element(e.by.id('ScrollView161')).scroll(100, 'down');
-    await e.element(e.by.id('ScrollView161')).scroll(100, 'up');
-    await e.element(e.by.id('ScrollView161')).scroll(100, 'right');
-    await e.element(e.by.id('ScrollView161')).scroll(100, 'left');
-    await e.element(e.by.id('ScrollView161')).scrollTo('bottom');
-    await e.element(e.by.id('ScrollView161')).scrollTo('top');
-    await e.element(e.by.id('ScrollView161')).scrollTo('left');
-    await e.element(e.by.id('ScrollView161')).scrollTo('right');
-    await e.element(e.by.id('ScrollView799')).swipe('down');
-    await e.element(e.by.id('ScrollView799')).swipe('down', 'fast');
-    await e.element(e.by.id('ScrollView799')).swipe('up', 'slow');
-    await e.element(e.by.id('ScrollView799')).swipe('left', 'fast');
-    await e.element(e.by.id('ScrollView799')).swipe('right', 'slow');
-    await e.element(e.by.id('ScrollView799')).swipe('down', 'fast', 0.9);
-    await e.element(e.by.id('ScrollView799')).swipe('up', 'slow', 0.9);
-    await e.element(e.by.id('ScrollView799')).swipe('left', 'fast', 0.9);
-    await e.element(e.by.id('ScrollView799')).swipe('right', 'slow', 0.9);
-    await e.element(e.by.id('ScrollView799')).atIndex(1);
-  });
+	it(`interactions`, async () => {
+		await e.element(e.by.label("Tap Me")).tap();
+		await e.element(e.by.label("Tap Me")).tapAtPoint({ x: 10, y: 10 });
+		await e.element(e.by.label("Tap Me")).longPress();
+		await e.element(e.by.id("UniqueId819")).multiTap(3);
+		await e.element(e.by.id("UniqueId937")).typeText("passcode");
+		await e.element(e.by.id("UniqueId005")).clearText();
+		await e.element(e.by.id("UniqueId005")).replaceText("replaceTo");
+		await e.element(e.by.id("ScrollView161")).scroll(100);
+		await e.element(e.by.id("ScrollView161")).scroll(100, "down");
+		await e.element(e.by.id("ScrollView161")).scroll(100, "up");
+		await e.element(e.by.id("ScrollView161")).scroll(100, "right");
+		await e.element(e.by.id("ScrollView161")).scroll(100, "left");
+		await e.element(e.by.id("ScrollView161")).scrollTo("bottom");
+		await e.element(e.by.id("ScrollView161")).scrollTo("top");
+		await e.element(e.by.id("ScrollView161")).scrollTo("left");
+		await e.element(e.by.id("ScrollView161")).scrollTo("right");
+		await e.element(e.by.id("ScrollView799")).swipe("down");
+		await e.element(e.by.id("ScrollView799")).swipe("down", "fast");
+		await e.element(e.by.id("ScrollView799")).swipe("up", "slow");
+		await e.element(e.by.id("ScrollView799")).swipe("left", "fast");
+		await e.element(e.by.id("ScrollView799")).swipe("right", "slow");
+		await e.element(e.by.id("ScrollView799")).swipe("down", "fast", 0.9);
+		await e.element(e.by.id("ScrollView799")).swipe("up", "slow", 0.9);
+		await e.element(e.by.id("ScrollView799")).swipe("left", "fast", 0.9);
+		await e.element(e.by.id("ScrollView799")).swipe("right", "slow", 0.9);
+		await e.element(e.by.id("ScrollView799")).atIndex(1);
+	});
 
-  it(`interactions with wrong parameters should throw`, async () => {
-    await expectToThrow(() => e.element(e.by.id('UniqueId819')).multiTap('NaN'));
-    await expectToThrow(() => e.element(e.by.id('UniqueId937')).typeText(0));
-    await expectToThrow(() => e.element(e.by.id('UniqueId005')).replaceText(3));
-    await expectToThrow(() => e.element(e.by.id('ScrollView161')).scroll('NaN', 'down'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView161')).scroll(100, 'noDirection'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView161')).scroll(100, 0));
-    await expectToThrow(() => e.element(e.by.id('ScrollView161')).scrollTo(0));
-    await expectToThrow(() => e.element(e.by.id('ScrollView161')).scrollTo('noDirection'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe(4, 'fast'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('noDirection', 0));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('noDirection', 'fast'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('down', 'NotFastNorSlow'));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('down', 'NotFastNorSlow', 0.9));
-    await expectToThrow(() => e.element(e.by.id('ScrollView799')).atIndex('NaN'));
-  });
+	it(`interactions with wrong parameters should throw`, async () => {
+		await expectToThrow(() =>
+			e.element(e.by.id("UniqueId819")).multiTap("NaN")
+		);
+		await expectToThrow(() => e.element(e.by.id("UniqueId937")).typeText(0));
+		await expectToThrow(() => e.element(e.by.id("UniqueId005")).replaceText(3));
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView161")).scroll("NaN", "down")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView161")).scroll(100, "noDirection")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView161")).scroll(100, 0)
+		);
+		await expectToThrow(() => e.element(e.by.id("ScrollView161")).scrollTo(0));
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView161")).scrollTo("noDirection")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).swipe(4, "fast")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).swipe("noDirection", 0)
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).swipe("noDirection", "fast")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).swipe("down", "NotFastNorSlow")
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).swipe("down", "NotFastNorSlow", 0.9)
+		);
+		await expectToThrow(() =>
+			e.element(e.by.id("ScrollView799")).atIndex("NaN")
+		);
+	});
 
-  it(`exportGlobals() should export api functions`, async () => {
-    const originalExpect = expect;
-    e.exportGlobals();
-    const newExpect = expect;
-    global.expect = originalExpect;
+	it(`exportGlobals() should export api functions`, async () => {
+		const originalExpect = expect;
+		e.exportGlobals();
+		const newExpect = expect;
+		global.expect = originalExpect;
 
-    expect(newExpect).not.toEqual(originalExpect);
-    expect(element).toBeDefined();
-    expect(waitFor).toBeDefined();
-    expect(by).toBeDefined();
-  });
+		expect(newExpect).not.toEqual(originalExpect);
+		expect(element).toBeDefined();
+		expect(waitFor).toBeDefined();
+		expect(by).toBeDefined();
+	});
 });
 
 async function expectToThrow(func) {
-  try {
-    await func();
-  } catch (ex) {
-    expect(ex).toBeDefined();
-  }
+	try {
+		await func();
+	} catch (ex) {
+		expect(ex).toBeDefined();
+	}
 }
 
 class MockExecutor {
-  async execute(invocation) {
-    if (typeof invocation === 'function') {
-      invocation = invocation();
-    }
-    expect(invocation.target).toBeDefined();
-    expect(invocation.target.type).toBeDefined();
-    expect(invocation.target.value).toBeDefined();
+	async execute(invocation) {
+		if (typeof invocation === "function") {
+			invocation = invocation();
+		}
+		expect(invocation.target).toBeDefined();
+		expect(invocation.target.type).toBeDefined();
+		expect(invocation.target.value).toBeDefined();
 
-    this.recurse(invocation);
-    await this.timeout(1);
-  }
+		this.recurse(invocation);
+		await this.timeout(1);
+	}
 
-  recurse(invocation) {
-    for (const key in invocation) {
-      if (invocation.hasOwnProperty(key)) {
-        if (invocation[key] instanceof Object) {
-          this.recurse(invocation[key]);
-        }
-        if (key === 'target' && invocation[key].type === 'Invocation') {
-          const innerValue = invocation.target.value;
-          expect(innerValue.target.type).toBeDefined();
-          expect(innerValue.target.value).toBeDefined();
-        }
-      }
-    }
-  }
+	recurse(invocation) {
+		for (const key in invocation) {
+			if (invocation.hasOwnProperty(key)) {
+				if (invocation[key] instanceof Object) {
+					this.recurse(invocation[key]);
+				}
+				if (key === "target" && invocation[key].type === "Invocation") {
+					const innerValue = invocation.target.value;
+					expect(innerValue.target.type).toBeDefined();
+					expect(innerValue.target.value).toBeDefined();
+				}
+			}
+		}
+	}
 
-  async timeout(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
+	async timeout(ms) {
+		return new Promise(resolve => setTimeout(resolve, ms));
+	}
 }

--- a/detox/src/ios/matchers.js
+++ b/detox/src/ios/matchers.js
@@ -1,120 +1,159 @@
-const invoke = require('../invoke');
-const GreyMatchers = require('./earlgreyapi/GREYMatchers');
-const GreyMatchersDetox = require('./earlgreyapi/GREYMatchers+Detox');
+const invoke = require("../invoke");
+const GreyMatchers = require("./earlgreyapi/GREYMatchers");
+const GreyMatchersDetox = require("./earlgreyapi/GREYMatchers+Detox");
 
 class Matcher {
-  withAncestor(matcher) {
-    const _originalMatcherCall = this._call;
-    this._call = invoke.callDirectly(GreyMatchersDetox.detoxMatcherForBothAndAncestorMatcher(_originalMatcherCall, matcher._call));
-    return this;
-  }
-  withDescendant(matcher) {
-    const _originalMatcherCall = this._call;
-    this._call = invoke.callDirectly(GreyMatchersDetox.detoxMatcherForBothAndDescendantMatcher(_originalMatcherCall, matcher._call));
-    return this;
-  }
-  and(matcher) {
-    const _originalMatcherCall = this._call;
-    this._call = invoke.callDirectly(GreyMatchersDetox.detoxMatcherForBothAnd(_originalMatcherCall, matcher._call));
-    return this;
-  }
-  not() {
-    const _originalMatcherCall = this._call;
-    this._call = invoke.callDirectly(GreyMatchersDetox.detoxMatcherForNot(_originalMatcherCall));
-    return this;
-  }
-  _avoidProblematicReactNativeElements() {
-    const _originalMatcherCall = this._call;
-    this._call = invoke.callDirectly(GreyMatchersDetox.detoxMatcherAvoidingProblematicReactNativeElements(_originalMatcherCall));
-    return this;
-  }
-  _extendToDescendantScrollViews() {
-    const _originalMatcherCall = this._call;
-    this._call = invoke.callDirectly(GreyMatchersDetox.detoxMatcherForScrollChildOfMatcher(_originalMatcherCall));
-    return this;
-  }
+	withAncestor(matcher) {
+		const _originalMatcherCall = this._call;
+		this._call = invoke.callDirectly(
+			GreyMatchersDetox.detoxMatcherForBothAndAncestorMatcher(
+				_originalMatcherCall,
+				matcher._call
+			)
+		);
+		return this;
+	}
+	withDescendant(matcher) {
+		const _originalMatcherCall = this._call;
+		this._call = invoke.callDirectly(
+			GreyMatchersDetox.detoxMatcherForBothAndDescendantMatcher(
+				_originalMatcherCall,
+				matcher._call
+			)
+		);
+		return this;
+	}
+	and(matcher) {
+		const _originalMatcherCall = this._call;
+		this._call = invoke.callDirectly(
+			GreyMatchersDetox.detoxMatcherForBothAnd(
+				_originalMatcherCall,
+				matcher._call
+			)
+		);
+		return this;
+	}
+	not() {
+		const _originalMatcherCall = this._call;
+		this._call = invoke.callDirectly(
+			GreyMatchersDetox.detoxMatcherForNot(_originalMatcherCall)
+		);
+		return this;
+	}
+	_avoidProblematicReactNativeElements() {
+		const _originalMatcherCall = this._call;
+		this._call = invoke.callDirectly(
+			GreyMatchersDetox.detoxMatcherAvoidingProblematicReactNativeElements(
+				_originalMatcherCall
+			)
+		);
+		return this;
+	}
+	_extendToDescendantScrollViews() {
+		const _originalMatcherCall = this._call;
+		this._call = invoke.callDirectly(
+			GreyMatchersDetox.detoxMatcherForScrollChildOfMatcher(
+				_originalMatcherCall
+			)
+		);
+		return this;
+	}
 }
 
 class LabelMatcher extends Matcher {
-  constructor(value) {
-    super();
-    this._call = invoke.callDirectly(GreyMatchersDetox.detox_matcherForAccessibilityLabel(value));
-  }
+	constructor(value) {
+		super();
+		this._call = invoke.callDirectly(
+			GreyMatchersDetox.detox_matcherForAccessibilityLabel(value)
+		);
+	}
 }
 
 class IdMatcher extends Matcher {
-  constructor(value) {
-    super();
-    this._call = invoke.callDirectly(GreyMatchers.matcherForAccessibilityID(value));
-  }
+	constructor(value) {
+		super();
+		this._call = invoke.callDirectly(
+			GreyMatchers.matcherForAccessibilityID(value)
+		);
+	}
 }
 
 class TypeMatcher extends Matcher {
-  constructor(value) {
-    super();
-    this._call = invoke.callDirectly(GreyMatchersDetox.detoxMatcherForClass(value));
-  }
+	constructor(value) {
+		super();
+		this._call = invoke.callDirectly(
+			GreyMatchersDetox.detoxMatcherForClass(value)
+		);
+	}
 }
 
 class TraitsMatcher extends Matcher {
-  constructor(value) {
-    super();
-    this._call = invoke.callDirectly(GreyMatchers.matcherForAccessibilityTraits(value));
-  }
+	constructor(value) {
+		super();
+		this._call = invoke.callDirectly(
+			GreyMatchers.matcherForAccessibilityTraits(value)
+		);
+	}
 }
 
 class VisibleMatcher extends Matcher {
-  constructor() {
-    super();
-    this._call = invoke.callDirectly(GreyMatchers.matcherForSufficientlyVisible());
-  }
+	constructor() {
+		super();
+		this._call = invoke.callDirectly(
+			GreyMatchers.matcherForSufficientlyVisible()
+		);
+	}
 }
 
 class NotVisibleMatcher extends Matcher {
-  constructor() {
-    super();
-    this._call = invoke.callDirectly(GreyMatchers.matcherForNotVisible());
-  }
+	constructor() {
+		super();
+		this._call = invoke.callDirectly(GreyMatchers.matcherForNotVisible());
+	}
 }
 
 class ExistsMatcher extends Matcher {
-  constructor() {
-    super();
-    this._call = invoke.callDirectly(GreyMatchers.matcherForNotNil());
-  }
+	constructor() {
+		super();
+		this._call = invoke.callDirectly(GreyMatchers.matcherForNotNil());
+	}
 }
 
 class NotExistsMatcher extends Matcher {
-  constructor() {
-    super();
-    this._call = invoke.callDirectly(GreyMatchers.matcherForNil());
-  }
+	constructor() {
+		super();
+		this._call = invoke.callDirectly(GreyMatchers.matcherForNil());
+	}
 }
 
 class TextMatcher extends Matcher {
-  constructor(value) {
-    super();
-    this._call = invoke.callDirectly(GreyMatchersDetox.detoxMatcherForText(value));
-  }
+	constructor(value) {
+		super();
+		this._call = invoke.callDirectly(
+			GreyMatchersDetox.detoxMatcherForText(value)
+		);
+	}
 }
 
 class ValueMatcher extends Matcher {
-  constructor(value) {
-    super();
-    this._call = invoke.callDirectly(GreyMatchers.matcherForAccessibilityValue(value));
-  }
+	constructor(value) {
+		super();
+		this._call = invoke.callDirectly(
+			GreyMatchers.matcherForAccessibilityValue(value)
+		);
+	}
 }
 
 module.exports = {
-  Matcher,
-  LabelMatcher,
-  IdMatcher,
-  TypeMatcher,
-  TraitsMatcher,
-  VisibleMatcher,
-  NotVisibleMatcher,
-  ExistsMatcher,
-  NotExistsMatcher,
-  TextMatcher,
-  ValueMatcher
+	Matcher,
+	LabelMatcher,
+	IdMatcher,
+	TypeMatcher,
+	TraitsMatcher,
+	VisibleMatcher,
+	NotVisibleMatcher,
+	ExistsMatcher,
+	NotExistsMatcher,
+	TextMatcher,
+	ValueMatcher
 };

--- a/detox/src/utils/argparse.js
+++ b/detox/src/utils/argparse.js
@@ -1,21 +1,21 @@
-const argv = require('minimist')(process.argv.slice(2));
+const argv = require("minimist")(process.argv.slice(2));
 
 function getArgValue(key) {
-  let value;
+	let value;
 
-  if (argv && argv[key]) {
-    value = argv[key];
-  } else {
-    const camelCasedKey = key.replace(/(\-\w)/g, (m) => m[1].toUpperCase());
-    value = process.env[camelCasedKey];
-    if (value === 'undefined') {
-      value = undefined;
-    }
-  }
+	if (argv && argv[key]) {
+		value = argv[key];
+	} else {
+		const camelCasedKey = key.replace(/(\-\w)/g, m => m[1].toUpperCase());
+		value = process.env[camelCasedKey];
+		if (value === "undefined") {
+			value = undefined;
+		}
+	}
 
-  return value;
+	return value;
 }
 
 module.exports = {
-  getArgValue
+	getArgValue
 };

--- a/detox/src/utils/argparse.test.js
+++ b/detox/src/utils/argparse.test.js
@@ -1,44 +1,44 @@
-jest.unmock('process');
+jest.unmock("process");
 
-describe('argparse', () => {
-  describe('using env variables', () => {
-    let argparse;
+describe("argparse", () => {
+	describe("using env variables", () => {
+		let argparse;
 
-    beforeEach(() => {
-      process.env.fooBar = 'a value';
-      process.env.testUndefinedProp = 'undefined';
-      argparse = require('./argparse');
-    });
+		beforeEach(() => {
+			process.env.fooBar = "a value";
+			process.env.testUndefinedProp = "undefined";
+			argparse = require("./argparse");
+		});
 
-    it(`nonexistent key should return undefined result`, () => {
-      expect(argparse.getArgValue('blah')).not.toBeDefined();
-    });
+		it(`nonexistent key should return undefined result`, () => {
+			expect(argparse.getArgValue("blah")).not.toBeDefined();
+		});
 
-    it(`existing key should return a result`, () => {
-      expect(argparse.getArgValue('foo-bar')).toBe('a value');
-    });
+		it(`existing key should return a result`, () => {
+			expect(argparse.getArgValue("foo-bar")).toBe("a value");
+		});
 
-    it('should return undefiend if process.env contain something with a string of undefiend' ,() => {
-      expect(argparse.getArgValue('testUndefinedProp')).toBe(undefined);
-    });
-  });
+		it("should return undefiend if process.env contain something with a string of undefiend", () => {
+			expect(argparse.getArgValue("testUndefinedProp")).toBe(undefined);
+		});
+	});
 
-  describe('using arguments', () => {
-    let argparse;
+	describe("using arguments", () => {
+		let argparse;
 
-    beforeEach(() => {
-      jest.mock('minimist');
-      const minimist = require('minimist');
-      minimist.mockReturnValue({'kebab-case-key': 'a value'});
-      argparse = require('./argparse');
-    });
+		beforeEach(() => {
+			jest.mock("minimist");
+			const minimist = require("minimist");
+			minimist.mockReturnValue({ "kebab-case-key": "a value" });
+			argparse = require("./argparse");
+		});
 
-    it(`nonexistent key should return undefined result`, () => {
-      expect(argparse.getArgValue('blah')).not.toBeDefined();
-    });
+		it(`nonexistent key should return undefined result`, () => {
+			expect(argparse.getArgValue("blah")).not.toBeDefined();
+		});
 
-    it(`existing key should return a result`, () => {
-      expect(argparse.getArgValue('kebab-case-key')).toBe('a value');
-    });
-  });
+		it(`existing key should return a result`, () => {
+			expect(argparse.getArgValue("kebab-case-key")).toBe("a value");
+		});
+	});
 });

--- a/detox/src/utils/environment.js
+++ b/detox/src/utils/environment.js
@@ -1,28 +1,30 @@
-const os = require('os');
-const path = require('path');
-const exec = require('child-process-promise').exec;
+const os = require("os");
+const path = require("path");
+const exec = require("child-process-promise").exec;
 
 function getAndroidSDKPath() {
-  let sdkPath = process.env.ANDROID_SDK_ROOT || process.env.ANDROID_HOME;
-  if (!sdkPath) {
-    throw new Error(`$ANDROID_SDK_ROOT is not defined, set the path to the SDK installation directory into $ANDROID_SDK_ROOT,
+	const sdkPath = process.env.ANDROID_SDK_ROOT || process.env.ANDROID_HOME;
+	if (!sdkPath) {
+		throw new Error(`$ANDROID_SDK_ROOT is not defined, set the path to the SDK installation directory into $ANDROID_SDK_ROOT,
     Go to https://developer.android.com/studio/command-line/variables.html for more details`);
-  }
-  return sdkPath;
+	}
+	return sdkPath;
 }
 
 function getDetoxVersion() {
-  return require(path.join(__dirname, '../../package.json')).version;
+	return require(path.join(__dirname, "../../package.json")).version;
 }
 
 async function getFrameworkPath() {
-  const detoxVersion = this.getDetoxVersion();
-  const sha1 = (await exec(`(echo "${detoxVersion}" && xcodebuild -version) | shasum | awk '{print $1}'`)).stdout.trim();
-  return `${os.homedir()}/Library/Detox/ios/${sha1}/Detox.framework`;
+	const detoxVersion = this.getDetoxVersion();
+	const sha1 = (await exec(
+		`(echo "${detoxVersion}" && xcodebuild -version) | shasum | awk '{print $1}'`
+	)).stdout.trim();
+	return `${os.homedir()}/Library/Detox/ios/${sha1}/Detox.framework`;
 }
 
 module.exports = {
-  getDetoxVersion,
-  getFrameworkPath,
-  getAndroidSDKPath
+	getDetoxVersion,
+	getFrameworkPath,
+	getAndroidSDKPath
 };

--- a/detox/src/utils/environment.test.js
+++ b/detox/src/utils/environment.test.js
@@ -1,42 +1,41 @@
-const _ = require('lodash');
+const _ = require("lodash");
 
-describe('Environment', () => {
-  let Environment;
-  let originalProcessEnv;
+describe("Environment", () => {
+	let Environment;
+	let originalProcessEnv;
 
-  beforeEach(() => {
-    originalProcessEnv = _.cloneDeep(process.env);
-    Environment = require('./environment');
-  });
+	beforeEach(() => {
+		originalProcessEnv = _.cloneDeep(process.env);
+		Environment = require("./environment");
+	});
 
-  beforeEach(() => {
-    process.env = _.cloneDeep(originalProcessEnv);
-    Environment = require('./environment');
-  });
+	beforeEach(() => {
+		process.env = _.cloneDeep(originalProcessEnv);
+		Environment = require("./environment");
+	});
 
-  it(`ANDROID_SDK_ROOT and ANDROID_HOME are defined, prefer ANDROID_SDK_ROOT`, () => {
-    process.env.ANDROID_SDK_ROOT = 'path/to/sdk/root';
-    process.env.ANDROID_HOME = 'path/to/android/home';
+	it(`ANDROID_SDK_ROOT and ANDROID_HOME are defined, prefer ANDROID_SDK_ROOT`, () => {
+		process.env.ANDROID_SDK_ROOT = "path/to/sdk/root";
+		process.env.ANDROID_HOME = "path/to/android/home";
 
-    const path = Environment.getAndroidSDKPath();
-    expect(path).toEqual('path/to/sdk/root');
-  });
+		const path = Environment.getAndroidSDKPath();
+		expect(path).toEqual("path/to/sdk/root");
+	});
 
-  it(`ANDROID_HOME is defined`, () => {
-    process.env.ANDROID_SDK_ROOT = undefined;
-    process.env.ANDROID_HOME = 'path/to/android/home';
+	it(`ANDROID_HOME is defined`, () => {
+		process.env.ANDROID_SDK_ROOT = undefined;
+		process.env.ANDROID_HOME = "path/to/android/home";
 
-    const path = Environment.getAndroidSDKPath();
-    expect(path).toEqual('path/to/android/home');
-  });
+		const path = Environment.getAndroidSDKPath();
+		expect(path).toEqual("path/to/android/home");
+	});
 
-  it(`ANDROID_SDK_ROOT and ANDROID_HOME are not defined`, () => {
-    process.env.ANDROID_SDK_ROOT = undefined;
-    process.env.ANDROID_HOME = undefined;
+	it(`ANDROID_SDK_ROOT and ANDROID_HOME are not defined`, () => {
+		process.env.ANDROID_SDK_ROOT = undefined;
+		process.env.ANDROID_HOME = undefined;
 
-    expect(Environment.getAndroidSDKPath)
-      .toThrow('$ANDROID_SDK_ROOT is not defined, set the path to the SDK installation directory into $ANDROID_SDK_ROOT');
-
-  });
+		expect(Environment.getAndroidSDKPath).toThrow(
+			"$ANDROID_SDK_ROOT is not defined, set the path to the SDK installation directory into $ANDROID_SDK_ROOT"
+		);
+	});
 });
-

--- a/detox/src/utils/exec.js
+++ b/detox/src/utils/exec.js
@@ -1,56 +1,65 @@
-const log = require('npmlog');
-const retry = require('../utils/retry');
-const exec = require('child-process-promise').exec;
+const log = require("npmlog");
+const retry = require("../utils/retry");
+const exec = require("child-process-promise").exec;
 
 let _operationCounter = 0;
 
 /**
 
  */
-async function execWithRetriesAndLogs(bin, options, statusLogs, retries = 10, interval = 1000) {
-  _operationCounter++;
+async function execWithRetriesAndLogs(
+	bin,
+	options,
+	statusLogs,
+	retries = 10,
+	interval = 1000
+) {
+	_operationCounter++;
 
-  let cmd;
-  if (options) {
-    cmd = `${options.prefix ? options.prefix + ' && ' : ''}${bin} ${options.args}`;
-  } else {
-    cmd = bin;
-  }
+	let cmd;
+	if (options) {
+		cmd = `${options.prefix
+			? options.prefix + " && "
+			: ""}${bin} ${options.args}`;
+	} else {
+		cmd = bin;
+	}
 
-  log.verbose(`${_operationCounter}: ${cmd}`);
+	log.verbose(`${_operationCounter}: ${cmd}`);
 
-  let result;
-  await retry({retries, interval}, async () => {
-    if (statusLogs && statusLogs.trying) {
-      log.info(`${_operationCounter}: ${statusLogs.trying}`);
-    }
-    result = await exec(cmd);
-  });
-  if (result === undefined) {
-    throw new Error(`${_operationCounter}: running "${cmd}" returned undefined`);
-  }
+	let result;
+	await retry({ retries, interval }, async () => {
+		if (statusLogs && statusLogs.trying) {
+			log.info(`${_operationCounter}: ${statusLogs.trying}`);
+		}
+		result = await exec(cmd);
+	});
+	if (result === undefined) {
+		throw new Error(
+			`${_operationCounter}: running "${cmd}" returned undefined`
+		);
+	}
 
-  if (result.stdout) {
-    log.verbose(`${_operationCounter}: stdout:`, result.stdout);
-  }
+	if (result.stdout) {
+		log.verbose(`${_operationCounter}: stdout:`, result.stdout);
+	}
 
-  if (result.stderr) {
-    log.verbose(`${_operationCounter}: stderr:`, result.stderr);
-  }
+	if (result.stderr) {
+		log.verbose(`${_operationCounter}: stderr:`, result.stderr);
+	}
 
-  if (statusLogs && statusLogs.successful) {
-    log.info(`${_operationCounter}: ${statusLogs.successful}`);
-  }
+	if (statusLogs && statusLogs.successful) {
+		log.info(`${_operationCounter}: ${statusLogs.successful}`);
+	}
 
-  //if (result.childProcess.exitCode !== 0) {
-  //  log.error(`${_operationCounter}: stdout:`, result.stdout);
-  //  log.error(`${_operationCounter}: stderr:`, result.stderr);
-  //}
+	//if (result.childProcess.exitCode !== 0) {
+	//  log.error(`${_operationCounter}: stdout:`, result.stdout);
+	//  log.error(`${_operationCounter}: stderr:`, result.stderr);
+	//}
 
-  return result;
+	return result;
 }
 
 module.exports = {
-  execWithRetriesAndLogs
+	execWithRetriesAndLogs
 };
-

--- a/detox/src/utils/exec.test.js
+++ b/detox/src/utils/exec.test.js
@@ -1,162 +1,165 @@
-const _ = require('lodash');
+const _ = require("lodash");
 
-describe('exec', () => {
-  let exec;
-  let cpp;
+describe("exec", () => {
+	let exec;
+	let cpp;
 
-  beforeEach(() => {
-    jest.mock('npmlog');
-    jest.mock('child-process-promise');
-    cpp = require('child-process-promise');
-    exec = require('./exec');
-  });
+	beforeEach(() => {
+		jest.mock("npmlog");
+		jest.mock("child-process-promise");
+		cpp = require("child-process-promise");
+		exec = require("./exec");
+	});
 
-  it(`exec command with no arguments successfully`, async () => {
-    mockCppSuccessful(cpp);
-    await exec.execWithRetriesAndLogs('bin');
-    expect(cpp.exec).toHaveBeenCalledWith(`bin`);
-  });
+	it(`exec command with no arguments successfully`, async () => {
+		mockCppSuccessful(cpp);
+		await exec.execWithRetriesAndLogs("bin");
+		expect(cpp.exec).toHaveBeenCalledWith(`bin`);
+	});
 
-  it(`exec command with no arguments successfully`, async () => {
-    const successfulResult = returnSuccessfulNoValue();
-    const resolvedPromise = Promise.resolve(successfulResult);
-    cpp.exec.mockReturnValueOnce(resolvedPromise);
-    await exec.execWithRetriesAndLogs('bin');
-    expect(cpp.exec).toHaveBeenCalledWith(`bin`);
-  });
+	it(`exec command with no arguments successfully`, async () => {
+		const successfulResult = returnSuccessfulNoValue();
+		const resolvedPromise = Promise.resolve(successfulResult);
+		cpp.exec.mockReturnValueOnce(resolvedPromise);
+		await exec.execWithRetriesAndLogs("bin");
+		expect(cpp.exec).toHaveBeenCalledWith(`bin`);
+	});
 
-  it(`exec command with arguments successfully`, async () => {
-    mockCppSuccessful(cpp);
+	it(`exec command with arguments successfully`, async () => {
+		mockCppSuccessful(cpp);
 
-    const options = {args: `--argument 123`};
-    await exec.execWithRetriesAndLogs('bin', options);
+		const options = { args: `--argument 123` };
+		await exec.execWithRetriesAndLogs("bin", options);
 
-    expect(cpp.exec).toHaveBeenCalledWith(`bin --argument 123`);
-  });
+		expect(cpp.exec).toHaveBeenCalledWith(`bin --argument 123`);
+	});
 
-  it(`exec command with arguments and prefix successfully`, async () => {
-    mockCppSuccessful(cpp);
+	it(`exec command with arguments and prefix successfully`, async () => {
+		mockCppSuccessful(cpp);
 
-    const options = {
-      args: `--argument 123`,
-      prefix: `export MY_PREFIX`
-    };
-    await exec.execWithRetriesAndLogs('bin', options);
+		const options = {
+			args: `--argument 123`,
+			prefix: `export MY_PREFIX`
+		};
+		await exec.execWithRetriesAndLogs("bin", options);
 
-    expect(cpp.exec).toHaveBeenCalledWith(`export MY_PREFIX && bin --argument 123`);
-  });
+		expect(cpp.exec).toHaveBeenCalledWith(
+			`export MY_PREFIX && bin --argument 123`
+		);
+	});
 
-  it(`exec command with arguments and status logs successfully`, async () => {
-    mockCppSuccessful(cpp);
+	it(`exec command with arguments and status logs successfully`, async () => {
+		mockCppSuccessful(cpp);
 
-    const options = {args: `--argument 123`};
-    const statusLogs = {
-      trying: `trying status log`,
-      successful: `successful status log`
-    };
-    await exec.execWithRetriesAndLogs('bin', options, statusLogs);
+		const options = { args: `--argument 123` };
+		const statusLogs = {
+			trying: `trying status log`,
+			successful: `successful status log`
+		};
+		await exec.execWithRetriesAndLogs("bin", options, statusLogs);
 
-    expect(cpp.exec).toHaveBeenCalledWith(`bin --argument 123`);
-  });
+		expect(cpp.exec).toHaveBeenCalledWith(`bin --argument 123`);
+	});
 
-  it(`exec command with undefined return should throw`, async () => {
-    cpp.exec.mockReturnValueOnce(undefined);
-    try {
-      await exec.execWithRetriesAndLogs('bin');
-      fail('should throw');
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  });
+	it(`exec command with undefined return should throw`, async () => {
+		cpp.exec.mockReturnValueOnce(undefined);
+		try {
+			await exec.execWithRetriesAndLogs("bin");
+			fail("should throw");
+		} catch (ex) {
+			expect(ex).toBeDefined();
+		}
+	});
 
-  it(`exec command and fail`, async () => {
-    const errorResult = returnErrorWithValue('error result');
-    const rejectedPromise = Promise.reject(errorResult);
-    cpp.exec.mockReturnValueOnce(rejectedPromise);
+	it(`exec command and fail`, async () => {
+		const errorResult = returnErrorWithValue("error result");
+		const rejectedPromise = Promise.reject(errorResult);
+		cpp.exec.mockReturnValueOnce(rejectedPromise);
 
-    try {
-      await exec.execWithRetriesAndLogs('bin', null, '', 1, 1);
-      fail('expected execWithRetriesAndLogs() to throw');
-    } catch (object) {
-      expect(cpp.exec).toHaveBeenCalledWith(`bin`);
-      expect(object).toBeDefined();
-    }
-  });
+		try {
+			await exec.execWithRetriesAndLogs("bin", null, "", 1, 1);
+			fail("expected execWithRetriesAndLogs() to throw");
+		} catch (object) {
+			expect(cpp.exec).toHaveBeenCalledWith(`bin`);
+			expect(object).toBeDefined();
+		}
+	});
 
-  it(`exec command with multiple failures`, async () => {
-    const errorResult = returnErrorWithValue('error result');
-    const rejectedPromise = Promise.reject(errorResult);
-    cpp.exec.mockReturnValueOnce(rejectedPromise)
-       .mockReturnValueOnce(rejectedPromise)
-       .mockReturnValueOnce(rejectedPromise)
-       .mockReturnValueOnce(rejectedPromise)
-       .mockReturnValueOnce(rejectedPromise)
-       .mockReturnValueOnce(rejectedPromise);
-    try {
-      await exec.execWithRetriesAndLogs('bin', null, '', 6, 1);
-      fail('expected execWithRetriesAndLogs() to throw');
-    } catch (object) {
-      expect(cpp.exec).toHaveBeenCalledWith(`bin`);
-      expect(cpp.exec).toHaveBeenCalledTimes(6);
-      expect(object).toBeDefined();
-    }
-  });
+	it(`exec command with multiple failures`, async () => {
+		const errorResult = returnErrorWithValue("error result");
+		const rejectedPromise = Promise.reject(errorResult);
+		cpp.exec
+			.mockReturnValueOnce(rejectedPromise)
+			.mockReturnValueOnce(rejectedPromise)
+			.mockReturnValueOnce(rejectedPromise)
+			.mockReturnValueOnce(rejectedPromise)
+			.mockReturnValueOnce(rejectedPromise)
+			.mockReturnValueOnce(rejectedPromise);
+		try {
+			await exec.execWithRetriesAndLogs("bin", null, "", 6, 1);
+			fail("expected execWithRetriesAndLogs() to throw");
+		} catch (object) {
+			expect(cpp.exec).toHaveBeenCalledWith(`bin`);
+			expect(cpp.exec).toHaveBeenCalledTimes(6);
+			expect(object).toBeDefined();
+		}
+	});
 
-  it(`exec command with multiple failures and then a success`, async () => {
-    const errorResult = returnErrorWithValue('error result');
-    const rejectedPromise = Promise.reject(errorResult);
-    const successfulResult = returnSuccessfulWithValue('successful result');
-    const resolvedPromise = Promise.resolve(successfulResult);
+	it(`exec command with multiple failures and then a success`, async () => {
+		const errorResult = returnErrorWithValue("error result");
+		const rejectedPromise = Promise.reject(errorResult);
+		const successfulResult = returnSuccessfulWithValue("successful result");
+		const resolvedPromise = Promise.resolve(successfulResult);
 
-    cpp.exec.mockReturnValueOnce(rejectedPromise)
-       .mockReturnValueOnce(rejectedPromise)
-       .mockReturnValueOnce(rejectedPromise)
-       .mockReturnValueOnce(rejectedPromise)
-       .mockReturnValueOnce(rejectedPromise)
-       .mockReturnValueOnce(resolvedPromise);
+		cpp.exec
+			.mockReturnValueOnce(rejectedPromise)
+			.mockReturnValueOnce(rejectedPromise)
+			.mockReturnValueOnce(rejectedPromise)
+			.mockReturnValueOnce(rejectedPromise)
+			.mockReturnValueOnce(rejectedPromise)
+			.mockReturnValueOnce(resolvedPromise);
 
-    await exec.execWithRetriesAndLogs('bin', null, '', 6, 1);
-    expect(cpp.exec).toHaveBeenCalledWith(`bin`);
-    expect(cpp.exec).toHaveBeenCalledTimes(6);
-  });
+		await exec.execWithRetriesAndLogs("bin", null, "", 6, 1);
+		expect(cpp.exec).toHaveBeenCalledWith(`bin`);
+		expect(cpp.exec).toHaveBeenCalledTimes(6);
+	});
 });
 
 function returnSuccessfulWithValue(value) {
-  const result = {
-    stdout: JSON.stringify(value),
-    stderr: "err",
-    childProcess: {
-      exitCode: 0
-    }
-  };
-  return result;
+	const result = {
+		stdout: JSON.stringify(value),
+		stderr: "err",
+		childProcess: {
+			exitCode: 0
+		}
+	};
+	return result;
 }
 
 function returnErrorWithValue(value) {
-  const result = {
-    stdout: "out",
-    stderr: value,
-    childProcess: {
-      exitCode: 1
-    }
-  };
-  return result;
+	const result = {
+		stdout: "out",
+		stderr: value,
+		childProcess: {
+			exitCode: 1
+		}
+	};
+	return result;
 }
 
 function returnSuccessfulNoValue() {
-  const result = {
-    childProcess: {
-      exitCode: 0
-    }
-  };
-  return result;
+	const result = {
+		childProcess: {
+			exitCode: 0
+		}
+	};
+	return result;
 }
 
 function mockCppSuccessful(cpp) {
-  const successfulResult = returnSuccessfulWithValue('successful result');
-  const resolvedPromise = Promise.resolve(successfulResult);
-  cpp.exec.mockReturnValueOnce(resolvedPromise);
+	const successfulResult = returnSuccessfulWithValue("successful result");
+	const resolvedPromise = Promise.resolve(successfulResult);
+	cpp.exec.mockReturnValueOnce(resolvedPromise);
 
-  return successfulResult;
+	return successfulResult;
 }
-

--- a/detox/src/utils/fsext.js
+++ b/detox/src/utils/fsext.js
@@ -1,18 +1,18 @@
-const fs = require('fs-extra');
-const path = require('path');
+const fs = require("fs-extra");
+const path = require("path");
 
-async function getDirectories (rootPath) {
-  let files = await fs.readdir(rootPath);
-  let dirs = [];
-  for (let file of files) {
-    let pathString = path.resolve(rootPath, file);
-    if ((await fs.lstat(pathString)).isDirectory()) {
-      dirs.push(file);
-    }
-  }
-  return dirs.sort();
+async function getDirectories(rootPath) {
+	const files = await fs.readdir(rootPath);
+	const dirs = [];
+	for (const file of files) {
+		const pathString = path.resolve(rootPath, file);
+		if ((await fs.lstat(pathString)).isDirectory()) {
+			dirs.push(file);
+		}
+	}
+	return dirs.sort();
 }
 
 module.exports = {
-  getDirectories
+	getDirectories
 };

--- a/detox/src/utils/retry.js
+++ b/detox/src/utils/retry.js
@@ -2,25 +2,28 @@ const DEFAULT_RETRIES = 10;
 const DEFAULT_INTERVAL = 500;
 
 async function retry(options, func) {
+	let fun = func;
+	let opts = options;
+
 	if (typeof options === "function") {
-		func = options;
-		options = {};
+		fun = options;
+		opts = {};
 	}
 
-	let { retries, interval } = options;
+	let { retries, interval } = opts;
 	retries = retries || DEFAULT_RETRIES;
 	interval = interval || DEFAULT_INTERVAL;
 
 	let currentRetry = 0;
 	while (currentRetry++ < retries) {
 		try {
-			return await func(currentRetry);
+			return await fun(currentRetry);
 		} catch (e) {
 			if (currentRetry === retries) {
 				throw e;
 			} else {
 				const sleep = currentRetry * interval;
-				await new Promise(accept => setTimeout(accept, sleep));
+				await new Promise(resolve => setTimeout(resolve, sleep));
 			}
 		}
 	}

--- a/detox/src/utils/retry.js
+++ b/detox/src/utils/retry.js
@@ -2,28 +2,28 @@ const DEFAULT_RETRIES = 10;
 const DEFAULT_INTERVAL = 500;
 
 async function retry(options, func) {
-  if (typeof options === 'function') {
-    func = options;
-    options = {};
-  }
+	if (typeof options === "function") {
+		func = options;
+		options = {};
+	}
 
-  let {retries, interval} = options;
-  retries = retries || DEFAULT_RETRIES;
-  interval = interval || DEFAULT_INTERVAL;
+	let { retries, interval } = options;
+	retries = retries || DEFAULT_RETRIES;
+	interval = interval || DEFAULT_INTERVAL;
 
-  let currentRetry = 0;
-  while (currentRetry++ < retries) {
-    try {
-      return await func(currentRetry);
-    } catch (e) {
-      if (currentRetry === retries) {
-        throw e;
-      } else {
-        const sleep = currentRetry * interval;
-        await new Promise((accept) => setTimeout(accept, sleep));
-      }
-    }
-  }
+	let currentRetry = 0;
+	while (currentRetry++ < retries) {
+		try {
+			return await func(currentRetry);
+		} catch (e) {
+			if (currentRetry === retries) {
+				throw e;
+			} else {
+				const sleep = currentRetry * interval;
+				await new Promise(accept => setTimeout(accept, sleep));
+			}
+		}
+	}
 }
 
 module.exports = retry;

--- a/detox/src/utils/retry.test.js
+++ b/detox/src/utils/retry.test.js
@@ -1,36 +1,39 @@
-describe('retry', () => {
-  let retry;
+describe("retry", () => {
+	let retry;
 
-  beforeEach(() => {
-    retry = require('./retry');
-  });
+	beforeEach(() => {
+		retry = require("./retry");
+	});
 
-  it(`a promise that rejects two times and then resolves, with default params`, async() => {
-    const mockFnc = jest.fn()
-                        .mockReturnValueOnce(Promise.reject())
-                        .mockReturnValueOnce(Promise.resolve());
-    await retry(mockFnc);
-    expect(mockFnc).toHaveBeenCalledTimes(2);
-  });
+	it(`a promise that rejects two times and then resolves, with default params`, async () => {
+		const mockFnc = jest
+			.fn()
+			.mockReturnValueOnce(Promise.reject())
+			.mockReturnValueOnce(Promise.resolve());
+		await retry(mockFnc);
+		expect(mockFnc).toHaveBeenCalledTimes(2);
+	});
 
-  it(`a promise that rejects two times and then resolves, with custom params`, async() => {
-    const mockFnc = jest.fn()
-                        .mockReturnValueOnce(Promise.reject())
-                        .mockReturnValueOnce(Promise.resolve());
-    await retry({retries: 2, interval: 1}, mockFnc);
-    expect(mockFnc).toHaveBeenCalledTimes(2);
-  });
+	it(`a promise that rejects two times and then resolves, with custom params`, async () => {
+		const mockFnc = jest
+			.fn()
+			.mockReturnValueOnce(Promise.reject())
+			.mockReturnValueOnce(Promise.resolve());
+		await retry({ retries: 2, interval: 1 }, mockFnc);
+		expect(mockFnc).toHaveBeenCalledTimes(2);
+	});
 
-  it(`a promise that rejects two times, with two retries`, async() => {
-    const mockFn = jest.fn()
-                       .mockReturnValueOnce(Promise.reject('a thing'))
-                       .mockReturnValueOnce(Promise.reject('a thing'));
-    try {
-      await retry({retries: 2, interval: 1}, mockFn);
-      fail('expected retry to fail to throw');
-    } catch (object) {
-      expect(mockFn).toHaveBeenCalledTimes(2);
-      expect(object).toBeDefined();
-    }
-  });
+	it(`a promise that rejects two times, with two retries`, async () => {
+		const mockFn = jest
+			.fn()
+			.mockReturnValueOnce(Promise.reject("a thing"))
+			.mockReturnValueOnce(Promise.reject("a thing"));
+		try {
+			await retry({ retries: 2, interval: 1 }, mockFn);
+			fail("expected retry to fail to throw");
+		} catch (object) {
+			expect(mockFn).toHaveBeenCalledTimes(2);
+			expect(object).toBeDefined();
+		}
+	});
 });

--- a/detox/src/utils/sh.js
+++ b/detox/src/utils/sh.js
@@ -1,18 +1,21 @@
-const cpp = require('child-process-promise');
-const fs = require('fs');
+const cpp = require("child-process-promise");
+const fs = require("fs");
 
-const sh = new Proxy({}, {
-  get: function(target, prop) {
-    if (target[prop] === undefined) {
-      return target[prop] = (...params) => {
-        return cpp.exec(`${prop} ${params.join(' ')}`);
-      };
-    } else {
-      return target[prop];
-    }
-  }
-});
+const sh = new Proxy(
+	{},
+	{
+		get: function(target, prop) {
+			if (target[prop] === undefined) {
+				return (target[prop] = (...params) => {
+					return cpp.exec(`${prop} ${params.join(" ")}`);
+				});
+			} else {
+				return target[prop];
+			}
+		}
+	}
+);
 
-process.env['PATH'] = `${process.env.PATH}:${sh.npm(`bin`)}`;
+process.env.PATH = `${process.env.PATH}:${sh.npm(`bin`)}`;
 
 module.exports = sh;

--- a/detox/src/utils/sh.test.js
+++ b/detox/src/utils/sh.test.js
@@ -1,27 +1,26 @@
-describe('sh', () => {
-  let sh;
-  let cpp;
+describe("sh", () => {
+	let sh;
+	let cpp;
 
-  beforeEach(() => {
-    jest.mock('child-process-promise');
-    cpp = require('child-process-promise');
-    sh = require('./sh');
-  });
+	beforeEach(() => {
+		jest.mock("child-process-promise");
+		cpp = require("child-process-promise");
+		sh = require("./sh");
+	});
 
-  it(`Call an undefined function with one string param should generate a full command string`, async () => {
-    await sh.cp('path/to/src pat/to/dest');
-    expect(cpp.exec).toHaveBeenCalledWith('cp path/to/src pat/to/dest');
-  });
+	it(`Call an undefined function with one string param should generate a full command string`, async () => {
+		await sh.cp("path/to/src pat/to/dest");
+		expect(cpp.exec).toHaveBeenCalledWith("cp path/to/src pat/to/dest");
+	});
 
-  it(`Call an undefined function with two string params should generate a full command string`, async () => {
-    await sh.cp('-r', 'path/to/src pat/to/dest');
-    expect(cpp.exec).toHaveBeenCalledWith('cp -r path/to/src pat/to/dest');
-  });
+	it(`Call an undefined function with two string params should generate a full command string`, async () => {
+		await sh.cp("-r", "path/to/src pat/to/dest");
+		expect(cpp.exec).toHaveBeenCalledWith("cp -r path/to/src pat/to/dest");
+	});
 
-
-  it(`Require an undefined param from sh and then initiate it as function should generate a full command string`, async () => {
-    const npm = require('./sh').npm;
-    await npm('-v');
-    expect(cpp.exec).toHaveBeenCalledWith('npm -v');
-  });
+	it(`Require an undefined param from sh and then initiate it as function should generate a full command string`, async () => {
+		const npm = require("./sh").npm;
+		await npm("-v");
+		expect(cpp.exec).toHaveBeenCalledWith("npm -v");
+	});
 });

--- a/detox/src/utils/uuid.js
+++ b/detox/src/utils/uuid.js
@@ -1,14 +1,26 @@
 function UUID() {
-  function s4() {
-    return Math.floor((1 + Math.random()) * 0x10000)
-               .toString(16)
-               .substring(1);
-  }
+	function s4() {
+		return Math.floor((1 + Math.random()) * 0x10000)
+			.toString(16)
+			.substring(1);
+	}
 
-  return s4() + s4() + '-' + s4() + '-' + s4() + '-'
-         + s4() + '-' + s4() + s4() + s4();
+	return (
+		s4() +
+		s4() +
+		"-" +
+		s4() +
+		"-" +
+		s4() +
+		"-" +
+		s4() +
+		"-" +
+		s4() +
+		s4() +
+		s4()
+	);
 }
 
 module.exports = {
-  UUID
+	UUID
 };

--- a/generation/core/generator.js
+++ b/generation/core/generator.js
@@ -206,6 +206,7 @@ module.exports = function({
 			const ast = t.program([createClass(json), createExport(json)]);
 			const output = generate(ast);
 
+			const eslintDisableComment = "/* eslint-disable */";
 			const commentBefore =
 				"/**\n\n\tThis code is generated.\n\tFor more information see generation/README.md.\n*/\n\n";
 
@@ -231,7 +232,12 @@ module.exports = function({
 				})
 				.join("\n");
 
-			const code = [commentBefore, globalFunctions, output.code].join("\n");
+			const code = [
+				eslintDisableComment,
+				commentBefore,
+				globalFunctions,
+				output.code
+			].join("\n");
 			fs.writeFileSync(outputFile, code, "utf8");
 
 			// Output methods that were not created due to missing argument support

--- a/generation/package.json
+++ b/generation/package.json
@@ -6,6 +6,7 @@
 	"private": true,
 	"scripts": {
 		"build": "./index.js",
+		"pretest": "npm run build",
 		"test": "jest",
 		"precommit": "lint-staged",
 		"format": "prettier ./**/*.{js,json,css,md} --write"


### PR DESCRIPTION
Closes #466 

## Commits

1. enable lint check in CI
2. Run `npm run lint --fix`
3. Add `lint-staged` as dependency, was missing previously
4. fix the eslint errors, by
    - changing code that was actually sub-optimal
    - disabling eslint checks which were in conflict with prettier
    - disabling eslint checks for patterns we use heavily or were super hard to fix (`consistent-return`)