### PR TITLE
Make compatible with BSD + GNU mktemp

### DIFF
--- a/detox/scripts/build_universal_framework.sh
+++ b/detox/scripts/build_universal_framework.sh
@@ -14,7 +14,7 @@ function remove_arch() {
 mkdir -p "${OUTPUT_DIR}"
 rm -fr "${OUTPUT_DIR}/${PROJECT_NAME}.framework"
 
-TEMP_DIR=$(mktemp -d $TMPDIR/DetoxBuild.XXXX)
+TEMP_DIR=$(mktemp -d "$TMPDIR"DetoxBuild.XXXX)
 echo TEMP_DIR = "${TEMP_DIR}"
 
 # Step 1. Build Device and Simulator versions

--- a/detox/scripts/build_universal_framework.sh
+++ b/detox/scripts/build_universal_framework.sh
@@ -14,7 +14,7 @@ function remove_arch() {
 mkdir -p "${OUTPUT_DIR}"
 rm -fr "${OUTPUT_DIR}/${PROJECT_NAME}.framework"
 
-TEMP_DIR=$(mktemp -d -t DetoxBuild)
+TEMP_DIR=$(mktemp -d DetoxBuild.XXXX)
 echo TEMP_DIR = "${TEMP_DIR}"
 
 # Step 1. Build Device and Simulator versions

--- a/detox/scripts/build_universal_framework.sh
+++ b/detox/scripts/build_universal_framework.sh
@@ -14,7 +14,7 @@ function remove_arch() {
 mkdir -p "${OUTPUT_DIR}"
 rm -fr "${OUTPUT_DIR}/${PROJECT_NAME}.framework"
 
-TEMP_DIR=$(mktemp -d DetoxBuild.XXXX)
+TEMP_DIR=$(mktemp -d $TMPDIR/DetoxBuild.XXXX)
 echo TEMP_DIR = "${TEMP_DIR}"
 
 # Step 1. Build Device and Simulator versions


### PR DESCRIPTION
avoid the `mktemp: too few X's in template 'DetoxBuild'` error on macosx when using mktemp from coreutils