### PR TITLE
[Android] Remove @override annotation to support RN 0.53-0.55 on detox 9.0

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/ReactBridgeIdlingResource.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/ReactBridgeIdlingResource.java
@@ -62,8 +62,6 @@ public class ReactBridgeIdlingResource implements IdlingResource, NotThreadSafeB
         // Log.i(LOG_TAG, "JS Bridge transitions to busy.");
     }
 
-    @Override
     public void onBridgeDestroyed() {
-
     }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/ReactBridgeIdlingResource.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/ReactBridgeIdlingResource.java
@@ -63,5 +63,6 @@ public class ReactBridgeIdlingResource implements IdlingResource, NotThreadSafeB
     }
 
     public void onBridgeDestroyed() {
+        
     }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/ReactBridgeIdlingResource.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/ReactBridgeIdlingResource.java
@@ -63,6 +63,5 @@ public class ReactBridgeIdlingResource implements IdlingResource, NotThreadSafeB
     }
 
     public void onBridgeDestroyed() {
-        
     }
 }


### PR DESCRIPTION
remove @override annotation on onBridgeDestroyed as it is not introduced until react-native 0.56 and breaks previous react-native versions

See https://github.com/wix/Detox/issues/919


The [NotThreadSafeBridgeIdleDebugListener](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/NotThreadSafeBridgeIdleDebugListener.java) interface doesn't add the method   `onBridgeDestroyed()` until RN 0.56 this causes builds prior than that to break with an error as follows:

```
Task :detox:compileMinReactNative46DebugJavaWithJavac FAILED
.../node_modules/detox/android/detox/src/main/java/com/wix/detox/espresso/ReactBridgeIdlingResource.java:65: error: method does not override or implement a method from a supertype
    @Override
    ^
Note: .../node_modules/detox/android/detox/src/main/java/com/wix/detox/espresso/MultiTap.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
```

This simply removes the `@Override` annotation without changing the expected functionality