### PR TITLE
Fix greeting from rendering and make sure it's matched, but now the test fails

### DIFF
--- a/detox/test/e2e/c-actions.js
+++ b/detox/test/e2e/c-actions.js
@@ -83,7 +83,7 @@ describe('Actions', () => {
 
   it('should wait for long timeout', async () => {
     await element(by.id('WhyDoAllTheTestIDsHaveTheseStrangeNames')).tap();
-    await expect(element(by.id('WhyDoAllTheTestIDsHaveTheseStrangeNames'))).toBeVisible();
+    await expect(element(by.text('Long Timeout Done!!!'))).toBeVisible();
   });
 
 });

--- a/detox/test/src/Screens/ActionsScreen.js
+++ b/detox/test/src/Screens/ActionsScreen.js
@@ -100,9 +100,9 @@ export default class ActionsScreen extends Component {
     });
   }
 
-  onLongTimeout(greeting) {
+  onLongTimeout() {
     setTimeout(() => {
-      greeting: 'Long Timeout Done'
+      this.setState({ greeting: 'Long Timeout Done' })
     }, 4000);
   }
 


### PR DESCRIPTION
For some reason a test for long timeout after press was not working at
all. I noticed that it tested the wrong thing (is button visible)
instead of greeting text which should have been appeared after 4k ms of
the button press.

Greeting text didn’t appear since there was a bug — which was weirdly
enough a valid Javascript syntax — which is now fixed.

However I’ve got no idea how to fix the failing test. Any help?