### PR TITLE
Fix for supporting multiple URL arguments for device.launchApp

### DIFF
--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -248,7 +248,7 @@ class AppleSimUtils {
   }
 
   _joinLaunchArgs(launchArgs) {
-    return _.map(launchArgs, (v, k) => `${k} ${v}`).join(' ').trim();
+    return _.map(launchArgs, (v, k) => `${k} "${v}"`).join(' ').trim();
   }
 
   async _launchMagically(frameworkPath, logsInfo, udid, bundleId, args, languageAndLocale) {


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [X] This change has been discussed in issue #1294 and the solution has been agreed upon with maintainers.

---

If passing a URL such as `https://testt.com/go/?screen=BehaviorLessons&behaviorKey=helpful` to `device.launchApp` the `&behaviorKey` URL parameter would not be passed on to the app. This PR fixes that.

Thanks to @LeoNatan for this fix.