### PR TITLE
Change 'deugging' to 'debugging' in TroubleShooting#RunningTests docs

### DIFF
--- a/docs/Troubleshooting.RunningTests.md
+++ b/docs/Troubleshooting.RunningTests.md
@@ -24,7 +24,7 @@ detox test --loglevel verbose
 ```
 
 
-### Enable deugging of synchronization issues
+### Enable debugging of synchronization issues
 
 See [here](https://github.com/wix/detox/blob/master/docs/Troubleshooting.Synchronization.md#identifying-which-synchronization-mechanism-causes-us-to-wait-too-much).
 


### PR DESCRIPTION
Very minor tweak: in the `Troubleshooting#RunningTests` documentation, the title

> Enable **deugging** of synchronization issues

changed to 
> Enable **debugging** of synchronization issues