### PR TITLE
Fix issues related to single-task activities

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -148,9 +148,12 @@ public final class Detox {
     public static void startActivityFromUrl(String url) {
         // Ideally, we would just call sActivityTestRule.launchActivity(intentWithUrl(url)) and get it over with.
         // BUT!!! as it turns out, Espresso has an issue where doing this for an activity running in the background
-        // would have it set up an ActivityMonitor which will spend its time waiting for the activity to load, *without ever being released*.
-        // It will finally fail after a 45 seconds timeout. The reason for the bug is in TODO.
-        // This is the core reason for this issue: https://github.com/wix/Detox/issues/1125
+        // would have Espresso set up an ActivityMonitor which will spend its time waiting for the activity to load, *without
+        // ever being released*. It will finally fail after a 45 seconds timeout.
+        // Without going into full details, it seems that activity test rules were not meant to be used this way. However,
+        // the all-new ActivityScenario implementation introduced in androidx could probably support this (e.g. by using
+        // dedicated methods such as moveToState(), which give better control over the lifecycle).
+        // In any case, this is the core reason for this issue: https://github.com/wix/Detox/issues/1125
         // What it forces us to do, then, is this -
         // 1. Launch the activity by "ourselves" from the OS (i.e. using context.startActivity()).
         // 2. Set up an activity monitor by ourselves -- such that it would block until the activity is ready.

--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -201,14 +201,6 @@ public final class Detox {
     private static Intent intentWithUrl(String url) {
         final Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setData(Uri.parse(url));
-
-        // This is "a must" in order to support various activity rules (potentially associated with different activities, that
-        // can handle this intent action + uri schema combination).
-        // If this is removed, Android's activity disambiguity bottom-selection dialog will show, prompting for a user selection,
-        // instead of 'just launching'.
-        if (sActivityTestRule.getActivity() != null) {
-            intent.setClass(InstrumentationRegistry.getTargetContext(), sActivityTestRule.getActivity().getClass());
-        }
         return intent;
     }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -1,9 +1,10 @@
 package com.wix.detox;
 
+import android.app.Activity;
+import android.app.Instrumentation;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.RemoteException;
@@ -69,9 +70,13 @@ import android.support.test.uiautomator.UiSelector;
  * <p>If not set, then Detox tests are no ops. So it's safe to mix it with other tests.</p>
  */
 public final class Detox {
-    static ActivityTestRule sActivityTestRule;
+    private static final String DETOX_URL_OVERRIDE_ARG = "detoxURLOverride";
+    private static final long ACTIVITY_LAUNCH_TIMEOUT = 10000L;
 
-    private Detox() {}
+    private static ActivityTestRule sActivityTestRule;
+
+    private Detox() {
+    }
 
     /**
      * <p>
@@ -108,13 +113,8 @@ public final class Detox {
      */
     public static void runTests(ActivityTestRule activityTestRule, @NonNull final Context context) {
         sActivityTestRule = activityTestRule;
-        Intent intent = null;
-        Bundle arguments = InstrumentationRegistry.getArguments();
-        String detoxURLOverride = arguments.getString("detoxURLOverride");
-        if (detoxURLOverride != null) {
-            intent = intentWithUrl(detoxURLOverride);
-        }
 
+        Intent intent = extractInitialIntent();
         activityTestRule.launchActivity(intent);
 
 
@@ -145,32 +145,39 @@ public final class Detox {
         }
     }
 
-    public static void launchActivity(Intent intent) {
-        sActivityTestRule.launchActivity(intent);
-    }
-
     public static void startActivityFromUrl(String url) {
-        launchActivity(intentWithUrl(url));
-    }
+        // Ideally, we would just call sActivityTestRule.launchActivity(intentWithUrl(url)) and get it over with.
+        // BUT!!! as it turns out, Espresso has an issue where doing this for an activity running in the background
+        // would have it set up an ActivityMonitor which will spend its time waiting for the activity to load, *without ever being released*.
+        // It will finally fail after a 45 seconds timeout. The reason for the bug is in TODO.
+        // This is the core reason for this issue: https://github.com/wix/Detox/issues/1125
+        // What it forces us to do, then, is this -
+        // 1. Launch the activity by "ourselves" from the OS (i.e. using context.startActivity()).
+        // 2. Set up an activity monitor by ourselves -- such that it would block until the activity is ready.
+        // ^ Hence the code below.
 
-    public static Intent intentWithUrl(String url) {
-        Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setData(Uri.parse(url));
-        return intent;
-    }
+        final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
+        final Intent intent = intentWithUrl(url);
+        final Activity activity = sActivityTestRule.getActivity();
+        final Instrumentation.ActivityMonitor activityMonitor = new Instrumentation.ActivityMonitor(activity.getClass().getName(), null, true);
+
+        activity.startActivity(intent);
+        instrumentation.addMonitor(activityMonitor);
+        instrumentation.waitForMonitorWithTimeout(activityMonitor, ACTIVITY_LAUNCH_TIMEOUT);
+    }
 
     // TODO: Can't get to launch the app back to previous instance using only intents from inside instrumentation (not sure why).
     // this is a (hopefully) temp solution. Should use intents instead.
     public static void launchMainActivity() throws RemoteException, UiObjectNotFoundException {
-        Context targetContext = InstrumentationRegistry.getTargetContext();
+        final Context targetContext = InstrumentationRegistry.getTargetContext();
 
 //        Intent intent = targetContext.getPackageManager().getLaunchIntentForPackage(targetContext.getPackageName());
 //        intent.setPackage(null);
 //        intent.removeCategory(Intent.CATEGORY_LAUNCHER);;
 //        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK|Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
 //        Log.d("Detox", intent.toString());
-//        launchActivity(intent);
+//        sActivityTestRule.launchActivity(intent);
 
         UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
         device.pressRecentApps();
@@ -178,5 +185,27 @@ public final class Detox {
         String appName = targetContext.getApplicationInfo().loadLabel(targetContext.getPackageManager()).toString();
         UiObject recentApp = device.findObject(selector.descriptionContains(appName));
         recentApp.click();
+    }
+
+    private static Intent extractInitialIntent() {
+        String detoxURLOverride = InstrumentationRegistry.getArguments().getString(DETOX_URL_OVERRIDE_ARG);
+        if (detoxURLOverride != null) {
+            return intentWithUrl(detoxURLOverride);
+        }
+        return null;
+    }
+
+    private static Intent intentWithUrl(String url) {
+        final Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse(url));
+
+        // This is "a must" in order to support various activity rules (potentially associated with different activities, that
+        // can handle this intent action + uri schema combination).
+        // If this is removed, Android's activity disambiguity bottom-selection dialog will show, prompting for a user selection,
+        // instead of 'just launching'.
+        if (sActivityTestRule.getActivity() != null) {
+            intent.setClass(InstrumentationRegistry.getTargetContext(), sActivityTestRule.getActivity().getClass());
+        }
+        return intent;
     }
 }

--- a/detox/src/android/espressoapi/Detox.js
+++ b/detox/src/android/espressoapi/Detox.js
@@ -35,18 +35,6 @@ class Detox {
     };
   }
 
-  static intentWithUrl(url) {
-    if (typeof url !== "string") throw new Error("url should be a string, but got " + (url + (" (" + (typeof url + ")"))));
-    return {
-      target: {
-        type: "Class",
-        value: "com.wix.detox.Detox"
-      },
-      method: "intentWithUrl",
-      args: [url]
-    };
-  }
-
   static launchMainActivity() {
     return {
       target: {

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -52,10 +52,9 @@ class Device {
       await this._terminateApp();
     }
 
-    let baseLaunchArgs = {};
-    if (params.launchArgs) {
-      baseLaunchArgs = params.launchArgs;
-    }
+    let baseLaunchArgs = {
+      ...params.launchArgs,
+    };
 
     if (params.url) {
       baseLaunchArgs['detoxURLOverride'] = params.url;

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -76,10 +76,6 @@ class Device {
       baseLaunchArgs['detoxDisableTouchIndicators'] = true;
     }
 
-    if (params.newInstance && params.androidSingleTask) {
-      baseLaunchArgs['forceSingleTask'] = true;
-    }
-
     const _bundleId = bundleId || this._bundleId;
     if (this._isAppInBackground(params, _bundleId)) {
       if (hasPayload) {

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -46,11 +46,10 @@ class Device {
     const hasPayload = this._assertHasSingleParam(payloadParams, params);
 
     if (params.delete) {
-      await this.deviceDriver.terminate(this._deviceId, this._bundleId);
-      await this.deviceDriver.uninstallApp(this._deviceId, this._bundleId);
-      await this.deviceDriver.installApp(this._deviceId, this._binaryPath, this._testBinaryPath);
+      await this._terminateApp();
+      await this._reinstallApp();
     } else if (params.newInstance) {
-      await this.deviceDriver.terminate(this._deviceId, this._bundleId);
+      await this._terminateApp();
     }
 
     let baseLaunchArgs = {};
@@ -75,6 +74,10 @@ class Device {
 
     if (params.disableTouchIndicators) {
       baseLaunchArgs['detoxDisableTouchIndicators'] = true;
+    }
+
+    if (params.newInstance && params.androidSingleTask) {
+      baseLaunchArgs['forceSingleTask'] = true;
     }
 
     const _bundleId = bundleId || this._bundleId;
@@ -252,6 +255,16 @@ class Device {
     } else {
       throw new Error(`app binary not found at '${absPath}', did you build it?`);
     }
+  }
+
+  async _terminateApp() {
+    await this.deviceDriver.terminate(this._deviceId, this._bundleId);
+    this._processes[this._bundleId] = undefined;
+  }
+
+  async _reinstallApp() {
+    await this.deviceDriver.uninstallApp(this._deviceId, this._bundleId);
+    await this.deviceDriver.installApp(this._deviceId, this._binaryPath, this._testBinaryPath);
   }
 }
 

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -197,6 +197,7 @@ describe('Device', () => {
       }, undefined);
   });
 
+
   it(`launchApp() with disableTouchIndicators should send a boolean switch as a param in launchParams`, async () => {
     device = await validDevice();
     await device.launchApp({disableTouchIndicators: true});
@@ -244,6 +245,28 @@ describe('Device', () => {
     expect(device.deviceDriver.launchApp).toHaveBeenCalledWith(device._deviceId,
       device._bundleId,
       {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test", "-arg1": "1", "-arg2": 2}, undefined);
+  });
+
+  it(`launchApp() should ask for a single-task if specified (for Android)`, async () => {
+    device = await validDevice();
+    await device.launchApp({newInstance: true, androidSingleTask: true});
+
+    expect(device.deviceDriver.launchApp).toHaveBeenCalledWith(device._deviceId,
+      device._bundleId,
+      {
+        "-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test", "-forceSingleTask": true,
+      }, undefined);
+  });
+
+  it(`launchApp() should NOT ask for a single-task (for Android) if newInstance isn't set as well`, async () => {
+    device = await validDevice();
+    await device.launchApp({newInstance: false, androidSingleTask: true});
+
+    expect(device.deviceDriver.launchApp).toHaveBeenCalledWith(device._deviceId,
+      device._bundleId,
+      {
+        "-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test",
+      }, undefined);
   });
 
   it(`sendToHome() should pass to device driver`, async () => {

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -247,28 +247,6 @@ describe('Device', () => {
       {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test", "-arg1": "1", "-arg2": 2}, undefined);
   });
 
-  it(`launchApp() should ask for a single-task if specified (for Android)`, async () => {
-    device = await validDevice();
-    await device.launchApp({newInstance: true, androidSingleTask: true});
-
-    expect(device.deviceDriver.launchApp).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {
-        "-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test", "-forceSingleTask": true,
-      }, undefined);
-  });
-
-  it(`launchApp() should NOT ask for a single-task (for Android) if newInstance isn't set as well`, async () => {
-    device = await validDevice();
-    await device.launchApp({newInstance: false, androidSingleTask: true});
-
-    expect(device.deviceDriver.launchApp).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {
-        "-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test",
-      }, undefined);
-  });
-
   it(`sendToHome() should pass to device driver`, async () => {
     device = validDevice();
     await device.sendToHome();

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const configurationsMock = require('../configurations.mock');
 
 const path = require('path');
@@ -237,14 +238,23 @@ describe('Device', () => {
       device._bundleId, {calendar: "YES"});
   });
 
-  it(`launchApp({launchArgs: }) should pass to native as launch args`, async () => {
+  it(`launchApp({launchArgs}) should pass to native as launch args`, async () => {
+    const launchArgs = {
+      arg1: "1",
+      arg2: 2,
+    };
+    const expectedArgs = {
+      "-detoxServer": "ws://localhost:8099",
+      "-detoxSessionId": "test",
+      "-arg1": "1",
+      "-arg2": 2,
+    };
+
     device = validDevice();
 
-    await device.launchApp({launchArgs: {arg1: "1", arg2: 2}});
+    await device.launchApp({launchArgs});
 
-    expect(device.deviceDriver.launchApp).toHaveBeenCalledWith(device._deviceId,
-      device._bundleId,
-      {"-detoxServer": "ws://localhost:8099", "-detoxSessionId": "test", "-arg1": "1", "-arg2": 2}, undefined);
+    expect(device.deviceDriver.launchApp).toHaveBeenCalledWith(device._deviceId, device._bundleId, expectedArgs, undefined);
   });
 
   it(`sendToHome() should pass to device driver`, async () => {
@@ -442,7 +452,7 @@ describe('Device', () => {
     expect(device.deviceDriver.deliverPayload).not.toHaveBeenCalled();
   });
 
-  it(`launchApp({url: url}) should check if process is in background and use openURL() instead of launch args`, async () => {
+  it(`launchApp({url}) should check if process is in background and use openURL() instead of launch args`, async () => {
     const processId = 1;
     device = validDevice();
     device.deviceDriver.getBundleIdFromBinary.mockReturnValue('test.bundle');
@@ -454,7 +464,7 @@ describe('Device', () => {
     expect(device.deviceDriver.deliverPayload).toHaveBeenCalledTimes(1);
   });
 
-  it(`launchApp({url: url}) should check if process is in background and if not use launch args`, async () => {
+  it(`launchApp({url}) should check if process is in background and if not use launch args`, async () => {
     const launchParams = {url: 'url://me'};
     const processId = 1;
     const newProcessId = 2;
@@ -469,7 +479,7 @@ describe('Device', () => {
     expect(device.deviceDriver.deliverPayload).not.toHaveBeenCalled();
   });
 
-  it(`launchApp({url: url}) should check if process is in background and use openURL() instead of launch args`, async () => {
+  it(`launchApp({url}) should check if process is in background and use openURL() instead of launch args`, async () => {
     const launchParams = {url: 'url://me'};
     const processId = 1;
 
@@ -483,7 +493,22 @@ describe('Device', () => {
     expect(device.deviceDriver.deliverPayload).toHaveBeenCalledWith({delayPayload: true, url: 'url://me'});
   });
 
-  it('launchApp({userActivity: userActivity}) should check if process is in background and if it is use deliverPayload', async () => {
+  it(`launchApp({params}) should keep user params unmodified`, async () => {
+    const params = {
+      url: 'some.url',
+      launchArgs: {
+        some: 'userArg',
+      }
+    };
+    const paramsClone = _.cloneDeep(params);
+
+    device = validDevice();
+    await device.launchApp(params);
+
+    expect(params).toEqual(paramsClone);
+  });
+
+  it('launchApp({userActivity}) should check if process is in background and if it is use deliverPayload', async () => {
     const launchParams = {userActivity: 'userActivity'};
     const processId = 1;
 
@@ -499,7 +524,7 @@ describe('Device', () => {
   });
 
 
-  it('launchApp({userNotification: userNotification}) should check if process is in background and if it is use deliverPayload', async () => {
+  it('launchApp({userNotification}) should check if process is in background and if it is use deliverPayload', async () => {
     const launchParams = {userNotification: 'notification'};
     const processId = 1;
 
@@ -514,7 +539,7 @@ describe('Device', () => {
     expect(device.deviceDriver.deliverPayload).toHaveBeenCalledTimes(1);
   });
 
-  it(`launchApp({userNotification: userNotification}) should check if process is in background and if not use launch args`, async () => {
+  it(`launchApp({userNotification}) should check if process is in background and if not use launch args`, async () => {
     const launchParams = {userNotification: 'notification'};
     const processId = 1;
     const newProcessId = 2;
@@ -529,7 +554,7 @@ describe('Device', () => {
     expect(device.deviceDriver.deliverPayload).not.toHaveBeenCalled();
   });
 
-  it(`launchApp({userNotification: userNotification, url: url}) should fail`, async () => {
+  it(`launchApp({userNotification, url}) should fail`, async () => {
     const launchParams = {userNotification: 'notification', url: 'url://me'};
     const processId = 1;
 

--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -25,7 +25,7 @@ public class DetoxTest {
      * Important so as to allow for some testing of Detox in this particular mode, which has been proven to introduce caveats.
      * </br>Here for internal usage; Not external-API related.
      */
-    private static final String FORCE_SINGLE_TASK_ACTIVITY_ARG = "forceSingleTask";
+    private static final String RUN_SINGLE_TASK_ACTIVITY_ARG = "androidSingleTaskActivity";
 
     @Rule
     public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
@@ -36,7 +36,7 @@ public class DetoxTest {
     @Test
     public void runDetoxTests() {
         final Bundle arguments = InstrumentationRegistry.getArguments();
-        final boolean forceSingleTaskActivity = Boolean.parseBoolean(arguments.getString(FORCE_SINGLE_TASK_ACTIVITY_ARG, "false"));
+        final boolean forceSingleTaskActivity = Boolean.parseBoolean(arguments.getString(RUN_SINGLE_TASK_ACTIVITY_ARG, "false"));
         final ActivityTestRule<?> rule = forceSingleTaskActivity ? mSingleInstanceActivityRule : mActivityRule;
         Detox.runTests(rule);
     }

--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -25,7 +25,7 @@ public class DetoxTest {
      * Important so as to allow for some testing of Detox in this particular mode, which has been proven to introduce caveats.
      * </br>Here for internal usage; Not external-API related.
      */
-    private static final String RUN_SINGLE_TASK_ACTIVITY_ARG = "androidSingleTaskActivity";
+    private static final String SINGLE_INSTANCE_ACTIVITY_ARG = "androidSingleInstanceActivity";
 
     @Rule
     public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
@@ -36,7 +36,7 @@ public class DetoxTest {
     @Test
     public void runDetoxTests() {
         final Bundle arguments = InstrumentationRegistry.getArguments();
-        final boolean forceSingleTaskActivity = Boolean.parseBoolean(arguments.getString(RUN_SINGLE_TASK_ACTIVITY_ARG, "false"));
+        final boolean forceSingleTaskActivity = Boolean.parseBoolean(arguments.getString(SINGLE_INSTANCE_ACTIVITY_ARG, "false"));
         final ActivityTestRule<?> rule = forceSingleTaskActivity ? mSingleInstanceActivityRule : mActivityRule;
         Detox.runTests(rule);
     }

--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -1,8 +1,10 @@
 package com.example;
 
+import android.os.Bundle;
 import android.support.test.filters.LargeTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
+import android.support.test.InstrumentationRegistry;
 
 import com.wix.detox.Detox;
 
@@ -18,11 +20,24 @@ import org.junit.runner.RunWith;
 @LargeTest
 public class DetoxTest {
 
+    /**
+     * A selector arg that when set 'true', will launch the {@link SingleInstanceActivity} rather than the default {@link MainActivity}.
+     * Important so as to allow for some testing of Detox in this particular mode, which has been proven to introduce caveats.
+     * </br>Here for internal usage; Not external-API related.
+     */
+    private static final String FORCE_SINGLE_TASK_ACTIVITY_ARG = "forceSingleTask";
+
     @Rule
     public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
 
+    @Rule
+    public ActivityTestRule<SingleInstanceActivity> mSingleInstanceActivityRule = new ActivityTestRule<>(SingleInstanceActivity.class, false, false);
+
     @Test
     public void runDetoxTests() {
-        Detox.runTests(mActivityRule);
+        final Bundle arguments = InstrumentationRegistry.getArguments();
+        final boolean forceSingleTaskActivity = Boolean.parseBoolean(arguments.getString(FORCE_SINGLE_TASK_ACTIVITY_ARG, "false"));
+        final ActivityTestRule<?> rule = forceSingleTaskActivity ? mSingleInstanceActivityRule : mActivityRule;
+        Detox.runTests(rule);
     }
 }

--- a/detox/test/android/app/src/main/AndroidManifest.xml
+++ b/detox/test/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+    >
 
       <!--
        The main, default activity; Note: always keep launchMode 'standard'
@@ -53,7 +54,7 @@
         <intent-filter>
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />
-            <data android:scheme="detoxtesturlscheme"/>
+            <data android:scheme="detoxtesturlscheme.singletask"/>
         </intent-filter>
        </activity>
 

--- a/detox/test/android/app/src/main/AndroidManifest.xml
+++ b/detox/test/android/app/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
 
       <!--
        MainActivity flavor that only runs in a 'singleInstance' launch mode.
-       Executed instead of the main by the test app given the "forceSingleTask" arg to instrumentation.
+       Executed instead of the main by the test app given a "androidSingleTaskActivity" arg to instrumentation.
        -->
       <activity
         android:name=".SingleInstanceActivity"

--- a/detox/test/android/app/src/main/AndroidManifest.xml
+++ b/detox/test/android/app/src/main/AndroidManifest.xml
@@ -47,14 +47,14 @@
        -->
       <activity
         android:name=".SingleInstanceActivity"
-        android:label="@string/app_single_task_name"
+        android:label="@string/app_name_single_instance"
         android:launchMode="singleInstance"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />
-            <data android:scheme="detoxtesturlscheme.singletask"/>
+            <data android:scheme="detoxtesturlscheme.singleinstance"/>
         </intent-filter>
        </activity>
 

--- a/detox/test/android/app/src/main/AndroidManifest.xml
+++ b/detox/test/android/app/src/main/AndroidManifest.xml
@@ -17,9 +17,14 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme">
+
+      <!--
+       The main, default activity; Note: always keep launchMode 'standard'
+       -->
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
+        android:launchMode="standard"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
@@ -27,14 +32,33 @@
             <category android:name="android.intent.category.LAUNCHER" />
             <category android:name="android.intent.category.DEFAULT" />
         </intent-filter>
-          <intent-filter>
-              <action android:name="android.intent.action.VIEW" />
-              <category android:name="android.intent.category.DEFAULT" />
-              <category android:name="android.intent.category.BROWSABLE" />
-              <data android:scheme="detoxtesturlscheme"/>
-          </intent-filter>
+        <intent-filter>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="detoxtesturlscheme"/>
+        </intent-filter>
       </activity>
+
+      <!--
+       MainActivity flavor that only runs in a 'singleInstance' launch mode.
+       Executed instead of the main by the test app given the "forceSingleTask" arg to instrumentation.
+       -->
+      <activity
+        android:name=".SingleInstanceActivity"
+        android:label="@string/app_single_task_name"
+        android:launchMode="singleInstance"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:windowSoftInputMode="adjustResize">
+        <intent-filter>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <data android:scheme="detoxtesturlscheme"/>
+        </intent-filter>
+       </activity>
+
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+
     </application>
 
 </manifest>

--- a/detox/test/android/app/src/main/java/com/example/SingleInstanceActivity.java
+++ b/detox/test/android/app/src/main/java/com/example/SingleInstanceActivity.java
@@ -1,0 +1,8 @@
+package com.example;
+
+/**
+ * A flavor of the {@link MainActivity} the is set in the manifest to run at a 'single-instance' launchMode,
+ * rather than at the default launch mode.
+ */
+public class SingleInstanceActivity extends MainActivity {
+}

--- a/detox/test/android/app/src/main/res/values/strings.xml
+++ b/detox/test/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Detox Test</string>
+    <string name="app_single_task_name">Detox Test (SingleTask)</string>
 </resources>

--- a/detox/test/android/app/src/main/res/values/strings.xml
+++ b/detox/test/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="app_name">Detox Test</string>
-    <string name="app_single_task_name">Detox Test (SingleTask)</string>
+    <string name="app_name_single_instance">Detox Test (SingleInstance)</string>
 </resources>

--- a/detox/test/e2e/15.urls.test.js
+++ b/detox/test/e2e/15.urls.test.js
@@ -7,8 +7,8 @@ describe('Open URLs', () => {
     await expect(element(by.text(testUrl))).toBeVisible();
   });
 
-  it(':android: device.launchApp() with a URL and a fresh app should launch app properly also in single-task mode', async () => {
-    await device.launchApp({newInstance: true, url: testUrl, androidSingleTask: true});
+  it(':android: device.launchApp() with a URL and a fresh app should launch app properly also in single-task activities', async () => {
+    await device.launchApp({newInstance: true, url: testUrl, launchArgs: {androidSingleTaskActivity: true}});
     await expect(element(by.text(testUrl))).toBeVisible();
   });
 
@@ -18,8 +18,8 @@ describe('Open URLs', () => {
     await expect(element(by.text(testUrl))).toBeVisible();
   });
 
-  it(':android: device.openURL() should should work properly also in single-task mode', async () => {
-    await device.launchApp({newInstance: true, androidSingleTask: true});
+  it(':android: device.openURL() should should work properly also in single-task activities', async () => {
+    await device.launchApp({newInstance: true, launchArgs: {androidSingleTaskActivity: true}});
     await device.openURL({url: testUrl});
     await expect(element(by.text(testUrl))).toBeVisible();
   });
@@ -31,8 +31,8 @@ describe('Open URLs', () => {
     await expect(element(by.text(testUrl))).toBeVisible();
   });
 
-  it(':android: device.launchApp() with a URL should work properly also in single-task mode', async () => {
-    await device.launchApp({newInstance: true, androidSingleTask: true});
+  it(':android: device.launchApp() with a URL should work properly also in single-task activities', async () => {
+    await device.launchApp({newInstance: true, launchArgs: {androidSingleTaskActivity: true}});
     await device.sendToHome();
     await device.launchApp({newInstance: false, url: testUrl});
     await expect(element(by.text(testUrl))).toBeVisible();

--- a/detox/test/e2e/15.urls.test.js
+++ b/detox/test/e2e/15.urls.test.js
@@ -1,40 +1,46 @@
 describe('Open URLs', () => {
 
-  const testUrl = 'detoxtesturlscheme://such-string';
-
-  it('device.launchApp() with a URL and a fresh app should launch app and trigger handling open url handling in app', async () => {
-    await device.launchApp({newInstance: true, url: testUrl});
-    await expect(element(by.text(testUrl))).toBeVisible();
+  const withDefaultArgs = () => ({
+    url: 'detoxtesturlscheme://such-string',
+    launchArgs: undefined,
   });
 
-  it(':android: device.launchApp() with a URL and a fresh app should launch app properly also in single-task activities', async () => {
-    await device.launchApp({newInstance: true, url: testUrl, launchArgs: {androidSingleTaskActivity: true}});
-    await expect(element(by.text(testUrl))).toBeVisible();
+  const withAndroidSingleTaskActivityArgs = () => ({
+    url: 'detoxtesturlscheme.singletask://such-string',
+    launchArgs: Object.freeze({ androidSingleTaskActivity: true }),
   });
 
-  it('device.openURL() should trigger open url handling in app when app is in foreground', async () => {
-    await device.launchApp({newInstance: true});
-    await device.openURL({url: testUrl});
-    await expect(element(by.text(testUrl))).toBeVisible();
-  });
+  [
+    {
+      platform: '',
+      ...withDefaultArgs(),
+    },
+    {
+      platform: 'android',
+      ...withAndroidSingleTaskActivityArgs(),
+    }
+  ].forEach(({platform, url, launchArgs}) => {
 
-  it(':android: device.openURL() should should work properly also in single-task activities', async () => {
-    await device.launchApp({newInstance: true, launchArgs: {androidSingleTaskActivity: true}});
-    await device.openURL({url: testUrl});
-    await expect(element(by.text(testUrl))).toBeVisible();
-  });
+    const _platform = platform ? `:${platform}: ` : '';
 
-  it('device.launchApp() with a URL should trigger url handling when app is in background', async () => {
-    await device.launchApp({newInstance: true});
-    await device.sendToHome();
-    await device.launchApp({newInstance: false, url: testUrl});
-    await expect(element(by.text(testUrl))).toBeVisible();
-  });
+    it(`${_platform}device.launchApp() with a URL and a fresh app should launch app and trigger handling open url handling in app`, async () => {
+      await device.launchApp({newInstance: true, url, launchArgs});
+      await expect(element(by.text(url))).toBeVisible();
+    });
 
-  it(':android: device.launchApp() with a URL should work properly also in single-task activities', async () => {
-    await device.launchApp({newInstance: true, launchArgs: {androidSingleTaskActivity: true}});
-    await device.sendToHome();
-    await device.launchApp({newInstance: false, url: testUrl});
-    await expect(element(by.text(testUrl))).toBeVisible();
+    it(`${_platform}device.openURL() should trigger open url handling in app when app is in foreground`, async () => {
+      await device.launchApp({newInstance: true, launchArgs});
+      await expect(element(by.text(url))).toBeNotVisible();
+      await device.openURL({url});
+      await expect(element(by.text(url))).toBeVisible();
+    });
+
+    it(`${_platform}device.launchApp() with a URL should trigger url handling when app is in background`, async () => {
+      await device.launchApp({newInstance: true, launchArgs});
+      await expect(element(by.text(url))).toBeNotVisible();
+      await device.sendToHome();
+      await device.launchApp({newInstance: false, url});
+      await expect(element(by.text(url))).toBeVisible();
+    });
   });
 });

--- a/detox/test/e2e/15.urls.test.js
+++ b/detox/test/e2e/15.urls.test.js
@@ -1,23 +1,40 @@
 describe('Open URLs', () => {
 
-  it('device.launchApp({{newInstance: true, url: url}) should launch app and trigger handling open url handling in app', async () => {
-    const url = 'detoxtesturlscheme://such-string';
-    await device.launchApp({newInstance: true, url: url});
-    await expect(element(by.text(url))).toBeVisible();
+  const testUrl = 'detoxtesturlscheme://such-string';
+
+  it('device.launchApp() with a URL and a fresh app should launch app and trigger handling open url handling in app', async () => {
+    await device.launchApp({newInstance: true, url: testUrl});
+    await expect(element(by.text(testUrl))).toBeVisible();
   });
 
-  it('device.openURL({url: url}) should trigger open url handling in app when app is in foreground', async () => {
-    const url = 'detoxtesturlscheme://such-string';
+  it(':android: device.launchApp() with a URL and a fresh app should launch app properly also in single-task mode', async () => {
+    await device.launchApp({newInstance: true, url: testUrl, androidSingleTask: true});
+    await expect(element(by.text(testUrl))).toBeVisible();
+  });
+
+  it('device.openURL() should trigger open url handling in app when app is in foreground', async () => {
     await device.launchApp({newInstance: true});
-    await device.openURL({url: url});
-    await expect(element(by.text(url))).toBeVisible();
+    await device.openURL({url: testUrl});
+    await expect(element(by.text(testUrl))).toBeVisible();
   });
 
-  it('device.launchApp({url: url}) should trigger open url handling in app when app is in background', async () => {
-    const url = 'detoxtesturlscheme://such-string';
+  it(':android: device.openURL() should should work properly also in single-task mode', async () => {
+    await device.launchApp({newInstance: true, androidSingleTask: true});
+    await device.openURL({url: testUrl});
+    await expect(element(by.text(testUrl))).toBeVisible();
+  });
+
+  it('device.launchApp() with a URL should trigger url handling when app is in background', async () => {
     await device.launchApp({newInstance: true});
     await device.sendToHome();
-    await device.launchApp({newInstance: false, url: url});
-    await expect(element(by.text(url))).toBeVisible();
+    await device.launchApp({newInstance: false, url: testUrl});
+    await expect(element(by.text(testUrl))).toBeVisible();
+  });
+
+  it(':android: device.launchApp() with a URL should work properly also in single-task mode', async () => {
+    await device.launchApp({newInstance: true, androidSingleTask: true});
+    await device.sendToHome();
+    await device.launchApp({newInstance: false, url: testUrl});
+    await expect(element(by.text(testUrl))).toBeVisible();
   });
 });

--- a/detox/test/e2e/15.urls.test.js
+++ b/detox/test/e2e/15.urls.test.js
@@ -1,13 +1,12 @@
 describe('Open URLs', () => {
-
   const withDefaultArgs = () => ({
     url: 'detoxtesturlscheme://such-string',
     launchArgs: undefined,
   });
 
-  const withAndroidSingleTaskActivityArgs = () => ({
-    url: 'detoxtesturlscheme.singletask://such-string',
-    launchArgs: Object.freeze({ androidSingleTaskActivity: true }),
+  const withSingleInstanceActivityArgs = () => ({
+    url: 'detoxtesturlscheme.singleinstance://such-string',
+    launchArgs: { androidSingleInstanceActivity: true },
   });
 
   [
@@ -17,10 +16,10 @@ describe('Open URLs', () => {
     },
     {
       platform: 'android',
-      ...withAndroidSingleTaskActivityArgs(),
+      ...withSingleInstanceActivityArgs(),
     }
-  ].forEach(({platform, url, launchArgs}) => {
-
+  ].forEach((testSpec) => {
+    const {platform, url, launchArgs} = testSpec;
     const _platform = platform ? `:${platform}: ` : '';
 
     it(`${_platform}device.launchApp() with a URL and a fresh app should launch app and trigger handling open url handling in app`, async () => {

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -107,7 +107,7 @@ buildscript {
 
 ### 4. Create Android Test class
 
-You need to add the file `android/app/src/androidTest/java/com/[your.package]/DetoxTest.java` and fill it like [this](../detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java), except that you need to change the package to your projects name.
+Add the file `android/app/src/androidTest/java/com/[your.package]/DetoxTest.java` and fill as in [the detox example app for NR](../examples/demo-react-native/android/app/src/androidTest/java/com/example/DetoxTest.java). **Don't forget to change the package name to your project's**.
 
 ### 5. Add Android configuration
 


### PR DESCRIPTION
- [ ] This is a small change 
- [x] This change has been discussed in issue #1125.

**Description:**

Address the problem specified in #1125.
The root cause resides in what appears to be an Espresso bug (still need to validate this). This PR introduces a workaround, along with associated improvements around the current confusion the android driver currently has around activities launching. I suppose that can be further improved, but one step at a time.