### PR TITLE
use new jest config key setupFilesAfterEnv

### DIFF
--- a/examples/demo-react-native-jest/e2e/config.json
+++ b/examples/demo-react-native-jest/e2e/config.json
@@ -1,4 +1,4 @@
 {
-  "setupTestFrameworkScriptFile" : "./init.js",
+  "setupFilesAfterEnv": ["./init.js"],
   "testEnvironment": "node"
 }


### PR DESCRIPTION


<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array

setupTestFrameworkScriptFile is deprecated in favor of setupFilesAfterEnv.

fixes warning
```
Option "setupTestFrameworkScriptFile" was replaced by configuration "setupFilesAfterEnv", which supports multiple paths.

  Please update your configuration.
```