### PR TITLE
Update Guide.Migration.md

### DIFF
--- a/docs/Guide.Migration.md
+++ b/docs/Guide.Migration.md
@@ -71,7 +71,7 @@ beforeEach(async function() {
   await adapter.beforeEach();
 });
 
-afterAll(async () => {
+afterAll(async function() {
   await adapter.afterAll();
   await detox.cleanup();
 });
@@ -85,7 +85,7 @@ jasmine.getEnv().addReporter(adapter);
 * Jest adapter requires a hook to `afterAll`:
 
 ```js
-afterAll(async () => {
+afterAll(async function() {
   await adapter.afterAll();
   await detox.cleanup();
 });


### PR DESCRIPTION
currently the migration doc for jest (https://github.com/wix/detox/blob/master/docs/Guide.Migration.md#jest) uses async function in `beforeEach` and async arrow function in `afterAll`. Given that the 

> NOTICE: Make sure you use ES5 functions in beforeEach and afterEach. this referes to mocha's test object, using arrow functions will result with failure to to acquire a correct this inside the adapter.

I'm guessing that both places should use `async function`