### PR TITLE
Add .tbzignore and use it when creating the Detox source tbz

### DIFF
--- a/detox/ios/.tbzignore
+++ b/detox/ios/.tbzignore
@@ -1,0 +1,12 @@
+build
+COSTouchVisualizer/ExampleObjC
+COSTouchVisualizer/ExampleSwift
+DetoxUserNotificationTests
+EarlGrey/Tests
+EarlGrey/Demo
+EarlGrey/docs
+EarlGrey/gem
+SocketRocket/TestChat
+SocketRocket/TestChatServer
+SocketRocket/Tests
+SocketRocket/TestSupport

--- a/detox/scripts/build.js
+++ b/detox/scripts/build.js
@@ -16,7 +16,7 @@ if (process.platform === 'darwin') {
   sh("ios/EarlGrey/Scripts/setup-earlgrey.sh");
   sh("find ./ios -name Build -type d -exec rm -rf {} ;");
 
-  sh("tar -cjf ../Detox-ios-src.tbz .", { cwd: "ios" });
+  sh("tar --exclude-from=.tbzignore -cjf ../Detox-ios-src.tbz .", { cwd: "ios" });
 }
 
 if (process.argv[2] === "android" || process.argv[3] === "android") {


### PR DESCRIPTION
This will significantly reduce TBZ size 