### PR TITLE
Fix postinstall script of detox on `sh`

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -27,7 +27,7 @@
     "test": "npm run unit",
     "unit:watch": "jest --watch",
     "prepublish": "npm run build",
-    "postinstall": "scripts/postinstall.sh"
+    "postinstall": "./scripts/postinstall.sh"
   },
   "devDependencies": {
     "eslint": "^4.11.0",

--- a/detox/scripts/postinstall.sh
+++ b/detox/scripts/postinstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 if [ `uname` == "Darwin" ]; then
   source "$(dirname ${0})/build_framework.ios.sh"


### PR DESCRIPTION
Related to https://github.com/wix/detox/issues/627#issuecomment-388379155.

We can reproduce the issue by the following script:

```bash
$ sh -c "touch script.sh && chmod +x script.sh && script.sh"
# sh: script.sh: command not found
```

