### PR TITLE
be explicit about supported RN versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,19 @@ The most difficult part of automated testing on mobile is the tip of the testing
 * **Cross Platform:** Write cross-platform tests in JavaScript. Currently supports iOS, Android is nearly complete.  View the [Android status page](/docs/More.AndroidSupportStatus.md).
 * **Runs on Devices** (not yet supported on iOS): Gain confidence to ship by testing your app on a device/simulator just like a real user.
 * **Automatically Synchronized:** Stops flakiness at the core by monitoring asynchronous operations in your app.
-* **React Native Support:** Built from the ground up to support React Native projects as well as pure native ones. Currently, React Native versions 0.44 and above are supported.
 * **Made For CI:** Execute your E2E tests on CI platforms like Travis without grief. 
 * **Test Runner Independent:** Use Mocha, AVA, or any other JavaScript test runner you like.
 * **Debuggable:** Modern async-await API allows breakpoints in asynchronous tests to work as expected.
+
+## Supported React Native versions
+
+Detox is built from the ground up to support React Native projects as well as pure native ones.
+
+|RN version| support |
+|--|--|
+| <= 0.50 | both platforms |
+| > 0.50 | iOS only |
+
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ The most difficult part of automated testing on mobile is the tip of the testing
 
 Detox is built from the ground up to support React Native projects as well as pure native ones.
 
-|RN version| support |
-|--|--|
-| <= 0.51 | both platforms |
-| >= 0.52 <= 0.55 | iOS only |
-| newer | please report |
+| RN version      | support        |
+| --------------- | -------------- |
+| <= 0.51         | both platforms |
+| >= 0.52 <= 0.55 | iOS only       |
+| newer           | please report  |
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Detox is built from the ground up to support React Native projects as well as pu
 
 |RN version| support |
 |--|--|
-| <= 0.50 | both platforms |
-| > 0.50 | iOS only |
+| <= 0.51 | both platforms |
+| >= 0.52 | iOS only |
 
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Detox is built from the ground up to support React Native projects as well as pu
 |RN version| support |
 |--|--|
 | <= 0.51 | both platforms |
-| >= 0.52 | iOS only |
-
+| >= 0.52 <= 0.55 | iOS only |
+| newer | please report |
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,9 @@ The most difficult part of automated testing on mobile is the tip of the testing
 
 Detox is built from the ground up to support React Native projects as well as pure native ones.
 
-| RN version      | support        |
-| --------------- | -------------- |
-| <= 0.51         | both platforms |
-| >= 0.52 <= 0.55 | iOS only       |
-| newer           | please report  |
+| iOS    | Android |
+| ------ | ------- |
+| <=0.55 | <=0.51  |
 
 ## Getting Started
 


### PR DESCRIPTION
motivation: readme contains information about supported versions and it should be more explicit because: 

* Currently is says "React Native versions 0.44 and above are supported." and the readme wasn't updated in 5 months, so it certainly wasn't correct in the time when 0.50 wasn't working on android. 
* It also isn't "future-proof" because whenever a new RN version is released, the sentence automatically makes user think the new version is supported which may not be true

For people like me who occasionally come to the repo to check if their RN version is supported, this will be a big help that will save time digging through issues.

I based the table contents on this [comment](https://github.com/wix/detox/issues/608#issuecomment-388679980), not sure what the supported versions really are.