### PR TITLE
Android Sync: Improve RN-timers idling resource such that it would skip over interval-timers

### DIFF
--- a/detox/test/e2e/09.stress-timeouts.test.js
+++ b/detox/test/e2e/09.stress-timeouts.test.js
@@ -33,4 +33,9 @@ describe('StressTimeouts', () => {
     await element(by.id('IntervalIgnore')).tap();
     await expect(element(by.text('Interval Ignored!!!'))).toBeVisible();
   });
+
+  it('should skip over setInterval', async () => {
+    await element(by.id('SkipOverInterval')).tap();
+    await expect(element(by.text('Interval Skipped-Over!!!'))).toBeVisible();
+  });
 });

--- a/detox/test/src/Screens/TimeoutsScreen.js
+++ b/detox/test/src/Screens/TimeoutsScreen.js
@@ -44,6 +44,10 @@ export default class TimeoutsScreen extends Component {
           <Text testID='IntervalIgnore' style={{color: 'blue', marginBottom: 20}}>Interval Ignore</Text>
         </TouchableOpacity>
 
+        <TouchableOpacity onPress={this.onIntervalSkipOver.bind(this, 'Interval Skipped-Over')}>
+          <Text testID='SkipOverInterval' style={{color: 'blue', marginBottom: 20}}>Interval Skip-Over</Text>
+        </TouchableOpacity>
+
       </View>
     );
   }
@@ -59,37 +63,42 @@ export default class TimeoutsScreen extends Component {
   }
 
   onTimeoutButtonPress(greeting, timeout) {
-    setTimeout(() => {
-      this.setState({
-        greeting: greeting
-      });
-    }, timeout);
+    setTimeout(() => this.setState({greeting}), timeout);
   }
 
   onTimeoutIgnoreButtonPress(greeting, timeout) {
-    setTimeout(() => {
-      console.log('this will happen soon');
-    }, timeout);
-    this.setState({
-      greeting: greeting
-    });
+    setTimeout(() => console.log('this will happen soon'), timeout);
+    this.setState({greeting});
   }
 
   onImmediateButtonPress(greeting) {
-    setImmediate(() => {
-      this.setState({
-        greeting: greeting
-      });
-    });
+    setImmediate(() => this.setState({greeting}));
   }
 
   onIntervalIgnoreButtonPress(greeting, interval) {
-    setInterval(() => {
-      console.log('this is recurring');
-    }, interval);
-    this.setState({
-      greeting: greeting
-    });
+    setInterval(() => console.log('this is recurring'), interval);
+    this.setState({greeting});
   }
 
+  onIntervalSkipOver(greeting) {
+    const busyPeriodTimeoutHandler = () => this.setState({greeting});
+    const idledTimeoutHandler = (timeMs) => console.log(`Non-busy keeping timer of ${timeMs}ms has expired`);
+
+    const interval = 88;
+    const busyKeepingTime = 600;
+    const idledTimeBase = 1500 + 1;
+    const foreverTimer = 2500;
+    let intervalId;
+
+    intervalId = setInterval(() => console.log(`this should show every ${interval}ms`), interval);
+    setTimeout(() => idledTimeoutHandler(idledTimeBase), idledTimeBase);
+    setTimeout(() => busyPeriodTimeoutHandler(), busyKeepingTime);
+    setTimeout(() => idledTimeoutHandler(idledTimeBase + 10), idledTimeBase + 10);
+    setTimeout(() => idledTimeoutHandler(idledTimeBase + 100), idledTimeBase + 100);
+    setTimeout(() => {
+      console.log('"Forever" timer expired - though it shouldn\'t have!');
+      clearInterval(intervalId);
+      this.setState({greeting: '???'});
+    }, foreverTimer);
+  }
 }


### PR DESCRIPTION
**Description:**

Though in 5a179cac we've improved the RN-timers idling resource on Android - making it effective for the 1st time, we didn't take repeating timers (i.e. JS intervals) into account.

This branch introduces an iOS-equivalent solution that simply ignores intervals and takes the nearest non-repeating timer as the one to inspect.
