### PR TITLE
Reverted relative import of detox

### DIFF
--- a/examples/demo-native-ios/e2e/init.js
+++ b/examples/demo-native-ios/e2e/init.js
@@ -1,5 +1,5 @@
 require('babel-polyfill');
-const detox = require('../../../detox/src/index');
+const detox = require('detox');
 const config = require('../package.json').detox;
 
 before(async () => {


### PR DESCRIPTION
Depending on the npm package means we don't need to `npm install` the root detox/ project.