### PR TITLE
Closes #805 - and prevents further bugs with older _.isFunction

### DIFF
--- a/detox/src/artifacts/templates/artifact/Artifact.js
+++ b/detox/src/artifacts/templates/artifact/Artifact.js
@@ -10,16 +10,16 @@ class Artifact {
     this._discardPromise = null;
 
     if (template) {
-      if (_.isFunction(template.start)) {
+      if (typeof template.start === 'function') {
         this.doStart = template.start.bind(template);
       }
-      if (_.isFunction(template.stop)) {
+      if (typeof template.stop === 'function') {
         this.doStop = template.stop.bind(template);
       }
-      if (_.isFunction(template.save)) {
+      if (typeof template.save === 'function') {
         this.doSave = template.save.bind(template);
       }
-      if (_.isFunction(template.discard)) {
+      if (typeof template.discard === 'function') {
         this.doDiscard = template.discard.bind(template);
       }
     }


### PR DESCRIPTION
Since Detox has a very relaxed Lodash version requirement (`^4.14.1` in [package.json](https://github.com/wix/detox/blob/master/detox/package.json#L47)), one of our users (@tachtevrenidis) had an issue (https://github.com/wix/detox/issues/805) when the older `_.isFunction` could not recognize `async function`.

Although, the issue itself was addressed quite a long time ago, in https://github.com/lodash/lodash/commit/95bc54a3ddc7a25f5e134f5b376a0d1d96118f49 , nevertheless I suggest this patch to prevent the further occurrences of this bug. This patch is too hard to locate and too expensive to debug (1+ hour of remote debug session in a video call).

@rotemmiz , can we get it merged soon? Many thanks in advance!!!!