### PR TITLE
fix(win32): new regexp for ADB.pid which is compatible with findstr utility

### DIFF
--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -110,7 +110,7 @@ class ADB {
   }
 
   async pidof(deviceId, bundleId) {
-    const bundleIdRegex = pipeCommands.escape.inQuotedRegexp(bundleId) + '\\s*$';
+    const bundleIdRegex = pipeCommands.escape.inQuotedRegexp(bundleId) + '[ ]*$';
     const grep = pipeCommands.search.regexp;
 
     const processes = await this.shell(deviceId, `ps | ${grep(bundleIdRegex)}`).catch(() => '');


### PR DESCRIPTION
Mentioned in #886