### PR TITLE
add blacklistRegex to GREYConfiguration on init

### DIFF
--- a/detox/ios/Detox/DetoxManager.m
+++ b/detox/ios/Detox/DetoxManager.m
@@ -45,6 +45,11 @@ static void detoxConditionalInit()
 	
 	NSUserDefaults* options = [NSUserDefaults standardUserDefaults];
 	
+	NSArray *blacklistRegex = [options arrayForKey:@"detoxURLBlacklistRegex"];
+	if (blacklistRegex){
+		[[GREYConfiguration sharedInstance] setValue:blacklistRegex forConfigKey:kGREYConfigKeyURLBlacklistRegex];
+	}
+	
 	NSString *detoxServer = [options stringForKey:@"detoxServer"];
 	NSString *detoxSessionId = [options stringForKey:@"detoxSessionId"];
 	if (!detoxServer || !detoxSessionId)

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -177,6 +177,16 @@ With this API, you can run sets of e2e tests per language. For example:
 });
 ```
 
+##### 10. Initialize the URL blacklist at device launch
+Launch the app with an URL blacklist to disable network synchronization on certain endpoints. Useful if the app makes frequent network calls to blacklisted endpoints upon startup. 
+
+```js
+await device.launchApp({
+  newInstance: true,
+  launchArgs: { detoxURLBlacklistRegex: ' \\("http://192.168.1.253:19001/onchange","https://e.crashlytics.com/spi/v2/events"\\)' },
+}); 
+```
+
 ### `device.relaunchApp(params)`
 **Deprecated** Use `device.launchApp(params)` instead. This method is now calling `launchApp({newInstance: true})` for backwards compatibility, it will be removed in Detox 6.X.X.<Br>
 Kill and relaunch the app defined in the current [`configuration`](APIRef.Configuration.md).
@@ -254,7 +264,7 @@ await device.setLocation(32.0853, 34.7818);
 
 ### `device.setURLBlacklist([urls])`
 
-Disable [EarlGrey's network synchronization mechanism](https://github.com/google/EarlGrey/blob/master/docs/api.md#network) on preffered endpoints. Useful if you want to on skip over synchronizing on certain URLs.
+Disable [EarlGrey's network synchronization mechanism](https://github.com/google/EarlGrey/blob/master/docs/api.md#network) on preferred endpoints. Useful if you want to on skip over synchronizing on certain URLs. To disable endpoints at initialization, pass in the blacklist at [device launch](#10-initialize-the-url-blacklist-at-device-launch).
 
 ```js
 await device.setURLBlacklist(['.*127.0.0.1.*']);


### PR DESCRIPTION
Allow the user to set the blacklist for EarlGrey upon initialization of the `DetoxManager`. This will also help fix https://github.com/wix/Detox/issues/917

# Why
When `device.launchApp` is called, it waits for the device to be ready. In order for the device to be ready, all the tracked Earl Grey resources must be idle. Because Earl Grey tracks all network requests by default, if there are any network calls happening, the app will be considered 'busy'. 

Consider the case where an app is making many network calls to an URL we wish to be blacklisted. First, the app must be launched via `device.launchApp`. Next, the blacklist needs to be set via `device.setURLBlacklist`. However, because there is currently no way to set the blacklist upon initialization, Earl Grey will always consider the app to be 'busy' and the call to `device.launchApp` will hang. 

This can be solved if the user is able to pass in their own blacklist array in `launchApp` like this:
```
  await device.launchApp({
    ...
    newInstance: true,
    launchArgs: { detoxURLBlacklistRegex: ' \\("http://192.168.1.253:19001/onchange","https://e.crashlytics.com/spi/v2/events"\\)' },
  }); 
```