### PR TITLE
Add quotes around xcode version output

### DIFF
--- a/detox/src/devices/AppleSimUtils.js
+++ b/detox/src/devices/AppleSimUtils.js
@@ -149,7 +149,7 @@ class AppleSimUtils {
     const match = /^Xcode (\S+)\.*\S*\s*/.exec(stdout);
     const majorVersion = parseInt(_.get(match, '[1]'));
     if (!_.isInteger(majorVersion) || majorVersion < 1) {
-      throw new Error(`Can't read Xcode version, got: ${stdout}`);
+      throw new Error(`Can't read Xcode version, got: '${stdout}'`);
     }
     return majorVersion;
   }

--- a/detox/src/devices/AppleSimUtils.test.js
+++ b/detox/src/devices/AppleSimUtils.test.js
@@ -190,7 +190,7 @@ describe('AppleSimUtils', () => {
         await uut.getXcodeVersion();
         fail(`should throw`);
       } catch (e) {
-        expect(e).toEqual(new Error(`Can't read Xcode version, got: undefined`));
+        expect(e).toEqual(new Error(`Can't read Xcode version, got: 'undefined'`));
       }
     });
 
@@ -200,7 +200,7 @@ describe('AppleSimUtils', () => {
         await uut.getXcodeVersion();
         fail(`should throw`);
       } catch (e) {
-        expect(e).toEqual(new Error(`Can't read Xcode version, got: Xcode bla`));
+        expect(e).toEqual(new Error(`Can't read Xcode version, got: 'Xcode bla'`));
       }
     });
   });


### PR DESCRIPTION
We rely on an external tools output here, so quoting
the place gives us a bit more information on why the
regex might fail in certain scenarios.

I am referring to failed builds like this one: https://travis-ci.org/wix/detox/jobs/325861194