### PR TITLE
(Android) Migrate UIAutomator to AndroidX (#1235)

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -61,6 +61,11 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.6.0'
     implementation 'com.squareup.okio:okio:1.13.0'
 
+    implementation 'org.apache.commons:commons-lang3:3.4'
+
+    // noinspection GradleDynamicVersion
+    compileOnly "com.facebook.react:react-native:+"
+
     // Versions are in-sync with the 'androidx-test-1.1.0' release/tag of the android-test github repo,
     // used by the Detox generator. See https://github.com/android/android-test/releases/tag/androidx-test-1.1.0
     // Important: Should remain so when generator tag is replaced!
@@ -69,11 +74,9 @@ dependencies {
     api 'androidx.test:rules:1.1.1'
     api 'androidx.test.ext:junit:1.1.0'
 
-    // noinspection GradleDynamicVersion
-    compileOnly "com.facebook.react:react-native:+"
-
-    implementation 'org.apache.commons:commons-lang3:3.4'
-    implementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
+    // Version is the latest; Cannot sync with the Github repo (e.g. android/android-test) because the androidx
+    // packaging version of associated classes is simply not there...
+    api 'androidx.test.uiautomator:uiautomator:2.2.0'
 
     testImplementation 'org.json:json:20140107'
     testImplementation 'junit:junit:4.12'

--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -9,13 +9,13 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.RemoteException;
 import android.support.annotation.NonNull;
-import android.support.test.uiautomator.UiDevice;
-import android.support.test.uiautomator.UiObject;
-import android.support.test.uiautomator.UiObjectNotFoundException;
-import android.support.test.uiautomator.UiSelector;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import androidx.test.rule.ActivityTestRule;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.UiSelector;
 
 /**
  * <p>Static class.</p>

--- a/detox/android/detox/src/main/java/com/wix/detox/uiautomator/UiAutomator.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/uiautomator/UiAutomator.java
@@ -1,8 +1,7 @@
 package com.wix.detox.uiautomator;
 
-import android.support.test.uiautomator.UiDevice;
-
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
 
 /**
  * Created by rotemm on 30/08/2017.

--- a/generation/index.js
+++ b/generation/index.js
@@ -31,8 +31,11 @@ const downloadedEspressoFilesMap = Object
   );
 
 const externalFilesToDownload = {
-  'https://android.googlesource.com/platform/frameworks/uiautomator/+/master/src/com/android/uiautomator/core/UiDevice.java?format=TEXT':
-    '../detox/src/android/espressoapi/UIDevice.js'
+// Disabled temporarily as we've switched to the androidx version of this class, which doesn't seem to exist online (not even
+// on android/android-test on Github). My only hope, for now, is to be able to inquire where it is released from (maven group/name
+// is androidx.test.uiautomator:uiautomator:x.y.z) either in Google i/o 2019 or on the next AMA on the /androiddev subreddit.
+// Note: the 'new' (androidx) and 'old' versions are identical (except for the package name, obviously).
+//  'https://android.googlesource.com/platform/frameworks/uiautomator/+/master/src/com/android/uiautomator/core/UiDevice.java?format=TEXT': '../detox/src/android/espressoapi/UIDevice.js'
 };
 
 const downloadedAndroidFilesMap = Object


### PR DESCRIPTION
- [x] This is a small change 
- [x] This change has been discussed in issue #1235 and the solution has been agreed upon with maintainers.

---

**Description:**

Fix #1235 - Migrate uiautomator to `androidx`' uiautomator, which was somehow left behind in the big `androidx` migrate we did a while ago.