### PR TITLE
Make detox.init() stricter - should log error as soon as it happens

### DIFF
--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -15,6 +15,7 @@ describe('index', () => {
       .mock('detox-server')
       .mock('./devices/Device')
       .mock('./utils/onTerminate')
+      .mock('./utils/logError')
       .mock('./client/Client')
       .mock('./Detox', () => jest.fn(() => mockDetox))
       .mock('./platform');
@@ -35,6 +36,7 @@ describe('index', () => {
   });
 
   it(`throws if there was no config passed`, async () => {
+    let logError = require('./utils/logError');
     let exception = undefined;
 
     try {
@@ -44,6 +46,7 @@ describe('index', () => {
     }
 
     expect(exception).toBeDefined();
+    expect(logError).toHaveBeenCalledWith(exception);
   });
 
   it(`throws if there is no devices in config`, async () => {


### PR DESCRIPTION
Since there is an issue with Jest that prints the exception that happened inside `beforeAll` inside regular tests, it is problematic to track where the actual issue took its place.

The pull request makes the following changes:

0) `validateConfig()` is merged inside `initializeDetox()` since it is quite small and used only once
1) `detox.init` wraps `initializeDetox` in try-catch statements, so that:
2) errors get logged
3) just in case, if there was something created in the middle, the `cleanup` method is called
4) errors are rethrown again
5) detox variable is set to `null` to prevent erroneous calls to `beforeEach`, `afterEach`, `cleanup`