### PR TITLE
Add explanation about the negative lookahead regex

### DIFF
--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -172,6 +172,17 @@ Use the Detox command line tools to test your project easily:
 detox test
 ```
 
+### Ran all test suites
+When the tests have completed you will see the following for completed Android tests in your terminal 
+
+`Ran all test suites matching /e2e/i with tests matching "^((?!:ios:).)*$".`
+
+Similarly for iOS tests you will see:
+
+`Ran all test suites matching /e2e/i with tests matching "^((?!:android:).)*$".`
+
+This maybe confusing at first, but this is due to the fact that Detox uses a negative lookahead to match the tests to run. Which means that for the expression to match, the part within `(?!...)` must not match. 
+
 That's it. Your first failing Detox test is running!
 
 Next, we'll go over usage and how to make this test [actually pass](Introduction.WritingFirstTest.md).


### PR DESCRIPTION
There seems to be a few questions on Stackoverflow about Detox running the wrong test suite. This is actually due to the fact that the users are misinterpreting the regex that is displayed in the terminal. Adding it to the readme should help those newer users that are unaware of the regex.

<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [ X] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

This isn't a particularly major issue but I have seen several posts on Stackoverflow from new users of Detox misunderstanding the terminal output when a test is run. Adding this proposed change would hopefully clarify the output for new users, and give those who choose to answer questions and official post to reference. 