### PR TITLE
Fix #981 device.launchApp launchArgs not passed to MainActivity on Android

### DIFF
--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -1,5 +1,8 @@
 package com.example;
 
+import android.content.Context;
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.LargeTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
@@ -19,7 +22,19 @@ import org.junit.runner.RunWith;
 public class DetoxTest {
 
     @Rule
-    public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
+    public ActivityTestRule<MainActivity> mActivityRule =
+        new ActivityTestRule<MainActivity>(MainActivity.class, false, false) {
+            @Override
+            protected Intent getActivityIntent() {
+                Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+                Intent result = new Intent(targetContext, MainActivity.class);
+
+                // Get the arguments passed to the Test Runner, and forward them to the MainActivity Intent
+                // so that they can be received by the app
+                result.putExtras(InstrumentationRegistry.getArguments());
+                return result;
+            }
+        };
 
     @Test
     public void runDetoxTests() {

--- a/detox/test/android/app/src/main/java/com/example/MainActivity.java
+++ b/detox/test/android/app/src/main/java/com/example/MainActivity.java
@@ -1,8 +1,28 @@
 package com.example;
 
+import android.os.Bundle;
 import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
 
 public class MainActivity extends ReactActivity {
+
+    /**
+     * Sets the launch options for the React View
+     */
+    @Override
+    protected ReactActivityDelegate createReactActivityDelegate() {
+        return new ReactActivityDelegate(this, getMainComponentName()) {
+            @Override
+            protected Bundle getLaunchOptions() {
+                String launchArgs = getLaunchArgs();
+                Bundle bundle = new Bundle();
+                if(launchArgs != null) {
+                    bundle.putString("launchArgs", launchArgs);
+                }
+                return bundle;
+            }
+        };
+    }
 
     /**
      * Returns the name of the main component registered from JavaScript.
@@ -13,4 +33,23 @@ public class MainActivity extends ReactActivity {
         return "example";
     }
 
+    /**
+     * Returns the intent extras as a single string of arguments
+     * This is done this way to be consistent with the arguments handling on
+     * the iOS side which allows for valueless args
+     */
+    protected String getLaunchArgs() {
+        Bundle bundle = getIntent().getExtras();
+        if (bundle == null) {
+            return null;
+        }
+
+        String string = "";
+        String dash = "-";
+        for (String key : bundle.keySet()) {
+            string += dash + key + " " + bundle.get(key);
+            dash = " -";
+        }
+        return string;
+    }
 }

--- a/detox/test/e2e/06.device.test.js
+++ b/detox/test/e2e/06.device.test.js
@@ -39,6 +39,12 @@ describe('Device', () => {
     await expect(element(by.text('Hello!!!'))).toBeVisible();
   });
 
+  it('launchApp with launchArgs - should pass the arguments through if specified', async () => {
+    await device.launchApp({newInstance: true, launchArgs: { test: 'argument1'}});
+    await element(by.text('Launch Arguments')).tap();
+    await expect(element(by.text('-test argument1'))).toBeVisible();
+  });
+
   // // Passing on iOS, not implemented on Android
   // it('launchApp in a different language', async () => {
   //   let languageAndLocale = {

--- a/detox/test/ios/example/AppDelegate.m
+++ b/detox/test/ios/example/AppDelegate.m
@@ -136,10 +136,21 @@ RCT_EXPORT_MODULE();
 #else
 	jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
-	
+
+  // Parse process arguments into a launchArgs initialProp that is passed to the react root view
+  NSMutableArray *arguments   = [[NSMutableArray alloc]initWithArray:[[NSProcessInfo processInfo] arguments]];
+  [arguments removeObjectAtIndex:0]; // Remove executable path
+  NSMutableDictionary *initialProps = [NSMutableDictionary dictionary];
+  if([arguments count] > 0) {
+    NSString *allArgs = [arguments componentsJoinedByString:@" "];
+    initialProps[@"launchArgs"] = allArgs;
+  } else {
+    initialProps = NULL;
+  }
+
 	RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
 														moduleName:@"example"
-												 initialProperties:nil
+												 initialProperties:initialProps
 													 launchOptions:launchOptions];
 	rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 	

--- a/detox/test/src/Screens/LaunchArgsScreen.js
+++ b/detox/test/src/Screens/LaunchArgsScreen.js
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+import {
+  Text,
+  View,
+} from 'react-native';
+
+export default class SanityScreen extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      args: this._parseLaunchArgs(props.launchArgs)
+    }
+    console.log('LaunchArgsScreen react component constructed (console.log test)');
+  }
+
+  render() {
+    return (
+      <View style={{flex: 1, paddingTop: 20, justifyContent: 'center', alignItems: 'center'}}>
+        <Text style={{fontSize: 25, marginBottom: 30}}>
+          Launch Arguments
+        </Text>
+        {
+          this.props.launchArgs
+          ? Object.keys(this.state.args).map(arg => <Text>{`-${arg} ${this.state.args[arg]}`}</Text>)
+          : <Text>No launch arguments passed</Text>
+        }
+      </View>
+    );
+  }
+
+  _parseLaunchArgs(args) {
+    if (typeof args !== 'string') {
+      return {};
+    }
+
+    const argsArray = args.match(/'[^']*'|"[^"]*"|\S+/g) || [];
+    let currentKey = 'default';
+    const argsObject = {};
+
+    argsArray.forEach(arg => {
+      if (arg.match(/^-/)) {
+        currentKey = arg.match(/^-+(.*)/)[1];
+        argsObject[currentKey] = true;
+      } else if (argsObject[currentKey] === true) {
+        argsObject[currentKey] = arg;
+      } else if (Array.isArray(argsObject[currentKey])) {
+        argsObject[currentKey] = [...argsObject[currentKey], arg];
+      } else {
+        argsObject[currentKey] = [argsObject[currentKey], arg];
+      }
+    })
+
+    return argsObject;
+  }
+
+
+}

--- a/detox/test/src/Screens/index.js
+++ b/detox/test/src/Screens/index.js
@@ -14,6 +14,7 @@ import LocationScreen from './LocationScreen';
 import ShakeScreen from './ShakeScreen';
 import DatePickerScreen from './DatePickerScreen';
 import LanguageScreen from './LanguageScreen';
+import LaunchArgsScreen from './LaunchArgsScreen';
 
 export {
   SanityScreen,
@@ -31,5 +32,6 @@ export {
   LocationScreen,
   ShakeScreen,
   DatePickerScreen,
-  LanguageScreen
+  LanguageScreen,
+  LaunchArgsScreen
 };

--- a/detox/test/src/app.js
+++ b/detox/test/src/app.js
@@ -14,6 +14,7 @@ class example extends Component {
     super(props);
     this.state = {
       screen: undefined,
+      screenProps: {},
       url: undefined,
       notification: undefined
     };
@@ -29,9 +30,9 @@ class example extends Component {
     );
   }
 
-  renderScreenButton(title, component) {
+  renderScreenButton(title, component, props = {}) {
     return this.renderButton(title, () => {
-      this.setState({screen: component});
+      this.setState({screen: component, screenProps: props});
     });
   }
 
@@ -98,12 +99,16 @@ class example extends Component {
             throw new Error('Simulated Crash')
           })}
           {this.renderScreenButton('Shake', Screens.ShakeScreen)}
+          {this.renderScreenButton('Launch Arguments', Screens.LaunchArgsScreen, {
+            launchArgs: this.props.launchArgs
+          })}
         </View>
       );
     }
     const Screen = this.state.screen;
+    const screenProps = this.state.screenProps;
     return (
-      <Screen/>
+      <Screen {...screenProps} />
     );
   }
 
@@ -117,5 +122,7 @@ class example extends Component {
     this.setState({url: params.url});
   }
 }
+
+example.defaultProps = { launchArgs: undefined }
 
 module.exports = example;


### PR DESCRIPTION
Fix example DetoxTest.java to pass launch arguments to activity being tested by cloning the command line arguments used when calling the test to the MainActivity Intent created in the test.