### PR TITLE
Update mocking guide for RN >= 0.57

### DIFF
--- a/docs/Guide.Mocking.md
+++ b/docs/Guide.Mocking.md
@@ -26,17 +26,7 @@ This replacement mechanism provides a lot of flexibility to change implementatio
 
 #### Configuration
 0. For RN < 0.55, setup `react-native-repackager` in your library.
-1. Configure Metro by creating `rn-cli.config.js` to root dir and setting `getSourceExts()` to prioritize any given source extension over the default one, by triggering each of these commands the bundler will take `e2e.js` over `.js`
-
-    ```js
-    module.exports = {
-      getSourceExts: () => process.env.RN_SRC_EXT ? 
-                           process.env.RN_SRC_EXT.split(',') : []
-    };
-
-    ```
-
-    or use the new format for metro configuration for RN >= 0.57 (or if you've metro >= 0.43)
+1. Configure Metro by creating `rn-cli.config.js` to root dir and setting `resolver.sourceExts` to prioritize any given source extension over the default one:
 
     ```js
     const defaultSourceExts = require('metro-config/src/defaults/defaults').sourceExts
@@ -47,6 +37,16 @@ This replacement mechanism provides a lot of flexibility to change implementatio
                     : defaultSourceExts
       }
     };
+    ```
+    
+    or if you have RN < 0.57 or Metro < 0.43 use the old Metro configuration format:
+    
+     ```js
+    module.exports = {
+      getSourceExts: () => process.env.RN_SRC_EXT ? 
+                           process.env.RN_SRC_EXT.split(',') : []
+    };
+
     ```
 
 2. Create `anyfile.e2e.js` alongside `anyfile.js`

--- a/docs/Guide.Mocking.md
+++ b/docs/Guide.Mocking.md
@@ -36,6 +36,19 @@ This replacement mechanism provides a lot of flexibility to change implementatio
 
     ```
 
+    or use the new format for metro configuration for RN >= 0.57 (or if you've metro >= 0.43)
+
+    ```js
+    const defaultSourceExts = require('metro-config/src/defaults/defaults').sourceExts
+    module.exports = {
+      resolver: { 
+        sourceExts: process.env.RN_SRC_EXT
+                    ? process.env.RN_SRC_EXT.split(',').concat(defaultSourceExts)
+                    : defaultSourceExts
+      }
+    };
+    ```
+
 2. Create `anyfile.e2e.js` alongside `anyfile.js`
 
 


### PR DESCRIPTION
Metro versions >= v0.43 have a new configuration format. By default RN >= 0.57 need to use this new configuration for rn-cli.config.js otherwise it won't work.

This PR updates the mocking guide with this new format which is needed to use e2e.js files in RN from version 0.57 