### PR TITLE
Allow execution of post-install scripts on paths with space

### DIFF
--- a/detox/scripts/postinstall.js
+++ b/detox/scripts/postinstall.js
@@ -1,5 +1,5 @@
 if (process.platform === "darwin") {
-	require("child_process").execSync(`${__dirname}/build_framework.ios.sh`, {
+	require("child_process").execFileSync(`${__dirname}/build_framework.ios.sh`, {
 		stdio: "inherit"
 	});
 }


### PR DESCRIPTION
We found that we where not able to install `detox` if the project is
installed on a path with spaces on parent directories.

For example, if we clone the project on `~/My Projects/my-project`,
running `npm install` will fail to locate the `detox/scripts/build_framework.ios.sh`.

```
/bin/sh: /Users/me/My: No such file or directory
child_process.js:615
    throw err;
    ^

Error: Command failed: /Users/me/My Projects/my-project/node_modules/detox/scripts/build_framework.ios.sh
    at checkExecSyncError (child_process.js:575:11)
```

This is related to [node's child_process](https://github.com/nodejs/node/issues/6803) handling of
filepaths on `exec`.

Instead of locating the file as `~/My Projects/my-project/node_modules/detox/scripts/build_framework.ios.sh`, it passes the argument as `~/My` and fails to execute.

This commit changes the execution process to threat the first argument as a file path, instead of arguments to `exec`, which triggers the split by space to determine the arguments.