### PR TITLE
Android: on headless mode, default to high-perf software renderes `swiftshader_indirect` and `angle_indirect`

### DIFF
--- a/detox/src/devices/android/Emulator.js
+++ b/detox/src/devices/android/Emulator.js
@@ -82,7 +82,7 @@ class Emulator {
     if (argparse.getArgValue('headless')) {
       switch (os.platform()) {
         case 'darwin':
-          return 'swiftshader_indirect';
+          return 'host';
         case 'linux':
           return 'swiftshader_indirect';
         case 'win32':

--- a/detox/src/devices/android/Emulator.js
+++ b/detox/src/devices/android/Emulator.js
@@ -29,7 +29,7 @@ class Emulator {
   async boot(emulatorName) {
     const emulatorArgs = _.compact([
       '-verbose',
-      '-gpu', os.platform() === 'darwin' ? 'host' : 'auto',
+      '-gpu', this.gpuMethod(),
       '-no-audio',
       argparse.getArgValue('headless') ? '-no-window' : '',
       `@${emulatorName}`
@@ -76,6 +76,23 @@ class Emulator {
       detach();
       log.verbose('stdout', '%s', childProcessOutput);
     });
+  }
+
+  gpuMethod() {
+    if (argparse.getArgValue('headless')) {
+      switch (os.platform()) {
+        case 'darwin':
+          return 'swiftshader_indirect';
+        case 'linux':
+          return 'swiftshader_indirect';
+        case 'win32':
+          return 'angle_indirect';
+        default:
+          return 'auto';
+      }
+    } else {
+      return 'host';
+    }
   }
 }
 


### PR DESCRIPTION
Android: on headless mode, default to high-perf software renderes `swiftshader_indirect` and `angle_indirect`