### PR TITLE
expose EarlGrey's matcherForInteractable

### DIFF
--- a/detox/src/ios/expect.js
+++ b/detox/src/ios/expect.js
@@ -11,6 +11,7 @@ const ExistsMatcher = matchers.ExistsMatcher;
 const NotExistsMatcher = matchers.NotExistsMatcher;
 const TextMatcher = matchers.TextMatcher;
 const ValueMatcher = matchers.ValueMatcher;
+const InteractableMatcher = matchers.InteractableMatcher;
 const GreyActions = require('./earlgreyapi/GREYActions');
 
 let invocationManager;
@@ -381,7 +382,8 @@ const by = {
   type: (value) => new TypeMatcher(value),
   traits: (value) => new TraitsMatcher(value),
   value: (value) => new ValueMatcher(value),
-  text: (value) => new TextMatcher(value)
+  text: (value) => new TextMatcher(value),
+  interactable: () => new InteractableMatcher()
 };
 
 const exportGlobals = () => {

--- a/detox/src/ios/expect.test.js
+++ b/detox/src/ios/expect.test.js
@@ -44,6 +44,10 @@ describe('expect', async () => {
     await e.expect(e.element(e.by.traits(['startsMedia', 'adjustable', 'allowsDirectInteraction', 'pageTurn']))).toBeNotVisible();
   });
 
+  it(`element by interactable`, async () => {
+    await e.expect(e.element(e.by.interactable())).toExist();
+  });
+
   it(`matcher helpers`, async () => {
     await e.expect(e.element(e.by.id('test').withAncestor(e.by.id('ancestor')))).toBeVisible();
     await e.expect(e.element(e.by.id('test').withDescendant(e.by.id('descendant')))).toBeVisible();

--- a/detox/src/ios/matchers.js
+++ b/detox/src/ios/matchers.js
@@ -105,6 +105,13 @@ class ValueMatcher extends Matcher {
   }
 }
 
+class InteractableMatcher extends Matcher {
+  constructor() {
+    super();
+    this._call = invoke.callDirectly(GreyMatchers.matcherForInteractable());
+  }
+}
+
 module.exports = {
   Matcher,
   LabelMatcher,
@@ -116,5 +123,6 @@ module.exports = {
   ExistsMatcher,
   NotExistsMatcher,
   TextMatcher,
-  ValueMatcher
+  ValueMatcher,
+  InteractableMatcher
 };

--- a/detox/test/e2e/b-matchers.js
+++ b/detox/test/e2e/b-matchers.js
@@ -67,4 +67,9 @@ describe('Matchers', () => {
     await expect(element(by.text('Product')).atIndex(2)).toHaveId('ProductId002');
   });
 
+  it(':ios: should match elements by (interactable)', async () => {
+    await element(by.id('duplicate-testID').and(by.interactable())).tap();
+    await expect(element(by.text('Interactable Working!!!'))).toBeVisible();
+  });
+
 });

--- a/detox/test/src/Screens/MatchersScreen.js
+++ b/detox/test/src/Screens/MatchersScreen.js
@@ -61,8 +61,16 @@ export default class MatchersScreen extends Component {
         </TouchableOpacity>
         <TouchableOpacity onPress={this.onButtonPress.bind(this, 'Third button pressed')}>
           <Text style={{color: 'brown', marginBottom: 20}}>Index</Text>
-        </TouchableOpacity>        
+        </TouchableOpacity>
 
+        <View style={{margin: 30, position: 'relative'}}>
+          <TouchableOpacity testID='duplicate-testID' onPress={this.onButtonPress.bind(this, 'Interactable Not Working')} style={{padding: 20}}>
+            <Text>overlapped</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity testID='duplicate-testID' onPress={this.onButtonPress.bind(this, 'Interactable Working')} style={{padding: 40, backgroundColor: 'gray', position: 'absolute', left: 0, right: 0}}>
+          </TouchableOpacity>
+        </View>
       </View>
     );
   }


### PR DESCRIPTION
Will expose EarlGrey's matcherForInteractable in `by` for iOS.