### PR TITLE
Support spaces in iOS app name

### DIFF
--- a/detox/src/devices/AppleSimUtils.js
+++ b/detox/src/devices/AppleSimUtils.js
@@ -70,7 +70,7 @@ class AppleSimUtils {
       trying: `Installing ${absPath}...`,
       successful: `${absPath} installed`
     };
-    await this._execSimctl({ cmd: `install ${udid} ${absPath}`, statusLogs });
+    await this._execSimctl({ cmd: `install ${udid} "${absPath}"`, statusLogs });
   }
 
   async uninstall(udid, bundleId) {

--- a/detox/src/devices/AppleSimUtils.test.js
+++ b/detox/src/devices/AppleSimUtils.test.js
@@ -250,7 +250,7 @@ describe('AppleSimUtils', () => {
       await uut.install('udid', 'somePath');
       expect(exec.execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
       expect(exec.execWithRetriesAndLogs).toHaveBeenCalledWith(
-        `/usr/bin/xcrun simctl install udid somePath`,
+        `/usr/bin/xcrun simctl install udid "somePath"`,
         undefined,
         expect.anything(),
         1);

--- a/detox/src/devices/SimulatorDriver.js
+++ b/detox/src/devices/SimulatorDriver.js
@@ -18,7 +18,7 @@ class SimulatorDriver extends IosDriver {
     const detoxFrameworkPath = await environment.getFrameworkPath();
 
     if (!fs.existsSync(detoxFrameworkPath)) {
-      throw new Error(`${detoxFrameworkPath} could not be found, this means either you changed a version of Xcode or Detox postinstall script was unsuccessful. 
+      throw new Error(`${detoxFrameworkPath} could not be found, this means either you changed a version of Xcode or Detox postinstall script was unsuccessful.
       To attempt a fix try running 'detox clean-framework-cache && detox build-framework-cache'`);
     }
   }
@@ -31,7 +31,7 @@ class SimulatorDriver extends IosDriver {
 
   async getBundleIdFromBinary(appPath) {
     try {
-      const result = await exec(`/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" ${path.join(appPath, 'Info.plist')}`);
+      const result = await exec(`/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" "${path.join(appPath, 'Info.plist')}"`);
       const bundleId = _.trim(result.stdout);
       if (_.isEmpty(bundleId)) {
         throw new Error();


### PR DESCRIPTION
Ran into some issues getting detox to work on the first project I used it with. This allow apps with spaces in the name to run correctly.