### PR TITLE
[WIP] Fixing Android support for demo-react-native example project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,4 @@ examples/demo-native-ios/ModuleCache
 yarn.lock
 detox/ios_src
 package-lock.json
+**/debug.keystore

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -42,7 +42,7 @@
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/app-release.apk",
-        "build": "pushd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && popd",
+        "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
         "name": "Nexus_5X_API_26"
       }

--- a/examples/demo-react-native/android/app/build.gradle
+++ b/examples/demo-react-native/android/app/build.gradle
@@ -4,15 +4,18 @@ import com.android.build.OutputFile
 apply from: "../../node_modules/react-native/react.gradle"
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 25
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "com.detox.rn.example"
         minSdkVersion 18
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+        testBuildType System.getProperty('testBuildType', 'debug')  //this will later be used to control the test apk build type
+        missingDimensionStrategy "minReactNative", "minReactNative46" //read note
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
@@ -55,16 +58,33 @@ android {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'
     }
+
+    signingConfigs {
+        release {
+            storeFile file('../debug.keystore')
+            storePassword 'android'
+            keyAlias 'debug'
+            keyPassword 'android'
+        }
+    }
+
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
+        }
+    }
 }
 
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.android.support:appcompat-v7:25.4.0"
     compile "com.facebook.react:react-native:+"  // From node_modules
 
-    androidTestCompile(project(path: ":detox", configuration: "oldOkhttpDebug"), {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+
+    androidTestImplementation(project(path: ":detox"))
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
 }
 
 // Run this once to be able to run the application with BUCK

--- a/examples/demo-react-native/android/build.gradle
+++ b/examples/demo-react-native/android/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.palantir:jacoco-coverage:0.4.0'
     }
 }

--- a/examples/demo-react-native/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/demo-react-native/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -6,8 +6,8 @@
     "start": "react-native start"
   },
   "dependencies": {
-    "react": "16.0.0-alpha.6",
-    "react-native": "0.44.0"
+    "react": "16.0.0",
+    "react-native": "0.52.0"
   },
   "devDependencies": {
     "mocha": "^4.0.1",
@@ -32,15 +32,15 @@
       },
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/app-debug.apk",
-        "build": "pushd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && popd",
+        "build": "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
         "name": "Nexus_5X_API_24_-_GPlay"
       },
       "android.emu.release": {
-        "binaryPath": "android/app/build/outputs/apk/app-release.apk",
-        "build": "pushd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && popd",
+        "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
+        "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
-        "name": "Nexus_5X_API_24_-_GPlay"
+        "name": "Nexus_5X_API_25_x86"
       }
   
     }

--- a/examples/demo-react-native/rn-cli.config.js
+++ b/examples/demo-react-native/rn-cli.config.js
@@ -1,7 +1,4 @@
-const blacklist = require('react-native/packager/blacklist');
+//const blacklist = require('react-native/packager/blacklist');
 
 module.exports = {
-  getBlacklistRE: () => blacklist([
-    /test\/.*/,
-  ]),
 };


### PR DESCRIPTION
Having problems with running Android tests on Travis CI, we tried to get any of the example projects, but without luck. This PR aims to update `demo-react-native` project to run Android tests.

Submitter version works, but requires some cleanups.