### PR TITLE
(Android) Restore example project tests in CI (context: issue #1323)

### DIFF
--- a/examples/demo-react-native-jest/e2e/init.js
+++ b/examples/demo-react-native-jest/e2e/init.js
@@ -1,9 +1,10 @@
+
 const detox = require('detox');
 const config = require('../package.json').detox;
 const adapter = require('detox/runners/jest/adapter');
 
 // Set the default timeout
-jest.setTimeout(120000);
+jest.setTimeout(300000);
 jasmine.getEnv().addReporter(adapter);
 
 beforeAll(async () => {

--- a/examples/demo-react-native/e2e/mocha.opts
+++ b/examples/demo-react-native/e2e/mocha.opts
@@ -1,4 +1,4 @@
 --recursive
---timeout 120000
+--timeout 300000
 --bail
 --file e2e/init.js

--- a/examples/demo-react-native/e2eExplicitRequire/mocha.opts
+++ b/examples/demo-react-native/e2eExplicitRequire/mocha.opts
@@ -1,3 +1,3 @@
 --recursive
---timeout 120000
+--timeout 300000
 --bail

--- a/scripts/demo-projects.android.sh
+++ b/scripts/demo-projects.android.sh
@@ -3,12 +3,12 @@
 source $(dirname "$0")/demo-projects.sh
 
 pushd examples/demo-react-native
-run_f "detox build -c android.emu.release"
-run_f "detox test -c android.emu.release"
-run_f "detox test e2eExplicitRequire -c android.emu.release --runner-config e2eExplicitRequire/mocha.opts"
+run_f "./node_modules/.bin/detox build -c android.emu.release"
+run_f "./node_modules/.bin/detox test -c android.emu.release --headless --loglevel verbose"
+run_f "./node_modules/.bin/detox test e2eExplicitRequire -c android.emu.release --runner-config e2eExplicitRequire/mocha.opts --headless --loglevel verbose"
 popd
 
 pushd examples/demo-react-native-jest
-run_f "detox build -c android.emu.release"
-run_f "detox test -c android.emu.release"
+run_f "./node_modules/.bin/detox build -c android.emu.release"
+run_f "./node_modules/.bin/detox test -c android.emu.release --headless --loglevel verbose"
 popd


### PR DESCRIPTION
Description:

This is one of the preliminaries for issue #1323: As Android arfiacts' packaging is available, we need to integrate their usage onto the CI. Hence the example projects' tests run.

Still needed to follow: same for iOS.