### PR TITLE
deprecated `--file` and `--specs`

### DIFF
--- a/detox/local-cli/detox.js
+++ b/detox/local-cli/detox.js
@@ -4,7 +4,7 @@ const program = require('commander');
 
 program
   .arguments('<process>')
-  .command('test', 'Initiating your test suite')
+  .command('test [testPatterns...]', 'Initiating your test suite')
   .command('init', '[convenience method] Scaffold initial e2e tests folder')
   .command('build', `[convenience method] Run the command defined in 'configuration.build'`)
   .command('run-server', 'Starts a standalone detox server')


### PR DESCRIPTION
- [x] This is a small change 
- [x] This change has been discussed in issue #1132

---

**Description:**

This PR deprecates the `--file` and `--specs`. The reason for this change is that `jest` and `mocha` already have their own implementation of how their default test pattern is set in their configs, and how you can override them in the cli. So instead of changing that to be different this is just using what those libraries already offer. Which in turn makes it more consistent for the end users.

```bash
detox test --spec 'test-ui/**/*.test.jsx'
detox test --file 'test-ui/**/*.test.jsx'
```

now becomes

```bash
detox test 'test-ui/**/*.test.jsx'
```

Also the default `detox test` now defaults to what ever is set in the jest/mocha configurations as the default.

Another advantage to this change is that when `--spec` and `--file` are fully removed from the cli it will allow mocha users to use the `--file` option that already exists in the mocha framework.

```bash
--file <file>                           include a file to be ran during the suite [file]
```

I have also accounted for for the quoting of the glob patterns like was done in #1083 so that functionality isn't removed.
