### PR TITLE
Fix links in detox object docs

### DIFF
--- a/docs/APIRef.DetoxObjectAPI.md
+++ b/docs/APIRef.DetoxObjectAPI.md
@@ -9,10 +9,10 @@ title: The `detox` Object
 
 ### Methods
 
-- [`detox.init()`](#detox.init)
-- [`detox.beforeEach()`](#detox.beforeEach)
-- [`detox.afterEach()`](#detox.afterEach)
-- [`detox.cleanup()`](#detox.cleanup)
+- [`detox.init()`](#detoxinit)
+- [`detox.beforeEach()`](#detoxbeforeeach)
+- [`detox.afterEach()`](#detoxaftereach)
+- [`detox.cleanup()`](#detoxcleanup)
 
 ### `detox.init()`
 The setup phase happens inside `detox.init()`. This is the phase where detox reads its configuration, starts a server, loads its expection library and starts a simulator.
@@ -27,7 +27,7 @@ before(async () => {
 });
 ```
 
-##### Explicit imports during initialization 
+##### Explicit imports during initialization
 Detox exports `device `, `expect`, `element`, `by` and `waitFor` as globals by default, if you want to control their initialization manually, set init detox with `initGlobals` set to `false`. This is useful when during E2E tests you also need to run regular expectations in node. jest `Expect` for instance, will not be overriden by Detox when this option is used.
 
 ```js


### PR DESCRIPTION
* Noticed the links to the methods for detox `object` didn't work, so went ahead an fixed them up.
* And apparently my editor cleaned up some whitespace 🤷‍♂️ 

#### GIFs
##### Before
![detox-object-broken](https://user-images.githubusercontent.com/10098988/44739713-2f5e0880-aabe-11e8-8951-0d1ff1089c22.gif)

##### After

![detox-object-fix](https://user-images.githubusercontent.com/10098988/44739707-29682780-aabe-11e8-982a-e55ebeb52346.gif)

