### PR TITLE
Add serverHost and shouldStartServer config

### DIFF
--- a/detox-server/src/DetoxServer.js
+++ b/detox-server/src/DetoxServer.js
@@ -7,11 +7,11 @@ log.heading = 'detox-server';
 log.loglevel = 'wss';
 
 class DetoxServer {
-  constructor(port) {
-    this.wss = new WebSocketServer({port: port});
+  constructor(port, host) {
+    this.wss = new WebSocketServer({port: port, host: host});
     this.sessions = {};
 
-    log.log('info', `${now()}:`, `server listening on localhost:${this.wss.options.port}...`);
+    log.log('info', `${now()}:`, `server listening on ${this.wss.options.host}:${this.wss.options.port}...`);
     this._setup();
   }
 

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -56,7 +56,8 @@ class Detox {
     const [sessionConfig, shouldStartServer] = await this._chooseSession(deviceConfig);
 
     if (shouldStartServer) {
-      this.server = new DetoxServer(new URL(sessionConfig.server).port);
+      const hostConfig = new URL(sessionConfig.serverHost ? sessionConfig.serverHost : sessionConfig.server);
+      this.server = new DetoxServer(hostConfig.port, hostConfig.hostname);
     }
 
     this.client = new Client(sessionConfig);
@@ -107,7 +108,7 @@ class Detox {
 
   async _chooseSession(deviceConfig) {
     let session = deviceConfig.session;
-    let shouldStartServer = false;
+    let shouldStartServer = deviceConfig.session && deviceConfig.session.shouldStartServer;
 
     if (!session) {
       session = this.userConfig.session;


### PR DESCRIPTION
`serverHost` config should override `detox-server` host and port values, enabling it to bind to an IP other than localhost. `shouldStartServer` should force the server start when we specify a session.

See https://github.com/wix/detox/issues/526 for more info