### PR TITLE
Move generation to babel-template for better readability

### DIFF
--- a/generation/core/generator.js
+++ b/generation/core/generator.js
@@ -181,21 +181,16 @@ module.exports = function getGenerator({
           : addArgumentContentSanitizerCall(arg, json.name)
     );
 
-    return t.returnStatement(
-      t.objectExpression([
-        t.objectProperty(
-          t.identifier('target'),
-          json.static
-            ? t.objectExpression([
-                t.objectProperty(t.identifier('type'), t.stringLiteral('Class')),
-                t.objectProperty(t.identifier('value'), t.stringLiteral(classValue(classJson)))
-              ])
-            : t.identifier('element')
-        ),
-        t.objectProperty(t.identifier('method'), t.stringLiteral(json.name)),
-        t.objectProperty(t.identifier('args'), t.arrayExpression(args))
-      ])
-    );
+    return template(`
+      return {
+        target: ${json.static ? '{ type: "Class", value: CLASS_VALUE }' : 'element'},
+        method: "${json.name}",
+        args: ARGS
+      };
+    `)({
+      ARGS: t.arrayExpression(args),
+      CLASS_VALUE: t.stringLiteral(classValue(classJson))
+    });
   }
 
   function createTypeCheck(json, functionName) {


### PR DESCRIPTION
Closes #744 and turns out that we actually can't move as much as I would like to, just because it is not possible with babel-template.