### PR TITLE
docs: fix missing article name in table of contents

### DIFF
--- a/docs/Guide.DebuggingInXcode.md
+++ b/docs/Guide.DebuggingInXcode.md
@@ -1,4 +1,7 @@
-# Debugging in Xcode During Detox Tests
+---
+id: Guide.DebuggingInXcode
+title: Debugging in Xcode During Detox Tests
+---
 
 > This is mostly useful for investigating weird crashes or when contributing to Detox itself. **This workflow isn't standard. Don't use it unless you have a good reason.**
 


### PR DESCRIPTION
PR fixes a missing title in ToC, see **Guide.DebuggingInXcode** on the screenshot.

![screenshot from 2018-04-24 11-04-34](https://user-images.githubusercontent.com/1962469/39174082-532b2800-47af-11e8-8e61-e80247fa13e5.png)
