### PR TITLE
Printing environment variables before `jest` test command

### DIFF
--- a/detox/local-cli/detox-test.js
+++ b/detox/local-cli/detox-test.js
@@ -129,7 +129,7 @@ function runJest() {
   const platformString = platform ? shellQuote(`--testNamePattern=^((?!${getPlatformSpecificString(platform)}).)*$`) : '';
   const binPath = path.join('node_modules', '.bin', 'jest');
   const command = `${binPath} ${testFolder} ${configFile} --maxWorkers=${program.workers} ${platformString}`;
-  const env = Object.assign({}, process.env, {
+  const detoxEnvironmentVariables = {
     configuration: program.configuration,
     loglevel: program.loglevel,
     cleanup: program.cleanup,
@@ -140,13 +140,26 @@ function runJest() {
     recordLogs: program.recordLogs,
     takeScreenshots: program.takeScreenshots,
     recordVideos: program.recordVideos,
-  });
+  };
 
-  console.log(command);
+  console.log(printEnvironmentVariables(detoxEnvironmentVariables) + command);
   cp.execSync(command, {
     stdio: 'inherit',
-    env,
+    env: {
+      ...process.env,
+      ...detoxEnvironmentVariables,
+    },
   });
+}
+
+function printEnvironmentVariables(envObject) {
+  return Object.entries(envObject).reduce((cli, [key, value]) => {
+    if (value == null) {
+      return cli;
+    }
+
+    return `${cli}${key}=${JSON.stringify(value)} `;
+  }, '');
 }
 
 function getDefaultRunnerConfig() {

--- a/detox/local-cli/detox-test.js
+++ b/detox/local-cli/detox-test.js
@@ -154,7 +154,7 @@ function runJest() {
 
 function printEnvironmentVariables(envObject) {
   return Object.entries(envObject).reduce((cli, [key, value]) => {
-    if (value == null) {
+    if (value === null || value === undefined || value === '') {
       return cli;
     }
 


### PR DESCRIPTION
For Node.js debugging purposes it is nice to be able to copy&paste `jest` test command that `detox test` produces as-is and prepend there `node --inspect-brk`.

Currently the printed command lacks a critical piece - environment variables configuration.

The improvement is going to look the following way:

```
x@y:~/Projects/detox/detox/test$ npm run e2e:android

> detox-test@0.0.1 e2e:android /home/x/Projects/detox/detox/test
> detox test --configuration android.emu.release --loglevel trace --take-screenshots all --record-videos none --record-logs all

configuration="android.emu.release" loglevel="trace" artifactsLocation="artifacts/android.emu.release.2018-07-24 09-58-04Z" recordLogs="all" takeScreenshots="all" recordVideos="none" node_modules/.bin/jest e2e --config=e2e/config.json --maxWorkers=1 '--testNamePattern=^((?!:ios:).)*$'
```