### PR TITLE
Exit process with error status code when a cli command fails

### DIFF
--- a/detox/local-cli/cli.js
+++ b/detox/local-cli/cli.js
@@ -26,6 +26,7 @@ yargs
         logger.error(line);
       }
       console.error('');
+      process.exit(1);
     }
 
     if (msg) {


### PR DESCRIPTION
Will wait for #1247 to be discussed

- [x] This is a small change 
- [x] This change has been discussed in issue #1247 and the solution has been agreed upon with maintainers.

---

**Description:**
Exits with status code `1` when an actual error (not a `yargs` validation error) is passed to the `.fail` callback