### PR TITLE
Update the document for Expo

### DIFF
--- a/docs/Guide.Expo.md
+++ b/docs/Guide.Expo.md
@@ -20,7 +20,7 @@ title: Expo
 }
 ```
 
-- Download the `Expo Client` from [Expo.io/tools](https://expo.io/tools).
+- Download the Expo Client iOS App from [Expo.io/tools](https://expo.io/tools#client).
 - Unzip the iOS IPA and **rename the folder** to `Exponent.app`. It'll have a file icon but will still be a folder.
 - Create `bin` folder and put `Exponent.app` inside so it matches the binaryPath set above.
 - Create an `e2e` and copy over the settings from [the example app](https://github.com/expo/with-detox-tests/tree/master/e2e)

--- a/docs/Guide.Expo.md
+++ b/docs/Guide.Expo.md
@@ -20,7 +20,7 @@ title: Expo
 }
 ```
 
-- Download the Expo app from [Expo.io/tools](https://expo.io/tools).
+- Download the `Expo Client` from [Expo.io/tools](https://expo.io/tools).
 - Unzip the iOS IPA and **rename the folder** to `Exponent.app`. It'll have a file icon but will still be a folder.
 - Create `bin` folder and put `Exponent.app` inside so it matches the binaryPath set above.
 - Create an `e2e` and copy over the settings from [the example app](https://github.com/expo/with-detox-tests/tree/master/e2e)


### PR DESCRIPTION
I've checked the [docs](https://expo.io/tools) right here for installation and thought that perhaps `Expo Client` is more clear than `Expo app`?