### PR TITLE
docs(APIRef.DetoxCLI) fix: missing - for options

### DIFF
--- a/docs/APIRef.DetoxCLI.md
+++ b/docs/APIRef.DetoxCLI.md
@@ -67,7 +67,7 @@ Initiating your test suite. <sup>[[1]](#notice-passthrough)</sup>
 
 | Option                                        | Description |
 | ---                                           | --- |
-| -c, -configuration \<device config\>          | Select a device configuration from your defined configurations, if not supplied, and there's only one configuration, detox will default to it |
+| -c, --configuration \<device config\>         | Select a device configuration from your defined configurations, if not supplied, and there's only one configuration, detox will default to it |
 | -o, --runner-config \<config\>                | Test runner config file, defaults to 'e2e/mocha.opts' for mocha and 'e2e/config.json' for jest. |
 | -n, --device-name [name]                      | Override the device name specified in a configuration. Useful for running a single build configuration on multiple devices. |
 | -l, --loglevel [value]                        | Log level: fatal, error, warn, info, verbose, trace |
@@ -80,7 +80,7 @@ Initiating your test suite. <sup>[[1]](#notice-passthrough)</sup>
 | -u, --cleanup                                 | Shutdown simulator when test is over, useful for CI scripts, to make sure detox exists cleanly with no residue |
 | -w, --workers                                 | [iOS Only] Specifies number of workers the test runner should spawn, requires a test runner with parallel execution support (Detox CLI currently supports Jest) |
 | -H, --headless                                | [Android Only] Launch Emulator in headless mode. Useful when running on CI. |
-| -gpu                                          | [Android Only] Launch Emulator with the specific -gpu [gpu mode] parameter. |
+| --gpu                                         | [Android Only] Launch Emulator with the specific -gpu [gpu mode] parameter. |
 | --no-color                                    | Disable colors in log output |
 | --help                                        | Show help |
 


### PR DESCRIPTION
Add missing - for --configuration and --gpu

<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Long option should be -- instead of - or else it will be error on parameter when run command

<img width="826" alt="Screen Shot 2019-04-17 at 00 25 11" src="https://user-images.githubusercontent.com/4032276/56230836-4ed68f80-60a7-11e9-93b8-3ace794b2db9.png">
Reference: https://travis-ci.org/guhungry/react-native-photo-manipulator/jobs/520852289
