### PR TITLE
code: omit passing explicitly default command-line args to test runners

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -181,6 +181,13 @@ module.exports.handler = async function test(program) {
     return fallback;
   }
 
+  function hasCustomValue(key) {
+    const value = program[key];
+    const metadata = module.exports.builder[key];
+
+    return (value !== metadata.default);
+  }
+
   function runMocha() {
     if (program.workers !== 1) {
       log.warn('Can not use -w, --workers. Parallel test execution is only supported with iOS and Jest');
@@ -198,9 +205,9 @@ module.exports.handler = async function test(program) {
       (platform ? `--grep ${getPlatformSpecificString()} --invert` : ''),
       (program.headless ? `--headless` : ''),
       (program.gpu ? `--gpu ${program.gpu}` : ''),
-      (program.recordLogs ? `--record-logs ${program.recordLogs}` : ''),
-      (program.takeScreenshots ? `--take-screenshots ${program.takeScreenshots}` : ''),
-      (program.recordVideos ? `--record-videos ${program.recordVideos}` : ''),
+      (hasCustomValue('record-logs') ? `--record-logs ${program.recordLogs}` : ''),
+      (hasCustomValue('take-screenshots') ? `--take-screenshots ${program.takeScreenshots}` : ''),
+      (hasCustomValue('record-videos') ? `--record-videos ${program.recordVideos}` : ''),
       (program.artifactsLocation ? `--artifacts-location "${program.artifactsLocation}"` : ''),
       (program.deviceName ? `--device-name "${program.deviceName}"` : ''),
       testFolder,

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -38,7 +38,7 @@ describe('test', () => {
       await callCli('./test', 'test');
 
       expect(mockExec).toHaveBeenCalledWith(
-        expect.stringContaining(`${normalize('node_modules/.bin/mocha')} --opts e2e/mocha.opts --configuration only --grep :ios: --invert --record-logs none --take-screenshots none --record-videos none --artifacts-location "${normalize('artifacts/only.')}`),
+        expect.stringContaining(`${normalize('node_modules/.bin/mocha')} --opts e2e/mocha.opts --configuration only --grep :ios: --invert --artifacts-location "${normalize('artifacts/only.')}`),
         expect.anything()
       );
 
@@ -144,7 +144,7 @@ describe('test', () => {
     }
     expect(mockExec).toHaveBeenCalledWith(
       expect.stringContaining(
-        `${normalize('node_modules/.bin/mocha')} --opts e2e/mocha.opts --configuration only --debug-synchronization 3000 --grep :ios: --invert --record-logs none --take-screenshots none --record-videos none --artifacts-location "${normalize('artifacts/only.')}`
+        `${normalize('node_modules/.bin/mocha')} --opts e2e/mocha.opts --configuration only --debug-synchronization 3000 --grep :ios: --invert --artifacts-location "${normalize('artifacts/only.')}`
       ),
       expect.anything()
     );


### PR DESCRIPTION
The pull request, in its essence, is decorative, and its goal is to reduce the redundancy of the command line arguments passed to Mocha.

For example, if we run `detox test`, without specifying artifact recording options, previously it yielded:

> node_modules/.bin/mocha --opts e2e/mocha.opts --configuration android.emu.release --grep :ios: --invert --record-logs none --take-screenshots none --record-videos none  --artifacts-location "artifacts/android.emu.release.2019-04-15 04-54-07Z" "e2e" e2e/01.sanity.test.js

With this pull request, the command line arguments list passed to Mocha, becomes terser:

> node_modules/.bin/mocha --opts e2e/mocha.opts --configuration android.emu.release --grep :ios: --invert --artifacts-location "artifacts/android.emu.release.2019-04-15 04-54-07Z" "e2e" e2e/01.sanity.test.js
