### PR TITLE
Clean up after build_framework

### DIFF
--- a/detox/scripts/build_framework.ios.sh
+++ b/detox/scripts/build_framework.ios.sh
@@ -20,6 +20,7 @@ function buildFramework {
   xcodebuild build -project "${detoxSourcePath}"/Detox.xcodeproj -scheme DetoxFramework -configuration Release -derivedDataPath "${detoxFrameworkDirPath}"/DetoxBuild BUILD_DIR="${detoxFrameworkDirPath}"/DetoxBuild/Build/Products &> "${detoxFrameworkDirPath}"/detox_ios.log
   mv "${detoxFrameworkDirPath}"/DetoxBuild/Build/Products/Release-universal/Detox.framework "${detoxFrameworkDirPath}"
   rm -fr "${detoxFrameworkDirPath}"/DetoxBuild
+  rm -fr "${detoxSourcePath}"
 
   echo "Done"
 }


### PR DESCRIPTION
Hi!

When building `Detox.framework`, the `ios_src` folder, which contains a Detox.xcodeproj file, is not deleted. Because of this, running `react-native link` will link this project and all its dependencies to the react-native app leading to code signing issues.

The following error occurs when Xcode tries to build SocketRocket : 

```
2018-02-20T10:11:02.9468320Z === BUILD TARGET TestChat OF PROJECT SocketRocket WITH CONFIGURATION Release ===
2018-02-20T10:11:02.9477620Z 
2018-02-20T10:11:02.9494720Z Check dependencies
2018-02-20T10:11:02.9526730Z Code Signing Warning: "TestChat" isn't code signed but requires entitlements. It is not possible to add entitlements to a binary without signing it.
2018-02-20T10:11:02.9576440Z Code Signing Error: Code signing is required for product type 'Application' in SDK 'iOS 11.1'
2018-02-20T10:11:03.0123850Z Code Signing Error: Code signing is required for product type 'Application' in SDK 'iOS 11.1'
```

This PR solves this issue by deleting the folder once the framework is built.
