### PR TITLE
Update Android emulator path to support SDK Tools >=25.3.0

### DIFF
--- a/detox/src/devices/android/Emulator.js
+++ b/detox/src/devices/android/Emulator.js
@@ -10,7 +10,9 @@ const argparse = require('../../utils/argparse');
 
 class Emulator {
   constructor() {
-    this.emulatorBin = path.join(Environment.getAndroidSDKPath(), 'emulator', 'emulator');
+    const newEmulatorPath = path.join(Environment.getAndroidSDKPath(), 'emulator', 'emulator');
+    const oldEmulatorPath = path.join(Environment.getAndroidSDKPath(), 'tools', 'emulator');
+    this.emulatorBin = fs.existsSync(newEmulatorPath) ? newEmulatorPath : oldEmulatorPath;
   }
 
   async listAvds() {

--- a/detox/src/devices/android/Emulator.js
+++ b/detox/src/devices/android/Emulator.js
@@ -10,7 +10,7 @@ const argparse = require('../../utils/argparse');
 
 class Emulator {
   constructor() {
-    this.emulatorBin = path.join(Environment.getAndroidSDKPath(), 'tools', 'emulator');
+    this.emulatorBin = path.join(Environment.getAndroidSDKPath(), 'emulator', 'emulator');
   }
 
   async listAvds() {


### PR DESCRIPTION
Since Android SDK Tools 25.3.0 (March 2017) The Android Emulator was removed from the SDK Tools package and moved to a different SDK directory: [Android Emulator v15.3.0 release notes](https://developer.android.com/studio/releases/emulator#25-3)

Also, according to [this issue in the google issue tracker](https://issuetracker.google.com/issues/66886035) the new path is also the preferred way of invoking the emulator, and the old path will at some point be deprecated / removed.

For recent API versions (and depending on the OS architecture) running the old tools/emulator can cause errors because the different architecture versions of the emulator won't be found in the tools folder of the Android SDK. By example, I'm using the Android SDK v27 build tools and the latest versions of all the Android tools, and when running the emulator with the command that detox uses I get the following errors:

```
usr/local/share/android-sdk/tools/emulator -verbose -gpu host -no-audio @Nexus_5_API_27
emulator:Android emulator version 26.0.3.0 (build_id 3965150)
emulator:Found AVD name 'Nexus_5_API_27'
emulator:Found AVD target architecture: x86
emulator:argv[0]: '/usr/local/share/android-sdk/tools/emulator'; program directory: '/usr/local/share/android-sdk/tools'
emulator:  Found directory: /usr/local/share/android-sdk/system-images/android-27/google_apis/x86/

emulator:Probing for /usr/local/share/android-sdk/system-images/android-27/google_apis/x86//kernel-ranchu: file missing
emulator:Auto-config: -engine classic (based on configuration)
emulator:  Found directory: /usr/local/share/android-sdk/system-images/android-27/google_apis/x86/

emulator:try dir /usr/local/share/android-sdk/tools
emulator:Looking for emulator-x86 to emulate 'x86' CPU
emulator:Probing program: /usr/local/share/android-sdk/tools/emulator64-x86
emulator:Probing program: /usr/local/share/android-sdk/tools/emulator-x86
PANIC: Missing emulator engine program for 'x86' CPU.
```

Given that from August this year the minimum target version required for submitting apps to the Play store will be API 26, the path of the emulator should be updated.