### PR TITLE
fix typo

### DIFF
--- a/detox/local-cli/detox-build.js
+++ b/detox/local-cli/detox-build.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const program = require('commander');
 const path = require('path');
 const cp = require('child_process');
-program.description(`[convince method] run the command defined in 'configuration.build'`)
+program.description(`[convenience method] run the command defined in 'configuration.build'`)
        .option('-c, --configuration [device configuration]', 'Select a device configuration from your defined configurations,'
                                                              + 'if not supplied, and there\'s only one configuration, detox will default to it')
   .parse(process.argv);

--- a/detox/local-cli/detox.js
+++ b/detox/local-cli/detox.js
@@ -5,7 +5,7 @@ const program = require('commander');
 program
   .arguments('<process>')
   .command('test', 'Initiating your test suite')
-  .command('build', `[convince method] Run the command defined in 'configuration.build'`)
+  .command('build', `[convenience method] Run the command defined in 'configuration.build'`)
   .command('run-server', 'Starts a standalone detox server')
   .command('init', 'Create initial e2e tests folder')
   .command('clean-framework-cache', `Delete all compiled framework binaries from ~/Library/Detox, they will be rebuilt on 'npm install' or when running 'build-framework-cache'`)


### PR DESCRIPTION
I noticed a typo in the `detox -h` command output. This fixes it.