### PR TITLE
fix: upgrade configs for Jest 24

### DIFF
--- a/detox/local-cli/templates/jest.js
+++ b/detox/local-cli/templates/jest.js
@@ -1,6 +1,6 @@
 const firstTestContent = require('./firstTestContent');
 const runnerConfig = `{
-    "setupTestFrameworkScriptFile": "./init.js",
+    "setupFilesAfterEnv": ["./init.js"],
     "testEnvironment": "node"
 }`;
 

--- a/detox/package.json
+++ b/detox/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "eslint": "^4.11.0",
     "eslint-plugin-node": "^6.0.1",
-    "jest": "23.x.x",
+    "jest": "24.x.x",
     "mockdate": "^2.0.1",
     "prettier": "1.7.0",
     "react-native": "0.56.0",

--- a/detox/src/android/expect.test.js
+++ b/detox/src/android/expect.test.js
@@ -1,4 +1,4 @@
-describe('expect', async () => {
+describe('expect', () => {
   let e;
 
   beforeEach(() => {

--- a/detox/src/ios/expect.test.js
+++ b/detox/src/ios/expect.test.js
@@ -1,4 +1,4 @@
-describe('expect', async () => {
+describe('expect', () => {
   let e;
 
   beforeEach(() => {

--- a/detox/test/e2e/config.json
+++ b/detox/test/e2e/config.json
@@ -1,5 +1,5 @@
 {
-  "setupTestFrameworkScriptFile" : "./helpers/init.js",
+  "setupFilesAfterEnv": ["./init.js"],
   "testEnvironment": "node",
   "bail": false,
   "verbose": true

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "detox": "^12.3.0",
     "express": "^4.15.3",
-    "jest": "^22.3.0",
     "lodash": "^4.14.1",
     "mocha": "^6.1.3"
   },

--- a/docs/Guide.Jest.md
+++ b/docs/Guide.Jest.md
@@ -19,6 +19,9 @@ npm install --save-dev jest
 detox init -r jest
 ```
 
+Please note, however, that the generated configuration files are not compatible
+with older versions of Jest (23.x or older).
+
 ### 3. Modify package.json
 
 ```json

--- a/examples/demo-react-native-jest/.babelrc
+++ b/examples/demo-react-native-jest/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["react-native"]
-}

--- a/examples/demo-react-native-jest/e2e/config.json
+++ b/examples/demo-react-native-jest/e2e/config.json
@@ -1,4 +1,4 @@
 {
-  "setupTestFrameworkScriptFile" : "./init.js",
+  "setupFilesAfterEnv": ["./init.js"],
   "testEnvironment": "node"
 }

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -4,20 +4,23 @@
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
-    "test-ios": "detox build --configuration ios.sim.debug && detox test --configuration ios.sim.debug",
-    "test-android": "detox build --configuration android.emu.debug && detox test --configuration android.emu.debug -l verbose",
-    "test-android-release": "detox build --configuration android.emu.release && detox test --configuration android.emu.release -l verbose"
+    "build:ios": "detox build --configuration ios.sim.debug",
+    "build:android-debug": "detox build --configuration android.emu.debug",
+    "build:android-release": "detox build --configuration android.emu.release",
+    "test:ios": "detox test --configuration ios.sim.debug",
+    "test:android-debug": "detox test --configuration android.emu.debug -l verbose",
+    "test:android-release": "detox test --configuration android.emu.release -l verbose",
+    "e2e:ios": "npm run build:ios && npm run test:ios",
+    "e2e:android-debug": "npm run build:android-debug && npm run test:android-debug",
+    "e2e:android-release": "npm run build:android-release && npm run test:android-release"
   },
   "dependencies": {
-    "react": "16.0.0",
-    "react-native": "0.51.1"
+    "react": "16.6.3",
+    "react-native": "0.57.x"
   },
   "devDependencies": {
-    "babel-jest": "21.2.0",
-    "babel-preset-react-native": "4.0.0",
     "detox": "^12.3.0",
-    "jest": "21.2.1",
-    "react-test-renderer": "16.0.0-beta.5"
+    "jest": "24.x.x"
   },
   "detox": {
     "specs": "",

--- a/generation/package.json
+++ b/generation/package.json
@@ -30,7 +30,7 @@
 		"uuid": "^3.2.1"
 	},
 	"devDependencies": {
-		"jest": "^20.0.4",
+		"jest": "^24.0.0",
 		"lint-staged": "^6.0.0",
 		"prettier": "^1.8.2"
 	},


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

The motivation is that since Jest 24 `setupTestFrameworkScriptFile` is deprecated, and `setupFilesAfterEnv` should be used instead.

Recently, @cs01 suggested his changes in pull request #1162 (and closed it, unfortunately), so the idea of this pull request is to refine it and extend to all the affected places in Detox codebase.

In the pull request, I've bumped Jest to `24` in every project it is required and made sure to fix all the warnings I've stumbled across.
