### PR TITLE
fix: post install script failure on windows

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -27,7 +27,7 @@
     "test": "npm run unit",
     "unit:watch": "jest --watch",
     "prepublish": "npm run build",
-    "postinstall": "scripts/postinstall.sh"
+    "postinstall": "node scripts/postinstall.js"
   },
   "devDependencies": {
     "eslint": "^4.11.0",

--- a/detox/scripts/postinstall.js
+++ b/detox/scripts/postinstall.js
@@ -1,0 +1,7 @@
+const { platform } = require('os');
+const { exec } = require('child_process');
+const { dirname } = require('path');
+
+if (platform() === 'darwin') {
+    exec(`${dirname(process.argv[1])}/build_framework.ios.sh`, console.log);
+}

--- a/detox/scripts/postinstall.sh
+++ b/detox/scripts/postinstall.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -e
-
-if [ `uname` == "Darwin" ]; then
-  source "$(dirname ${0})/build_framework.ios.sh"
-fi


### PR DESCRIPTION
To allow developers to `npm i` a project that has detox as a dependency on Windows we changed the post install script from a bash script to js script and run using node.