### PR TITLE
New Actions: `tapBackspaceKey` and `tapReturnKey`

### DIFF
--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -204,10 +204,10 @@ class Element {
   async multiTap(times) {
     return await new ActionInteraction(this, new MultiClickAction(times)).execute();
   }
-  async pressBackspaceKey() {
+  async tapBackspaceKey() {
     return await new ActionInteraction(this, new PressKeyAction(67)).execute();
   }
-  async pressReturnKey() {
+  async tapReturnKey() {
     return await new ActionInteraction(this, new TypeTextAction('\n')).execute();
   }
   async typeText(value) {

--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -54,6 +54,13 @@ class MultiClickAction extends Action {
   }
 }
 
+class PressKeyAction extends Action {
+  constructor(value) {
+    super();
+    this._call = invoke.callDirectly(ViewActionsApi.pressKey(value));
+  }
+}
+
 class TypeTextAction extends Action {
   constructor(value) {
     super();
@@ -196,6 +203,12 @@ class Element {
   }
   async multiTap(times) {
     return await new ActionInteraction(this, new MultiClickAction(times)).execute();
+  }
+  async pressBackspaceKey() {
+    return await new ActionInteraction(this, new PressKeyAction(67)).execute();
+  }
+  async pressReturnKey() {
+    return await new ActionInteraction(this, new TypeTextAction('\n')).execute();
   }
   async typeText(value) {
     return await new ActionInteraction(this, new TypeTextAction(value)).execute();

--- a/detox/src/android/expect.test.js
+++ b/detox/src/android/expect.test.js
@@ -103,8 +103,8 @@ describe('expect', async () => {
     await e.element(e.by.label('Tap Me')).longPress();
     await e.element(e.by.id('UniqueId819')).multiTap(3);
     await e.element(e.by.id('UniqueId937')).typeText('passcode');
-    await e.element(e.by.id('UniqueId937')).pressBackspaceKey();
-    await e.element(e.by.id('UniqueId937')).pressReturnKey();
+    await e.element(e.by.id('UniqueId937')).tapBackspaceKey();
+    await e.element(e.by.id('UniqueId937')).tapReturnKey();
     await e.element(e.by.id('UniqueId005')).clearText();
     await e.element(e.by.id('UniqueId005')).replaceText('replaceTo');
     await e.element(e.by.id('ScrollView161')).scroll(100);

--- a/detox/src/android/expect.test.js
+++ b/detox/src/android/expect.test.js
@@ -35,14 +35,14 @@ describe('expect', async () => {
   it(`element by type`, async () => {
     await e.expect(e.element(e.by.type('test'))).toBeVisible();
   });
-  
+
   it(`element by traits`, async () => {
     await e.expect(e.element(e.by.traits(['button', 'link', 'header', 'search']))).toBeVisible();
     await e.expect(e.element(e.by.traits(['image', 'selected', 'plays', 'key']))).toBeNotVisible();
     await e.expect(e.element(e.by.traits(['text', 'summary', 'disabled', 'frequentUpdates']))).toBeNotVisible();
     await e.expect(e.element(e.by.traits(['startsMedia', 'adjustable', 'allowsDirectInteraction', 'pageTurn']))).toBeNotVisible();
   });
-  
+
   it(`matcher helpers`, async () => {
     await e.expect(e.element(e.by.id('test').withAncestor(e.by.id('ancestor')))).toBeVisible();
     await e.expect(e.element(e.by.id('test').withDescendant(e.by.id('descendant')))).toBeVisible();
@@ -103,6 +103,8 @@ describe('expect', async () => {
     await e.element(e.by.label('Tap Me')).longPress();
     await e.element(e.by.id('UniqueId819')).multiTap(3);
     await e.element(e.by.id('UniqueId937')).typeText('passcode');
+    await e.element(e.by.id('UniqueId937')).pressBackspaceKey();
+    await e.element(e.by.id('UniqueId937')).pressReturnKey();
     await e.element(e.by.id('UniqueId005')).clearText();
     await e.element(e.by.id('UniqueId005')).replaceText('replaceTo');
     await e.element(e.by.id('ScrollView161')).scroll(100);

--- a/detox/src/ios/expect.js
+++ b/detox/src/ios/expect.js
@@ -278,10 +278,10 @@ class Element {
   async multiTap(value) {
     return await new ActionInteraction(this, new MultiTapAction(value)).execute();
   }
-  async pressBackspaceKey() {
+  async tapBackspaceKey() {
     return await new ActionInteraction(this, new TypeTextAction('\b')).execute();
   }
-  async pressReturnKey() {
+  async tapReturnKey() {
     return await new ActionInteraction(this, new TypeTextAction('\n')).execute();
   }
   async typeText(value) {

--- a/detox/src/ios/expect.js
+++ b/detox/src/ios/expect.js
@@ -278,6 +278,12 @@ class Element {
   async multiTap(value) {
     return await new ActionInteraction(this, new MultiTapAction(value)).execute();
   }
+  async pressBackspaceKey() {
+    return await new ActionInteraction(this, new TypeTextAction('\b')).execute();
+  }
+  async pressReturnKey() {
+    return await new ActionInteraction(this, new TypeTextAction('\n')).execute();
+  }
   async typeText(value) {
     return await new ActionInteraction(this, new TypeTextAction(value)).execute();
   }

--- a/detox/src/ios/expect.test.js
+++ b/detox/src/ios/expect.test.js
@@ -80,7 +80,7 @@ describe('expect', async () => {
     await e.waitFor(e.element(e.by.id('id'))).toHaveValue('value');
     await e.waitFor(e.element(e.by.id('id'))).toNotHaveValue('value');
 
-  
+
 
     await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).scroll(50, 'down');
     await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).scroll(50);
@@ -104,6 +104,8 @@ describe('expect', async () => {
     await e.element(e.by.label('Tap Me')).longPress(2000);
     await e.element(e.by.id('UniqueId819')).multiTap(3);
     await e.element(e.by.id('UniqueId937')).typeText('passcode');
+    await e.element(e.by.id('UniqueId937')).pressBackspaceKey();
+    await e.element(e.by.id('UniqueId937')).pressReturnKey();
     await e.element(e.by.id('UniqueId005')).clearText();
     await e.element(e.by.id('UniqueId005')).replaceText('replaceTo');
     await e.element(e.by.id('ScrollView161')).scroll(100);

--- a/detox/src/ios/expect.test.js
+++ b/detox/src/ios/expect.test.js
@@ -104,8 +104,8 @@ describe('expect', async () => {
     await e.element(e.by.label('Tap Me')).longPress(2000);
     await e.element(e.by.id('UniqueId819')).multiTap(3);
     await e.element(e.by.id('UniqueId937')).typeText('passcode');
-    await e.element(e.by.id('UniqueId937')).pressBackspaceKey();
-    await e.element(e.by.id('UniqueId937')).pressReturnKey();
+    await e.element(e.by.id('UniqueId937')).tapBackspaceKey();
+    await e.element(e.by.id('UniqueId937')).tapReturnKey();
     await e.element(e.by.id('UniqueId005')).clearText();
     await e.element(e.by.id('UniqueId005')).replaceText('replaceTo');
     await e.element(e.by.id('ScrollView161')).scroll(100);

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -38,13 +38,13 @@ describe('Actions', () => {
   it('should press the backspace key on an element', async () => {
     await element(by.id('UniqueId937')).tap();
     await element(by.id('UniqueId937')).typeText('testx');
-    await element(by.id('UniqueId937')).pressBackspaceKey();
+    await element(by.id('UniqueId937')).tapBackspaceKey();
     await expect(element(by.text('test'))).toBeVisible();
   });
 
   it('should press the return key on an element', async () => {
     await element(by.id('UniqueId937')).tap();
-    await element(by.id('UniqueId937')).pressReturnKey();
+    await element(by.id('UniqueId937')).tapReturnKey();
     await expect(element(by.text('Return Working!!!'))).toBeVisible();
   });
 

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -29,11 +29,23 @@ describe('Actions', () => {
     await expect(element(by.id('UniqueId819'))).toHaveText('Taps: 1');
   });
 
-  // Backspace is supported by using "\b" in the string. Return key is supported with "\n"
   it('should type in an element', async () => {
     await element(by.id('UniqueId937')).tap();
     await element(by.id('UniqueId937')).typeText('passcode');
     await expect(element(by.text('Type Working!!!'))).toBeVisible();
+  });
+
+  it('should press the backspace key on an element', async () => {
+    await element(by.id('UniqueId937')).tap();
+    await element(by.id('UniqueId937')).typeText('testx');
+    await element(by.id('UniqueId937')).pressBackspaceKey();
+    await expect(element(by.text('test'))).toBeVisible();
+  });
+
+  it('should press the return key on an element', async () => {
+    await element(by.id('UniqueId937')).tap();
+    await element(by.id('UniqueId937')).pressReturnKey();
+    await expect(element(by.text('Return Working!!!'))).toBeVisible();
   });
 
   it('should clear text in an element', async () => {

--- a/detox/test/src/Screens/ActionsScreen.js
+++ b/detox/test/src/Screens/ActionsScreen.js
@@ -60,6 +60,7 @@ export default class ActionsScreen extends Component {
           onChangeText={this.onChangeTypeText.bind(this)}
           value={this.state.typeText}
           testID='UniqueId937'
+          onSubmitEditing={this.onReturn.bind(this)}
         />
 
         <TextInput style={{ height: 40, borderColor: 'gray', borderWidth: 1, marginBottom: 20, marginHorizontal: 20, padding: 5 }}
@@ -120,6 +121,12 @@ export default class ActionsScreen extends Component {
   onButtonPress(greeting) {
     this.setState({
       greeting: greeting
+    });
+  }
+
+  onReturn() {
+    this.setState({
+      greeting: "Return Working"
     });
   }
 

--- a/docs/APIRef.ActionsOnElement.md
+++ b/docs/APIRef.ActionsOnElement.md
@@ -56,14 +56,14 @@ await element(by.id('tappable')).tapAtPoint({x:5, y:10});
 ```
 
 ### `tapBackspaceKey()`
-Tap the backspace key on the built-in keyboard.<br><br>
+Tap the backspace key on the built-in keyboard.
 
 ```js
 await element(by.id('textField')).tapBackspaceKey();
 ```
 
 ### `tapReturnKey()`
-Tap the return key on the built-in keyboard.<br><br>
+Tap the return key on the built-in keyboard.
 
 ```js
 await element(by.id('textField')).tapReturnKey();

--- a/docs/APIRef.ActionsOnElement.md
+++ b/docs/APIRef.ActionsOnElement.md
@@ -15,6 +15,8 @@ Actions are functions that emulate user behavior. They are being performed on ma
 - [`.longPress()`](#longpress)
 - [`.multiTap()`](#multitaptimes)
 - [`.tapAtPoint()`](#tapatpoint)
+- [`.tapBackspaceKey()`](#tapbackspacekey)
+- [`.tapReturnKey()`](#tapreturnkey)
 - [`.typeText()`](#typetexttext)
 - [`.replaceText()`](#replacetexttext)
 - [`.clearText()`](#cleartext)
@@ -47,10 +49,24 @@ await element(by.id('tappable')).multiTap(3);
 ```
 ### `tapAtPoint()`
 Simulate tap at a specific point on an element.<br><br>
-Note: The point coordinates are relative to the matched element and the element size could changes on different devices or even when changing the device font size.   
+Note: The point coordinates are relative to the matched element and the element size could changes on different devices or even when changing the device font size.
 
 ```js
 await element(by.id('tappable')).tapAtPoint({x:5, y:10});
+```
+
+### `tapBackspaceKey()`
+Tap the backspace key on the built-in keyboard.<br><br>
+
+```js
+await element(by.id('textField')).tapBackspaceKey();
+```
+
+### `tapReturnKey()`
+Tap the return key on the built-in keyboard.<br><br>
+
+```js
+await element(by.id('textField')).tapReturnKey();
 ```
 
 ### `typeText(text)`
@@ -61,7 +77,7 @@ await element(by.id('textField')).typeText('passcode');
 ```
 
 > **Note:** Make sure hardware keyboard is disconnected. Otherwise, Detox may fail when attempting to type text.
-> 
+>
 > To make sure hardware keyboard is disconnected, open the simulator from Xcode and make sure **Hardware** -> **Keyboard** -> **Connect Hardware Keyboard** is deselected (or press ⇧⌘K).
 
 ### `replaceText(text)`


### PR DESCRIPTION
- [X] This change has been discussed in issue #1039 and the solution has been agreed upon with maintainers.

---

This PR adds support for pressing the backspace and return keys on both iOS and Android. Although iOS support exists by using typeText and the `\b` and `\n` keys, this was unclear and not cross-platform. The pressBackspaceKey and pressReturnKey methods abstract these features for both platforms.

**Note:** I did try adding a `numberOfTimes` parameter as a shortcut for pressing the backspace or return key multiple times, however I wasn't able to figure out the simplest way for executing multiple actions:

For both Android and iOS, the addition `numberOfTimes` for pressReturnKey is pretty straightforward:
```javascript
async pressReturnKey(numberOfTimes = 1) {
  if (numberOfTimes && typeof numberOfTimes !== 'number') { throw new Error('...') }
  return await new ActionInteraction(this, new TypeTextAction('\n'.repeat(numberOfTimes))).execute();
}
```

For pressBackspaceKey on iOS, it can be implemented the same way as return, replacing `\n` with `\b`. For Android, however, I'm not sure how to invoke multiple `PressKeyActions`. Either way, I think this can be added in a follow up PR if it's determined to be useful.

cc @LeoNatan
