### PR TITLE
List possible values for `type`

### DIFF
--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -10,10 +10,10 @@ title: Configuration Options
 
 |Configuration Params|Details|
 |---|---|
-|`binaryPath`|relative path to the ipa/app due to be  tested (make sure you build the app in a project relative path)|
-|`type`|device type, currently only `ios.simulator` is supported|
-|`name`|device name, aligns to the device list avaliable through `xcrun simctl list` for example, this is one line of the output of `xcrun simctl list`: `A3C93900-6D17-4830-8FBE-E102E4BBCBB9  iPhone 7  Shutdown  iPhone 7  iOS 10.2`, ir order to choose the first `iPhone 7` regardless of OS version, use `iPhone 7`. <br>To be OS specific use `iPhone 7, iOS 10.2`|
-|`build`| **[optional]** build command (either `xcodebuild`, `react-native run-ios`, etc...), will be later available through detox CLI tool.|
+|`binaryPath`| Relative path to the ipa/app due to be  tested (make sure you build the app in a project relative path)|
+|`type`| Device type, available options are `ios.simulator`, `ios.none`, `android.emulator`, and `android.attached`. Currently only `ios.simulator` is supported. |
+|`name`| Device name, aligns to the device list avaliable through `xcrun simctl list` for example, this is one line of the output of `xcrun simctl list`: `A3C93900-6D17-4830-8FBE-E102E4BBCBB9  iPhone 7  Shutdown  iPhone 7  iOS 10.2`, ir order to choose the first `iPhone 7` regardless of OS version, use `iPhone 7`. <br>To be OS specific use `iPhone 7, iOS 10.2`|
+|`build`| **[optional]** Build command (either `xcodebuild`, `react-native run-ios`, etc...), will be later available through detox CLI tool.|
 	
 **Example:**
 

--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -11,7 +11,7 @@ title: Configuration Options
 |Configuration Params|Details|
 |---|---|
 |`binaryPath`| Relative path to the ipa/app due to be  tested (make sure you build the app in a project relative path)|
-|`type`| Device type, available options are `ios.simulator`, `ios.none`, `android.emulator`, and `android.attached`. Currently only `ios.simulator` is supported. |
+|`type`| Device type, available options are `ios.simulator`, `ios.none`, `android.emulator`, and `android.attached`. |
 |`name`| Device name, aligns to the device list avaliable through `xcrun simctl list` for example, this is one line of the output of `xcrun simctl list`: `A3C93900-6D17-4830-8FBE-E102E4BBCBB9  iPhone 7  Shutdown  iPhone 7  iOS 10.2`, ir order to choose the first `iPhone 7` regardless of OS version, use `iPhone 7`. <br>To be OS specific use `iPhone 7, iOS 10.2`|
 |`build`| **[optional]** Build command (either `xcodebuild`, `react-native run-ios`, etc...), will be later available through detox CLI tool.|
 	


### PR DESCRIPTION
Lists the possible values for the `type` configuration, even though `ios.simulator` is the only supported value.