### PR TITLE
Add guide for integrating TypeScript with Detox + Jest

### DIFF
--- a/docs/Guide.TypeScriptIntegrationJest.md
+++ b/docs/Guide.TypeScriptIntegrationJest.md
@@ -84,6 +84,8 @@ Add typings for Detox, Jest, and Jasmine (the latter two are used in `init.ts`),
 npm install --save-dev @types/detox @types/jest @types/jasmine
 ```
 
+Note: [`@types/detox`](https://www.npmjs.com/package/@types/detox) is maintained by the community and not by Wix.
+
 You should now be able to run your Detox tests, written in TypeScript! If you're not writing your unit tests with TypeScript and Jest, you can skip the next section.
 
 ### 5. Unit test collisions

--- a/docs/Guide.TypeScriptIntegrationJest.md
+++ b/docs/Guide.TypeScriptIntegrationJest.md
@@ -1,0 +1,111 @@
+---
+id: Guide.TypeScriptJest
+title: Integrating TypeScript with Detox + Jest
+---
+
+## Usage
+
+### 0. Initialize Detox in your project
+
+Follow the [Getting Started](Introduction.GettingStarted.md) Guide to set up Detox with [Jest as your test runner](Guide.Jest.md) (optionally, set up Detox to [test Android](Introduction.Android.md) as well). When you are finished with that, we will make some changes to your project:
+
+- Remove Detox from `package.json` at the root level
+
+- Create a `package.json` in the `e2e` folder and add Detox and Jest to the project dependencies:
+
+```sh
+npm uninstall detox
+cd e2e
+npm init -y
+npm install -D detox jest
+```
+
+You should then move the settings for Detox from the root-level `package.json` to the `e2e/package.json`, but make sure that you update the `build` and `binaryPath` values for your Detox configurations:
+
+```json
+{
+  // ...
+  "detox": {
+    "configurations": {
+      "ios.sim.debug": {
+        "binaryPath": "../ios/build/Build/Products/Debug-iphonesimulator/YourAppName.app",
+        "build": "xcodebuild -project ../ios/YourAppName.xcodeproj -scheme YourAppName -configuration Debug -sdk iphonesimulator -derivedDataPath ../ios/build",
+        "type": "ios.simulator",
+        "name": "iPhone X"
+      },
+      "android.emu.debug": {
+        "binaryPath": "../android/app/build/outputs/apk/debug/app-debug.apk",
+        "build": "cd ../android; ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug; cd ../e2e",
+        "type": "android.emulator",
+        "name": "Pixel_2_API_27"
+      },
+      "android.emu.release": {
+        "binaryPath": "../android/app/build/outputs/apk/release/app-release.apk",
+        "build": "cd ../android; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release; cd ../e2e",
+        "type": "android.emulator",
+        "name": "Pixel_2_API_27"
+      }
+    }
+  }
+}
+```
+
+Before moving on, make sure that you can still successfully run your Detox tests.
+
+### 1. Add TypeScript + `ts-jest` to `e2e/package.json`
+
+```sh
+npm install --save-dev typescript ts-jest
+```
+
+### 2. Configure Jest to use `ts-jest`
+
+Modify your Jest configuration (`e2e/config.json` by default) to include the following properties
+
+```json
+{
+  "preset": "ts-jest",
+  "testEnvironment": "node",
+  "setupTestFrameworkScriptFile": "./init.ts"
+}
+```
+
+NB: this is mostly the same output of running `ts-jest config:init`, with `setupTestFrameworkScriptFile` being the only added property.
+
+### 3. `.js` -> `.ts`
+
+Convert all files in the `e2e` directory ending in `.js` to `.ts`
+
+### 4. Add typings for Detox, Jest, and Jasmine
+
+Add typings for Detox, Jest, and Jasmine (the latter two are used in `init.ts`), as well as for other modules that you use in your Detox tests.
+
+```sh
+npm install --save-dev @types/detox @types/jest @types/jasmine
+```
+
+You should now be able to run your Detox tests, written in TypeScript! If you're not writing your unit tests with TypeScript and Jest, you can skip the next section.
+
+### 5. Unit test collisions
+
+Detox overrides certain global members that were defined by Jest (such as `expect`), which means that their typings collide and will cause compiler errors if you try to use them in the same project. This means that we need to set up TypeScript to ignore Detox when compiling our unit tests, which isn't straightforward since the default type-lookup behavior of TypeScript [will automatically include typings from `node_modules` under the root directory](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types) (i.e. `e2e/node_modules`). Therefore, we'll set the main `tsconfig.json` to ignore typings within the `e2e/node_modules/@types` directory, and only consider typings in the root-level `node_modules`, while `e2e/tsconfig.json` will include types from both the `e2e` and root directory `node_modules`:
+
+```json
+{
+  // tsconfig.json
+  "compilerOptions": {
+    "typeRoots": ["node_modules/@types"]
+  }
+}
+```
+
+```json
+{
+  // e2e/tsconfig.json
+  "compilerOptions": {
+    "typeRoots": ["node_modules/@types", "../node_modules/@types"]
+  }
+}
+```
+
+With those `typeRoots` settings, you should now be able to run both your unit tests and Detox tests successfully and with no compiler errors.

--- a/docs/Guide.TypeScriptIntegrationJest.md
+++ b/docs/Guide.TypeScriptIntegrationJest.md
@@ -7,10 +7,9 @@ title: Integrating TypeScript with Detox + Jest
 
 ### 0. Initialize Detox in your project
 
-Follow the [Getting Started](Introduction.GettingStarted.md) Guide to set up Detox with [Jest as your test runner](Guide.Jest.md) (optionally, set up Detox to [test Android](Introduction.Android.md) as well). When you are finished with that, we will make some changes to your project:
+After following the [Getting Started](Introduction.GettingStarted.md) Guide to set up Detox + Jest, we will make some changes to your project:
 
 - Remove Detox from `package.json` at the root level
-
 - Create a `package.json` in the `e2e` folder and add Detox and Jest to the project dependencies:
 
 ```sh
@@ -20,7 +19,7 @@ npm init -y
 npm install -D detox jest
 ```
 
-You should then move the settings for Detox from the root-level `package.json` to the `e2e/package.json`, but make sure that you update the `build` and `binaryPath` values for your Detox configurations:
+Creating the `e2e` directory will be needed to prevent a typing collision issue with Jest and Detox (see step 5). You should then move the settings for Detox from the root-level `package.json` to the `e2e/package.json`, but make sure that you update the `build` and `binaryPath` values for your Detox configurations:
 
 ```json
 {

--- a/docs/Guide.TypeScriptIntegrationJest.md
+++ b/docs/Guide.TypeScriptIntegrationJest.md
@@ -9,22 +9,22 @@ title: Integrating TypeScript with Detox + Jest
 
 After following the [Getting Started](Introduction.GettingStarted.md) Guide to set up Detox + Jest, we will make some changes to your project:
 
-- Remove Detox from `package.json` at the root level
+- Remove Detox from `package.json` at the root level: `npm uninstall detox`
 - Create a `package.json` in the `e2e` folder and add Detox and Jest to the project dependencies:
 
 ```sh
-npm uninstall detox
 cd e2e
 npm init -y
 npm install -D detox jest
 ```
 
-Creating the `e2e` directory will be needed to prevent a typing collision issue with Jest and Detox (see step 5). You should then move the settings for Detox from the root-level `package.json` to the `e2e/package.json`, but make sure that you update the `build` and `binaryPath` values for your Detox configurations:
+You should then move the settings for Detox from the root-level `package.json` to the `e2e/package.json`, but make sure that you update the `build`, `binaryPath`, and `runner-config` values for your Detox configurations:
 
 ```json
 {
   // ...
   "detox": {
+    "runner-config": "./config.json",
     "configurations": {
       "ios.sim.debug": {
         "binaryPath": "../ios/build/Build/Products/Debug-iphonesimulator/YourAppName.app",
@@ -48,6 +48,14 @@ Creating the `e2e` directory will be needed to prevent a typing collision issue 
   }
 }
 ```
+
+- Edit `init.js` to `require` the Detox configuration from `e2e/package.json` instead of the root-level `package.json`
+
+```js
+const config = require('./package.json').detox;
+```
+
+Moving all Detox-related code into the `e2e` directory is necessary to prevent a typing collision issue with Jest and Detox (see step 5).
 
 Before moving on, make sure that you can still successfully run your Detox tests.
 

--- a/docs/Guide.TypeScriptIntegrationJest.md
+++ b/docs/Guide.TypeScriptIntegrationJest.md
@@ -5,61 +5,13 @@ title: Integrating TypeScript with Detox + Jest
 
 ## Usage
 
-### 0. Initialize Detox in your project
+This guide assumes you've got a project using Detox with Jest, and you want to write your Detox tests in [TypeScript](https://www.typescriptlang.org).
 
-After following the [Getting Started](Introduction.GettingStarted.md) Guide to set up Detox + Jest, we will make some changes to your project:
+- Refer to [this guide](./Guide.Jest.md) if you need to set up such a project.
 
-- Remove Detox from `package.json` at the root level: `npm uninstall detox`
-- Create a `package.json` in the `e2e` folder and add Detox and Jest to the project dependencies:
+### 1. Add TypeScript + `ts-jest` to `package.json`
 
-```sh
-cd e2e
-npm init -y
-npm install -D detox jest
-```
-
-You should then move the settings for Detox from the root-level `package.json` to the `e2e/package.json`, but make sure that you update the `build`, `binaryPath`, and `runner-config` values for your Detox configurations:
-
-```json
-{
-  // ...
-  "detox": {
-    "runner-config": "./config.json",
-    "configurations": {
-      "ios.sim.debug": {
-        "binaryPath": "../ios/build/Build/Products/Debug-iphonesimulator/YourAppName.app",
-        "build": "xcodebuild -project ../ios/YourAppName.xcodeproj -scheme YourAppName -configuration Debug -sdk iphonesimulator -derivedDataPath ../ios/build",
-        "type": "ios.simulator",
-        "name": "iPhone X"
-      },
-      "android.emu.debug": {
-        "binaryPath": "../android/app/build/outputs/apk/debug/app-debug.apk",
-        "build": "cd ../android; ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug; cd ../e2e",
-        "type": "android.emulator",
-        "name": "Pixel_2_API_27"
-      },
-      "android.emu.release": {
-        "binaryPath": "../android/app/build/outputs/apk/release/app-release.apk",
-        "build": "cd ../android; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release; cd ../e2e",
-        "type": "android.emulator",
-        "name": "Pixel_2_API_27"
-      }
-    }
-  }
-}
-```
-
-- Edit `init.js` to `require` the Detox configuration from `e2e/package.json` instead of the root-level `package.json`
-
-```js
-const config = require('./package.json').detox;
-```
-
-Moving all Detox-related code into the `e2e` directory is necessary to prevent a typing collision issue with Jest and Detox (see step 5).
-
-Before moving on, make sure that you can still successfully run your Detox tests.
-
-### 1. Add TypeScript + `ts-jest` to `e2e/package.json`
+We'll be using [ts-jest](https://kulshekhar.github.io/ts-jest/) to run Jest tests with TypeScript.
 
 ```sh
 npm install --save-dev typescript ts-jest
@@ -91,30 +43,43 @@ Add typings for Detox, Jest, and Jasmine (the latter two are used in `init.ts`),
 npm install --save-dev @types/detox @types/jest @types/jasmine
 ```
 
+### 5. Writing tests
+
+It's recommended that you import the Detox methods instead of their globally defined counterparts, to avoid a typing issue between Detox and Jest. This can be enforced by calling `detox.init` with `{ initGlobals: false }`
+
+Your `init.ts` would look simliar to this:
+
+```ts
+import { cleanup, init } from 'detox';
+import * as adapter from 'detox/runners/jest/adapter';
+
+const config = require('../package.json').detox;
+
+jest.setTimeout(120000);
+jasmine.getEnv().addReporter(adapter);
+
+beforeAll(async () => {
+  await init(config, { initGlobals: false });
+});
+
+beforeEach(async () => {
+  await adapter.beforeEach();
+});
+
+afterAll(async () => {
+  await adapter.afterAll();
+  await cleanup();
+});
+```
+
+Note: the global constants are still defined in the typings, so using the globals will not result in a `tsc` error.
+
+Your tests would then import the Detox methods from the `detox` module like so:
+
+```ts
+import { by, device, expect, element, waitFor } from 'detox';
+```
+
 Note: [`@types/detox`](https://www.npmjs.com/package/@types/detox) is maintained by the community and not by Wix.
 
-You should now be able to run your Detox tests, written in TypeScript! If you're not writing your unit tests with TypeScript and Jest, you can skip the next section.
-
-### 5. Unit test collisions
-
-Detox overrides certain global members that were defined by Jest (such as `expect`), which means that their typings collide and will cause compiler errors if you try to use them in the same project. This means that we need to set up TypeScript to ignore Detox when compiling our unit tests, which isn't straightforward since the default type-lookup behavior of TypeScript [will automatically include typings from `node_modules` under the root directory](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types) (i.e. `e2e/node_modules`). Therefore, we'll set the main `tsconfig.json` to ignore typings within the `e2e/node_modules/@types` directory, and only consider typings in the root-level `node_modules`, while `e2e/tsconfig.json` will include types from both the `e2e` and root directory `node_modules`:
-
-```json
-{
-  // tsconfig.json
-  "compilerOptions": {
-    "typeRoots": ["node_modules/@types"]
-  }
-}
-```
-
-```json
-{
-  // e2e/tsconfig.json
-  "compilerOptions": {
-    "typeRoots": ["node_modules/@types", "../node_modules/@types"]
-  }
-}
-```
-
-With those `typeRoots` settings, you should now be able to run both your unit tests and Detox tests successfully and with no compiler errors.
+You should now be able to run your Detox tests, written in TypeScript!

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ sidebar_label: Overview
 - [Advanced Mocking With Detox](Guide.Mocking.md)
 - [Migration Between Detox Versions](Guide.Migration.md)
 - [Use Jest as Test Runner](Guide.Jest.md)
+- [Integrating TypeScript with Detox + Jest](Guide.TypeScriptIntegrationJest.md)
 - [Parallel Test Execution](Guide.ParallelTestExecution.md)
 
 ## Under The Hood


### PR DESCRIPTION
Adds a page in the `docs` folder with instructions on converting a Detox + Jest project to allow for writing the tests with TypeScript. Would love feedback on the guide!

I do have a couple of thoughts:
- Should this just be an extension of the Jest guide, since this is specific to that setup?
- There should probably be a Mocha counterpart for this (I don't use Mocha, however, so this would need to come from the community)