### PR TITLE
Use legacy build system to build framework

### DIFF
--- a/detox/scripts/build_universal_framework.sh
+++ b/detox/scripts/build_universal_framework.sh
@@ -19,14 +19,14 @@ echo TEMP_DIR = "${TEMP_DIR}"
 
 # Step 1. Build Device and Simulator versions
 
-BUILD_IOS=`xcodebuild -project "${PROJECT}" -scheme Detox ONLY_ACTIVE_ARCH=NO -configuration "${CONFIGURATION}" -arch arm64 -sdk iphoneos VALID_ARCHS=arm64 -showBuildSettings  | awk -F= '/TARGET_BUILD_DIR/{x=$NF; gsub(/^[ \t]+|[ \t]+$/,"",x); print x}'`
-BUILD_SIM=`xcodebuild -project "${PROJECT}" -scheme Detox -configuration "${CONFIGURATION}" -arch x86_64 -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO VALID_ARCHS=x86_64 -showBuildSettings  | awk -F= '/TARGET_BUILD_DIR/{x=$NF; gsub(/^[ \t]+|[ \t]+$/,"",x); print x}'`
+BUILD_IOS=`xcodebuild -project "${PROJECT}" -UseNewBuildSystem=NO -scheme Detox ONLY_ACTIVE_ARCH=NO -configuration "${CONFIGURATION}" -arch arm64 -sdk iphoneos VALID_ARCHS=arm64 -showBuildSettings  | awk -F= '/TARGET_BUILD_DIR/{x=$NF; gsub(/^[ \t]+|[ \t]+$/,"",x); print x}'`
+BUILD_SIM=`xcodebuild -project "${PROJECT}" -UseNewBuildSystem=NO -scheme Detox -configuration "${CONFIGURATION}" -arch x86_64 -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO VALID_ARCHS=x86_64 -showBuildSettings  | awk -F= '/TARGET_BUILD_DIR/{x=$NF; gsub(/^[ \t]+|[ \t]+$/,"",x); print x}'`
 
 echo ${BUILD_IOS}
 echo ${BUILD_SIM}
 
-xcodebuild -project "${PROJECT}" -scheme Detox ONLY_ACTIVE_ARCH=NO -configuration "${CONFIGURATION}" -arch arm64 -sdk iphoneos build VALID_ARCHS=arm64
-xcodebuild -project "${PROJECT}" -scheme Detox -configuration "${CONFIGURATION}" -arch x86_64 -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO build VALID_ARCHS=x86_64
+xcodebuild -project "${PROJECT}" -UseNewBuildSystem=NO -scheme Detox ONLY_ACTIVE_ARCH=NO -configuration "${CONFIGURATION}" -arch arm64 -sdk iphoneos build VALID_ARCHS=arm64
+xcodebuild -project "${PROJECT}" -UseNewBuildSystem=NO -scheme Detox -configuration "${CONFIGURATION}" -arch x86_64 -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO build VALID_ARCHS=x86_64
 
 # Step 2. Copy the framework structure (from iphoneos build) to the universal folder
 


### PR DESCRIPTION
In Xcode 10, the build system defaults to the `New Build System` launched in Xcode 9. Because of this, the `postinstall` script fails with the following error (only important parts added. [see here for complete log](https://gist.github.com/karanjthakkar/6a5cda03cc223e688f4e7e623fa43750)): 

```
<blah blah>

PhaseScriptExecution Run\ Script /Users/karanthakkar/Library/Detox/ios/3b8bf121e33a47a46e6d2ca92c7d743d2d56b3cf/DetoxBuild/Build/Intermediates.noindex/Detox.build/Release-iphoneos/DetoxFramework.build/Script-3941F4F61DC6203000F23DAC.sh (in target: DetoxFramework)

<blah blah>

note: Using new build system

error: Could not delete `/Users/karanthakkar/Work/skyscanner-app/react-native/node_modules/detox/ios_src/COSTouchVisualizer/Classes/build` because it was not created by the build system and it is not a subfolder of derived data.


** CLEAN FAILED **

<blah blah>


** BUILD FAILED **


The following build commands failed:
	PhaseScriptExecution Run\ Script /Users/karanthakkar/Library/Detox/ios/3b8bf121e33a47a46e6d2ca92c7d743d2d56b3cf/DetoxBuild/Build/Intermediates.noindex/Detox.build/Release-iphoneos/DetoxFramework.build/Script-3941F4F61DC6203000F23DAC.sh
(1 failure)

```

Here's another report in the wild for a similar case: https://github.com/lionheart/openradar-mirror/issues/19856

Fixes #913

PS: While this is something that fixes the issue in the short term, someone who's more proficient with the iOS ecosystem should look into how to fix this properly for the future. 🙂 This is as far as I could go with my very minimal knowledge.