### PR TITLE
Fix homepage in detox & detox-server package.json

### DIFF
--- a/detox-server/package.json
+++ b/detox-server/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/wix/detox/issues"
   },
-  "homepage": "https://github.com/wix/detox/detox-server",
+  "homepage": "https://github.com/wix/detox#readme",
   "main": "./src/index.js",
   "author": "Tal Kol <talkol@gmail.com>",
   "license": "MIT",

--- a/detox/package.json
+++ b/detox/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/wix/detox/issues"
   },
-  "homepage": "https://github.com/wix/detox/detox",
+  "homepage": "https://github.com/wix/detox#readme",
   "main": "./src/index.js",
   "author": "Tal Kol <talkol@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This fixes some broken links to the homepage.

I decided to link to the main readme from the `detox-server` `package.json`, let me know if you'd rather have it link to the specific `README.md`.