### PR TITLE
(Android) Introduce Proguard all-around

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -18,6 +18,8 @@ android {
         targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
+
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     testOptions {

--- a/detox/android/detox/proguard-rules-app.pro
+++ b/detox/android/detox/proguard-rules-app.pro
@@ -1,0 +1,1 @@
+-keep class com.facebook.react.ReactInstanceManager { *; }

--- a/detox/android/detox/proguard-rules.pro
+++ b/detox/android/detox/proguard-rules.pro
@@ -1,17 +1,14 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /Users/rotemm/Library/Android/sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+-dontwarn org.xmlpull.**
+-dontwarn sun.misc.**
 
-# Add any project specific keep options here:
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-dontnote android.**
+-dontnote androidx.**
+-dontnote java.**
+-dontnote javax.**
+-dontnote kotlin.**
+-dontnote org.apache.**
+-dontnote junit.**
+-dontnote org.junit.**
+-dontnote org.joor.**
+-dontnote org.hamcrest.**
+-dontnote com.facebook.**

--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -25,6 +25,24 @@ android {
         */
     }
 
+    signingConfigs {
+        release {
+            storeFile file("keystore.jks")
+            storePassword "12345678"
+            keyAlias "key0"
+            keyPassword "12345678"
+        }
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro', "${project(':detox').projectDir}/proguard-rules-app.pro"
+
+            signingConfig signingConfigs.release
+        }
+    }
+
     productFlavors {
         flavorDimensions "compileRNFromSource"
         fromSource {
@@ -35,20 +53,6 @@ android {
         }
     }
 
-    signingConfigs {
-        release {
-            storeFile file("keystore.jks")
-            storePassword "12345678"
-            keyAlias "key0"
-            keyPassword "12345678"
-        }
-    }
-    buildTypes {
-        release {
-            signingConfig signingConfigs.release
-        }
-    }
-
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'
         exclude 'META-INF/NOTICE'
@@ -56,7 +60,6 @@ android {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'
     }
-
 }
 
 dependencies {

--- a/detox/test/android/app/proguard-rules.pro
+++ b/detox/test/android/app/proguard-rules.pro
@@ -1,67 +1,16 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /usr/local/Cellar/android-sdk/24.3.3/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Most needed rules come from React Native's proguard-rules.pro (either .aar or source) -- hence
+# the lean configuration file.
+###
 
-# Add any project specific keep options here:
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Disabling obfuscation is useful if you collect stack traces from production crashes
-# (unless you are using a system that supports de-obfuscate the stack traces).
 -dontobfuscate
 
-# React Native
+-dontnote android.net.**
+-dontnote org.apache.**
 
-# Keep our interfaces so they can be used by other ProGuard rules.
-# See http://sourceforge.net/p/proguard/bugs/466/
--keep,allowobfuscation @interface com.facebook.proguard.annotations.DoNotStrip
--keep,allowobfuscation @interface com.facebook.proguard.annotations.KeepGettersAndSetters
+# An addition to RN's 'keep' and 'dontwarn' configs -- need to also 'dontnote' some stuff.
 
-# Do not strip any method/class that is annotated with @DoNotStrip
--keep @com.facebook.proguard.annotations.DoNotStrip class *
--keepclassmembers class * {
-    @com.facebook.proguard.annotations.DoNotStrip *;
-}
-
--keepclassmembers @com.facebook.proguard.annotations.KeepGettersAndSetters class * {
-  void set*(***);
-  *** get*();
-}
-
--keep class * extends com.facebook.react.bridge.JavaScriptModule { *; }
--keep class * extends com.facebook.react.bridge.NativeModule { *; }
--keepclassmembers,includedescriptorclasses class * { native <methods>; }
--keepclassmembers class *  { @com.facebook.react.uimanager.UIProp <fields>; }
--keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactProp <methods>; }
--keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactPropGroup <methods>; }
-
--dontwarn com.facebook.react.**
-
-# TextLayoutBuilder uses a non-public Android constructor within StaticLayout.
-# See libs/proxy/src/main/java/com/facebook/fbui/textlayoutbuilder/proxy for details.
--dontwarn android.text.StaticLayout
-
-# okhttp
-
--keepattributes Signature
--keepattributes *Annotation*
--keep class okhttp3.** { *; }
--keep interface okhttp3.** { *; }
--dontwarn okhttp3.**
-
-# okio
-
--keep class sun.misc.Unsafe { *; }
--dontwarn java.nio.file.*
--dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
--dontwarn okio.**
+-dontnote com.facebook.**
+-dontnote sun.misc.Unsafe
+-dontnote okhttp3.**
+-dontnote okio.**

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -147,6 +147,27 @@ Using the `android.emu.debug` configuration from above, you can invoke it in the
 detox test -c android.emu.debug
 ```
 
+## Proguard (Minification)
+
+In apps running [minification using Proguard](https://developer.android.com/studio/build/shrink-code), in order for Detox to work well on release builds, please enable some Detox proguard-configuration rules by applying the custom configuration file on top of your own. Typically, this is defined using the `proguardFiles` statement in the minification-enabled build-type in your `app/build.gradle`:
+
+```groovy
+    buildTypes {
+        // 'release' is typically the default proguard-enabled build-type
+        release {
+            minifyEnabled true
+          
+            // The last expression results in a path to Detox' custom rules file
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro', "${project(':detox').projectDir}/proguard-rules-app.pro"
+
+            // ...
+        }
+    }
+
+```
+
+
+
 ## Troubleshooting
 
 ### Problem: `Duplicate files copied in ...`


### PR DESCRIPTION
- [x] This is a small change 
- [x] This change has been discussed in issue #1216 and the solution has been agreed upon with maintainers.

---

**Description:**

Add Proguard configuration in a two-fold way:
1. Enable minification in Android test app.
2. Add config scripts + documentation for apps running Detox over minified apps.

Fixes #1216 