### PR TITLE
Android: Support RN50-51 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       os: osx
       osx_image: xcode9.2
       env:
-        - REACT_NATIVE_VERSION=0.49.3
+        - REACT_NATIVE_VERSION=0.51.1
       install:
       - ./scripts/install.ios.sh
       script:
@@ -25,7 +25,7 @@ matrix:
       os: linux
       jdk: oraclejdk8
       env:
-        - REACT_NATIVE_VERSION=0.49.3
+        - REACT_NATIVE_VERSION=0.51.1
       android:
         components:
           - build-tools-27.0.2
@@ -44,7 +44,7 @@ matrix:
       os: osx
       osx_image: xcode9
       env:
-        - REACT_NATIVE_VERSION=0.49.3
+        - REACT_NATIVE_VERSION=0.51.1
       install:
       - ./scripts/install.ios.sh
       script:

--- a/detox/android/detox/src/main/java/com/wix/detox/DetoxManager.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/DetoxManager.java
@@ -67,7 +67,7 @@ class DetoxManager implements WebSocketClient.ActionHandler {
     void start() {
         if (detoxServerUrl != null && detoxSessionId != null) {
             if (ReactNativeSupport.isReactNativeApp()) {
-                ReactNativeSupport.waitForReactNativeLoad(reactNativeHostHolder);
+                ReactNativeCompat.waitForReactNativeLoad(reactNativeHostHolder);
             }
 
             wsClient = new WebSocketClient(this);
@@ -124,7 +124,6 @@ class DetoxManager implements WebSocketClient.ActionHandler {
                         }
                         break;
                     case "isReady":
-                        // It's always ready, because reload, waitForRn are both synchronous.
                         wsClient.sendAction("ready", Collections.emptyMap(), messageId);
                         break;
                     case "cleanup":

--- a/detox/android/detox/src/main/java/com/wix/detox/ReactNativeCompat.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/ReactNativeCompat.java
@@ -1,0 +1,36 @@
+package com.wix.detox;
+
+import org.joor.Reflect;
+
+import java.util.Map;
+
+public class ReactNativeCompat {
+    static Map<String, Object> VERSION;
+
+    static {
+        try {
+            Class reactNativeVersion = Class.forName("com.facebook.react.modules.systeminfo.ReactNativeVersion");
+            VERSION = Reflect.on(reactNativeVersion).field("VERSION").get();
+        } catch (ClassNotFoundException e) {
+        }
+
+    }
+
+    public static int getMinor() {
+        return (Integer) VERSION.get("minor");
+    }
+
+    public static void waitForReactNativeLoad(Object reactNativeHostHolder) {
+        if (getMinor() >= 50) {
+            ReactNativeSupport.waitForReactNativeLoad(reactNativeHostHolder);
+            try {
+                //TODO- Temp hack to make Detox usable for RN>=50 till we find a better sync solution.
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        } else {
+            ReactNativeSupport.waitForReactNativeLoad(reactNativeHostHolder);
+        }
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/ReactNativeCompat.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/ReactNativeCompat.java
@@ -2,6 +2,7 @@ package com.wix.detox;
 
 import org.joor.Reflect;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class ReactNativeCompat {
@@ -12,6 +13,11 @@ public class ReactNativeCompat {
             Class reactNativeVersion = Class.forName("com.facebook.react.modules.systeminfo.ReactNativeVersion");
             VERSION = Reflect.on(reactNativeVersion).field("VERSION").get();
         } catch (ClassNotFoundException e) {
+            //ReactNativeVersion was introduced in RN50, default to latest previous version.
+            VERSION = new HashMap<>();
+            VERSION.put("major", 0);
+            VERSION.put("minor", 49);
+            VERSION.put("patch", 0);
         }
 
     }

--- a/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
@@ -138,7 +138,7 @@ public class ReactNativeSupport {
             }
         });
 
-        waitForReactNativeLoad(reactNativeHostHolder);
+        ReactNativeCompat.waitForReactNativeLoad(reactNativeHostHolder);
     }
 
     // Ideally we would not store this at all.

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/AnimatedModuleIdlingResource.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/AnimatedModuleIdlingResource.java
@@ -112,7 +112,7 @@ public class AnimatedModuleIdlingResource implements IdlingResource, Choreograph
         if (callback != null) {
             callback.onTransitionToIdle();
         }
-        Log.i(LOG_TAG, "AnimatedModule is idle.");
+//        Log.i(LOG_TAG, "AnimatedModule is idle.");
         return true;
     }
 
@@ -124,7 +124,7 @@ public class AnimatedModuleIdlingResource implements IdlingResource, Choreograph
             if (callback != null) {
                 callback.onTransitionToIdle();
             }
-            Log.i(LOG_TAG, "AnimatedModule is idle, no operations");
+//            Log.i(LOG_TAG, "AnimatedModule is idle, no operations");
             return true;
         }
         return false;
@@ -173,7 +173,7 @@ public class AnimatedModuleIdlingResource implements IdlingResource, Choreograph
             if (callback != null) {
                 callback.onTransitionToIdle();
             }
-            Log.i(LOG_TAG, "AnimatedModule is idle.");
+//            Log.i(LOG_TAG, "AnimatedModule is idle.");
             return true;
         }
         return false;

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/AnimatedModuleIdlingResource.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/AnimatedModuleIdlingResource.java
@@ -5,10 +5,10 @@ import android.support.test.espresso.IdlingResource;
 import android.util.Log;
 import android.view.Choreographer;
 
+import com.wix.detox.ReactNativeCompat;
+
 import org.joor.Reflect;
 import org.joor.ReflectException;
-
-import java.sql.Ref;
 
 /**
  * Created by simonracz on 25/08/2017.
@@ -18,13 +18,14 @@ import java.sql.Ref;
  * <p>
  * Espresso IdlingResource for React Native's Animated Module.
  * </p>
- *
+ * <p>
  * <p>
  * Hooks up to React Native internals to monitor the state of the animations.
  * </p>
- *
+ * <p>
  * This Idling Resource is inherently tied to the UI Module IR. It must be registered after
  * the UI Module IR. This order is not enforced now.
+ *
  * @see <a href="https://github.com/facebook/react-native/blob/259eac8c30b536abddab7925f4c51f0bf7ced58d/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java#L143">AnimatedModule</a>
  */
 public class AnimatedModuleIdlingResource implements IdlingResource, Choreographer.FrameCallback {
@@ -82,7 +83,7 @@ public class AnimatedModuleIdlingResource implements IdlingResource, Choreograph
                 return false;
             }
 
-            if (!(boolean)Reflect.on(reactContext).call(METHOD_HAS_NATIVE_MODULE, animModuleClass).get()) {
+            if (!(boolean) Reflect.on(reactContext).call(METHOD_HAS_NATIVE_MODULE, animModuleClass).get()) {
                 Log.e(LOG_TAG, "Can't find Animated Module.");
                 if (callback != null) {
                     callback.onTransitionToIdle();
@@ -90,81 +91,92 @@ public class AnimatedModuleIdlingResource implements IdlingResource, Choreograph
                 return true;
             }
 
-            Object animModule = Reflect.on(reactContext)
-                    .call(METHOD_GET_NATIVE_MODULE, animModuleClass)
-                    .get();
-            Object operationsLock = Reflect.on(animModule)
-                    .field(LOCK_OPERATIONS)
-                    .get();
-            boolean operationsAreEmpty;
-            boolean animationsConsideredIdle;
-            synchronized (operationsLock) {
-                Object operations = Reflect.on(animModule)
-                        .field(FIELD_OPERATIONS).get();
-                if (operations == null) {
-                    operationsAreEmpty = true;
-                } else {
-                    operationsAreEmpty = Reflect.on(operations).call(METHOD_IS_EMPTY).get();
+            if (ReactNativeCompat.getMinor() >= 51) {
+                if(isIdleRN51(animModuleClass)) {
+                    return true;
                 }
-            }
-            Object nodesManager = Reflect.on(animModule)
-                    .field(FIELD_NODES_MANAGER)
-                    .get();
-
-            // We do this in this complicated way
-            // to not consider looped animations
-            // as a busy state.
-            int updatedNodesSize = Reflect.on(nodesManager)
-                    .field(FIELD_UPDATED_NODES)
-                    .call(METHOD_SIZE)
-                    .get();
-            if (updatedNodesSize > 0) {
-                animationsConsideredIdle = false;
             } else {
-                Object activeAnims = Reflect.on(nodesManager)
-                        .field(FIELD_ACTIVE_ANIMATIONS)
-                        .get();
-                int activeAnimsSize = Reflect.on(activeAnims)
-                        .call(METHOD_SIZE)
-                        .get();
-                if (activeAnimsSize == 0) {
-                    animationsConsideredIdle = true;
-                } else {
-                    animationsConsideredIdle = true;
-                    for (int i = 0; i < activeAnimsSize; ++i) {
-                        int iterations = Reflect.on(activeAnims)
-                                .call(METHOD_VALUE_AT, i)
-                                .field(FIELD_ITERATIONS)
-                                .get();
-                        // -1 means it is looped
-                        if (iterations != -1) {
-                            animationsConsideredIdle = false;
-                            break;
-                        }
-                    }
+                if (isIdleRNOld(animModuleClass)) {
+                    return true;
                 }
-            }
-
-            if (operationsAreEmpty && animationsConsideredIdle) {
-                if (callback != null) {
-                    callback.onTransitionToIdle();
-                }
-                // Log.i(LOG_TAG, "AnimatedModule is idle.");
-                return true;
             }
 
             Log.i(LOG_TAG, "AnimatedModule is busy.");
             Choreographer.getInstance().postFrameCallback(this);
             return false;
         } catch (ReflectException e) {
-            // Log.e(LOG_TAG, "Couldn't set up RN AnimatedModule listener, old RN version?");
-            // Log.e(LOG_TAG, "Can't set up RN AnimatedModule listener", e.getCause());
+            Log.e(LOG_TAG, "Couldn't set up RN AnimatedModule listener, old RN version?");
+            Log.e(LOG_TAG, "Can't set up RN AnimatedModule listener", e.getCause());
         }
 
         if (callback != null) {
             callback.onTransitionToIdle();
         }
+        Log.i(LOG_TAG, "AnimatedModule is idle.");
         return true;
+    }
+
+    private boolean isIdleRN51(Object animModuleClass) {
+        Object animModule = Reflect.on(reactContext).call(METHOD_GET_NATIVE_MODULE, animModuleClass).get();
+        Object nodesManager = Reflect.on(animModule).call("getNodesManager").get();
+        boolean hasActiveAnimations = Reflect.on(nodesManager).call("hasActiveAnimations").get();
+        if (!hasActiveAnimations) {
+            if (callback != null) {
+                callback.onTransitionToIdle();
+            }
+            Log.i(LOG_TAG, "AnimatedModule is idle, no operations");
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isIdleRNOld(Object animModuleClass) {
+        Object animModule = Reflect.on(reactContext).call(METHOD_GET_NATIVE_MODULE, animModuleClass).get();
+        Object operationsLock = Reflect.on(animModule).field(LOCK_OPERATIONS).get();
+        boolean operationsAreEmpty;
+        boolean animationsConsideredIdle;
+        synchronized (operationsLock) {
+            Object operations = Reflect.on(animModule).field(FIELD_OPERATIONS).get();
+            if (operations == null) {
+                operationsAreEmpty = true;
+            } else {
+                operationsAreEmpty = Reflect.on(operations).call(METHOD_IS_EMPTY).get();
+            }
+        }
+        Object nodesManager = Reflect.on(animModule).field(FIELD_NODES_MANAGER).get();
+
+        // We do this in this complicated way
+        // to not consider looped animations
+        // as a busy state.
+        int updatedNodesSize = Reflect.on(nodesManager).field(FIELD_UPDATED_NODES).call(METHOD_SIZE).get();
+        if (updatedNodesSize > 0) {
+            animationsConsideredIdle = false;
+        } else {
+            Object activeAnims = Reflect.on(nodesManager).field(FIELD_ACTIVE_ANIMATIONS).get();
+            int activeAnimsSize = Reflect.on(activeAnims).call(METHOD_SIZE).get();
+            if (activeAnimsSize == 0) {
+                animationsConsideredIdle = true;
+            } else {
+                animationsConsideredIdle = true;
+                for (int i = 0; i < activeAnimsSize; ++i) {
+                    int iterations = Reflect.on(activeAnims).call(METHOD_VALUE_AT, i).field(FIELD_ITERATIONS).get();
+                    // -1 means it is looped
+                    if (iterations != -1) {
+                        animationsConsideredIdle = false;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (operationsAreEmpty && animationsConsideredIdle) {
+            if (callback != null) {
+                callback.onTransitionToIdle();
+            }
+            Log.i(LOG_TAG, "AnimatedModule is idle.");
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/detox/android/detox/src/minReactNative46/java/com/wix/detox/WebSocketClient.java
+++ b/detox/android/detox/src/minReactNative46/java/com/wix/detox/WebSocketClient.java
@@ -36,7 +36,7 @@ public class WebSocketClient extends WebSocketListener {
 
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, Response response) {
-        Log.e(LOG_TAG, "Detox Error: ", t);
+//        Log.e(LOG_TAG, "Detox Error: ", t);
 
         //OKHttp won't recover from failure if it got ConnectException,
         // this is a workaround to make the websocket client try reconnecting when failed.

--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -20,7 +20,6 @@ function setInvocationManager(im) {
   invocationManager = im;
 }
 
-const ViewAssertions = 'android.support.test.espresso.assertion.ViewAssertions';
 const DetoxMatcher = 'com.wix.detox.espresso.DetoxMatcher';
 const DetoxAssertion = 'com.wix.detox.espresso.DetoxAssertion';
 const EspressoDetox = 'com.wix.detox.espresso.EspressoDetox';
@@ -107,7 +106,6 @@ class SwipeAction extends Action {
 
 class Interaction {
   async execute() {
-    //if (!this._call) throw new Error(`Interaction.execute cannot find a valid _call, got ${typeof this._call}`);
     await invocationManager.execute(this._call);
   }
 }

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -1,6 +1,7 @@
 const AsyncWebSocket = require('./AsyncWebSocket');
 const actions = require('./actions/actions');
 const argparse = require('../utils/argparse');
+const retry = require('../utils/retry');
 
 class Client {
   constructor(config) {
@@ -65,7 +66,7 @@ class Client {
       this.slowInvocationStatusHandler = this.slowInvocationStatus();
     }
     try {
-      await this.sendAction(new actions.Invoke(invocation));
+      await retry({retries: 3, interval: 200}, async() => await this.sendAction(new actions.Invoke(invocation)));
     } catch (err) {
       this.successfulTestRun = false;
       throw new Error(err);

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -66,7 +66,7 @@ class Client {
       this.slowInvocationStatusHandler = this.slowInvocationStatus();
     }
     try {
-      await retry({retries: 3, interval: 200}, async() => await this.sendAction(new actions.Invoke(invocation)));
+      await this.sendAction(new actions.Invoke(invocation));
     } catch (err) {
       this.successfulTestRun = false;
       throw new Error(err);

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -12,8 +12,8 @@
     "build:android": "detox build --configuration android.emu.release"
   },
   "dependencies": {
-    "react": "16.0.0-beta.5",
-    "react-native": "0.49.3"
+    "react": "16.2.0",
+    "react-native": "0.53.x"
   },
   "devDependencies": {
     "detox": "^7.0.0",

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -12,8 +12,8 @@
     "build:android": "detox build --configuration android.emu.release"
   },
   "dependencies": {
-    "react": "16.2.0",
-    "react-native": "0.53.x"
+    "react": "16.0.0",
+    "react-native": "0.51.x"
   },
   "devDependencies": {
     "detox": "^7.0.0",


### PR DESCRIPTION
This PR aims to:
1. Add support for changes made in [NativeAnimatedModule](https://github.com/facebook/react-native/commit/2b4ff6ea19dc674cf035ee419daa132cde8d1f5e#diff-a735317509988b7133cb51f6ea6cbd1f) 
2. Temp fix for `waitForReactNativeLoad` by adding Thread.sleep() on RN>=50, not ideal, but will enable usage of Detox on RN51 projects even before we find the true culprit of this sync defect.