### PR TITLE
fix(android): install APK with a file path that needs escaping

### DIFF
--- a/detox/src/devices/android/AAPT.js
+++ b/detox/src/devices/android/AAPT.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const Environment = require('../../utils/environment');
 const path = require('path');
 const exec = require('../../utils/exec').execWithRetriesAndLogs;
+const escape = require('../../utils/pipeCommands').escape.inQuotedString;
 const egrep = require('../../utils/pipeCommands').search.fragment;
 const fsext = require('../../utils/fsext');
 
@@ -23,7 +24,7 @@ class AAPT {
   async getPackageName(apkPath) {
     await this._prepare();
     const process = await exec(
-      `${this.aaptBin} dump badging "${apkPath}" | ${egrep("package: name=")}`,
+      `${this.aaptBin} dump badging "${escape(apkPath)}" | ${egrep("package: name=")}`,
       undefined, undefined, 1
     );
 

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -102,7 +102,7 @@ class ADB {
   }
 
   async install(deviceId, apkPath) {
-    apkPath = `"${apkPath}"`;
+    apkPath = `"${escape.inQuotedString(apkPath)}"`;
     
     const apiLvl = await this.apiLevel(deviceId);
 

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -102,6 +102,8 @@ class ADB {
   }
 
   async install(deviceId, apkPath) {
+    apkPath = `"${apkPath}"`;
+    
     const apiLvl = await this.apiLevel(deviceId);
 
     let childProcess;

--- a/detox/src/devices/android/ADB.test.js
+++ b/detox/src/devices/android/ADB.test.js
@@ -31,8 +31,16 @@ describe('ADB', () => {
   });
 
   it(`install`, async () => {
-    await adb.install('path/to/app');
-    expect(exec).toHaveBeenCalledTimes(2);
+    await adb.install('emulator-5556', 'path inside "quotes" to/app');
+
+    expect(exec).toHaveBeenCalledWith(
+      expect.stringContaining('adb -s emulator-5556 shell "getprop ro.build.version.sdk"'),
+      undefined, undefined, 1
+    );
+
+    expect(exec).toHaveBeenCalledWith(
+      expect.stringContaining('adb -s emulator-5556 install -rg "path inside \\"quotes\\" to/app"'),
+      undefined, undefined, 1);
   });
 
   it(`uninstall`, async () => {


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 

---

**Description:**

Windows users with spaces in their APK path face an issue where the path is broken by spaces. I faced this issue and tried escaping the space, but it turned out the solution was to remove the backslash escapes I added and use quotation marks, like "path". Apostrophes like 'path' don't work.

For reference,
https://android.stackexchange.com/questions/185951/script-to-pull-from-directory-containing-spaces

This fixed the problem for me and I'm now able to run `detox build`.

I considered other places in the code where the path could be wrapped in quotes, but this seemed like the simplest and only place necessary.
