### PR TITLE
hotfix: read unexpected EOF error message in logs

### DIFF
--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -151,7 +151,7 @@ class ADB {
 
   async isBootComplete(deviceId) {
     try {
-      const bootComplete = await this.shell(deviceId, `getprop dev.bootcomplete`);
+      const bootComplete = await this.shell(deviceId, `getprop dev.bootcomplete`, { silent: true });
       return (bootComplete === '1');
     } catch (ex) {
       return false;

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -201,7 +201,7 @@ class ADB {
    * @returns ChildProcessPromise
    */
   logcat(deviceId, { file, pid, time }) {
-    let shellCommand = 'logcat -v brief';
+    let shellCommand = 'logcat';
 
     // HACK: cannot make this function async, otherwise ChildProcessPromise.childProcess field will get lost,
     // and this will break interruptProcess() call for any logcat promise.
@@ -210,13 +210,23 @@ class ADB {
       shellCommand += ` -T "${time}"`;
     }
 
-    if (pid > 0) {
-      const __pid = String(pid).padStart(5);
-      shellCommand += ` | grep "(${__pid}):"`;
-   }
+    if (apiLevel < 24) {
+			if (pid > 0) {
+				const __pid = String(pid).padStart(5);
+				shellCommand += `-v brief | grep "(${__pid}):"`;
+			}
 
-    if (file) {
-      shellCommand += ` >> ${file}`;
+			if (file) {
+				shellCommand += ` >> ${file}`;
+			}
+    } else {
+			if (pid > 0) {
+				shellCommand += ` --pid=${pid}`;
+			}
+
+			if (file) {
+				shellCommand += ` -f ${file}`;
+			}
     }
 
     return this.spawn(deviceId, ['shell', shellCommand]);

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -211,22 +211,22 @@ class ADB {
     }
 
     if (apiLevel < 24) {
-			if (pid > 0) {
-				const __pid = String(pid).padStart(5);
-				shellCommand += ` -v brief | grep "(${__pid}):"`;
-			}
+      if (pid > 0) {
+        const __pid = String(pid).padStart(5);
+        shellCommand += ` -v brief | grep "(${__pid}):"`;
+      }
 
-			if (file) {
-				shellCommand += ` >> ${file}`;
-			}
+      if (file) {
+        shellCommand += ` >> ${file}`;
+      }
     } else {
-			if (pid > 0) {
-				shellCommand += ` --pid=${pid}`;
-			}
+      if (pid > 0) {
+        shellCommand += ` --pid=${pid}`;
+      }
 
-			if (file) {
-				shellCommand += ` -f ${file}`;
-			}
+      if (file) {
+        shellCommand += ` -f ${file}`;
+      }
     }
 
     return this.spawn(deviceId, ['shell', shellCommand]);

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -213,7 +213,7 @@ class ADB {
     if (apiLevel < 24) {
 			if (pid > 0) {
 				const __pid = String(pid).padStart(5);
-				shellCommand += `-v brief | grep "(${__pid}):"`;
+				shellCommand += ` -v brief | grep "(${__pid}):"`;
 			}
 
 			if (file) {


### PR DESCRIPTION
Seeing lately errors like this:

```
detox[39596] ERROR: [exec.js/SPAWN_STDERR, #31] read: unexpected EOF!
```

Looks like a workaround for unsupported logcat `-f` option on older API levels did not work 100% correctly. So I think we could revert to the previous logic for API levels that support it.

- [x] verify on API levels 19-25