### PR TITLE
ci(android): fix demo-react-native project

### DIFF
--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -14,7 +14,7 @@
     "mocha": "^4.0.1"
   },
   "detox": {
-    "specs": "",
+    "specs": "e2e",
     "test-runner": "mocha",
     "runner-config": "e2e/mocha.opts",
     "configurations": {
@@ -32,13 +32,13 @@
       },
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
-        "build": "pushd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && popd",
+        "build": "cd android ; ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug ; cd -",
         "type": "android.emulator",
         "name": "Nexus_5X_API_26"
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
-        "build": "pushd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && popd",
+        "build": "cd android ; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release ; cd -",
         "type": "android.emulator",
         "name": "Nexus_5X_API_26"
       }

--- a/scripts/demo-projects.ios.sh
+++ b/scripts/demo-projects.ios.sh
@@ -4,7 +4,7 @@ source $(dirname "$0")/demo-projects.sh
 
 pushd examples/demo-react-native
 run_f "detox build -c ios.sim.release"
-run_f "detox test -c ios.sim.release e2e"
+run_f "detox test -c ios.sim.release"
 run_f "detox test -c ios.sim.release e2eExplicitRequire --runner-config e2eExplicitRequire/mocha.opts"
 popd
 


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Makes `scripts/demo-projects.android.sh` pass and enables us to set up another Jenkins job for the demo projects (specifically for Android)