### PR TITLE
Add getViewportSize for device

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -42,6 +42,7 @@
     "commander": "^2.15.1",
     "fs-extra": "^4.0.2",
     "get-port": "^2.1.0",
+    "image-size": "^0.6.3",
     "ini": "^1.3.4",
     "lodash": "^4.17.5",
     "minimist": "^1.2.0",

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -208,6 +208,10 @@ class Device {
     return this.deviceDriver.getPlatform(this._deviceId);
   }
 
+  async getViewportSize() {
+    return await this.deviceDriver.getViewportSize(this._deviceId);
+  }
+
   async _cleanup() {
     await this.deviceDriver.cleanup(this._deviceId, this._bundleId);
   }

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -149,6 +149,26 @@ class ADB {
     return Number(stdout.slice(0, stdout.indexOf(' ')));
   }
 
+  async getViewportSize(deviceId) {
+    const { stdout } = await this.adbCmd(deviceId, 'shell wm size').catch(e => e);
+  
+    const sizeRegex = /(\d+)x(\d+)/i
+  
+    const matches = stdout && stdout.match(sizeRegex)
+  
+    if (matches && matches.length === 3) {
+      return {
+        width: +matches[1],
+        height: +matches [2]
+      }
+    } else {
+      return {
+        width: undefined,
+        height: undefined
+      }
+    }
+  }
+
   async isBootComplete(deviceId) {
     try {
       const bootComplete = await this.shell(deviceId, `getprop dev.bootcomplete`, { silent: true });

--- a/detox/src/devices/drivers/AndroidDriver.js
+++ b/detox/src/devices/drivers/AndroidDriver.js
@@ -62,6 +62,10 @@ class AndroidDriver extends DeviceDriverBase {
     await this.invocationManager.execute(call);
   }
 
+  async getViewportSize(deviceId) {
+    return await this.adb.getViewportSize(deviceId);
+  }
+
   getTestApkPath(originalApkPath) {
     const testApkPath = APKPath.getTestApkPath(originalApkPath);
 

--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -2,6 +2,8 @@ const exec = require('child-process-promise').exec;
 const path = require('path');
 const fs = require('fs');
 const _ = require('lodash');
+const tempfile = require('tempfile');
+const sizeOf = require('image-size');
 const IosDriver = require('./IosDriver');
 const AppleSimUtils = require('../ios/AppleSimUtils');
 const configuration = require('../../configuration');
@@ -103,6 +105,20 @@ class SimulatorDriver extends IosDriver {
   async shutdown(deviceId) {
     await this._applesimutils.shutdown(deviceId);
     await this.emitter.emit('shutdownDevice', { deviceId });
+  }
+
+  async getViewportSize(udid) {
+    const temporaryFilePath = tempfile('.png');
+
+    await this._applesimutils.takeScreenshot(udid, temporaryFilePath)
+
+    var dimensions = sizeOf(temporaryFilePath);
+
+    fs.unlinkSync(temporaryFilePath);
+    
+    delete dimensions.type
+
+    return dimensions
   }
 
   async setLocation(deviceId, lat, lon) {

--- a/detox/test/e2e/06.device.test.js
+++ b/detox/test/e2e/06.device.test.js
@@ -78,6 +78,34 @@ describe('Device', () => {
     await expect(element(by.text('Shaken, not stirred'))).toBeVisible();
   });
 
+  it(':ios: iPhone X viewport should equal 1125x2436', async () => {
+    const size = await device.getViewportSize();
+
+    if (!size) {
+      throw new Error("Could not retrieve viewport size");
+    }
+    if (size.width !== 1125) {
+      throw new Error("Width did not equal 1125");
+    }
+    if (size.height !== 2436) {
+      throw new Error("Height did not equal 2436");
+    }
+  });
+
+  it(':android: Nexus 5X viewport should equal 1080x1920', async () => {
+    const size = await device.getViewportSize();
+
+    if (!size) {
+      throw new Error("Could not retrieve viewport size");
+    }
+    if (size.width !== 1080) {
+      throw new Error("Width did not equal 1080");
+    }
+    if (size.height !== 1920) {
+      throw new Error("Height did not equal 1920");
+    }
+  });
+
   describe(':android: device back button', () => {
     beforeEach(async() => {
       await device.reloadReactNative();

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -24,6 +24,7 @@ title: The `device` Object
 - [`device.disableSynchronization()`](#devicedisablesynchronization)
 - [`device.resetContentAndSettings()`](#deviceresetcontentandsettings)
 - [`device.getPlatform()`](#devicegetplatform)
+- [`device.getViewportSize()`](#devicegetviewportsize)
 - [`device.pressBack()` **Android Only**](#devicepressback-android-only)
 - [`device.shake()` **iOS Only**](#deviceshake-ios-only)
 
@@ -306,6 +307,14 @@ Returns the current device, `ios` or `android`.
 if (device.getPlatform() === 'ios') {
   await expect(loopSwitch).toHaveValue('1');
 }
+```
+
+### `device.getViewportSize()`
+Returns the current device viewport/screen size. The return value will be an object containing a `width` and `height` property. As an example, these values can be used to scroll relative to the height of the screen.
+
+```js
+const viewportSize =  await device.getViewportSize();
+await element(by.id('scrollView')).scroll(viewportSize.height / 4, 'down');
 ```
 
 ### `device.pressBack()` **Android Only**


### PR DESCRIPTION
### Motivation

Wanting to use the same code to scroll relative to height of device on both iOS and Android meant that we have to know the viewport size. So, in order to avoid depending on hard coded values, I've added a `device.getViewportSize`-function to retrieve the width and height of the current device. We use this internally at [ice](https://ice.no) for our Detox-tests.

### Discussion

On Android it is pretty straightforward to retrieve the viewport size through `adb shell wm size`.

On iOS I could not find a similar command, so I hack around it by checking the size of a screenshot taken on the device. Since taking a screenshot is functionality Detox already had, I thought maybe this implementation was acceptable. Also added the `image-size` npm package to help with retrieving the size of the screenshot. If there are alternative ways of solving this on iOS I'm all ears though.

Also added a E2E-test for iOS and Android each checking the device sizes for the E2E devices.

Hope this is found to be useful!