### PR TITLE
fix: simulator log plugin issue

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -47,7 +47,7 @@
     "proper-lockfile": "^3.0.2",
     "sanitize-filename": "^1.6.1",
     "shell-utils": "^1.0.9",
-    "tail": "^1.2.3",
+    "tail": "^2.0.0",
     "telnet-client": "0.15.3",
     "tempfile": "^2.0.0",
     "ws": "^1.1.1",

--- a/detox/src/artifacts/ArtifactsManager.js
+++ b/detox/src/artifacts/ArtifactsManager.js
@@ -4,7 +4,6 @@ const path = require('path');
 const util = require('util');
 const log = require('../utils/logger').child({ __filename });
 const argparse = require('../utils/argparse');
-const DetoxRuntimeError = require('../errors/DetoxRuntimeError');
 const ArtifactPathBuilder = require('./utils/ArtifactPathBuilder');
 
 class ArtifactsManager {
@@ -78,13 +77,23 @@ class ArtifactsManager {
 
   subscribeToDeviceEvents(deviceEmitter) {
     deviceEmitter.on('bootDevice', this.onBootDevice.bind(this));
+    deviceEmitter.on('beforeShutdownDevice', this.onBeforeShutdownDevice.bind(this));
     deviceEmitter.on('shutdownDevice', this.onShutdownDevice.bind(this));
     deviceEmitter.on('beforeLaunchApp', this.onBeforeLaunchApp.bind(this));
     deviceEmitter.on('launchApp', this.onLaunchApp.bind(this));
+    deviceEmitter.on('beforeTerminateApp', this.onBeforeTerminateApp.bind(this));
   }
 
   async onBootDevice(deviceInfo) {
     await this._callPlugins('onBootDevice', deviceInfo);
+  }
+
+  async onBeforeTerminateApp(appInfo) {
+    await this._callPlugins('onBeforeTerminateApp', appInfo);
+  }
+
+  async onBeforeShutdownDevice(deviceInfo) {
+    await this._callPlugins('onBeforeShutdownDevice', deviceInfo);
   }
 
   async onShutdownDevice(deviceInfo) {

--- a/detox/src/artifacts/ArtifactsManager.test.js
+++ b/detox/src/artifacts/ArtifactsManager.test.js
@@ -88,9 +88,11 @@ describe('ArtifactsManager', () => {
           name: 'testPlugin',
           disable: jest.fn(),
           onBootDevice: jest.fn(),
+          onBeforeShutdownDevice: jest.fn(),
           onShutdownDevice: jest.fn(),
           onBeforeLaunchApp: jest.fn(),
           onLaunchApp: jest.fn(),
+          onBeforeTerminateApp: jest.fn(),
           onBeforeAll: jest.fn(),
           onBeforeEach: jest.fn(),
           onAfterEach: jest.fn(),
@@ -249,6 +251,10 @@ describe('ArtifactsManager', () => {
           deviceId: 'testDeviceId',
         }));
 
+        itShouldCatchErrorsOnPhase('onBeforeShutdownDevice', () => ({
+          deviceId: 'testDeviceId'
+        }));
+
         itShouldCatchErrorsOnPhase('onShutdownDevice', () => ({
           deviceId: 'testDeviceId'
         }));
@@ -262,6 +268,11 @@ describe('ArtifactsManager', () => {
           bundleId: 'testBundleId',
           deviceId: 'testDeviceId',
           pid: 2018,
+        }));
+
+        itShouldCatchErrorsOnPhase('onBeforeTerminateApp', () => ({
+          bundleId: 'testBundleId',
+          deviceId: 'testDeviceId',
         }));
       });
 
@@ -319,6 +330,31 @@ describe('ArtifactsManager', () => {
           expect(testPlugin.onBootDevice).not.toHaveBeenCalled();
           await artifactsManager.onBootDevice(bootInfo);
           expect(testPlugin.onBootDevice).toHaveBeenCalledWith(bootInfo);
+        });
+      });
+
+      describe('onBeforeTerminateApp', () => {
+        it('should call onBeforeTerminateApp in plugins', async () => {
+          const terminateInfo = {
+            deviceId: 'testDeviceId',
+            bundleId: 'testBundleId',
+          };
+
+          expect(testPlugin.onBeforeTerminateApp).not.toHaveBeenCalled();
+          await artifactsManager.onBeforeTerminateApp(terminateInfo);
+          expect(testPlugin.onBeforeTerminateApp).toHaveBeenCalledWith(terminateInfo);
+        });
+      });
+
+      describe('onBeforeShutdownDevice', () => {
+        it('should call onBeforeShutdownDevice in plugins', async () => {
+          const shutdownInfo = {
+            deviceId: 'testDeviceId',
+          };
+
+          expect(testPlugin.onBeforeShutdownDevice).not.toHaveBeenCalled();
+          await artifactsManager.onBeforeShutdownDevice(shutdownInfo);
+          expect(testPlugin.onBeforeShutdownDevice).toHaveBeenCalledWith(shutdownInfo);
         });
       });
 

--- a/detox/src/artifacts/__snapshots__/ArtifactsManager.test.js.snap
+++ b/detox/src/artifacts/__snapshots__/ArtifactsManager.test.js.snap
@@ -84,6 +84,34 @@ Array [
 ]
 `;
 
+exports[`ArtifactsManager .artifactsApi hooks error handling should catch .onBeforeShutdownDevice errors 1`] = `
+Array [
+  Array [
+    Object {
+      "err": [Error: test onBeforeShutdownDevice error],
+      "event": "PLUGIN_ERROR",
+      "methodName": "onBeforeShutdownDevice",
+      "plugin": "testPlugin",
+    },
+    "Caught exception inside function call: testPlugin.onBeforeShutdownDevice({ deviceId: 'testDeviceId' })",
+  ],
+]
+`;
+
+exports[`ArtifactsManager .artifactsApi hooks error handling should catch .onBeforeTerminateApp errors 1`] = `
+Array [
+  Array [
+    Object {
+      "err": [Error: test onBeforeTerminateApp error],
+      "event": "PLUGIN_ERROR",
+      "methodName": "onBeforeTerminateApp",
+      "plugin": "testPlugin",
+    },
+    "Caught exception inside function call: testPlugin.onBeforeTerminateApp({ bundleId: 'testBundleId', deviceId: 'testDeviceId' })",
+  ],
+]
+`;
+
 exports[`ArtifactsManager .artifactsApi hooks error handling should catch .onBootDevice errors 1`] = `
 Array [
   Array [

--- a/detox/src/artifacts/log/ios/SimulatorLogPlugin.js
+++ b/detox/src/artifacts/log/ios/SimulatorLogPlugin.js
@@ -9,20 +9,14 @@ class SimulatorLogPlugin extends LogArtifactPlugin {
     this.appleSimUtils = config.appleSimUtils;
   }
 
-  async onShutdownDevice(event) {
-    await super.onShutdownDevice(event);
+  async onBeforeShutdownDevice(event) {
+    await super.onBeforeShutdownDevice(event);
     await this._tryStopCurrentRecording();
   }
 
   async onBeforeLaunchApp(event) {
     await super.onBeforeLaunchApp(event);
     await this._tryStopCurrentRecording();
-  }
-
-  async _tryStopCurrentRecording() {
-    if (this.currentRecording) {
-      await this.currentRecording.stop();
-    }
   }
 
   async onLaunchApp(event) {
@@ -32,6 +26,12 @@ class SimulatorLogPlugin extends LogArtifactPlugin {
       await this.currentRecording.start({
         readFromBeginning: true,
       });
+    }
+  }
+
+  async _tryStopCurrentRecording() {
+    if (this.currentRecording) {
+      await this.currentRecording.stop();
     }
   }
 

--- a/detox/src/artifacts/templates/artifact/Artifact.js
+++ b/detox/src/artifacts/templates/artifact/Artifact.js
@@ -1,4 +1,4 @@
-const _ = require('lodash');
+const fs = require('fs-extra');
 const log = require('../../../utils/logger').child({ __filename });
 
 class Artifact {
@@ -101,6 +101,15 @@ class Artifact {
   async doSave(artifactPath) {}
 
   async doDiscard() {}
+
+  static async moveTemporaryFile(logger, source, destination) {
+    if (await fs.exists(source)) {
+      logger.debug({ event: 'MOVE_FILE' }, `moving "${source}" to ${destination}`);
+      await fs.move(source, destination);
+    } else {
+      logger.error({ event: 'MOVE_FILE_ERROR'} , `did not find temporary file: ${source}`);
+    }
+  }
 }
 
 module.exports = Artifact;

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
@@ -40,12 +40,14 @@ class ArtifactPlugin {
    * @param {Object} event - Launch app event object
    * @param {string} event.deviceId - Current deviceId
    * @param {string} event.bundleId - Current bundleId
+   * @param {Object} event.launchArgs - Mutable key-value pairs of args before the launch
    * @return {Promise<void>} - when done
    */
   async onBeforeLaunchApp(event) {
     Object.assign(this.context, {
       bundleId: event.bundleId,
       deviceId: event.deviceId,
+      launchArgs: event.launchArgs,
       pid: NaN,
     });
   }
@@ -60,6 +62,7 @@ class ArtifactPlugin {
    * @param {Object} event - Launch app event object
    * @param {string} event.deviceId - Current deviceId
    * @param {string} event.bundleId - Current bundleId
+   * @param {Object} event.launchArgs - key-value pairs of launch args
    * @param {number} event.pid - Process id of the running app
    * @return {Promise<void>} - when done
    */
@@ -67,6 +70,7 @@ class ArtifactPlugin {
     Object.assign(this.context, {
       bundleId: event.bundleId,
       deviceId: event.deviceId,
+      launchArgs: event.launchArgs,
       pid: event.pid,
    });
   }
@@ -86,6 +90,38 @@ class ArtifactPlugin {
       deviceId: event.deviceId,
       bundleId: '',
       pid: NaN,
+    });
+  }
+
+  /**
+   * Hook that is supposed to be called before app is terminated
+   *
+   * @protected
+   * @async
+   * @param {Object} event - Device shutdown event object
+   * @param {string} event.deviceId - Current deviceId
+   * @param {string} event.bundleId - Current bundleId
+   * @return {Promise<void>} - when done
+   */
+  async onBeforeTerminateApp(event) {
+    Object.assign(this.context, {
+      deviceId: event.deviceId,
+      bundleId: event.bundleId,
+    });
+  }
+
+  /**
+   * Hook that is supposed to be called before device.shutdown() happens
+   *
+   * @protected
+   * @async
+   * @param {Object} event - Device shutdown event object
+   * @param {string} event.deviceId - Current deviceId
+   * @return {Promise<void>} - when done
+   */
+  async onBeforeShutdownDevice(event) {
+    Object.assign(this.context, {
+      deviceId: event.deviceId,
     });
   }
 
@@ -113,7 +149,9 @@ class ArtifactPlugin {
    * @async
    * @return {Promise<void>} - when done
    */
-  async onBeforeAll() {}
+  async onBeforeAll() {
+    this.context.testSummary = null;
+  }
 
   /**
    * Hook that is called before a test begins
@@ -123,7 +161,9 @@ class ArtifactPlugin {
    * @param {TestSummary} testSummary - has name of currently running test
    * @return {Promise<void>} - when done
    */
-  async onBeforeEach(testSummary) {}
+  async onBeforeEach(testSummary) {
+    this.context.testSummary = testSummary;
+  }
 
   /***
    * @protected
@@ -131,7 +171,9 @@ class ArtifactPlugin {
    * @param {TestSummary} testSummary - has name and status of test that ran
    * @return {Promise<void>} - when done
    */
-  async onAfterEach(testSummary) {}
+  async onAfterEach(testSummary) {
+    this.context.testSummary = testSummary;
+  }
 
   /**
    * Hook that is called after all tests run
@@ -141,6 +183,7 @@ class ArtifactPlugin {
    * @return {Promise<void>} - when done
    */
   async onAfterAll() {
+    this.context.testSummary = null;
     this._logDisableWarning();
   }
 
@@ -156,9 +199,11 @@ class ArtifactPlugin {
 
     this.onTerminate = _.noop;
     this.onBootDevice = _.noop;
+    this.onBeforeShutdownDevice = _.noop;
     this.onShutdownDevice = _.noop;
     this.onBeforeLaunchApp = _.noop;
     this.onLaunchApp = _.noop;
+    this.onBeforeTerminateApp = _.noop;
     this.onBeforeAll = _.noop;
     this.onBeforeEach = _.noop;
     this.onAfterEach = _.noop;

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.test.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.test.js
@@ -75,7 +75,10 @@ describe(ArtifactPlugin, () => {
     it('should update context on .onBeforeLaunchApp', async () => {
       await expect(plugin.onBeforeLaunchApp({
         deviceId: 'testDeviceId',
-        bundleId: 'testBundleId'
+        bundleId: 'testBundleId',
+        launchArgs: {
+          detoxSessionId: 'test',
+        },
       }));
 
       expect(plugin.context).toMatchSnapshot();
@@ -85,7 +88,19 @@ describe(ArtifactPlugin, () => {
       await expect(plugin.onLaunchApp({
         deviceId: 'testDeviceId',
         bundleId: 'testBundleId',
+        launchArgs: {
+          detoxSessionId: 'test',
+        },
         pid: 2018
+      }));
+
+      expect(plugin.context).toMatchSnapshot();
+    });
+
+    it('should update context on .onBeforeTerminateApp', async () => {
+      await expect(plugin.onBeforeTerminateApp({
+        deviceId: 'testDeviceId',
+        bundleId: 'testBundleId',
       }));
 
       expect(plugin.context).toMatchSnapshot();
@@ -100,6 +115,14 @@ describe(ArtifactPlugin, () => {
       expect(plugin.context).toMatchSnapshot();
     });
 
+    it('should have .onBeforeShutdownDevice', async () => {
+      await expect(plugin.onBeforeShutdownDevice({
+        deviceId: 'testDeviceId'
+      }));
+
+      expect(plugin.context).toMatchSnapshot();
+    });
+
     it('should have .onShutdownDevice', async () => {
       await expect(plugin.onShutdownDevice({
         deviceId: 'testDeviceId'
@@ -108,19 +131,29 @@ describe(ArtifactPlugin, () => {
       expect(plugin.context).toMatchSnapshot();
     });
 
-    it('should have .onBeforeAll', async () =>
-      await expect(plugin.onBeforeAll()).resolves.toBe(void 0));
-
-    it('should have .onBeforeEach', async () => {
-      const testSummary = testSummaries.running();
-      await expect(plugin.onBeforeEach(testSummary)).resolves.toBe(void 0);
+    it('should have .onBeforeAll, which resets context.testSummary if called', async () => {
+      plugin.context.testSummary = {};
+      await plugin.onBeforeAll();
+      expect(plugin.context.testSummary).toBe(null);
     });
 
-    it('should have .onAfterEach', async () =>
-      await expect(plugin.onAfterEach(testSummaries.failed())).resolves.toBe(void 0));
+    it('should have .onBeforeEach, which updates context.testSummary if called', async () => {
+      const testSummary = testSummaries.running();
+      await plugin.onBeforeEach(testSummary);
+      expect(plugin.context.testSummary).toBe(testSummary);
+    });
 
-    it('should have .onAfterAll', async () =>
-      await expect(plugin.onAfterAll()).resolves.toBe(void 0));
+    it('should have .onAfterEach, which updates context.testSummary if called', async () => {
+      const testSummary = testSummaries.failed();
+      await plugin.onAfterEach(testSummary);
+      expect(plugin.context.testSummary).toBe(testSummary);
+    });
+
+    it('should have .onAfterAll, which resets context.testSummary if called', async () => {
+      plugin.context.testSummary = {};
+      await plugin.onAfterAll();
+      expect(plugin.context.testSummary).toBe(null);
+    });
 
     describe('.onTerminate', () => {
       it('should disable plugin with a reason', async () => {
@@ -133,9 +166,11 @@ describe(ArtifactPlugin, () => {
         await plugin.onTerminate();
 
         expect(plugin.onBootDevice).toBe(plugin.onTerminate);
+        expect(plugin.onBeforeShutdownDevice).toBe(plugin.onTerminate);
         expect(plugin.onShutdownDevice).toBe(plugin.onTerminate);
         expect(plugin.onBeforeLaunchApp).toBe(plugin.onTerminate);
         expect(plugin.onLaunchApp).toBe(plugin.onTerminate);
+        expect(plugin.onBeforeTerminateApp).toBe(plugin.onTerminate);
         expect(plugin.onBeforeAll).toBe(plugin.onTerminate);
         expect(plugin.onBeforeEach).toBe(plugin.onTerminate);
         expect(plugin.onAfterEach).toBe(plugin.onTerminate);

--- a/detox/src/artifacts/templates/plugin/StartupAndTestRecorderPlugin.js
+++ b/detox/src/artifacts/templates/plugin/StartupAndTestRecorderPlugin.js
@@ -22,6 +22,8 @@ class StartupAndTestRecorderPlugin extends WholeTestRecorderPlugin {
   }
 
   async onBeforeAll() {
+    await super.onBeforeAll();
+
     if (this.enabled) {
       const recording = this.createStartupRecording();
       await recording.start();

--- a/detox/src/artifacts/templates/plugin/__snapshots__/ArtifactPlugin.test.js.snap
+++ b/detox/src/artifacts/templates/plugin/__snapshots__/ArtifactPlugin.test.js.snap
@@ -8,6 +8,13 @@ Array [
 ]
 `;
 
+exports[`ArtifactPlugin lifecycle hooks should have .onBeforeShutdownDevice 1`] = `
+Object {
+  "deviceId": "testDeviceId",
+  "shouldNotBeDeletedFromContext": "extraProperty",
+}
+`;
+
 exports[`ArtifactPlugin lifecycle hooks should have .onBootDevice 1`] = `
 Object {
   "bundleId": "",
@@ -21,6 +28,9 @@ exports[`ArtifactPlugin lifecycle hooks should have .onLaunchApp 1`] = `
 Object {
   "bundleId": "testBundleId",
   "deviceId": "testDeviceId",
+  "launchArgs": Object {
+    "detoxSessionId": "test",
+  },
   "pid": 2018,
   "shouldNotBeDeletedFromContext": "extraProperty",
 }
@@ -39,7 +49,18 @@ exports[`ArtifactPlugin lifecycle hooks should update context on .onBeforeLaunch
 Object {
   "bundleId": "testBundleId",
   "deviceId": "testDeviceId",
+  "launchArgs": Object {
+    "detoxSessionId": "test",
+  },
   "pid": NaN,
+  "shouldNotBeDeletedFromContext": "extraProperty",
+}
+`;
+
+exports[`ArtifactPlugin lifecycle hooks should update context on .onBeforeTerminateApp 1`] = `
+Object {
+  "bundleId": "testBundleId",
+  "deviceId": "testDeviceId",
   "shouldNotBeDeletedFromContext": "extraProperty",
 }
 `;

--- a/detox/src/artifacts/video/SimulatorRecordVideoPlugin.js
+++ b/detox/src/artifacts/video/SimulatorRecordVideoPlugin.js
@@ -28,11 +28,7 @@ class SimulatorRecordVideoPlugin extends VideoArtifactPlugin {
         }
       },
       save: async (artifactPath) => {
-        if (await fs.exists(temporaryFilePath)) {
-          await fs.move(temporaryFilePath, artifactPath);
-        } else {
-          log.error({ event: 'MOVE_FILE_ERROR' }, `could not find temporary file at: "${temporaryFilePath}"`);
-        }
+        await Artifact.moveTemporaryFile(log, temporaryFilePath, artifactPath);
       },
       discard: async () => {
         await fs.remove(temporaryFilePath);

--- a/detox/src/devices/drivers/AndroidDriver.js
+++ b/detox/src/devices/drivers/AndroidDriver.js
@@ -128,6 +128,7 @@ class AndroidDriver extends DeviceDriverBase {
   }
 
   async terminate(deviceId, bundleId) {
+    await this.emitter.emit('beforeTerminateApp', { deviceId, bundleId });
     await this._terminateInstrumentation();
     await this.adb.terminate(deviceId, bundleId);
   }

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -11,7 +11,9 @@ class DeviceDriverBase {
     this.emitter = new AsyncEmitter({
       events: [
         'bootDevice',
+        'beforeShutdownDevice',
         'shutdownDevice',
+        'beforeTerminateApp',
         'beforeLaunchApp',
         'launchApp',
       ],

--- a/detox/src/devices/drivers/EmulatorDriver.js
+++ b/detox/src/devices/drivers/EmulatorDriver.js
@@ -110,6 +110,7 @@ class EmulatorDriver extends AndroidDriver {
   }
 
   async shutdown(deviceId) {
+    await this.emitter.emit('beforeShutdownDevice', { deviceId });
     const port = _.split(deviceId, '-')[1];
     const telnet = new EmulatorTelnet();
     await telnet.connect(port);

--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -93,6 +93,7 @@ class SimulatorDriver extends IosDriver {
   }
 
   async terminate(deviceId, bundleId) {
+    await this.emitter.emit('beforeTerminateApp', { deviceId, bundleId });
     await this._applesimutils.terminate(deviceId, bundleId);
   }
 
@@ -101,6 +102,7 @@ class SimulatorDriver extends IosDriver {
   }
 
   async shutdown(deviceId) {
+    await this.emitter.emit('beforeShutdownDevice', { deviceId });
     await this._applesimutils.shutdown(deviceId);
     await this.emitter.emit('shutdownDevice', { deviceId });
   }


### PR DESCRIPTION
Fixes a critical bug in CI regression test suite.

```
23:12:51   1) Device
23:12:51        resetContentAndSettings() + install() + relaunch() - should tap successfully:
23:12:51      Uncaught Error [ERR_UNHANDLED_ERROR]: Unhandled error. (watch for /Users/jenkins/Library/Developer/CoreSimulator/Devices/258A3C6B-EFAC-4A4D-8B14-E7F1FD8E9D16/data/tmp/detox.last_launch_app_log.out failed: Error: ENOENT: no such file or directory, stat '/Users/jenkins/Library/Developer/CoreSimulator/Devices/258A3C6B-EFAC-4A4D-8B14-E7F1FD8E9D16/data/tmp/detox.last_launch_app_log.out')
23:12:51       at Tail.watch (/Users/jenkins/.jenkins/workspace/detox-ios-56-master/detox/node_modules/tail/lib/tail.js:97:12)
23:12:51       at Timeout.setTimeout [as _onTimeout] (/Users/jenkins/.jenkins/workspace/detox-ios-56-master/detox/node_modules/tail/lib/tail.js:160:25)
```

The main idea is to `unwatch()` logs in `onBeforeShutdownDevice` phase, when they are still there. It appears that shutting device down automatically erases the dir with the logs, so we can't unwatch them correctly.

The pull request also extends `ArtifactManager`'s lifecycle by adding two new events: `onBeforeShutdownDevice` and `onBeforeTerminateApp`.

The pull request upgrades `tail` dependency from `1.x` to `2.x` and removes a hack related to https://github.com/lucagrulla/node-tail/issues/40 (fixed in 2.0.0).