### PR TITLE
Corrected typo.

### DIFF
--- a/docs/APIRef.MockingUserNotifications.md
+++ b/docs/APIRef.MockingUserNotifications.md
@@ -9,7 +9,7 @@ Detox supports mocking user notifications for iOS apps.
 
 ### Mocking App Launch with a Notification
 
-Using `relauchApp()` with custom params will trigger the mocking mechanism.
+Using `relaunchApp()` with custom params will trigger the mocking mechanism.
 
 ```js
 await device.relaunchApp({userNotification: notification});


### PR DESCRIPTION
relauch -> relauNch.

- [  X ] This is a small change 

**Description:**
Corrected typo in relauNch word.