### PR TITLE
feat: specify resuing existing app in Detox.init() params

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -22,7 +22,7 @@ class Device {
 
     await this.deviceDriver.prepare();
 
-    if (!argparse.getArgValue('reuse')) {
+    if (!argparse.getArgValue('reuse') && !params.reuse) {
       await this.deviceDriver.uninstallApp(this._deviceId, this._bundleId);
       await this.deviceDriver.installApp(this._deviceId, this._binaryPath, this._testBinaryPath);
     }

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -108,11 +108,20 @@ describe('Device', () => {
       await device.prepare();
     });
 
-    it(`when reuse is enabled should not uninstall and install`, async () => {
+    it(`when reuse is enabled in CLI args should not uninstall and install`, async () => {
       const device = validDevice();
       argparse.getArgValue.mockReturnValue(true);
 
       await device.prepare();
+
+      expect(driverMock.driver.uninstallApp).not.toHaveBeenCalled();
+      expect(driverMock.driver.installApp).not.toHaveBeenCalled();
+    });
+
+    it(`when reuse is enabled in params should not uninstall and install`, async () => {
+      const device = validDevice();
+
+      await device.prepare({reuse: true});
 
       expect(driverMock.driver.uninstallApp).not.toHaveBeenCalled();
       expect(driverMock.driver.installApp).not.toHaveBeenCalled();

--- a/docs/APIRef.DetoxObjectAPI.md
+++ b/docs/APIRef.DetoxObjectAPI.md
@@ -65,6 +65,17 @@ before(async () => {
 });
 ```
 
+#### Reusing existing app
+By default `await detox.init(config);` will uninstall and install the app. If you wish to reuse the existing app for a faster run, add `{reuse: true}` param to your init.
+
+```js
+const config = require('../package.json').detox;
+
+before(async () => {
+  await detox.init(config, {reuse: true});
+});
+```
+
 ### `detox.beforeEach()`
 
 This method should be called at the start of every test to let Detox's artifacts lifecycle know it is the time to start recording logs and videos, or to take another `beforeEach.png` screenshot. Although this is one of usage of `beforeEach`, Detox does not limit itself to this usage and may utilize calls to `beforeEach` for additional purposes in the future.


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Detox-CLI supports to reuse existing app for a faster test run. When using detox with Cucumber or other test runners, we can't run test cases with Detox-CLI.

This PR add a new parameter to `Detox.init()` method to support reusing programmatically.

```js
Detox.init(config, {reuse: true});
``` 