### PR TITLE
Fix keyWindow.rootViewController nullability on iOS

### DIFF
--- a/detox/ios/Detox/DetoxAppDelegateProxy.m
+++ b/detox/ios/Detox/DetoxAppDelegateProxy.m
@@ -23,6 +23,11 @@
 	return self;
 }
 
+- (BOOL)_canBecomeKeyWindow
+{
+	return NO;
+}
+
 @end
 
 @class DetoxAppDelegateProxy;


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

***Issue: https://github.com/wix/Detox/issues/1230***

Some iOS developer use `[UIApplicaiton sharedApplication].keyWindow.rootViewController` as a convenient way to get a VC instance. Surely, this isn't suggested, but it's widely used anyway.
When the app is driven by Detox, this call would return null. It's because DTXTouchVisualizerWindow has a very high windowLevel and doesn't has any ViewController.

This PR fixes this issue by avoid making DTXTouchVisualizerWindow the keyWindow.