### PR TITLE
 Allow Regular Expressions in Jest Runner

### DIFF
--- a/detox/local-cli/detox-test.js
+++ b/detox/local-cli/detox-test.js
@@ -145,8 +145,9 @@ function runJest() {
 
   const platformString = platform ? shellQuote(`--testNamePattern=^((?!${getPlatformSpecificString(platform)}).)*$`) : '';
   const binPath = path.join('node_modules', '.bin', 'jest');
+  const quotedTestFolder = `"${testFolder}"`
   const color = program.color ? '' : ' --no-color';
-  const command = `${binPath} ${testFolder} ${configFile}${color} --maxWorkers=${program.workers} ${platformString} ${collectExtraArgs()}`;
+  const command = `${binPath} ${quotedTestFolder} ${configFile}${color} --maxWorkers=${program.workers} ${platformString} ${collectExtraArgs()}`;
   const detoxEnvironmentVariables = {
     configuration: program.configuration,
     loglevel: program.loglevel,


### PR DESCRIPTION
- [x] This change has been discussed in issue #1081  and the solution has been agreed upon with maintainers.

---

**Description:**

Jest allows you to [provide a regex pattern](https://jestjs.io/docs/en/cli#jest-regexfortestfiles) in order to run tests. Unfortunately I am unable to get the tests to run when the regex pattern is passed to Jest.

In the Jest documentation it's mentioned that:

>Depending on your terminal, you may need to quote this argument: jest "my.*(complex)?pattern"

The proposed solution wraps the file argument in quotation marks to in order to support regex patterns along side specifying a file path.