### PR TITLE
Add CLI parameter for overriding device name

### DIFF
--- a/detox/local-cli/detox-test.js
+++ b/detox/local-cli/detox-test.js
@@ -45,6 +45,8 @@ program
     '[Android Only] Launch Emulator in headless mode. Useful when running on CI.')
   .option('-w, --workers <n>',
     '[iOS Only] Specifies number of workers the test runner should spawn, requires a test runner with parallel execution support (Detox CLI currently supports Jest)', 1)
+  .option('-n, --device-name [name]',
+    'Override the device name specified in a configuration. Useful for running a single build configuration on multiple devices.')
   .parse(process.argv);
 
 program.artifactsLocation = buildDefaultArtifactsRootDirpath(program.configuration, program.artifactsLocation);
@@ -120,7 +122,7 @@ function runMocha() {
   const binPath = path.join('node_modules', '.bin', 'mocha');
   const command = `${binPath} ${testFolder} ${configFile} ${configuration} ${loglevel} ${color} ` +
     `${cleanup} ${reuse} ${debugSynchronization} ${platformString} ${headless} ` +
-    `${logs} ${screenshots} ${videos} ${artifactsLocation}`;
+    `${logs} ${screenshots} ${videos} ${artifactsLocation} ${deviceName}`;
 
   console.log(command);
   cp.execSync(command, {stdio: 'inherit'});
@@ -144,6 +146,7 @@ function runJest() {
     recordLogs: program.recordLogs,
     takeScreenshots: program.takeScreenshots,
     recordVideos: program.recordVideos,
+    deviceName: program.deviceName
   };
 
   console.log(printEnvironmentVariables(detoxEnvironmentVariables) + command);

--- a/detox/local-cli/detox-test.js
+++ b/detox/local-cli/detox-test.js
@@ -117,6 +117,7 @@ function runMocha() {
   const videos = program.recordVideos ? `--record-videos ${program.recordVideos}` : '';
   const headless = program.headless ? `--headless` : '';
   const color = program.color ? '' : '--no-colors';
+  const deviceName = program.deviceName ? `--device-name "${program.deviceName}"` : '';
 
   const debugSynchronization = program.debugSynchronization ? `--debug-synchronization ${program.debugSynchronization}` : '';
   const binPath = path.join('node_modules', '.bin', 'mocha');

--- a/detox/src/index.js
+++ b/detox/src/index.js
@@ -12,6 +12,7 @@ let detox;
 
 function getDeviceConfig(configurations) {
   const configurationName = argparse.getArgValue('configuration');
+  const deviceOverride = argparse.getArgValue('device-name');
 
   const deviceConfig = (!configurationName && _.size(configurations) === 1)
     ? _.values(configurations)[0]
@@ -21,6 +22,11 @@ function getDeviceConfig(configurations) {
     throw new Error(`Cannot determine which configuration to use. use --configuration to choose one of the following:
                       ${Object.keys(configurations)}`);
   }
+
+  if (deviceOverride) {
+    deviceConfig.name = deviceOverride;
+  }
+
   if (!deviceConfig.type) {
     configuration.throwOnEmptyType();
   }

--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -97,6 +97,23 @@ describe('index', () => {
     expect(exception).toBeDefined();
   });
 
+  it(`constructs detox with device name passed in '--device-name' cli value`, async () => {
+    process.env.deviceName = 'iPhone X';
+    const Detox = require('./Detox');
+
+    await detox.init(schemes.validOneDeviceNoSession);
+
+    const expectedConfig = {
+      ...schemes.validOneDeviceNoSession.configurations['ios.sim.release'],
+      name: 'iPhone X'
+    }
+
+    expect(Detox).toHaveBeenCalledWith({
+      deviceConfig: expectedConfig,
+      session: undefined,
+    });
+  });
+
   it(`throws if a device has no name`, async () => {
     let exception = undefined;
 

--- a/docs/APIRef.DetoxCLI.md
+++ b/docs/APIRef.DetoxCLI.md
@@ -59,7 +59,7 @@ Initiating your test suite
 | -p, --platform [ios/android]                  | Run platform specific tests. Runs tests with invert grep on `:platform:`, e.g test with substring `:ios:` in its name will not run when passing `--platform android` |
 | -H, --headless                                | [Android Only] Launch Emulator in headless mode. Useful when running on CI. |
 | -w, --workers                                 | [iOS Only] Specifies number of workers the test runner should spawn, requires a test runner with parallel execution support (Detox CLI currently supports Jest) |
-
+| -n, --device-name [name]                                 | Override the device name specified in a configuration. Useful for running a single build configuration on multiple devices. |
 > NOTE: such log levels as `silly` and `wss` are deprecated since detox@8.1.0 and will be removed in 9.0.0.
 
 ### build


### PR DESCRIPTION
For #875 

This PR adds an extra command line param to `detox test` to override the device name in a given configuration. This is handy for when you want to run a test for the same configuration across multiple devices. E.g:

```
detox build --configuration ios.sim.release --device-name 'iPhone X'
```