### PR TITLE
Fixed section link in doc

### DIFF
--- a/docs/APIRef.waitFor.md
+++ b/docs/APIRef.waitFor.md
@@ -14,7 +14,7 @@ Test async code with waitFor.<br>
 - [`.toHaveText()`](#tohavetexttext)
 - [`.toHaveValue()`](#tohavevaluevalue)
 - [`.withTimeout()`](#withtimeoutmillis)
-- [`.whileElement()`](#whileelement)
+- [`.whileElement()`](#whileelementelement)
 
 >NOTE: Every `waitFor` call must set a timeout using `withTimeout()`. Calling `waitFor` without setting a timeout **will do nothing**.
 


### PR DESCRIPTION
Fixed the section link for the 'whileElement()' section link in the Manual Synchronization doc.