### PR TITLE
[Android] allow config extension

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -1,11 +1,18 @@
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext;
+
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 25;
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '26.0.2';
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 18;
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 25;
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion '26.0.2'
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
     defaultConfig {
-        minSdkVersion 18
-        targetSdkVersion 25
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
👋 Wix!

First of all thanks for making detox, is really amazing 😄 

As per the title, I've created this super small PR to allow the android build file to inherit config from the root project, that comes in really handy if the project pulling in detox needs different configs.

I've ~stole~ borrowed the names from [https://github.com/react-native-community/react-native-linear-gradient/blob/master/android/build.gradle](https://github.com/react-native-community/react-native-linear-gradient/blob/master/android/build.gradle) given it's from the react native community it should be ok

I didn't open an issue for this, do you need me to?