### PR TITLE
feat(log): dump pending network requests on test timeout

### DIFF
--- a/detox/runners/jest/DetoxJestAdapter.js
+++ b/detox/runners/jest/DetoxJestAdapter.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const DetoxRuntimeError = require('../../src/errors/DetoxRuntimeError');
 
 class DetoxJestAdapter /* implements JasmineReporter */ {
@@ -60,9 +61,18 @@ class DetoxJestAdapter /* implements JasmineReporter */ {
       title: result.description,
       fullName: result.fullName,
       status: result.status,
+      timedOut: this._hasTimedOut(result),
     };
 
     this._enqueue(() => this._afterEach(spec));
+  }
+
+  _hasTimedOut(result) {
+    return _.chain(result.failedExpectations)
+      .map('error')
+      .compact()
+      .some(e => _.includes(e.message, 'Timeout'))
+      .value();
   }
 
   _enqueue(fn) {

--- a/detox/runners/mocha/DetoxMochaAdapter.js
+++ b/detox/runners/mocha/DetoxMochaAdapter.js
@@ -16,6 +16,7 @@ class DetoxMochaAdapter {
       title: context.currentTest.title,
       fullName: context.currentTest.fullTitle(),
       status: this._mapStatus(context, true),
+      timedOut: context.currentTest.timedOut,
     });
   }
 

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -90,6 +90,7 @@ class Detox {
     await this._artifactsManager.onAfterAll();
 
     if (this._client) {
+      this._client.dumpPendingRequests();
       await this._client.cleanup();
     }
 
@@ -109,7 +110,10 @@ class Detox {
   async beforeEach(testSummary) {
     this._validateTestSummary(testSummary);
     this._logTestRunCheckpoint('DETOX_BEFORE_EACH', testSummary);
-    await this._handleAppCrashIfAny(testSummary.fullName);
+    await this._dumpUnhandledErrorsIfAny({
+      pendingRequests: false,
+      testName: testSummary.fullName,
+    });
     await this._artifactsManager.onBeforeEach(testSummary);
   }
 
@@ -117,7 +121,10 @@ class Detox {
     this._validateTestSummary(testSummary);
     this._logTestRunCheckpoint('DETOX_AFTER_EACH', testSummary);
     await this._artifactsManager.onAfterEach(testSummary);
-    await this._handleAppCrashIfAny(testSummary.fullName);
+    await this._dumpUnhandledErrorsIfAny({
+      pendingRequests: testSummary.timedOut,
+      testName: testSummary.fullName,
+    });
   }
 
   _logTestRunCheckpoint(event, { status, fullName }) {
@@ -150,7 +157,11 @@ class Detox {
     }
   }
 
-  async _handleAppCrashIfAny(testName) {
+  async _dumpUnhandledErrorsIfAny({ testName, pendingRequests }) {
+    if (pendingRequests) {
+      this._client.dumpPendingRequests();
+    }
+
     const pendingAppCrash = this._client.getPendingCrashAndReset();
 
     if (pendingAppCrash) {

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -159,7 +159,7 @@ class Detox {
 
   async _dumpUnhandledErrorsIfAny({ testName, pendingRequests }) {
     if (pendingRequests) {
-      this._client.dumpPendingRequests();
+      this._client.dumpPendingRequests({testName});
     }
 
     const pendingAppCrash = this._client.getPendingCrashAndReset();

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -166,6 +166,27 @@ describe('Detox', () => {
     expect(device.launchApp).toHaveBeenCalledTimes(1);
   });
 
+  it(`handleAppCrash should not dump pending requests if testSummary has no timeout flag`, async () => {
+    Detox = require('./Detox');
+    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
+    const testSummary = { title: 'test', fullName: 'suite - test', status: 'failed' };
+
+    await detox.init();
+    await detox.afterEach(testSummary);
+
+    expect(detox._client.dumpPendingRequests).not.toHaveBeenCalled();
+  });
+
+  it(`handleAppCrash should dump pending requests if testSummary has timeout flag`, async () => {
+    Detox = require('./Detox');
+    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
+    const testSummary = { title: 'test', fullName: 'suite - test', status: 'failed', timedOut: true };
+
+    await detox.init();
+    await detox.afterEach(testSummary);
+    expect(detox._client.dumpPendingRequests).toHaveBeenCalled();
+  });
+
   describe('.artifactsManager', () => {
     let artifactsManager;
 

--- a/detox/src/client/AsyncWebSocket.js
+++ b/detox/src/client/AsyncWebSocket.js
@@ -59,7 +59,7 @@ class AsyncWebSocket {
 
     return new Promise(async(resolve, reject) => {
       message.messageId = messageId || this.messageIdCounter++;
-      this.inFlightPromises[message.messageId] = {resolve, reject};
+      this.inFlightPromises[message.messageId] = {message, resolve, reject};
       const messageAsString = JSON.stringify(message);
       this.log.trace({ event: 'WEBSOCKET_SEND' }, `${messageAsString}`);
       this.ws.send(messageAsString);
@@ -94,6 +94,12 @@ class AsyncWebSocket {
       return false;
     }
     return this.ws.readyState === WebSocket.OPEN;
+  }
+
+  resetInFlightPromises() {
+    _.forEach(this.inFlightPromises, (_, messageId) => {
+      delete this.inFlightPromises[messageId];
+    });
   }
 
   rejectAll(error) {

--- a/detox/src/client/AsyncWebSocket.test.js
+++ b/detox/src/client/AsyncWebSocket.test.js
@@ -186,6 +186,16 @@ describe('AsyncWebSocket', () => {
     await expect(message2).rejects.toEqual(error);
   });
 
+  it(`resetInFlightPromises should erase all pending promises`, async () => {
+    await connect(client);
+    client.send(generateRequest());
+    client.send(generateRequest());
+
+    expect(_.size(client.inFlightPromises)).toBe(2);
+    client.resetInFlightPromises();
+    expect(_.size(client.inFlightPromises)).toBe(0);
+  });
+
   async function connect(client) {
     const result = {};
     const promise = client.open();

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -137,8 +137,11 @@ class Client {
     }, this.slowInvocationTimeout);
   }
 
-  dumpPendingRequests() {
-    const messages = _.values(this.ws.inFlightPromises).map(p => p.message);
+  dumpPendingRequests({testName} = {}) {
+    const messages = _.values(this.ws.inFlightPromises)
+      .map(p => p.message)
+      .filter(m => m.type !== 'currentStatus');
+
     if (_.isEmpty(messages)) {
       return;
     }
@@ -147,7 +150,12 @@ class Client {
     for (const msg of messages) {
       dump += `\n  (id = ${msg.messageId}) ${msg.type}: ${JSON.stringify(msg.params)}`;
     }
-    dump += '\n\nThat might be a reason to why your test suite fails with a timeout error.\n';
+
+    const notice = testName
+      ? `That might be the reason why the test "${testName}" has timed out.`
+      : `Unresponded network requests might result in timeout errors in Detox tests.`;
+
+    dump += `\n\n${notice}\n`;
 
     log.warn({ event: 'PENDING_REQUESTS'}, dump);
     this.ws.resetInFlightPromises();

--- a/detox/src/client/__snapshots__/Client.test.js.snap
+++ b/detox/src/client/__snapshots__/Client.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Client dumpPendingRequests() - should dump if there are pending requests 1`] = `
+Array [
+  Object {
+    "event": "PENDING_REQUESTS",
+  },
+  "App has not responded to the network requests below:
+  (id = -49642) cleanup: {}
+
+That might be a reason to why your test suite fails with a timeout error.
+",
+]
+`;

--- a/detox/src/client/__snapshots__/Client.test.js.snap
+++ b/detox/src/client/__snapshots__/Client.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Client dumpPendingRequests() - should dump if there are pending requests 1`] = `
+exports[`Client dumpPendingRequests() - if there are pending requests - should dump generic message if not testName is specified 1`] = `
 Array [
   Object {
     "event": "PENDING_REQUESTS",
@@ -8,7 +8,20 @@ Array [
   "App has not responded to the network requests below:
   (id = -49642) cleanup: {}
 
-That might be a reason to why your test suite fails with a timeout error.
+Unresponded network requests might result in timeout errors in Detox tests.
+",
+]
+`;
+
+exports[`Client dumpPendingRequests() - if there are pending requests - should dump specific message if testName is specified 1`] = `
+Array [
+  Object {
+    "event": "PENDING_REQUESTS",
+  },
+  "App has not responded to the network requests below:
+  (id = -49642) cleanup: {}
+
+That might be the reason why the test \\"Login screen should log in\\" has timed out.
 ",
 ]
 `;


### PR DESCRIPTION
**Description:**

Currently, it is not easy to track what requests to `testee` have never been resolved, leading to timeout errors in tests.

To make it Detox debug-friendly in those cases, I suggest dumping pending network requests if:

1. a test has failed with a timeout (mocha offers this as an API, in Jest I scan for timeouts in failed expectations)
2. in `detox.cleanup()`, before we clean up the client.

Although it does not cover all the cases (e.g. cannot catch infinite `detox._client.cleanup()` but looks like a good start IMO.