### PR TITLE
Report iOS app readiness right after launch

### DIFF
--- a/detox/ios/Detox/DetoxManager.m
+++ b/detox/ios/Detox/DetoxManager.m
@@ -101,10 +101,8 @@ static void detoxConditionalInit()
 
 - (void)_appDidLaunch:(NSNotification*)note
 {
-	[EarlGrey detox_safeExecuteSync:^{
 		self.isReady = YES;
 		[self _sendGeneralReadyMessage];
-	}];
 }
 
 - (void)_sendGeneralReadyMessage


### PR DESCRIPTION
When app launches, do not wait for app to become idle to report that app is ready. Readiness does not mean that app should be idle.