### PR TITLE
Allow Regular Expressions in Jest Runner

### DIFF
--- a/detox/local-cli/detox-test.js
+++ b/detox/local-cli/detox-test.js
@@ -134,8 +134,9 @@ function runJest() {
 
   const platformString = platform ? shellQuote(`--testNamePattern=^((?!${getPlatformSpecificString(platform)}).)*$`) : '';
   const binPath = path.join('node_modules', '.bin', 'jest');
+  const testFolderString = `"${testFolder}"`
   const color = program.color ? '' : ' --no-color';
-  const command = `${binPath} ${testFolder} ${configFile}${color} --maxWorkers=${program.workers} ${platformString}`;
+  const command = `${binPath} ${testFolderString} ${configFile}${color} --maxWorkers=${program.workers} ${platformString}`;
   const detoxEnvironmentVariables = {
     configuration: program.configuration,
     loglevel: program.loglevel,


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Jest [allows](https://jestjs.io/docs/en/cli#jest-regexfortestfiles) you to provide a regex pattern in order to run tests. Unfortunately, with the current state of the Detox CLI, when the regex pattern is passed to Jest, the tests fail to run. 

They mention that:
> Depending on your terminal, you may need to quote this argument: jest "my.*(complex)?pattern"

The proposed solution wraps the `file` argument in quotation marks to in order to support regex patterns along side specifying a file path.