### PR TITLE
fix: append newline to package.json on detox init

### DIFF
--- a/detox/local-cli/init.js
+++ b/detox/local-cli/init.js
@@ -100,7 +100,7 @@ function patchPackageJson(packageJson, runnerName) {
 
 function savePackageJson(filepath, json) {
   try {
-    fs.writeFileSync(filepath, JSON.stringify(json, null, 2));
+    fs.writeFileSync(filepath, JSON.stringify(json, null, 2) + '\n');
   } catch (err) {
     log.error(PREFIX, `Failed to write changes into ./package.json due to the error:\n${err.message}`);
   }


### PR DESCRIPTION
Resolves #1272 

- [x] This is a small change 