### PR TITLE
update build.gradle in demo-react-native

### DIFF
--- a/examples/demo-react-native/android/build.gradle
+++ b/examples/demo-react-native/android/build.gradle
@@ -14,7 +14,7 @@ allprojects {
         jcenter()
         google()
         maven {
-            url "$projectDir/../../node_modules/react-native/android"
+            url "$rootDir/../node_modules/react-native/android"
         }
     }
 }


### PR DESCRIPTION
I was having some issues running the demo (stuff from react-native was not being found during build), and this seems to fix it. Note that this is the same value as in https://github.com/wix/detox/blob/master/examples/demo-react-native-jest/android/build.gradle which was generated with a newer version of RN


steps to reproduce:
- clone repo and cd to the example folder
- run yarn
- run `detox build --configuration android.emu.debug` output:

```
vojta@Vojta-MacBook-Pro demo-react-native (master)$ detox build --configuration android.emu.debug
pushd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && popd
~/dev/temp/Detox/examples/demo-react-native/android ~/dev/temp/Detox/examples/demo-react-native

> Configure project :app
WARNING: The option 'android.enableAapt2' is deprecated and should not be used anymore.
Use 'android.enableAapt2=true' to remove this warning.
It will be removed at the end of 2018..

> Configure project :detox
WARNING: The option 'android.enableAapt2' is deprecated and should not be used anymore.
Use 'android.enableAapt2=true' to remove this warning.
It will be removed at the end of 2018..

> Task :detox:compileMinReactNative44DebugJavaWithJavac
/Users/vojta/dev/temp/Detox/examples/demo-react-native/node_modules/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java:11: error: cannot find symbol
import com.facebook.react.ReactApplication;
                         ^
  symbol:   class ReactApplication
  location: package com.facebook.react
/Users/vojta/dev/temp/Detox/examples/demo-react-native/node_modules/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java:63: error: cannot find symbol
        return ((ReactApplication) context).getReactNativeHost().getReactInstanceManager();
                 ^
  symbol:   class ReactApplication
  location: class ReactNativeSupport
/Users/vojta/dev/temp/Detox/examples/demo-react-native/node_modules/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java:96: error: cannot find symbol
                instanceManager.recreateReactContextInBackground();
                               ^
  symbol:   method recreateReactContextInBackground()
  location: variable instanceManager of type ReactInstanceManager
/Users/vojta/dev/temp/Detox/examples/demo-react-native/node_modules/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java:139: error: cannot find symbol
                                instanceManager.removeReactInstanceEventListener(this);
                                               ^
  symbol:   method removeReactInstanceEventListener(<anonymous ReactInstanceEventListener>)
  location: variable instanceManager of type ReactInstanceManager
Note: /Users/vojta/dev/temp/Detox/examples/demo-react-native/node_modules/detox/android/detox/src/main/java/com/wix/detox/espresso/MultiTap.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
4 errors

> Task :detox:compileMinReactNative44DebugJavaWithJavac FAILED

FAILURE: Build failed with an exception.
```

after making the change this works fine for me