### PR TITLE
Support testApk path for gradle builds with multiple flavor matrix

### DIFF
--- a/detox/src/devices/android/APKPath.js
+++ b/detox/src/devices/android/APKPath.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const _ = require('lodash');
+const string = require('../../utils/string');
 
 class APKPath {
 
@@ -12,9 +13,14 @@ class APKPath {
     const flavorDimensions = _.slice(splitFileName, 1, splitFileName.length - 1);
 
     tempPath = _.dropRight(tempPath, 1); //buildType
-    tempPath = _.dropRight(tempPath, flavorDimensions.length); //flavorDimensions
 
-    const testApkPath = path.join(tempPath.join(path.sep), 'androidTest', flavorDimensions.join(path.sep), buildType, `${originalApkPathObj.name}-androidTest${originalApkPathObj.ext}`);
+    let flavorDimensionsPath = '';
+    if (flavorDimensions.length > 0) {
+      flavorDimensionsPath = string.lowerCamelCaseJoin(flavorDimensions);
+      tempPath = _.dropRight(tempPath, 1); //flavorDimensions
+    }
+
+    const testApkPath = path.join(tempPath.join(path.sep), 'androidTest', flavorDimensionsPath, buildType, `${originalApkPathObj.name}-androidTest${originalApkPathObj.ext}`);
     return testApkPath;
   }
 }

--- a/detox/src/devices/android/APKPath.test.js
+++ b/detox/src/devices/android/APKPath.test.js
@@ -12,10 +12,9 @@ describe('APKPath', () => {
   });
 
   it(`path for a gradle build flavor`, async () => {
-    const inputApkPath = '~/somePath/build/outputs/apk/development/debug/app-development-debug.apk';
-    const expectedTestApkPath = '~/somePath/build/outputs/apk/androidTest/development/debug/app-development-debug-androidTest.apk';
+    const inputApkPath = '~/android/app/build/outputs/apk/pocPlayStore/debug/app-poc-playStore-debug.apk';
+    const expectedTestApkPath = '~/android/app/build/outputs/apk/androidTest/pocPlayStore/debug/app-poc-playStore-debug-androidTest.apk';
     expect(APKPath.getTestApkPath(inputApkPath)).toEqual(expectedTestApkPath);
   });
 
 });
-

--- a/detox/src/devices/android/APKPath.test.js
+++ b/detox/src/devices/android/APKPath.test.js
@@ -12,6 +12,12 @@ describe('APKPath', () => {
   });
 
   it(`path for a gradle build flavor`, async () => {
+    const inputApkPath = '~/somePath/build/outputs/apk/development/debug/app-development-debug.apk';
+    const expectedTestApkPath = '~/somePath/build/outputs/apk/androidTest/development/debug/app-development-debug-androidTest.apk';
+    expect(APKPath.getTestApkPath(inputApkPath)).toEqual(expectedTestApkPath);
+  });
+
+  it(`path for a gradle build with multiple flavors`, async () => {
     const inputApkPath = '~/android/app/build/outputs/apk/pocPlayStore/debug/app-poc-playStore-debug.apk';
     const expectedTestApkPath = '~/android/app/build/outputs/apk/androidTest/pocPlayStore/debug/app-poc-playStore-debug-androidTest.apk';
     expect(APKPath.getTestApkPath(inputApkPath)).toEqual(expectedTestApkPath);

--- a/detox/src/utils/string.js
+++ b/detox/src/utils/string.js
@@ -1,0 +1,24 @@
+const _ = require('lodash');
+
+function capitalizeFirstLetter(string) {
+  if (_.isEmpty(string)) {
+    return '';
+  }
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function lowerCamelCaseJoin(array) {
+  if (_.isEmpty(array)) {
+    return '';
+  }
+  const [first, ...rest] = array;
+  let retVal = first;
+  _.forEach(rest, (str) => {
+    retVal += capitalizeFirstLetter(str);
+  })
+  return retVal;
+}
+module.exports = {
+  capitalizeFirstLetter,
+  lowerCamelCaseJoin
+};

--- a/detox/src/utils/string.test.js
+++ b/detox/src/utils/string.test.js
@@ -1,0 +1,32 @@
+describe('string', () => {
+  let string;
+
+  beforeEach(() => {
+    string = require('./string');
+  });
+
+  describe('lowerCamelCaseJoin', () => {
+    it(`should capitalize first letter of each array item after the first`, () => {
+      expect(string.lowerCamelCaseJoin(['foo', 'bar'])).toBe('fooBar');
+    });
+    it(`should gracefully handle an empty array`, () => {
+      expect(string.lowerCamelCaseJoin([])).toBe('');
+    });
+    it(`should gracefully handle empty input`, () => {
+      expect(string.lowerCamelCaseJoin()).toBe('');
+    });
+  });
+
+  describe('capitalizeFirstLetter', () => {
+    it(`should capitalize first letter`, () => {
+      expect(string.capitalizeFirstLetter('blah')).toBe('Blah');
+    });
+    it(`should gracefully handle an empty string`, () => {
+      expect(string.capitalizeFirstLetter('')).toBe('');
+    });
+    it(`should gracefully handle empty input`, () => {
+      expect(string.capitalizeFirstLetter()).toBe('');
+    });
+  });
+
+});


### PR DESCRIPTION
I initially created issue #522 as I wasn't familiar with this codebase to PR a solution.

Since then PR #537 was created to fix it.

Unfortunately I still have the problem.  In my real life app example my input SDK path is
```
~/android/app/build/outputs/apk/pocPlayStore/debug/app-poc-playStore-debug.apk
```
and the detox build physically builds to 
```
~/android/app/build/outputs/apk/androidTest/pocPlayStore/debug/app-poc-playStore-debug-androidTest.apk
```

I built off #537 adding my real world example to the tests and updated required logic to generate the expected result. 

I introduced a new strings util file as I needed to do some string manipulation.  Mainly converting `['poc', 'playStore']` to `pocPlayStore`.