### PR TITLE
Update java-method-parser to AST-based version

### DIFF
--- a/generation/package.json
+++ b/generation/package.json
@@ -13,7 +13,10 @@
 	"author": "DanielMSchmidt <danielmschmidt92@gmail.com>",
 	"license": "MIT",
 	"lint-staged": {
-		"*.{js,json,css,md}": ["prettier --write", "git add"]
+		"*.{js,json,css,md}": [
+			"prettier --write",
+			"git add"
+		]
 	},
 	"dependencies": {
 		"babel-generate-guard-clauses": "2.0.5",
@@ -22,7 +25,7 @@
 		"download-file-sync": "1.0.4",
 		"babel-template": "6.26.0",
 		"objective-c-parser": "1.2.3",
-		"java-method-parser": "0.4.5",
+		"java-method-parser": "1.0.0-1",
 		"remove": "0.1.5"
 	},
 	"devDependencies": {
@@ -31,7 +34,9 @@
 		"prettier": "^1.8.2"
 	},
 	"jest": {
-		"coveragePathIgnorePatterns": ["<rootDir>/index.js"],
+		"coveragePathIgnorePatterns": [
+			"<rootDir>/index.js"
+		],
 		"resetMocks": true,
 		"resetModules": true,
 		"coverageThreshold": {


### PR DESCRIPTION
This version uses an AST instead of regex-based parsing.

## How to review

- checkout the branch and go to `generation`
- run `npm install && npm run build`
- read through the [PR in `java-method-parser` which introduces the AST-based approach](https://github.com/DanielMSchmidt/java-method-parser/pull/45)


## Trade-Offs

- You will experience a longer generation time (~ 3-5 minutes instead of a few seconds). We would need to decide if the possibly increased stability is worth it or not :) 

## ToDos (after review)

- [ ] Publish official major version if we want to go with the AST-based approach. If this gets approved I will do the bump and update the version accordingly before merging.