### PR TITLE
Follow-up windows changes

### DIFF
--- a/detox/local-cli/detox-test.js
+++ b/detox/local-cli/detox-test.js
@@ -117,7 +117,7 @@ function runMocha() {
 function runJest() {
   const configFile = runnerConfig ? `--config=${runnerConfig}` : '';
 
-  const platformString = platform ? `--testNamePattern='^((?!${getPlatformSpecificString(platform)}).)*$'` : '';
+  const platformString = platform ? shellQuote(`--testNamePattern=^((?!${getPlatformSpecificString(platform)}).)*$`) : '';
   const binPath = path.join('node_modules', '.bin', 'jest');
   const command = `${binPath} ${testFolder} ${configFile} --maxWorkers=${program.workers} ${platformString}`;
   const env = Object.assign({}, process.env, {
@@ -175,6 +175,11 @@ function getDefaultConfiguration() {
   if (_.size(config.configurations) === 1) {
     return _.keys(config.configurations)[0];
   }
+}
+
+// This is very incomplete, don't use this for user input!
+function shellQuote(input) {
+  return process.platform !== 'win32' ? `'${input}'` : `"${input}"`;
 }
 
 run();

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -1,5 +1,18 @@
 const schemes = require('./configurations.mock');
 
+const defaultPlatformEnv = {
+  darwin: {},
+  linux: {
+    // Not set by default on Ubuntu
+    // XDG_DATA_HOME: '/home/detox-user/.local/share',
+  },
+  win32: {
+    // Required for appdatapath.js
+    LOCALAPPDATA: 'C:\\Users\\detox-user\\AppData\\Local',
+    USERPROFILE: 'C:\\Users\\detox-user',
+  },
+};
+
 describe('Detox', () => {
   let fs;
   let Detox;
@@ -31,7 +44,8 @@ describe('Detox', () => {
     setCustomMock('./client/Client', clientMockData);
     setCustomMock('./devices/Device', deviceMockData);
 
-    process.env = {};
+    process.env = Object.assign({}, defaultPlatformEnv[process.platform]);
+
     global.device = undefined;
 
     jest.mock('./devices/IosDriver');


### PR DESCRIPTION
A couple quick fixes for `detox test --platform` and detox self unit tests running on windows.