### PR TITLE
Added com.android.support:support-annotations

### DIFF
--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -54,6 +54,7 @@ dependencies {
 	...
     androidTestImplementation(project(path: ":detox"))
     androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support:support-annotations:24.1.1
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test:rules:1.0.1'
     ...


### PR DESCRIPTION
Added com.android.support:support-annotations to the dependency instructions, as the sample ```DetoxTest.java``` uses annotations.