### PR TITLE
hotfix: added a retry on install (XCode 10 issue)

### DIFF
--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -106,7 +106,7 @@ class AppleSimUtils {
       trying: `Installing ${absPath}...`,
       successful: `${absPath} installed`
     };
-    await this._execSimctl({ cmd: `install ${udid} "${absPath}"`, statusLogs });
+    await this._execSimctl({ cmd: `install ${udid} "${absPath}"`, statusLogs, retries: 2 });
   }
 
   async uninstall(udid, bundleId) {


### PR DESCRIPTION
Resolves #954 

I suggest merging a hotfix given a blocker status of `appleSimUtils.install()` with XCode 10.

@LeoNatan , @rotemmiz , what do you think?
@guyca , can you check if it helps in your case, please?