### PR TITLE
Android bugfix: support unauthenticated adb connection

### DIFF
--- a/detox/src/devices/android/EmulatorTelnet.js
+++ b/detox/src/devices/android/EmulatorTelnet.js
@@ -22,7 +22,9 @@ class EmulatorTelnet {
 
     await this.connection.connect(params);
     const auth = await fs.readFile(path.join(os.homedir(), '.emulator_console_auth_token'), 'utf8');
-    await this.exec(`auth ${auth}`);
+    if (auth) {
+      await this.exec(`auth ${auth}`);
+    }
   }
 
   async exec(command) {


### PR DESCRIPTION
In case `.emulator_console_auth_token` is missing or empty, `auth` command fails silently, but its error (or rather info of incorrect usage) polluts the output of subsequent command (in this case https://github.com/wix/detox/blob/master/detox/src/devices/EmulatorDriver.js#L57 - more specifically https://github.com/wix/detox/blob/master/detox/src/devices/android/ADB.js#L30).

This results in unexpected values being returned by `exec` (https://github.com/wix/detox/blob/master/detox/src/devices/android/EmulatorTelnet.js#L28).

In such situation detox tests start running before the device is booted, I've reported this problem before in  https://github.com/wix/detox/issues/594

