### PR TITLE
EarlGrey detox_safeExecuteSync causes detox to hang and tests to never run

### DIFF
--- a/detox/ios/Detox/DetoxManager.m
+++ b/detox/ios/Detox/DetoxManager.m
@@ -101,10 +101,8 @@ static void detoxConditionalInit()
 
 - (void)_appDidLaunch:(NSNotification*)note
 {
-	[EarlGrey detox_safeExecuteSync:^{
-		self.isReady = YES;
-		[self _sendGeneralReadyMessage];
-	}];
+	self.isReady = YES;
+	[self _sendGeneralReadyMessage];
 }
 
 - (void)_sendGeneralReadyMessage


### PR DESCRIPTION
Would fix:

https://github.com/wix/Detox/issues/842
https://github.com/wix/Detox/issues/917

and friends

This code was added in 7.3.0 and since 7.3.0 we weren't able to use detox at our company
https://github.com/wix/Detox/compare/7.2.0...7.3.0

Due to our setup we always disable earlygrey `device.disableSynchronization();` perhaps it's related