### PR TITLE
change ES5 function to arrow function for consistency

### DIFF
--- a/docs/Guide.Migration.md
+++ b/docs/Guide.Migration.md
@@ -67,7 +67,7 @@ beforeAll(async () => {
   await detox.init(config);
 });
 
-beforeEach(async function() {
+beforeEach(async () => {
   await adapter.beforeEach();
 });
 


### PR DESCRIPTION
in the jest migration guide, there are both ES5 function and arrow functions, so this makes it a little more consistent. related: https://github.com/wix/detox/pull/866#issuecomment-408868168