### PR TITLE
code: lower status of artifact manager errors

### DIFF
--- a/detox/src/artifacts/ArtifactsManager.js
+++ b/detox/src/artifacts/ArtifactsManager.js
@@ -165,14 +165,14 @@ class ArtifactsManager {
 
   _unhandledPluginExceptionHandler(err, { plugin, methodName, args }) {
     const logObject = {
-      event: 'PLUGIN_ERROR',
+      event: 'SUPPRESS_PLUGIN_ERROR',
       plugin: plugin.name,
       err,
       methodName,
     };
 
     const callSignature = this._composeCallSignature(plugin.name, methodName, args);
-    log.error(logObject, `Caught exception inside function call: ${callSignature}`);
+    log.warn(logObject, `Suppressed error inside function call: ${callSignature}`);
   }
 
   _idleCallbackErrorHandle(err, caller) {

--- a/detox/src/artifacts/ArtifactsManager.test.js
+++ b/detox/src/artifacts/ArtifactsManager.test.js
@@ -232,7 +232,7 @@ describe('ArtifactsManager', () => {
             });
 
             await artifactsManager[hookName](argFactory());
-            expect(proxy.logger.error.mock.calls).toMatchSnapshot();
+            expect(proxy.logger.warn.mock.calls).toMatchSnapshot();
           });
         }
 

--- a/detox/src/artifacts/__snapshots__/ArtifactsManager.test.js.snap
+++ b/detox/src/artifacts/__snapshots__/ArtifactsManager.test.js.snap
@@ -1,29 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArtifactsManager .artifactsApi .requestIdleCallback() should catch errors, report them if callback fails, and move on  1`] = `
-Array [
-  Array [
-    Object {
-      "err": [Error: test onIdleCallback error],
-      "event": "PLUGIN_ERROR",
-      "methodName": "onIdleCallback",
-      "plugin": "testPlugin",
-    },
-    "Caught exception inside function call: testPlugin.onIdleCallback()",
-  ],
-]
-`;
+exports[`ArtifactsManager .artifactsApi .requestIdleCallback() should catch errors, report them if callback fails, and move on  1`] = `Array []`;
 
 exports[`ArtifactsManager .artifactsApi hooks error handling should catch .onAfterAll errors 1`] = `
 Array [
   Array [
     Object {
       "err": [Error: test onAfterAll error],
-      "event": "PLUGIN_ERROR",
+      "event": "SUPPRESS_PLUGIN_ERROR",
       "methodName": "onAfterAll",
       "plugin": "testPlugin",
     },
-    "Caught exception inside function call: testPlugin.onAfterAll()",
+    "Suppressed error inside function call: testPlugin.onAfterAll()",
   ],
 ]
 `;
@@ -33,11 +21,11 @@ Array [
   Array [
     Object {
       "err": [Error: test onAfterEach error],
-      "event": "PLUGIN_ERROR",
+      "event": "SUPPRESS_PLUGIN_ERROR",
       "methodName": "onAfterEach",
       "plugin": "testPlugin",
     },
-    "Caught exception inside function call: testPlugin.onAfterEach({ title: 'test', fullName: 'Suite test', status: 'passed' })",
+    "Suppressed error inside function call: testPlugin.onAfterEach({ title: 'test', fullName: 'Suite test', status: 'passed' })",
   ],
 ]
 `;
@@ -47,11 +35,11 @@ Array [
   Array [
     Object {
       "err": [Error: test onBeforeAll error],
-      "event": "PLUGIN_ERROR",
+      "event": "SUPPRESS_PLUGIN_ERROR",
       "methodName": "onBeforeAll",
       "plugin": "testPlugin",
     },
-    "Caught exception inside function call: testPlugin.onBeforeAll()",
+    "Suppressed error inside function call: testPlugin.onBeforeAll()",
   ],
 ]
 `;
@@ -61,11 +49,11 @@ Array [
   Array [
     Object {
       "err": [Error: test onBeforeEach error],
-      "event": "PLUGIN_ERROR",
+      "event": "SUPPRESS_PLUGIN_ERROR",
       "methodName": "onBeforeEach",
       "plugin": "testPlugin",
     },
-    "Caught exception inside function call: testPlugin.onBeforeEach({ title: 'test', fullName: 'Suite test', status: 'running' })",
+    "Suppressed error inside function call: testPlugin.onBeforeEach({ title: 'test', fullName: 'Suite test', status: 'running' })",
   ],
 ]
 `;
@@ -75,11 +63,11 @@ Array [
   Array [
     Object {
       "err": [Error: test onBeforeLaunchApp error],
-      "event": "PLUGIN_ERROR",
+      "event": "SUPPRESS_PLUGIN_ERROR",
       "methodName": "onBeforeLaunchApp",
       "plugin": "testPlugin",
     },
-    "Caught exception inside function call: testPlugin.onBeforeLaunchApp({ bundleId: 'testBundleId', deviceId: 'testDeviceId' })",
+    "Suppressed error inside function call: testPlugin.onBeforeLaunchApp({ bundleId: 'testBundleId', deviceId: 'testDeviceId' })",
   ],
 ]
 `;
@@ -89,11 +77,11 @@ Array [
   Array [
     Object {
       "err": [Error: test onBeforeShutdownDevice error],
-      "event": "PLUGIN_ERROR",
+      "event": "SUPPRESS_PLUGIN_ERROR",
       "methodName": "onBeforeShutdownDevice",
       "plugin": "testPlugin",
     },
-    "Caught exception inside function call: testPlugin.onBeforeShutdownDevice({ deviceId: 'testDeviceId' })",
+    "Suppressed error inside function call: testPlugin.onBeforeShutdownDevice({ deviceId: 'testDeviceId' })",
   ],
 ]
 `;
@@ -103,11 +91,11 @@ Array [
   Array [
     Object {
       "err": [Error: test onBeforeTerminateApp error],
-      "event": "PLUGIN_ERROR",
+      "event": "SUPPRESS_PLUGIN_ERROR",
       "methodName": "onBeforeTerminateApp",
       "plugin": "testPlugin",
     },
-    "Caught exception inside function call: testPlugin.onBeforeTerminateApp({ bundleId: 'testBundleId', deviceId: 'testDeviceId' })",
+    "Suppressed error inside function call: testPlugin.onBeforeTerminateApp({ bundleId: 'testBundleId', deviceId: 'testDeviceId' })",
   ],
 ]
 `;
@@ -117,11 +105,11 @@ Array [
   Array [
     Object {
       "err": [Error: test onBootDevice error],
-      "event": "PLUGIN_ERROR",
+      "event": "SUPPRESS_PLUGIN_ERROR",
       "methodName": "onBootDevice",
       "plugin": "testPlugin",
     },
-    "Caught exception inside function call: testPlugin.onBootDevice({ coldBoot: false, deviceId: 'testDeviceId' })",
+    "Suppressed error inside function call: testPlugin.onBootDevice({ coldBoot: false, deviceId: 'testDeviceId' })",
   ],
 ]
 `;
@@ -131,11 +119,11 @@ Array [
   Array [
     Object {
       "err": [Error: test onLaunchApp error],
-      "event": "PLUGIN_ERROR",
+      "event": "SUPPRESS_PLUGIN_ERROR",
       "methodName": "onLaunchApp",
       "plugin": "testPlugin",
     },
-    "Caught exception inside function call: testPlugin.onLaunchApp({ bundleId: 'testBundleId', deviceId: 'testDeviceId', pid: 2018 })",
+    "Suppressed error inside function call: testPlugin.onLaunchApp({ bundleId: 'testBundleId', deviceId: 'testDeviceId', pid: 2018 })",
   ],
 ]
 `;
@@ -145,11 +133,11 @@ Array [
   Array [
     Object {
       "err": [Error: test onShutdownDevice error],
-      "event": "PLUGIN_ERROR",
+      "event": "SUPPRESS_PLUGIN_ERROR",
       "methodName": "onShutdownDevice",
       "plugin": "testPlugin",
     },
-    "Caught exception inside function call: testPlugin.onShutdownDevice({ deviceId: 'testDeviceId' })",
+    "Suppressed error inside function call: testPlugin.onShutdownDevice({ deviceId: 'testDeviceId' })",
   ],
 ]
 `;
@@ -159,11 +147,11 @@ Array [
   Array [
     Object {
       "err": [Error: test onTerminate error],
-      "event": "PLUGIN_ERROR",
+      "event": "SUPPRESS_PLUGIN_ERROR",
       "methodName": "onTerminate",
       "plugin": "testPlugin",
     },
-    "Caught exception inside function call: testPlugin.onTerminate()",
+    "Suppressed error inside function call: testPlugin.onTerminate()",
   ],
 ]
 `;

--- a/detox/src/artifacts/log/ios/SimulatorLogRecording.js
+++ b/detox/src/artifacts/log/ios/SimulatorLogRecording.js
@@ -96,17 +96,9 @@ class SimulatorLogRecording extends Artifact {
 
     log.trace({ event: 'TAIL_CREATE' }, `starting to watch ${prefix} log: ${file}`);
 
-    const tail = new Tail(file, {
-      fromBeginning: this._readFromBeginning,
-      logger: {
-        info: _.noop,
-        error: (...args) => log.error({ event: 'TAIL_ERROR' }, ...args),
-      },
-    }).on('line', (line) => {
-      this._appendLine(prefix, line);
-    }).on('error', (err) => {
-      log.error({ event: 'TAIL_UNHANDLED_ERROR', err });
-    });
+    const tail = new Tail(file, { fromBeginning: this._readFromBeginning })
+      .on('line', (line) => { this._appendLine(prefix, line); })
+      .on('error', (err) => { log.warn({ event: 'TAIL_ERROR' }, err); });
 
     return tail;
   }


### PR DESCRIPTION
Currently, errors emerging inside artifacts manager and plugins are printed with `ERROR` priority which often confuses people that have a failing test due to other reasons and lead them in a wrong direction.

That's why it is reasonable to switch `log.error` to `log.warn` inside artifacts subsystem - in reality, we suppress the errors, not letting them impact the execution of test scenarios.

![Screenshot from 2019-04-11 10-52-17](https://user-images.githubusercontent.com/1962469/55940038-f5560700-5c47-11e9-8dfe-99beaba3d12e.png)

The issue was discussed with @LeoNatan.
