### PR TITLE
Migrate uiautomator to AndroidX

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     compileOnly "com.facebook.react:react-native:+"
 
     implementation 'org.apache.commons:commons-lang3:3.4'
-    implementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
+    implementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 
     testImplementation 'org.json:json:20140107'
     testImplementation 'junit:junit:4.12'

--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -9,13 +9,13 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.RemoteException;
 import android.support.annotation.NonNull;
-import android.support.test.uiautomator.UiDevice;
-import android.support.test.uiautomator.UiObject;
-import android.support.test.uiautomator.UiObjectNotFoundException;
-import android.support.test.uiautomator.UiSelector;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import androidx.test.rule.ActivityTestRule;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.UiSelector;
 
 /**
  * <p>Static class.</p>

--- a/detox/android/detox/src/main/java/com/wix/detox/uiautomator/UiAutomator.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/uiautomator/UiAutomator.java
@@ -1,8 +1,7 @@
 package com.wix.detox.uiautomator;
 
-import android.support.test.uiautomator.UiDevice;
-
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
 
 /**
  * Created by rotemm on 30/08/2017.


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [X] This is a small change 
- [X] This change has been discussed in issue #1235  and the solution has been agreed upon with maintainers.

---

**Description:**
This PR migrates the uiautomator dependency from `com.android.support.test.uiautomator:uiautomator-v18:2.1.3` to `androidx.test.uiautomator:uiautomator:2.2.0`