### PR TITLE
Docs: Use jest.setTimeout instead of jasmine timeout

### DIFF
--- a/docs/Guide.Jest.md
+++ b/docs/Guide.Jest.md
@@ -26,7 +26,7 @@ const detox = require('detox');
 const config = require('../package.json').detox;
 
 // Set the default timeout
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
+jest.setTimeout(120000);
 
 beforeAll(async () => {
   await detox.init(config);

--- a/docs/Guide.Jest.md
+++ b/docs/Guide.Jest.md
@@ -25,7 +25,7 @@ You should remove `e2e/mocha.opts`, you no longer need it.
 const detox = require('detox');
 const config = require('../package.json').detox;
 
-// Set the default timeout of 120s
+// Set the default test timeout of 120s
 jest.setTimeout(120000);
 
 beforeAll(async () => {

--- a/docs/Guide.Jest.md
+++ b/docs/Guide.Jest.md
@@ -25,7 +25,7 @@ You should remove `e2e/mocha.opts`, you no longer need it.
 const detox = require('detox');
 const config = require('../package.json').detox;
 
-// Set the default timeout
+// Set the default timeout of 120s
 jest.setTimeout(120000);
 
 beforeAll(async () => {


### PR DESCRIPTION
## Summary 
Replace `jasmine.DEFAULT_TIMEOUT_INTERVAL` with `jest.setTimeout()` in Jest Guide.
Since jest@20 or so [jest.setTimeout](https://facebook.github.io/jest/docs/en/jest-object.html#jestsettimeouttimeout) is available, instead of jasmine-specific timeout constant. I think it's worth using official APIs when available.