### PR TITLE
fix: e2e test on timezones different from LA

### DIFF
--- a/detox/test/e2e/17.datePicker.test.js
+++ b/detox/test/e2e/17.datePicker.test.js
@@ -5,15 +5,14 @@ describe(':ios: DatePicker', () => {
     });
 
     it('datePicker should trigger change handler correctly', async () => {
-      await element(by.type('UIPickerView')).setColumnToValue(1,"6");
-      await element(by.type('UIPickerView')).setColumnToValue(2,"34");
-      await expect(element(by.id("timeLabel"))).toHaveText('choosenTime is 6:34');
+      await element(by.type('UIPickerView')).setColumnToValue(1, "6");
+      await element(by.type('UIPickerView')).setColumnToValue(2, "34");
+      await expect(element(by.id('localTimeLabel'))).toHaveText('Time: 06:34');
     });
 
     it('can select dates on a UIDatePicker', async () => {
       await element(by.type('UIDatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "yyyy-MM-dd'T'HH:mm:ssZZZZZ");
-
-      await expect(element(by.id('dateTimeLabel'))).toHaveText('choosenDateTime is 2-6-2019 5:10');
+      await expect(element(by.id('utcDateLabel'))).toHaveText('Date (UTC): Feb 6th, 2019');
+      await expect(element(by.id('utcTimeLabel'))).toHaveText('Time (UTC): 1:10 PM');
     });
-
 });

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -14,6 +14,7 @@
     "verify-artifacts:android": "jest ./scripts/verify_artifacts_are_not_missing.android.test.js --testEnvironment node"
   },
   "dependencies": {
+    "moment": "^2.24.0",
     "react": "16.4.1",
     "react-native": "0.56.0"
   },

--- a/detox/test/src/Screens/DatePickerScreen.js
+++ b/detox/test/src/Screens/DatePickerScreen.js
@@ -1,61 +1,67 @@
+import moment from 'moment';
 import React, { Component } from 'react';
 import { Text, View, StyleSheet, DatePickerIOS } from 'react-native';
 
 export default class DatePickerScreen extends Component {
   constructor(props) {
     super(props);
+
     this.state = {
       chosenDate: new Date()
     };
-    this._setDate = this._setDate.bind(this);
+
+    this.setDate = this.setDate.bind(this);
   }
 
-  _setDate(newDate) {
+  setDate(newDate) {
     this.setState({
       chosenDate: newDate
     });
   }
 
-  getTime() {
-    minutes = this.state.chosenDate.getMinutes();
-    hour = this.state.chosenDate.getHours();
-
-    if (hour > 12) {
-      hour = hour - 12;
-    }
-    return `${hour}:${minutes}`;
+  getTimeLocal() {
+    return moment(this.state.chosenDate).format("hh:mm");
   }
 
-  getDateTime() {
-    year = this.state.chosenDate.getFullYear();
-    month = this.state.chosenDate.getMonth() + 1;
-    day = this.state.chosenDate.getDate();
+  getTimeUTC() {
+    return moment(this.state.chosenDate).utc().format("h:mm A");
+  }
 
-    return `${month}-${day}-${year} ${this.getTime()}`;
+  getDateUTC() {
+    return moment(this.state.chosenDate).utc().format("MMM Do, YYYY");
   }
 
   render() {
     return (
-      <View style={{flex: 1, paddingTop: 20, justifyContent: 'center', alignItems: 'center'}}>
-        <Text style={styles.dateText} testID='timeLabel'>
-          {"choosenTime is " + this.getTime()}
+      <View style={styles.container}>
+        <Text style={styles.dateText} testID="utcDateLabel">
+          {"Date (UTC): " + this.getDateUTC()}
         </Text>
-        <Text style={styles.dateText} testID="dateTimeLabel">
-          {"choosenDateTime is " + this.getDateTime()}
+        <Text style={styles.dateText} testID='utcTimeLabel'>
+          {"Time (UTC): " + this.getTimeUTC()}
         </Text>
-        <DatePickerIOS style={styles.datePicker} date={this.state.chosenDate} onDateChange={this._setDate} />
+        <Text style={styles.dateText} testID='localTimeLabel'>
+          {"Time: " + this.getTimeLocal()}
+        </Text>
+        <DatePickerIOS style={styles.datePicker} date={this.state.chosenDate} onDateChange={this.setDate} />
       </View>
     );
   }
 }
 
 const styles = StyleSheet.create({
-    datePicker: {
-      width:'100%',
-      height:200,
-      backgroundColor:'green'
-    },
-    dateText: {
-      textAlign:'center'
-    }
+  container: {
+    flex: 1,
+    paddingTop: 20,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  datePicker: {
+    width:'100%',
+    height:200,
+    backgroundColor:'green'
+  },
+  dateText: {
+    textAlign:'center'
+  }
 });


### PR DESCRIPTION
The recent contribution in February to `DatePickerIOS` functionality does not pass end-to-end tests locally due to a timezone issue.

The pull request removes timezone ambiguities between test code and example app code, so you don't need to switch to Los Angeles time locally to make the tests pass.