### PR TITLE
build_framework.ios.sh: echo/exit from current shell

### DIFF
--- a/detox/scripts/build_framework.ios.sh
+++ b/detox/scripts/build_framework.ios.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e -x
 
 # Ensure Xcode is installed or print a warning message and return.
-xcodebuild -version &>/dev/null || (echo "WARNING: Xcode is not installed on this machine. Skipping iOS framework build phase" && exit 0)
+xcodebuild -version &>/dev/null || { echo "WARNING: Xcode is not installed on this machine. Skipping iOS framework build phase"; exit 0; }
 
 detoxRootPath="$(dirname $(dirname ${0}))"
 detoxVersion=`node -p "require('${detoxRootPath}/package.json').version"`


### PR DESCRIPTION
The `()` syntax spawns a subshell and executes the commands. Hence, the "successful" `exit 0` is trapped and is effectively a no-op. This change instead moves the execution of the `echo` statement to the parent shell which causes the `exit 0` to actually kill the process where it is.

This is part of the fixes to the `build_framework.ios.sh` shell script that I had requested in #897.

This PR changes from subprocess execution to in-shell execution. The biggest change that this makes is that it causes the `exit 0` to actually stop the shell script.