### PR TITLE
Fix typo in APIRef.DetoxObjectAPI.md

### DIFF
--- a/docs/APIRef.DetoxObjectAPI.md
+++ b/docs/APIRef.DetoxObjectAPI.md
@@ -28,7 +28,7 @@ before(async () => {
 ```
 
 ##### Explicit imports during initialization
-Detox exports `device `, `expect`, `element`, `by` and `waitFor` as globals by default, if you want to control their initialization manually, set init detox with `initGlobals` set to `false`. This is useful when during E2E tests you also need to run regular expectations in node. jest `Expect` for instance, will not be overriden by Detox when this option is used.
+Detox exports `device`, `expect`, `element`, `by` and `waitFor` as globals by default, if you want to control their initialization manually, set init detox with `initGlobals` set to `false`. This is useful when during E2E tests you also need to run regular expectations in node. jest `Expect` for instance, will not be overriden by Detox when this option is used.
 
 ```js
 before(async () => {


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x]  This is a small change 

---

**Description:**

Previously there was an extra space between device and \`. Now, there is not.