### PR TITLE
Avoid NPE when DetoxServerUrl and DetoxSessionId are not set

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/DetoxManager.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/DetoxManager.java
@@ -86,7 +86,9 @@ class DetoxManager implements WebSocketClient.ActionHandler {
                 stopping = true;
                 ReactNativeSupport.currentReactContext = null;
                 ReactNativeSupport.removeEspressoIdlingResources(reactNativeHostHolder);
-                wsClient.close();
+                if (wsClient != null) {
+                    wsClient.close();
+                }
                 Looper.myLooper().quit();
             }
         });


### PR DESCRIPTION
By the JavaDocs of Detox.java, "If not set, then Detox tests are no ops. So it's safe to mix it with other tests."

However, this is not true, since the code will throw a NullPointerException and crash the tests. A simple nullcheck will avoid it.

As a side recommendation, the usage of nullability annotations helps catching this issues. Please consider adding them to the project. I am happy to do so if deemed acceptable.