### PR TITLE
[android][v10] fix broken android build

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     })
     implementation 'com.android.support.test:runner:1.0.2'
     implementation 'com.android.support.test:rules:1.0.2'
-    compileOnly "com.facebook.react:react-native:+"
+    api "com.facebook.react:react-native:+"
 
     implementation 'org.apache.commons:commons-lang3:3.4'
     implementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
@@ -90,5 +90,5 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.8.0'
     testImplementation 'org.apache.commons:commons-io:1.3.2'
     testImplementation 'com.nhaarman:mockito-kotlin:1.4.0'
-    testImplementation "com.facebook.react:react-native:+"
+    testCompileOnly "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

Currently I'm unable to build Detox v10 (have updated to match v10 docs) in my project; with the current gradle Configuration methods used for React Native the build will fail with:

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all files for configuration ':detox:minReactNative46DebugCompileClasspath'.
> Could not resolve com.squareup.okhttp3:okhttp:3.6.0.
  Required by:
      project :detox
   > Cannot find a version of 'com.squareup.okhttp3:okhttp' that satisfies the version constraints: 
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okhttp3:okhttp:3.6.0'
        Constraint path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okhttp3:okhttp' strictly '3.6.0' because of the following reason: minReactNative46DebugRuntimeClasspath uses version 3.6.0
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okhttp3:okhttp:3.6.0'
        Constraint path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okhttp3:okhttp' strictly '3.6.0' because of the following reason: minReactNative46DebugRuntimeClasspath uses version 3.6.0
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okhttp3:okhttp:3.6.0'
        Constraint path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okhttp3:okhttp' strictly '3.6.0' because of the following reason: minReactNative46DebugRuntimeClasspath uses version 3.6.0
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okhttp3:okhttp:3.6.0'
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.facebook.react:react-native:0.58.0-rc.2' --> 'com.squareup.okhttp3:okhttp:3.11.0'
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.facebook.react:react-native:0.58.0-rc.2' --> 'com.facebook.fresco:imagepipeline-okhttp3:1.10.0' --> 'com.squareup.okhttp3:okhttp:3.10.0'
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.facebook.react:react-native:0.58.0-rc.2' --> 'com.squareup.okhttp3:okhttp-urlconnection:3.11.0' --> 'com.squareup.okhttp3:okhttp:3.11.0'

> Could not resolve com.squareup.okio:okio:1.13.0.
  Required by:
      project :detox
   > Cannot find a version of 'com.squareup.okio:okio' that satisfies the version constraints: 
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okio:okio:1.13.0'
        Constraint path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okio:okio' strictly '1.13.0' because of the following reason: minReactNative46DebugRuntimeClasspath uses version 1.13.0
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okio:okio:1.13.0'
        Constraint path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okio:okio' strictly '1.13.0' because of the following reason: minReactNative46DebugRuntimeClasspath uses version 1.13.0
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okio:okio:1.13.0'
        Constraint path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okio:okio' strictly '1.13.0' because of the following reason: minReactNative46DebugRuntimeClasspath uses version 1.13.0
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okio:okio:1.13.0'
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.facebook.react:react-native:0.58.0-rc.2' --> 'com.squareup.okio:okio:1.14.0'
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.squareup.okhttp3:okhttp:3.11.0' --> 'com.squareup.okio:okio:1.14.0'
        Dependency path '@react-native-firebase/tests:detox:unspecified' --> 'com.facebook.react:react-native:0.58.0-rc.2' --> 'com.squareup.okhttp3:okhttp:3.11.0' --> 'com.squareup.okio:okio:1.14.0'

.... TRUNCATED
```

This fails despite the correct repositories() existing where these modules exist, the only way it builds for me is updating detox to use the `api` and `testCompile` only configurations for React Native.

**After Change**:

Build confirmed working:
![image](https://user-images.githubusercontent.com/5347038/51140403-5daa6d80-183e-11e9-8d46-f8b5e5163054.png)

Detox confirmed working:
![image](https://user-images.githubusercontent.com/5347038/51141032-fc839980-183f-11e9-945b-d1f845947a4d.png)


A copy of my app with detox can be seen here for reference: https://github.com/invertase/react-native-firebase/tree/mono-v6.x.x/tests
