### PR TITLE
feat: --take-screenshot manual mode by default

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -92,8 +92,8 @@ module.exports.builder = {
   },
   'take-screenshots': {
     group: 'Debugging:',
-    choices: ['failing', 'all', 'none'],
-    default: 'none',
+    choices: ['manual', 'failing', 'all', 'none'],
+    default: 'manual',
     describe:
       'Save screenshots before and after each test to artifacts directory. Pass "failing" to save screenshots of failing tests only.'
   },

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -88,7 +88,7 @@ describe('test', () => {
           env: expect.objectContaining({
             configuration: 'only',
             recordLogs: 'none',
-            takeScreenshots: 'none',
+            takeScreenshots: 'manual',
             recordVideos: 'none',
             artifactsLocation: expect.stringContaining(normalize('artifacts/only.')),
           }),

--- a/detox/src/artifacts/screenshot/ScreenshotArtifactPlugin.js
+++ b/detox/src/artifacts/screenshot/ScreenshotArtifactPlugin.js
@@ -12,7 +12,8 @@ class ScreenshotArtifactPlugin extends TwoSnapshotsPerTestPlugin {
 
     const takeScreenshots = argparse.getArgValue('take-screenshots');
 
-    this.enabled = takeScreenshots && takeScreenshots !== 'none';
+    this.enabled = takeScreenshots === 'all' || takeScreenshots === 'failing';
+    this.allowManualScreenshots = !takeScreenshots || takeScreenshots === 'manual';
     this.keepOnlyFailedTestsArtifacts = takeScreenshots === 'failing';
     this._warnAboutNotImplementedMode = _.once(this._warnAboutNotImplementedMode.bind(this));
   }
@@ -39,11 +40,13 @@ class ScreenshotArtifactPlugin extends TwoSnapshotsPerTestPlugin {
   }
 
   async onUserAction({ type, options }) {
-    switch (type) {
-      case 'takeScreenshot':
-        return this.keepOnlyFailedTestsArtifacts
-          ? this._warnAboutNotImplementedMode()
-          : this.takeSnapshot(options.name);
+    if (this.enabled || this.allowManualScreenshots) {
+      switch (type) {
+        case 'takeScreenshot':
+          return this.keepOnlyFailedTestsArtifacts
+            ? this._warnAboutNotImplementedMode()
+            : this.takeSnapshot(options.name);
+      }
     }
   }
 

--- a/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.js
+++ b/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.js
@@ -11,14 +11,14 @@ class TwoSnapshotsPerTestPlugin extends ArtifactPlugin {
 
   async onBeforeEach(testSummary) {
     await super.onBeforeEach(testSummary);
-    await this.takeSnapshot('beforeEach');
+    await this._takeAutomaticSnapshot('beforeEach');
   }
 
   async onAfterEach(testSummary) {
     await super.onAfterEach(testSummary);
 
     if (this.shouldKeepArtifactOfTest(testSummary)) {
-      await this.takeSnapshot('afterEach');
+      await this._takeAutomaticSnapshot('afterEach');
       this.startSavingSnapshot('beforeEach');
       this.startSavingSnapshot('afterEach');
     } else {
@@ -49,14 +49,16 @@ class TwoSnapshotsPerTestPlugin extends ArtifactPlugin {
     delete this.snapshots.afterEach;
   }
 
+  async _takeAutomaticSnapshot(name) {
+    if (this.enabled) {
+      await this.takeSnapshot(name);
+    }
+  }
+
   /***
    * @protected
    */
   async takeSnapshot(name) {
-    if (!this.enabled) {
-      return;
-    }
-
     const snapshot = this.snapshots[name] = this.createTestArtifact();
     await snapshot.start();
     await snapshot.stop();

--- a/docs/APIRef.Artifacts.md
+++ b/docs/APIRef.Artifacts.md
@@ -16,7 +16,9 @@ Artifacts are disabled by default. Two things are required to enable them:
 
 * To record `.log` files, add `--record-logs all` (or `--record-logs failing`, if you want to keep logs only for failing tests).
 * To record `.mp4` test run videos, add `--record-videos all` (or `--record-videos failing`, if you want to keep video recordings only for failing tests).
-* To record `.png` screenshots before and after each test, add `--take-screenshots all` (or `--take-screenshots failing`, if you want to keep only screenshots of failing tests).
+* To take `.png` screenshots before and after each test, add `--take-screenshots all` (or `--take-screenshots failing`, if you want to keep only screenshots of failing tests).  
+Alternatively, you might leverage `await device.takeScreenshot('your screenshot name')` API to have manual control over taking the screenshots.  
+To disable screenshots subsystem forcibly, use `--take-screenshots none`.
 * To change artifacts root directory location (by default it is `./artifacts`), add `--artifacts-location <path>`.  
 **NOTE:** There is a slightly obscure convention. If you want to create automatically a subdirectory with timestamp and configuration name (to avoid file overwrites upon consquent re-runs), specify a path to directory that does not end with a slash. Otherwise, if you want to put artifacts straight to the specified directory (in a case where you make a single run only, e.g. on CI), add a slash (or a backslash) to the end.
 

--- a/docs/APIRef.DetoxCLI.md
+++ b/docs/APIRef.DetoxCLI.md
@@ -74,7 +74,7 @@ Initiating your test suite. <sup>[[1]](#notice-passthrough)</sup>
 | -d, --debug-synchronization \<value\>         | When an action/expectation takes a significant amount time use this option to print device synchronization status. The status will be printed if the action takes more than [value]ms to complete |
 | -a, --artifacts-location \<path\>             | Artifacts (logs, screenshots, etc) root directory.<sup>[[2]](#notice-artifacts)</sup> |
 | --record-logs [failing/all/none]              | Save logs during each test to artifacts directory. Pass "failing" to save logs of failing tests only. The default value is **none**. |
-| --take-screenshots [failing/all/none]         | Save screenshots before and after each test to artifacts directory. Pass "failing" to save screenshots of failing tests only. The default value is **none**. |
+| --take-screenshots [manual/failing/all/none]  | Save screenshots before and after each test to artifacts directory. Pass "failing" to save screenshots of failing tests only. The default value is **manual**. |
 | --record-videos [failing/all/none]            | Save screen recordings of each test to artifacts directory. Pass "failing" to save recordings of failing tests only. The default value is **none**. |
 | -r, --reuse                                   | Reuse existing installed app (do not delete + reinstall) for a faster run. |
 | -u, --cleanup                                 | Shutdown simulator when test is over, useful for CI scripts, to make sure detox exists cleanly with no residue |

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -327,7 +327,7 @@ describe('Menu items', () => {
 * If the test passes, the screenshot will be put to `<artifacts-location>/✓ Menu items should have Logout/tap on menu.png`.
 * If the test fails, the screenshot will be put to `<artifacts-location>/✗ Menu items should have Logout/tap on menu.png`.
 
-> NOTE: at the moment, taking screenshots on-demand is supported **only** in `--take-screenshots all` mode.
+> NOTE: At the moment, taking screenshots on-demand in `--take-screenshots failing` mode is not yet implemented.
 
 ### `device.pressBack()` **Android Only**
 Simulate press back button.


### PR DESCRIPTION
Resolves #1278.

- [x] This is a small change 
- [x] This change has been discussed in issue #1278 and the solution has been agreed upon with maintainers.

---

**Description:**

Adds `--take-screenshot manual` mode, which is used by default from now on.

In `manual` mode, `device.takeScreenshot` is enabled as well, but `beforeEach.png` and `afterEach.png` screenshots are not being taken.

To have `device.takeScreenshot` API disabled forcibly, use `--take-screenshot none`.