### PR TITLE
hotfix: redundant logs in the folder

### DIFF
--- a/detox/local-cli/cli.js
+++ b/detox/local-cli/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+global.DETOX_CLI = true;
 const yargs = require('yargs');
 const logger = require('../src/utils/logger').child({ __filename });
 

--- a/detox/src/utils/logger.js
+++ b/detox/src/utils/logger.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const fs = require('fs-extra');
 const path = require('path');
 const bunyan = require('bunyan');
@@ -62,7 +61,7 @@ function init() {
   const levelFromArg = argparse.getArgValue('loglevel');
   const level = adaptLogLevelName(levelFromArg);
   const logBaseFilename = path.join(argparse.getArgValue('artifacts-location') || '', `detox_pid_${process.pid}`);
-  const shouldRecordLogs = ['failing', 'all'].indexOf(argparse.getArgValue('record-logs')) >= 0;
+  const shouldRecordLogs = typeof DETOX_CLI === 'undefined' && ['failing', 'all'].indexOf(argparse.getArgValue('record-logs')) >= 0;
 
   const bunyanStreams = [createPlainBunyanStream({ level })];
   if (shouldRecordLogs) {


### PR DESCRIPTION
A hacky but efficient enough solution to prevent a bug introduced in `12.1.0` with the `yargs` transition.

Prevents appearance of `detox_<pid>.log` files in your current working directory if you don't specify explicitly `--artifacts-location` to the Detox CLI. It's very annoying and quickly pollutes the project folder.

Previously, those very short logs were not created at all in these cases, so we don't really lose much by suppressing them again. Later we can think on how to do better.