### PR TITLE
update expo usage guides

### DIFF
--- a/docs/Guide.Expo.md
+++ b/docs/Guide.Expo.md
@@ -5,7 +5,7 @@ title: Expo
 
 ## Usage with Expo (iOS)
 
-- Install `detox` and `detox-expo-helpers` (yarn or npm)
+- Install `detox` 9.0.6 or higher, `detox-expo-helpers` and `expo-detox-hook` (yarn or npm)
 - Add `detox` configuration to [package.json](https://github.com/expo/with-detox-tests/blob/master/package.json#L21-L29):
 
 ```es6


### PR DESCRIPTION
Expo apps didn't play well with detox 7 and above. I've since made some fixes for this, and it works for detox v9.0.6 now. Updating docs to reflect this change.