### PR TITLE
fix: enable acquiring an already attached emulator by ADB name

### DIFF
--- a/detox/src/devices/drivers/AttachedAndroidDriver.js
+++ b/detox/src/devices/drivers/AttachedAndroidDriver.js
@@ -10,7 +10,7 @@ class AttachedAndroidDriver extends AndroidDriver {
   }
 
   async acquireFreeDevice(name) {
-    const deviceId = await this.findDeviceId({name: name});
+    const deviceId = await this.findDeviceId({adbName: name});
     await this.adb.apiLevel(name);
     await this.adb.unlockScreen(deviceId);
     return deviceId;


### PR DESCRIPTION
Resolves #1027 

/cc @jgreen210 