### PR TITLE
append instead of clobber SIM_CTL_DYLD_INSERT_LIBRARIES

### DIFF
--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -262,7 +262,7 @@ class AppleSimUtils {
       dylibs = `${process.env.SIMCTL_CHILD_DYLD_INSERT_LIBRARIES}:${dylibs}`;
     }
 
-    const launchBin = `/bin/cat /dev/null >${logsInfo.absStdout} 2>${logsInfo.absStderr} && ` +
+    let launchBin = `/bin/cat /dev/null >${logsInfo.absStdout} 2>${logsInfo.absStderr} && ` +
       `SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="${dylibs}" ` +
       `/usr/bin/xcrun simctl launch --stdout=${logsInfo.simStdout} --stderr=${logsInfo.simStderr} ` +
       `${udid} ${bundleId} --args ${args}`;

--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -257,10 +257,15 @@ class AppleSimUtils {
       `        tail -F ${logsInfo.absJoined}`
     };
 
-    let launchBin = `/bin/cat /dev/null >${logsInfo.absStdout} 2>${logsInfo.absStderr} && ` +
-      `SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="${frameworkPath}/Detox" ` +
+    let dylibs = `${frameworkPath}/Detox`;
+    if (process.env.SIMCTL_CHILD_DYLD_INSERT_LIBRARIES) {
+      dylibs = `${process.env.SIMCTL_CHILD_DYLD_INSERT_LIBRARIES}:${dylibs}`;
+    }
+
+    const launchBin = `/bin/cat /dev/null >${logsInfo.absStdout} 2>${logsInfo.absStderr} && ` +
+      `SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="${dylibs}" ` +
       `/usr/bin/xcrun simctl launch --stdout=${logsInfo.simStdout} --stderr=${logsInfo.simStderr} ` +
-      `${udid} ${bundleId} --args ${args}`;;
+      `${udid} ${bundleId} --args ${args}`;
 
       if (!!languageAndLocale && !!languageAndLocale.language) {
         launchBin += ` -AppleLanguages "(${languageAndLocale.language})"`;

--- a/detox/src/devices/ios/AppleSimUtils.test.js
+++ b/detox/src/devices/ios/AppleSimUtils.test.js
@@ -348,6 +348,26 @@ describe('AppleSimUtils', () => {
       }
     });
 
+    it('should append framework path to existing dyld path if present', async () => {
+      const origEnvVar = process.env.SIMCTL_CHILD_DYLD_INSERT_LIBRARIES;
+      process.env.SIMCTL_CHILD_DYLD_INSERT_LIBRARIES = '/tmp';
+      environment.getFrameworkPath.mockReturnValueOnce(Promise.resolve('thePathToFrameworks'));
+      try {
+        await uut.launch('udid', 'theBundleId');
+        expect(exec.execWithRetriesAndLogs.mock.calls).toMatchSnapshot();
+      } catch (e) {
+        fail(`should throw`);
+      } finally {
+        if (origEnvVar){
+          // set the env var back to what it used to be
+          process.env.SIMCTL_CHILD_DYLD_INSERT_LIBRARIES = origEnvVar;
+        } else {
+          // env var was never set to begin with, delete it
+          delete process.env.SIMCTL_CHILD_DYLD_INSERT_LIBRARIES;
+        } 
+      }
+    });
+
     it('returns the parsed id', async () => {
       exec.execWithRetriesAndLogs.mockReturnValueOnce(Promise.resolve({ stdout: 'appId: 12345 \n' }));
       const result = await uut.launch('udid', 'theBundleId');

--- a/detox/src/devices/ios/__snapshots__/AppleSimUtils.test.js.snap
+++ b/detox/src/devices/ios/__snapshots__/AppleSimUtils.test.js.snap
@@ -192,6 +192,21 @@ Array [
 ]
 `;
 
+exports[`AppleSimUtils launch should append framework path to existing dyld path if present 1`] = `
+Array [
+  Array [
+    "/bin/cat /dev/null >/Users/detox/Library/Developer/CoreSimulator/Devices/udid/data/tmp/detox.last_launch_app_log.out 2>/Users/detox/Library/Developer/CoreSimulator/Devices/udid/data/tmp/detox.last_launch_app_log.err && SIMCTL_CHILD_DYLD_INSERT_LIBRARIES=\\"/tmp:thePathToFrameworks/Detox\\" /usr/bin/xcrun simctl launch --stdout=/tmp/detox.last_launch_app_log.out --stderr=/tmp/detox.last_launch_app_log.err udid theBundleId --args ",
+    undefined,
+    Object {
+      "successful": "theBundleId launched. The stdout and stderr logs were recreated, you can watch them with:
+        tail -F /Users/detox/Library/Developer/CoreSimulator/Devices/udid/data/tmp/detox.last_launch_app_log.{out,err}",
+      "trying": "Launching theBundleId...",
+    },
+    1,
+  ],
+]
+`;
+
 exports[`AppleSimUtils openUrl calls xcrun simctl 1`] = `
 Array [
   Array [


### PR DESCRIPTION
Whatever the user specifies in `SIM_CTL_DYLD_INSERT_LIBRARIES` should propagate through and be reflected in the `xcrun simctl launch` call that AppleSimUtils makes.

My use case: I am passing in my own dylibs that I specify in `SIM_CTL_DYLD_INSERT_LIBRARIES`, and I would like this dylib to get used by my app. This will also help me fix https://github.com/wix/detox/issues/917

I append the detox framework path to the env var, separated by a colon, as this is the format expected specified by `man dyld`: 

```
DYLD_INSERT_LIBRARIES
              This is a colon separated list of dynamic libraries to load before the ones specified in the program.  This lets you test new modules of
              existing dynamic shared libraries that are used in flat-namespace images by loading a temporary dynamic shared library with just the new
              modules.   Note  that  this  has  no  effect  on  images  built  a  two-level  namespace  images  using  a dynamic shared library unless
              DYLD_FORCE_FLAT_NAMESPACE is also used.
```