### PR TITLE
Resolves #831

### DIFF
--- a/detox/src/devices/android/ADB.test.js
+++ b/detox/src/devices/android/ADB.test.js
@@ -45,16 +45,14 @@ describe('ADB', () => {
     expect(exec).toHaveBeenCalledTimes(1);
   });
 
-  it(`pidof`, async () => {
-    adb.shell = async () => `
-com.google.android.apps.google.google.google.test.go 2245
-com.wix.detox.test                                  10670
-com.google.android.dialer                           17214`;
+  it(`pidof (success)`, async () => {
+    adb.shell = async () => `u0_a19        2199  1701 3554600  70264 0                   0 s com.google.android.ext.services `;
+    expect(await adb.pidof('', 'com.google.android.ext.services')).toBe(2199);
+  });
 
-    expect(await adb.pidof('', 'com.google.android.apps.google.google.google.test.go')).toBe(2245);
-    expect(await adb.pidof('', 'com.wix.detox.test')).toBe(10670);
-    expect(await adb.pidof('', 'com.google.android.dialer')).toBe(17214);
-    expect(await adb.pidof('', 'unexisting bundle')).toBe(NaN);
+  it(`pidof (failure)`, async () => {
+    adb.shell = async () => ``;
+    expect(await adb.pidof('', 'com.google.android.ext.services')).toBe(NaN);
   });
 
   it(`unlockScreen`, async () => {

--- a/detox/src/utils/regexEscape.js
+++ b/detox/src/utils/regexEscape.js
@@ -1,0 +1,7 @@
+const SPECIAL_CHARS = /([\^\$\[\]\*\.\\])/g;
+
+function regexEscape(exactString) {
+  return exactString.replace(SPECIAL_CHARS, "\\$1");
+}
+
+module.exports = regexEscape;

--- a/detox/src/utils/regexEscape.test.js
+++ b/detox/src/utils/regexEscape.test.js
@@ -1,0 +1,23 @@
+const regexEscape = require('./regexEscape');
+
+describe(regexEscape.name, () => {
+  it('should not escape non-special characters', () => {
+    const nonspecial = 'bundle_name';
+    expect(regexEscape(nonspecial)).toBe(nonspecial);
+  });
+
+  it('should escape [\\]', () => {
+    const bundleId = '[kworker\\0:0]';
+    expect(regexEscape(bundleId)).toBe('\\[kworker\\\\0:0\\]');
+  });
+
+  it('should escape ^*$', () => {
+    const bundleId = '^ma*tch$';
+    expect(regexEscape(bundleId)).toBe('\\^ma\\*tch\\$');
+  });
+
+  it('should escape dots', () => {
+    const bundleId = 'com.company.bundle';
+    expect(regexEscape(bundleId)).toBe('com\\.company\\.bundle');
+  });
+});


### PR DESCRIPTION
Changes `ADB.pidof()` helper method implementation to the most backward-compatible way: `ps | grep`.
Tested on API 19, 21, 28.