### PR TITLE
(Android) Switch example projects to use .aar

### DIFF
--- a/examples/demo-react-native-jest/android/app/build.gradle
+++ b/examples/demo-react-native-jest/android/app/build.gradle
@@ -44,8 +44,9 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro', "${project(':detox').projectDir}/proguard-rules-app.pro"
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
 
             signingConfig signingConfigs.release
         }
@@ -80,10 +81,8 @@ dependencies {
     // noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"
 
-    androidTestImplementation 'androidx.test:runner:1.1.0'
-    androidTestImplementation 'androidx.test:rules:1.1.0'
+    androidTestImplementation('com.wix:detox:+') { transitive = true }
     androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation(project(path: ":detox"))
 }
 
 

--- a/examples/demo-react-native-jest/android/app/proguard-rules.pro
+++ b/examples/demo-react-native-jest/android/app/proguard-rules.pro
@@ -1,70 +1,16 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /usr/local/Cellar/android-sdk/24.3.3/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Most needed rules come from React Native's proguard-rules.pro (either .aar or source) -- hence
+# the lean configuration file.
+###
 
-# Add any project specific keep options here:
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Disabling obfuscation is useful if you collect stack traces from production crashes
-# (unless you are using a system that supports de-obfuscate the stack traces).
 -dontobfuscate
 
-# React Native
+-dontnote android.net.**
+-dontnote org.apache.**
 
-# Keep our interfaces so they can be used by other ProGuard rules.
-# See http://sourceforge.net/p/proguard/bugs/466/
--keep,allowobfuscation @interface com.facebook.proguard.annotations.DoNotStrip
--keep,allowobfuscation @interface com.facebook.proguard.annotations.KeepGettersAndSetters
--keep,allowobfuscation @interface com.facebook.common.internal.DoNotStrip
+# An addition to RN's 'keep' and 'dontwarn' configs -- need to also 'dontnote' some stuff.
 
-# Do not strip any method/class that is annotated with @DoNotStrip
--keep @com.facebook.proguard.annotations.DoNotStrip class *
--keep @com.facebook.common.internal.DoNotStrip class *
--keepclassmembers class * {
-    @com.facebook.proguard.annotations.DoNotStrip *;
-    @com.facebook.common.internal.DoNotStrip *;
-}
-
--keepclassmembers @com.facebook.proguard.annotations.KeepGettersAndSetters class * {
-  void set*(***);
-  *** get*();
-}
-
--keep class * extends com.facebook.react.bridge.JavaScriptModule { *; }
--keep class * extends com.facebook.react.bridge.NativeModule { *; }
--keepclassmembers,includedescriptorclasses class * { native <methods>; }
--keepclassmembers class *  { @com.facebook.react.uimanager.UIProp <fields>; }
--keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactProp <methods>; }
--keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactPropGroup <methods>; }
-
--dontwarn com.facebook.react.**
-
-# TextLayoutBuilder uses a non-public Android constructor within StaticLayout.
-# See libs/proxy/src/main/java/com/facebook/fbui/textlayoutbuilder/proxy for details.
--dontwarn android.text.StaticLayout
-
-# okhttp
-
--keepattributes Signature
--keepattributes *Annotation*
--keep class okhttp3.** { *; }
--keep interface okhttp3.** { *; }
--dontwarn okhttp3.**
-
-# okio
-
--keep class sun.misc.Unsafe { *; }
--dontwarn java.nio.file.*
--dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
--dontwarn okio.**
+-dontnote com.facebook.**
+-dontnote sun.misc.Unsafe
+-dontnote okhttp3.**
+-dontnote okio.**

--- a/examples/demo-react-native-jest/android/build.gradle
+++ b/examples/demo-react-native-jest/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlinVersion = '1.3.0'
-    ext.detoxKotlinVersion = '1.3.0'
+    ext.detoxKotlinVersion = ext.kotlinVersion
 
     repositories {
         jcenter()
@@ -22,6 +22,10 @@ allprojects {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
+        }
+        maven {
+            // All of Detox' artifacts are provided via the npm module
+            url "$rootDir/../node_modules/detox/Detox-android"
         }
     }
 }

--- a/examples/demo-react-native-jest/android/settings.gradle
+++ b/examples/demo-react-native-jest/android/settings.gradle
@@ -1,6 +1,3 @@
 rootProject.name = 'DemoReactNativeJest'
 
-include ':detox'
-project(':detox').projectDir = new File(rootProject.projectDir, '../node_modules/detox/android/detox')
-
 include ':app'

--- a/examples/demo-react-native/android/app/build.gradle
+++ b/examples/demo-react-native/android/app/build.gradle
@@ -39,8 +39,10 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
+
             signingConfig signingConfigs.release
         }
     }
@@ -68,10 +70,10 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:appcompat-v7:27.1.1"
-    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.facebook.react:react-native:+'  // From node_modules
 
-    androidTestImplementation(project(path: ":detox"))
+    androidTestImplementation('com.wix:detox:+') { transitive = true }
     androidTestImplementation 'junit:junit:4.12'
 }
 

--- a/examples/demo-react-native/android/app/proguard-rules.pro
+++ b/examples/demo-react-native/android/app/proguard-rules.pro
@@ -1,63 +1,16 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /usr/local/Cellar/android-sdk/24.3.3/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Most needed rules come from React Native's proguard-rules.pro (either .aar or source) -- hence
+# the lean configuration file.
+###
 
-# Add any project specific keep options here:
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Disabling obfuscation is useful if you collect stack traces from production crashes
-# (unless you are using a system that supports de-obfuscate the stack traces).
 -dontobfuscate
 
-# React Native
+-dontnote android.net.**
+-dontnote org.apache.**
 
-# Keep our interfaces so they can be used by other ProGuard rules.
-# See http://sourceforge.net/p/proguard/bugs/466/
--keep,allowobfuscation @interface com.facebook.proguard.annotations.DoNotStrip
--keep,allowobfuscation @interface com.facebook.proguard.annotations.KeepGettersAndSetters
+# An addition to RN's 'keep' and 'dontwarn' configs -- need to also 'dontnote' some stuff.
 
-# Do not strip any method/class that is annotated with @DoNotStrip
--keep @com.facebook.proguard.annotations.DoNotStrip class *
--keepclassmembers class * {
-    @com.facebook.proguard.annotations.DoNotStrip *;
-}
-
--keepclassmembers @com.facebook.proguard.annotations.KeepGettersAndSetters class * {
-  void set*(***);
-  *** get*();
-}
-
--keep class * extends com.facebook.react.bridge.JavaScriptModule { *; }
--keep class * extends com.facebook.react.bridge.NativeModule { *; }
--keepclassmembers,includedescriptorclasses class * { native <methods>; }
--keepclassmembers class *  { @com.facebook.react.uimanager.UIProp <fields>; }
--keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactProp <methods>; }
--keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactPropGroup <methods>; }
-
--dontwarn com.facebook.react.**
-
-# okhttp
-
--keepattributes Signature
--keepattributes *Annotation*
--keep class okhttp3.** { *; }
--keep interface okhttp3.** { *; }
--dontwarn okhttp3.**
-
-# okio
-
--keep class sun.misc.Unsafe { *; }
--dontwarn java.nio.file.*
--dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
--dontwarn okio.**
+-dontnote com.facebook.**
+-dontnote sun.misc.Unsafe
+-dontnote okhttp3.**
+-dontnote okio.**

--- a/examples/demo-react-native/android/build.gradle
+++ b/examples/demo-react-native/android/build.gradle
@@ -20,5 +20,8 @@ allprojects {
         maven {
             url "$rootDir/../node_modules/react-native/android"
         }
+        maven {
+            url "$rootDir/../node_modules/detox/Detox-android"
+        }
     }
 }

--- a/examples/demo-react-native/android/settings.gradle
+++ b/examples/demo-react-native/android/settings.gradle
@@ -1,6 +1,3 @@
 rootProject.name = 'DetoxRNExample'
 
 include ':app'
-
-include ':detox'
-project(':detox').projectDir = new File(rootProject.projectDir, '../node_modules/detox/android/detox')

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -3,7 +3,17 @@
   "version": "12.4.0",
   "private": true,
   "scripts": {
-    "start": "react-native start"
+    "start": "react-native start",
+    "build:ios": "detox build --configuration ios.sim.debug",
+    "build:android-debug": "detox build --configuration android.emu.debug",
+    "build:android-release": "detox build --configuration android.emu.release",
+    "test:ios": "detox test --configuration ios.sim.debug",
+    "test:android-debug": "detox test --configuration android.emu.debug -l verbose",
+    "test:android-release": "detox test --configuration android.emu.release -l verbose",
+    "test:android-explicit-require": "detox test e2eExplicitRequire -c android.emu.release -l verbose --runner-config e2eExplicitRequire/mocha.opts",
+    "e2e:ios": "npm run build:ios && npm run test:ios",
+    "e2e:android-debug": "npm run build:android-debug && npm run test:android-debug",
+    "e2e:android-release": "npm run build:android-release && npm run test:android-release"
   },
   "dependencies": {
     "react": "16.4.1",

--- a/scripts/ci.android.sh
+++ b/scripts/ci.android.sh
@@ -12,6 +12,6 @@ mv node_modules/react-native/ReactAndroid/release.gradle node_modules/react-nati
 cp extras/release.gradle node_modules/react-native/ReactAndroid/
 
 run_f "npm run build:android"
-run_f "npm run e2e:android -- --headless"
+run_f "npm run e2e:android -- --headless --loglevel verbose"
 # run_f "npm run verify-artifacts:android"
 popd

--- a/scripts/demo-projects.android.sh
+++ b/scripts/demo-projects.android.sh
@@ -2,13 +2,17 @@
 
 source $(dirname "$0")/demo-projects.sh
 
+pushd detox/android
+run_f "./gradlew publish -Dversion=999.999.999"
+popd
+
 pushd examples/demo-react-native
-run_f "./node_modules/.bin/detox build -c android.emu.release"
-run_f "./node_modules/.bin/detox test -c android.emu.release --headless --loglevel verbose"
-run_f "./node_modules/.bin/detox test e2eExplicitRequire -c android.emu.release --runner-config e2eExplicitRequire/mocha.opts --headless --loglevel verbose"
+run_f "npm run build:android-release"
+run_f "npm run test:android-release -- --headless"
+run_f "npm run test:android-explicit-require -- --headless"
 popd
 
 pushd examples/demo-react-native-jest
-run_f "./node_modules/.bin/detox build -c android.emu.release"
-run_f "./node_modules/.bin/detox test -c android.emu.release --headless --loglevel verbose"
+run_f "npm run build:android-release"
+run_f "npm run test:android-release -- --headless"
 popd


### PR DESCRIPTION
**Description:**

Integrate detox packaging and usage of the artifact (i.e. `aar` file) into the android example projects.
Yet another step underway to resolving #1323 .