### PR TITLE
Add generation for GREYInteraction

### DIFF
--- a/detox/src/invoke/Invoke.test.js
+++ b/detox/src/invoke/Invoke.test.js
@@ -1,0 +1,11 @@
+const {call} = require('./Invoke');
+
+describe('call', () => {
+  it('handles target as thunk', () => {
+    expect(call(() =>  'fn', 'method')()).toEqual({
+      target: { type: 'Invocation', value: 'fn' },
+      method: 'method',
+      args: []
+    })
+  });
+});

--- a/detox/src/ios/earlgreyapi/GREYActions.js
+++ b/detox/src/ios/earlgreyapi/GREYActions.js
@@ -94,6 +94,54 @@ simulate a long press.
     };
   }
 
+  /*Returns an action that holds down finger for specified @c duration to simulate a long press.
+
+@param duration The duration of the long press.
+
+@return A GREYAction that performs a long press on an element.
+*/static actionForLongPressWithDuration(duration) {
+    if (typeof duration !== "number") throw new Error("duration should be a number, but got " + (duration + (" (" + (typeof duration + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForLongPressWithDuration:",
+      args: [{
+        type: "CGFloat",
+        value: duration
+      }]
+    };
+  }
+
+  /*Returns an action that holds down finger for specified @c duration at the specified @c point
+(interpreted as being relative to the element) to simulate a long press.
+
+@param point    The point that should be tapped.
+@param duration The duration of the long press.
+
+@return A GREYAction that performs a long press on an element.
+*/static actionForLongPressAtPointDuration(point, duration) {
+    if (typeof point !== "object") throw new Error("point should be a object, but got " + (point + (" (" + (typeof point + ")"))));
+    if (typeof point.x !== "number") throw new Error("point.x should be a number, but got " + (point.x + (" (" + (typeof point.x + ")"))));
+    if (typeof point.y !== "number") throw new Error("point.y should be a number, but got " + (point.y + (" (" + (typeof point.y + ")"))));
+    if (typeof duration !== "number") throw new Error("duration should be a number, but got " + (duration + (" (" + (typeof duration + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "GREYActions"
+      },
+      method: "actionForLongPressAtPoint:duration:",
+      args: [{
+        type: "CGPoint",
+        value: point
+      }, {
+        type: "CGFloat",
+        value: duration
+      }]
+    };
+  }
+
   /*Returns an action that scrolls a @c UIScrollView by @c amount (in points) in the specified
 @c direction.
 

--- a/detox/src/ios/earlgreyapi/GREYCondition.js
+++ b/detox/src/ios/earlgreyapi/GREYCondition.js
@@ -1,0 +1,68 @@
+/**
+
+	This code is generated.
+	For more information see generation/README.md.
+*/
+
+
+
+class GREYCondition {
+  /*Waits for the condition to be met until the specified @c seconds have elapsed.
+
+Will poll the condition as often as possible on the main thread while still giving a fair chance
+for other sources and handlers to be serviced.
+
+@remark Waiting on conditions with this method is very CPU intensive on the main thread. If
+you do not need to return immediately after the condition is met, the consider using
+GREYCondition::waitWithTimeout:pollInterval:
+
+@param seconds Amount of time to wait for the condition to be met, in seconds.
+
+@return @c YES if the condition was met before the timeout, @c NO otherwise.
+*/static waitWithTimeout(element, seconds) {
+    if (typeof seconds !== "number") throw new Error("seconds should be a number, but got " + (seconds + (" (" + (typeof seconds + ")"))));
+    return {
+      target: {
+        type: "Invocation",
+        value: element
+      },
+      method: "waitWithTimeout:",
+      args: [{
+        type: "CGFloat",
+        value: seconds
+      }]
+    };
+  }
+
+  /*Waits for the condition to be met until the specified @c seconds have elapsed. Will poll the
+condition immediately and then no more than once every @c interval seconds. Will attempt to poll
+the condition as close as possible to every @c interval seconds.
+
+@remark Will allow the main thread to sleep instead of busily checking the condition.
+
+@param seconds  Amount of time to wait for the condition to be met, in seconds.
+@param interval The minimum time that should elapse between checking the condition.
+
+@return @c YES if the condition was met before the timeout, @c NO otherwise.
+*/static waitWithTimeoutPollInterval(element, seconds, interval) {
+    if (typeof seconds !== "number") throw new Error("seconds should be a number, but got " + (seconds + (" (" + (typeof seconds + ")"))));
+    if (typeof interval !== "number") throw new Error("interval should be a number, but got " + (interval + (" (" + (typeof interval + ")"))));
+    return {
+      target: {
+        type: "Invocation",
+        value: element
+      },
+      method: "waitWithTimeout:pollInterval:",
+      args: [{
+        type: "CGFloat",
+        value: seconds
+      }, {
+        type: "CGFloat",
+        value: interval
+      }]
+    };
+  }
+
+}
+
+module.exports = GREYCondition;

--- a/detox/src/ios/earlgreyapi/GREYConditionDetox.js
+++ b/detox/src/ios/earlgreyapi/GREYConditionDetox.js
@@ -1,0 +1,47 @@
+/**
+
+	This code is generated.
+	For more information see generation/README.md.
+*/
+
+
+function sanitize_greyElementInteraction(value) {
+	return {
+		type: "Invocation",
+		value
+	};
+} 
+class GREYCondition {
+  static detoxConditionForElementMatched(interaction) {
+    if (typeof interaction !== "object") {
+      throw new Error('interaction should be a GREYElementInteraction, but got ' + JSON.stringify(interaction));
+    }
+
+    return {
+      target: {
+        type: "Class",
+        value: "GREYCondition"
+      },
+      method: "detoxConditionForElementMatched:",
+      args: [sanitize_greyElementInteraction(interaction)]
+    };
+  }
+
+  static detoxConditionForNotElementMatched(interaction) {
+    if (typeof interaction !== "object") {
+      throw new Error('interaction should be a GREYElementInteraction, but got ' + JSON.stringify(interaction));
+    }
+
+    return {
+      target: {
+        type: "Class",
+        value: "GREYCondition"
+      },
+      method: "detoxConditionForNotElementMatched:",
+      args: [sanitize_greyElementInteraction(interaction)]
+    };
+  }
+
+}
+
+module.exports = GREYCondition;

--- a/detox/src/ios/earlgreyapi/GREYInteraction.js
+++ b/detox/src/ios/earlgreyapi/GREYInteraction.js
@@ -1,0 +1,146 @@
+/**
+
+	This code is generated.
+	For more information see generation/README.md.
+*/
+
+
+
+class GREYInteraction {
+  /*Indicates that the current interaction should be performed on a UI element contained inside
+another UI element that is uniquely matched by @c rootMatcher.
+
+@param rootMatcher Matcher used to select the container of the element the interaction
+will be performed on.
+
+@return The provided GREYInteraction instance, with an appropriate rootMatcher.
+*/static inRoot(element, rootMatcher) {
+    if (typeof rootMatcher !== "object" || rootMatcher.type !== "Invocation" || typeof rootMatcher.value !== "object" || typeof rootMatcher.value.target !== "object" || rootMatcher.value.target.value !== "GREYMatchers") {
+      throw new Error('rootMatcher should be a GREYMatcher, but got ' + JSON.stringify(rootMatcher));
+    }
+
+    return {
+      target: {
+        type: "Invocation",
+        value: element
+      },
+      method: "inRoot:",
+      args: [rootMatcher]
+    };
+  }
+
+  /*Performs the @c action repeatedly on the the element matching the @c matcher until the element
+to interact with (specified by GREYInteraction::selectElementWithMatcher:) is found or a
+timeout occurs. The search action is only performed when coupled with
+GREYInteraction::performAction:, GREYInteraction::assert:, or
+GREYInteraction::assertWithMatcher: APIs. This API only creates an interaction consisting of
+repeated executions of the search action provided. You need to call an action or assertion
+after this in order to interaction with the element being searched for.
+
+For example, this code will perform an upward scroll of 50 points until an element is found
+and then tap on it:
+@code
+[[[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"elementToFind")]
+usingSearchAction:grey_scrollInDirection(kGREYDirectionUp, 50.0f)
+onElementWithMatcher:grey_accessibilityID(@"ScrollingWindow")]
+performAction:grey_tap()] // This should be separately called for the action.
+@endcode
+
+@param action  The action to be performed on the element.
+@param matcher The matcher that the element matches.
+
+@return The provided GREYInteraction instance, with an appropriate action and matcher.
+*/static usingSearchActionOnElementWithMatcher(element, action, matcher) {
+    if (typeof action !== "object" || action.type !== "Invocation" || typeof action.value !== "object" || typeof action.value.target !== "object" || action.value.target.value !== "GREYActions") {
+      throw new Error('action should be a GREYAction, but got ' + JSON.stringify(action));
+    }
+
+    if (typeof matcher !== "object" || matcher.type !== "Invocation" || typeof matcher.value !== "object" || typeof matcher.value.target !== "object" || matcher.value.target.value !== "GREYMatchers") {
+      throw new Error('matcher should be a GREYMatcher, but got ' + JSON.stringify(matcher));
+    }
+
+    return {
+      target: {
+        type: "Invocation",
+        value: element
+      },
+      method: "usingSearchAction:onElementWithMatcher:",
+      args: [action, matcher]
+    };
+  }
+
+  /*Performs an @c action on the selected UI element.
+
+@param action The action to be performed on the @c element.
+@throws NSException if the action fails.
+
+@return The provided GREYInteraction instance with an appropriate action.
+*/static performAction(element, action) {
+    if (typeof action !== "object" || action.type !== "Invocation" || typeof action.value !== "object" || typeof action.value.target !== "object" || action.value.target.value !== "GREYActions") {
+      throw new Error('action should be a GREYAction, but got ' + JSON.stringify(action));
+    }
+
+    return {
+      target: {
+        type: "Invocation",
+        value: element
+      },
+      method: "performAction:",
+      args: [action]
+    };
+  }
+
+  /*Performs an assertion that evaluates @c matcher on the selected UI element.
+
+@param matcher The matcher to be evaluated on the @c element.
+
+@return The provided GREYInteraction instance with a matcher to be evaluated on an element.
+*/static assertWithMatcher(element, matcher) {
+    if (typeof matcher !== "object" || matcher.type !== "Invocation" || typeof matcher.value !== "object" || typeof matcher.value.target !== "object" || matcher.value.target.value !== "GREYMatchers") {
+      throw new Error('matcher should be a GREYMatcher, but got ' + JSON.stringify(matcher));
+    }
+
+    return {
+      target: {
+        type: "Invocation",
+        value: element
+      },
+      method: "assertWithMatcher:",
+      args: [matcher]
+    };
+  }
+
+  /*In case of multiple matches, selects the element at the specified index. In case of the
+index being over the number of matched elements, it throws an exception. Please make sure
+that this is used after you've created the matcher. For example, in case three elements are
+matched, and you wish to match with the second one, then @c atIndex would be used in this
+manner:
+
+@code
+[[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Generic Matcher")] atIndex:1];
+@endcode
+
+@param index        The zero-indexed position of the element in the list of matched elements
+to be selected.
+@throws NSException if the @c index is more than the number of matched elements.
+
+@return An interaction (assertion or an action) to be performed on the element at the
+specified index in the list of matched elements.
+*/static atIndex(element, index) {
+    if (typeof index !== "number") throw new Error("index should be a number, but got " + (index + (" (" + (typeof index + ")"))));
+    return {
+      target: {
+        type: "Invocation",
+        value: element
+      },
+      method: "atIndex:",
+      args: [{
+        type: "NSInteger",
+        value: index
+      }]
+    };
+  }
+
+}
+
+module.exports = GREYInteraction;

--- a/detox/src/ios/earlgreyapi/GREYMatchers.js
+++ b/detox/src/ios/earlgreyapi/GREYMatchers.js
@@ -60,7 +60,7 @@ function sanitize_uiAccessibilityTraits(value) {
 			default:
 				throw new Error(
 					`Unknown trait '${
-						value[i]
+					value[i]
 					}', see list in https://facebook.github.io/react-native/docs/accessibility.html#accessibilitytraits-ios`
 				);
 		}

--- a/detox/src/ios/expect.js
+++ b/detox/src/ios/expect.js
@@ -12,11 +12,18 @@ const NotExistsMatcher = matchers.NotExistsMatcher;
 const TextMatcher = matchers.TextMatcher;
 const ValueMatcher = matchers.ValueMatcher;
 const GreyActions = require('./earlgreyapi/GREYActions');
+const GreyInteraction = require('./earlgreyapi/GREYInteraction');
+const GreyCondition = require('./earlgreyapi/GREYCondition');
+const GreyConditionDetox = require('./earlgreyapi/GREYConditionDetox');
 
 let invocationManager;
 
 function setInvocationManager(im) {
   invocationManager = im;
+}
+
+function callThunk(element) {
+  return typeof element._call === 'function' ? element._call() : element._call;
 }
 
 //// examples
@@ -41,7 +48,7 @@ detox.invoke.execute(_getInteraction2);
 
 */
 
-class Action {}
+class Action { }
 
 class TapAction extends Action {
   constructor() {
@@ -171,20 +178,15 @@ class Interaction {
 class ActionInteraction extends Interaction {
   constructor(element, action) {
     super();
-    //if (!(element instanceof Element)) throw new Error(`ActionInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
-    //if (!(action instanceof Action)) throw new Error(`ActionInteraction ctor 2nd argument must be a valid Action, got ${typeof action}`);
-    this._call = invoke.call(element._call, 'performAction:', action._call);
-    // TODO: move this.execute() here from the caller
+
+    this._call = GreyInteraction.performAction(callThunk(element), callThunk(action));
   }
 }
 
 class MatcherAssertionInteraction extends Interaction {
   constructor(element, matcher) {
     super();
-    //if (!(element instanceof Element)) throw new Error(`MatcherAssertionInteraction ctor 1st argument must be a valid Element, got ${typeof element}`);
-    //if (!(matcher instanceof Matcher)) throw new Error(`MatcherAssertionInteraction ctor 2nd argument must be a valid Matcher, got ${typeof matcher}`);
-    this._call = invoke.call(element._call, 'assertWithMatcher:', matcher._call);
-    // TODO: move this.execute() here from the caller
+    this._call = GreyInteraction.assertWithMatcher(callThunk(element), callThunk(matcher));
   }
 }
 
@@ -205,11 +207,15 @@ class WaitForInteraction extends Interaction {
   async withTimeout(timeout) {
     if (typeof timeout !== 'number') throw new Error(`WaitForInteraction withTimeout argument must be a number, got ${typeof timeout}`);
     if (timeout < 0) throw new Error('timeout must be larger than 0');
-    let _conditionCall = invoke.call(invoke.IOS.Class('GREYCondition'), 'detoxConditionForElementMatched:', this._element._call);
-    if (this._notCondition) {
-      _conditionCall = invoke.call(invoke.IOS.Class('GREYCondition'), 'detoxConditionForNotElementMatched:', this._element._call);
+
+    let _conditionCall;
+    if (!this._notCondition) {
+      _conditionCall = GreyConditionDetox.detoxConditionForElementMatched(callThunk(this._element));
+    } else {
+      _conditionCall = GreyConditionDetox.detoxConditionForNotElementMatched(callThunk(this._element));
     }
-    this._call = invoke.call(_conditionCall, 'waitWithTimeout:', invoke.IOS.CGFloat(timeout/1000));
+
+    this._call = GreyCondition.waitWithTimeout(_conditionCall, timeout / 1000)
     await this.execute();
   }
   whileElement(searchMatcher) {
@@ -227,10 +233,11 @@ class WaitForActionInteraction extends Interaction {
     this._originalMatcher = matcher;
     this._searchMatcher = searchMatcher;
   }
+
   async _execute(searchAction) {
-    //if (!searchAction instanceof Action) throw new Error(`WaitForActionInteraction _execute argument must be a valid Action, got ${typeof searchAction}`);
-    const _interactionCall = invoke.call(this._element._call, 'usingSearchAction:onElementWithMatcher:', searchAction._call, this._searchMatcher._call);
-    this._call = invoke.call(_interactionCall, 'assertWithMatcher:', this._originalMatcher._call);
+    const _interactionCall = GreyInteraction.usingSearchActionOnElementWithMatcher(callThunk(this._element), callThunk(searchAction), callThunk(this._searchMatcher));
+
+    this._call = GreyInteraction.assertWithMatcher(_interactionCall, callThunk(this._originalMatcher));
     await this.execute();
   }
   async scroll(amount, direction = 'down') {
@@ -296,7 +303,7 @@ class Element {
   }
 }
 
-class Expect {}
+class Expect { }
 
 class ExpectElement extends Expect {
   constructor(element) {
@@ -329,7 +336,7 @@ class ExpectElement extends Expect {
   }
 }
 
-class WaitFor {}
+class WaitFor { }
 
 class WaitForElement extends WaitFor {
   constructor(element) {

--- a/generation/__tests__/global-functions.js
+++ b/generation/__tests__/global-functions.js
@@ -136,6 +136,16 @@ describe("globals", () => {
 				_call: "I am a call"
 			};
 			expect(globals.sanitize_matcher(matcherLikeObj)).toBe("I am a call");
+
+		});
+	});
+
+	describe("sanitize_greyElementInteraction", () => {
+		it("should wrap the argument in an invocation", () => {
+			expect(globals.sanitize_greyElementInteraction("Foo")).toEqual({
+				type: "Invocation",
+				value: "Foo"
+			});
 		});
 	});
 });

--- a/generation/__tests__/global-functions.js
+++ b/generation/__tests__/global-functions.js
@@ -136,7 +136,6 @@ describe("globals", () => {
 				_call: "I am a call"
 			};
 			expect(globals.sanitize_matcher(matcherLikeObj)).toBe("I am a call");
-
 		});
 	});
 

--- a/generation/__tests__/ios.js
+++ b/generation/__tests__/ios.js
@@ -333,6 +333,28 @@ describe("iOS generation", () => {
 		});
 	});
 
+	describe("instance methods", () => {
+		it("should expose the instance methods as static ones", () => {
+			expect(ExampleClass.performAction).toBeInstanceOf(Function);
+		});
+
+		it("should have the first arg set as invocation", () => {
+			expect(ExampleClass.performAction("MyClass", "Foo")).toEqual({
+				target: {
+					type: "Invocation",
+					value: "MyClass"
+				},
+				method: "performAction:",
+				args: [
+					{
+						type: "NSString",
+						value: "Foo"
+					}
+				]
+			});
+		});
+	});
+
 	afterAll(() => {
 		// Clean up
 		remove.removeSync("./__tests__/generated-ios");

--- a/generation/adapters/ios.js
+++ b/generation/adapters/ios.js
@@ -6,7 +6,9 @@ const {
 	isBoolean,
 	isPoint,
 	isOneOf,
+	isGreyAction,
 	isGreyMatcher,
+	isGreyElementInteraction,
 	isArray
 } = require("../core/type-checks");
 const { callGlobal } = require("../helpers");
@@ -24,7 +26,9 @@ const typeCheckInterfaces = {
 	GREYDirection: isOneOf(["left", "right", "up", "down"]),
 	GREYContentEdge: isOneOf(["left", "right", "top", "bottom"]),
 	GREYPinchDirection: isOneOf(["outward", "inward"]),
+	"id<GREYAction>": isGreyAction,
 	"id<GREYMatcher>": isGreyMatcher,
+	"GREYElementInteraction*": isGreyElementInteraction,
 	UIAccessibilityTraits: isArray
 };
 
@@ -43,6 +47,11 @@ const contentSanitizersForType = {
 		type: "NSInteger",
 		name: "sanitize_uiAccessibilityTraits",
 		value: callGlobal("sanitize_uiAccessibilityTraits")
+	},
+	"GREYElementInteraction*": {
+		type: "Invocation",
+		name: "sanitize_greyElementInteraction",
+		value: callGlobal("sanitize_greyElementInteraction")
 	}
 };
 
@@ -55,16 +64,21 @@ module.exports = generator({
 		"CGPoint",
 		"GREYContentEdge",
 		"GREYDirection",
+		"GREYElementInteraction*",
 		"NSInteger",
 		"NSString *",
 		"NSString",
 		"NSUInteger",
+		"id<GREYAction>",
 		"id<GREYMatcher>",
+		"CFTimeInterval",
 		"UIAccessibilityTraits"
 	],
 	renameTypesMap: {
 		NSUInteger: "NSInteger",
-		"NSString *": "NSString"
+		"NSString *": "NSString",
+		CFTimeInterval: "CGFloat"
 	},
-	classValue: ({ name }) => name
+	classValue: ({ name }) => name,
+	blacklistedFunctionNames: ["init"]
 });

--- a/generation/core/generator.js
+++ b/generation/core/generator.js
@@ -7,13 +7,14 @@ const fs = require("fs");
 
 const { methodNameToSnakeCase } = require("../helpers");
 let globalFunctionUsage = {};
-module.exports = function({
+module.exports = function getGenerator({
 	typeCheckInterfaces,
 	renameTypesMap,
 	supportedTypes,
 	classValue,
 	contentSanitizersForFunction,
-	contentSanitizersForType
+	contentSanitizersForType,
+	blacklistedFunctionNames = []
 }) {
 	/**
 	 * the input provided by objective-c-parser looks like this:
@@ -51,9 +52,16 @@ module.exports = function({
 			t.classBody(
 				json.methods
 					.filter(filterMethodsWithUnsupportedParams)
+					.filter(filterMethodsWithBlacklistedName)
 					.map(createMethod.bind(null, json))
 			),
 			[]
+		);
+	}
+
+	function filterMethodsWithBlacklistedName({ name }) {
+		return !blacklistedFunctionNames.find(
+			blacklisted => name.indexOf(blacklisted) !== -1
 		);
 	}
 
@@ -81,13 +89,19 @@ module.exports = function({
 	}
 
 	function createMethod(classJson, json) {
+		const args = json.args.map(({ name }) => t.identifier(name));
+
+		if (!json.static) {
+			args.unshift(t.identifier("element"));
+		}
+
 		const m = t.classMethod(
 			"method",
 			t.identifier(methodNameToSnakeCase(json.name)),
-			json.args.map(({ name }) => t.identifier(name)),
+			args,
 			t.blockStatement(createMethodBody(classJson, json)),
 			false,
-			json.static
+			true
 		);
 
 		if (json.comment) {
@@ -126,7 +140,10 @@ module.exports = function({
 			[]
 		);
 		const typeChecks = allTypeChecks.filter(check => typeof check === "object");
-		const returnStatement = createReturnStatement(classJson, sanitizedJson);
+		const returnStatement = createReturnStatement(
+			classJson,
+			sanitizedJson
+		);
 		return [...typeChecks, returnStatement];
 	}
 
@@ -154,6 +171,7 @@ module.exports = function({
 
 		return t.identifier(json.name);
 	}
+
 	function addArgumentTypeSanitizer(json) {
 		if (contentSanitizersForType[json.type]) {
 			return contentSanitizersForType[json.type].type;
@@ -163,24 +181,31 @@ module.exports = function({
 	}
 
 	// These types need no wrapping with {type: ..., value: }
-	const plainArgumentTypes = ["id<GREYMatcher>", "String"];
+	const plainArgumentTypes = [
+		"id<GREYAction>",
+		"id<GREYMatcher>",
+		"GREYElementInteraction*",
+		"String"
+	];
+
 	function shouldBeWrapped({ type }) {
 		return !plainArgumentTypes.includes(type);
 	}
+
 	function createReturnStatement(classJson, json) {
 		const args = json.args.map(
 			arg =>
 				shouldBeWrapped(arg)
 					? t.objectExpression([
-							t.objectProperty(
-								t.identifier("type"),
-								t.stringLiteral(addArgumentTypeSanitizer(arg))
-							),
-							t.objectProperty(
-								t.identifier("value"),
-								addArgumentContentSanitizerCall(arg, json.name)
-							)
-					  ])
+						t.objectProperty(
+							t.identifier("type"),
+							t.stringLiteral(addArgumentTypeSanitizer(arg))
+						),
+						t.objectProperty(
+							t.identifier("value"),
+							addArgumentContentSanitizerCall(arg, json.name)
+						)
+					])
 					: addArgumentContentSanitizerCall(arg, json.name)
 		);
 
@@ -189,10 +214,12 @@ module.exports = function({
 				t.objectProperty(
 					t.identifier("target"),
 					t.objectExpression([
-						t.objectProperty(t.identifier("type"), t.stringLiteral("Class")),
+						t.objectProperty(t.identifier("type"), t.stringLiteral(json.static ? "Class" : "Invocation")),
 						t.objectProperty(
 							t.identifier("value"),
-							t.stringLiteral(classValue(classJson))
+							json.static
+								? t.stringLiteral(classValue(classJson))
+								: t.identifier("element")
 						)
 					])
 				),
@@ -212,10 +239,10 @@ module.exports = function({
 		const isListOfChecks = typeCheckCreator instanceof Array;
 		return isListOfChecks
 			? typeCheckCreator.map(singleCheck => singleCheck(json))
-			: typeCheckCreator(json);
+			: (typeof typeCheckCreator === "function" ? typeCheckCreator(json) : t.emptyStatement());
 	}
 
-	return function(files) {
+	return function generator(files) {
 		Object.entries(files).forEach(([inputFile, outputFile]) => {
 			globalFunctionUsage = {};
 			const input = fs.readFileSync(inputFile, "utf8");
@@ -224,6 +251,12 @@ module.exports = function({
 			const json = isObjectiveC
 				? objectiveCParser(input)
 				: javaMethodParser(input);
+
+			// set default name
+			if (!json.name) {
+				const pathFragments = outputFile.split("/");
+				json.name = pathFragments[pathFragments.length - 1].replace(".js", "");
+			}
 			const ast = t.program([createClass(json), createExport(json)]);
 			const output = generate(ast);
 

--- a/generation/core/generator.js
+++ b/generation/core/generator.js
@@ -140,10 +140,7 @@ module.exports = function getGenerator({
 			[]
 		);
 		const typeChecks = allTypeChecks.filter(check => typeof check === "object");
-		const returnStatement = createReturnStatement(
-			classJson,
-			sanitizedJson
-		);
+		const returnStatement = createReturnStatement(classJson, sanitizedJson);
 		return [...typeChecks, returnStatement];
 	}
 
@@ -197,15 +194,15 @@ module.exports = function getGenerator({
 			arg =>
 				shouldBeWrapped(arg)
 					? t.objectExpression([
-						t.objectProperty(
-							t.identifier("type"),
-							t.stringLiteral(addArgumentTypeSanitizer(arg))
-						),
-						t.objectProperty(
-							t.identifier("value"),
-							addArgumentContentSanitizerCall(arg, json.name)
-						)
-					])
+							t.objectProperty(
+								t.identifier("type"),
+								t.stringLiteral(addArgumentTypeSanitizer(arg))
+							),
+							t.objectProperty(
+								t.identifier("value"),
+								addArgumentContentSanitizerCall(arg, json.name)
+							)
+					  ])
 					: addArgumentContentSanitizerCall(arg, json.name)
 		);
 
@@ -214,7 +211,10 @@ module.exports = function getGenerator({
 				t.objectProperty(
 					t.identifier("target"),
 					t.objectExpression([
-						t.objectProperty(t.identifier("type"), t.stringLiteral(json.static ? "Class" : "Invocation")),
+						t.objectProperty(
+							t.identifier("type"),
+							t.stringLiteral(json.static ? "Class" : "Invocation")
+						),
 						t.objectProperty(
 							t.identifier("value"),
 							json.static
@@ -239,7 +239,9 @@ module.exports = function getGenerator({
 		const isListOfChecks = typeCheckCreator instanceof Array;
 		return isListOfChecks
 			? typeCheckCreator.map(singleCheck => singleCheck(json))
-			: (typeof typeCheckCreator === "function" ? typeCheckCreator(json) : t.emptyStatement());
+			: typeof typeCheckCreator === "function"
+				? typeCheckCreator(json)
+				: t.emptyStatement();
 	}
 
 	return function generator(files) {

--- a/generation/core/global-functions.js
+++ b/generation/core/global-functions.js
@@ -127,7 +127,7 @@ function sanitize_uiAccessibilityTraits(value) {
 			default:
 				throw new Error(
 					`Unknown trait '${
-						value[i]
+					value[i]
 					}', see list in https://facebook.github.io/react-native/docs/accessibility.html#accessibilitytraits-ios`
 				);
 		}
@@ -142,11 +142,20 @@ function sanitize_matcher(matcher) {
 	return originalMatcher.type ? originalMatcher.value : originalMatcher;
 } // END sanitize_matcher
 
+
+function sanitize_greyElementInteraction(value) {
+	return {
+		type: "Invocation",
+		value
+	};
+} // END sanitize_greyElementInteraction
+
 module.exports = {
 	sanitize_greyDirection,
 	sanitize_greyContentEdge,
 	sanitize_uiAccessibilityTraits,
 	sanitize_android_direction,
 	sanitize_android_edge,
-	sanitize_matcher
+	sanitize_matcher,
+	sanitize_greyElementInteraction
 };

--- a/generation/core/global-functions.js
+++ b/generation/core/global-functions.js
@@ -127,7 +127,7 @@ function sanitize_uiAccessibilityTraits(value) {
 			default:
 				throw new Error(
 					`Unknown trait '${
-					value[i]
+						value[i]
 					}', see list in https://facebook.github.io/react-native/docs/accessibility.html#accessibilitytraits-ios`
 				);
 		}
@@ -141,7 +141,6 @@ function sanitize_matcher(matcher) {
 		typeof matcher._call === "function" ? matcher._call() : matcher._call;
 	return originalMatcher.type ? originalMatcher.value : originalMatcher;
 } // END sanitize_matcher
-
 
 function sanitize_greyElementInteraction(value) {
 	return {

--- a/generation/core/type-checks.js
+++ b/generation/core/type-checks.js
@@ -26,8 +26,33 @@ const isGreyMatcher = ({ name }) =>
     throw new Error('${name} should be a GREYMatcher, but got ' + JSON.stringify(ARG));
   }
 `)({
-		ARG: t.identifier(name)
-	});
+			ARG: t.identifier(name)
+		});
+const isGreyAction = ({ name }) =>
+	template(`
+  if (
+    typeof ARG !== "object" || 
+    ARG.type !== "Invocation" ||
+    typeof ARG.value !== "object" || 
+    typeof ARG.value.target !== "object" ||
+    ARG.value.target.value !== "GREYActions"
+  ) {
+    throw new Error('${name} should be a GREYAction, but got ' + JSON.stringify(ARG));
+    }
+`)({
+			ARG: t.identifier(name)
+		});
+const isGreyElementInteraction = ({ name }) =>
+	template(`
+  if (
+    typeof ARG !== "object"
+  ) {
+		// TODO: This currently only checks for object, we should add more fine grained checks here
+    throw new Error('${name} should be a GREYElementInteraction, but got ' + JSON.stringify(ARG));
+  }
+`)({
+			ARG: t.identifier(name)
+		});
 const isArray = ({ name }) =>
 	template(`
 if (
@@ -37,8 +62,8 @@ if (
     throw new Error('${name} must be an array, got ' + typeof ARG);
   }
 `)({
-		ARG: t.identifier(name)
-	});
+			ARG: t.identifier(name)
+		});
 
 const isOfClass = className => ({ name }) =>
 	template(`
@@ -53,8 +78,8 @@ const isOfClass = className => ({ name }) =>
 		throw new Error('${name} should be an instance of ${className}, got "' + ARG + '", it appears that ' + additionalErrorInfo);
 	}
 	`)({
-		ARG: t.identifier(name)
-	});
+			ARG: t.identifier(name)
+		});
 
 module.exports = {
 	isNumber,
@@ -62,7 +87,9 @@ module.exports = {
 	isBoolean,
 	isPoint,
 	isOneOf,
+	isGreyAction,
 	isGreyMatcher,
 	isArray,
-	isOfClass
+	isOfClass,
+	isGreyElementInteraction,
 };

--- a/generation/core/type-checks.js
+++ b/generation/core/type-checks.js
@@ -14,8 +14,8 @@ const isPoint = [
 	generateTypeCheck("number", { selector: "y" })
 ];
 const isOneOf = generateIsOneOfCheck;
-const isGreyMatcher = ({ name }) =>
-	template(`
+function isGreyMatcher({ name }) {
+	return template(`
   if (
     typeof ARG !== "object" || 
     ARG.type !== "Invocation" ||
@@ -26,10 +26,12 @@ const isGreyMatcher = ({ name }) =>
     throw new Error('${name} should be a GREYMatcher, but got ' + JSON.stringify(ARG));
   }
 `)({
-			ARG: t.identifier(name)
-		});
-const isGreyAction = ({ name }) =>
-	template(`
+		ARG: t.identifier(name)
+	});
+}
+
+function isGreyAction({ name }) {
+	return template(`
   if (
     typeof ARG !== "object" || 
     ARG.type !== "Invocation" ||
@@ -40,10 +42,12 @@ const isGreyAction = ({ name }) =>
     throw new Error('${name} should be a GREYAction, but got ' + JSON.stringify(ARG));
     }
 `)({
-			ARG: t.identifier(name)
-		});
-const isGreyElementInteraction = ({ name }) =>
-	template(`
+		ARG: t.identifier(name)
+	});
+}
+
+function isGreyElementInteraction({ name }) {
+	return template(`
   if (
     typeof ARG !== "object"
   ) {
@@ -51,10 +55,11 @@ const isGreyElementInteraction = ({ name }) =>
     throw new Error('${name} should be a GREYElementInteraction, but got ' + JSON.stringify(ARG));
   }
 `)({
-			ARG: t.identifier(name)
-		});
-const isArray = ({ name }) =>
-	template(`
+		ARG: t.identifier(name)
+	});
+}
+function isArray({ name }) {
+	return template(`
 if (
   (typeof ARG !== 'object') || 
   (!ARG instanceof Array)
@@ -62,11 +67,13 @@ if (
     throw new Error('${name} must be an array, got ' + typeof ARG);
   }
 `)({
-			ARG: t.identifier(name)
-		});
+		ARG: t.identifier(name)
+	});
+}
 
-const isOfClass = className => ({ name }) =>
-	template(`
+function isOfClass(className) {
+	return ({ name }) =>
+		template(`
 	if (
 		typeof ARG !== 'object' ||
 		typeof ARG.constructor !== 'function' ||
@@ -80,6 +87,7 @@ const isOfClass = className => ({ name }) =>
 	`)({
 			ARG: t.identifier(name)
 		});
+}
 
 module.exports = {
 	isNumber,
@@ -91,5 +99,5 @@ module.exports = {
 	isGreyMatcher,
 	isArray,
 	isOfClass,
-	isGreyElementInteraction,
+	isGreyElementInteraction
 };

--- a/generation/fixtures/example.h
+++ b/generation/fixtures/example.h
@@ -62,3 +62,9 @@
 + (id<GREYAction>)actionWithUnknownType:(WTFType *)wat;
 + (id<GREYAction>)actionWithKnown:(NSUInteger)iknowdis andUnknownType:(WTFTypalike *)wat;
 + (id<GREYMatcher>)detoxMatcherForBoth:(id<GREYMatcher>)firstMatcher andAncestorMatcher:(id<GREYMatcher>)ancestorMatcher;
+
+
+// This method is an instance method
+// For us this means that we don't set the class type, but let it be set from the outside
+// This is an assumption based on our current experience with EarlGrey, we might need to rework this at some point
+- (instancetype)performAction:(NSString *)action;

--- a/generation/index.js
+++ b/generation/index.js
@@ -6,7 +6,13 @@ const iosFiles = {
 	"../detox/ios/Detox/GREYMatchers+Detox.h":
 		"../detox/src/ios/earlgreyapi/GREYMatchers+Detox.js",
 	"../detox/ios/EarlGrey/EarlGrey/Matcher/GREYMatchers.h":
-		"../detox/src/ios/earlgreyapi/GREYMatchers.js"
+		"../detox/src/ios/earlgreyapi/GREYMatchers.js",
+	"../detox/ios/EarlGrey/EarlGrey/Core/GREYInteraction.h":
+		"../detox/src/ios/earlgreyapi/GREYInteraction.js",
+	"../detox/ios/Detox/GREYCondition+Detox.h":
+		"../detox/src/ios/earlgreyapi/GREYConditionDetox.js",
+	"../detox/ios/EarlGrey/EarlGrey/Synchronization/GREYCondition.h":
+		"../detox/src/ios/earlgreyapi/GREYCondition.js"
 };
 
 generateIOSAdapters(iosFiles);

--- a/generation/package.json
+++ b/generation/package.json
@@ -1,51 +1,46 @@
 {
-  "name": "generation",
-  "version": "0.0.1",
-  "description": "Generate wrapper code for native dependencies",
-  "main": "index.js",
-  "private": true,
-  "scripts": {
-    "build": "./index.js",
-    "test": "jest",
-    "precommit": "lint-staged",
-    "format": "prettier ./**/*.{js,json,css,md} --write"
-  },
-  "author": "DanielMSchmidt <danielmschmidt92@gmail.com>",
-  "license": "MIT",
-  "lint-staged": {
-    "*.{js,json,css,md}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  "dependencies": {
-    "babel-generate-guard-clauses": "2.0.5",
-    "babel-generator": "6.26.1",
-    "babel-types": "6.25.0",
-    "download-file-sync": "1.0.4",
-    "babel-template": "6.26.0",
-    "objective-c-parser": "1.2.2",
-    "java-method-parser": "0.4.5",
-    "remove": "0.1.5"
-  },
-  "devDependencies": {
-    "jest": "^20.0.4",
-    "lint-staged": "^6.0.0",
-    "prettier": "^1.8.2"
-  },
-  "jest": {
-    "coveragePathIgnorePatterns": [
-      "<rootDir>/index.js"
-    ],
-    "resetMocks": true,
-    "resetModules": true,
-    "coverageThreshold": {
-      "global": {
-        "statements": 100,
-        "branches": 100,
-        "functions": 100,
-        "lines": 100
-      }
-    }
-  }
+	"name": "generation",
+	"version": "0.0.1",
+	"description": "Generate wrapper code for native dependencies",
+	"main": "index.js",
+	"private": true,
+	"scripts": {
+		"build": "./index.js",
+		"test": "jest",
+		"precommit": "lint-staged",
+		"format": "prettier ./**/*.{js,json,css,md} --write"
+	},
+	"author": "DanielMSchmidt <danielmschmidt92@gmail.com>",
+	"license": "MIT",
+	"lint-staged": {
+		"*.{js,json,css,md}": ["prettier --write", "git add"]
+	},
+	"dependencies": {
+		"babel-generate-guard-clauses": "2.0.5",
+		"babel-generator": "6.26.1",
+		"babel-types": "6.25.0",
+		"download-file-sync": "1.0.4",
+		"babel-template": "6.26.0",
+		"objective-c-parser": "1.2.2",
+		"java-method-parser": "0.4.5",
+		"remove": "0.1.5"
+	},
+	"devDependencies": {
+		"jest": "^20.0.4",
+		"lint-staged": "^6.0.0",
+		"prettier": "^1.8.2"
+	},
+	"jest": {
+		"coveragePathIgnorePatterns": ["<rootDir>/index.js"],
+		"resetMocks": true,
+		"resetModules": true,
+		"coverageThreshold": {
+			"global": {
+				"statements": 100,
+				"branches": 100,
+				"functions": 100,
+				"lines": 100
+			}
+		}
+	}
 }

--- a/generation/package.json
+++ b/generation/package.json
@@ -18,16 +18,20 @@
       "git add"
     ]
   },
+  "dependencies": {
+    "babel-generate-guard-clauses": "2.0.5",
+    "babel-generator": "6.26.1",
+    "babel-types": "6.25.0",
+    "download-file-sync": "1.0.4",
+    "babel-template": "6.26.0",
+    "objective-c-parser": "1.2.2",
+    "java-method-parser": "0.4.5",
+    "remove": "0.1.5"
+  },
   "devDependencies": {
-    "babel-generator": "^6.25.0",
-    "babel-types": "^6.25.0",
-    "download-file-sync": "^1.0.4",
     "jest": "^20.0.4",
-    "lerna": "2.0.0-rc.4",
     "lint-staged": "^6.0.0",
-    "objective-c-parser": "1.1.0",
-    "prettier": "^1.8.2",
-    "remove": "^0.1.5"
+    "prettier": "^1.8.2"
   },
   "jest": {
     "coveragePathIgnorePatterns": [
@@ -43,10 +47,5 @@
         "lines": 100
       }
     }
-  },
-  "dependencies": {
-    "babel-generate-guard-clauses": "^2.0.0",
-    "babel-template": "^6.26.0",
-    "java-method-parser": "^0.4.5"
   }
 }


### PR DESCRIPTION
This PR moves most iOS calls over to generated code (`detox_selectElementWithMatcher` is the only missing one and it's a bit of a special case.