### PR TITLE
fix: remove dead code preventing recording dtxrec on launch

### DIFF
--- a/detox/ios/Detox/DetoxManager.m
+++ b/detox/ios/Detox/DetoxManager.m
@@ -108,13 +108,10 @@ static void detoxConditionalInit()
 		_recordingManager = [DetoxInstrumentsManager new];
 	});
 	
-	if([NSUserDefaults.standardUserDefaults objectForKey:@"currentTestSummaryDataURL"])
+	NSString* recordingPath = [NSUserDefaults.standardUserDefaults objectForKey:@"recordingPath"];
+	if(recordingPath != nil)
 	{
-		NSString* recordingPath = [NSUserDefaults.standardUserDefaults objectForKey:@"recordingPath"];
-		if(recordingPath != nil)
-		{
-			[self _handlePerformanceRecording:@{@"recordingPath": recordingPath} isFromLaunch:YES completionHandler:nil];
-		}
+		[self _handlePerformanceRecording:@{@"recordingPath": recordingPath} isFromLaunch:YES completionHandler:nil];
 	}
 	
 	return self;


### PR DESCRIPTION
@LeoNatan, I am trying to resolve #1339.

**Description:**

1. I see a dead `if` statement, which prevents the recording from happening in that scenario. Could it be the reason why I see that weird behavior? Could you please review my change - check out `Files changed (1)` tab, please?

2. Unfortunately, I don't think this is all we need to fix #1339. If I patch the code with this PR and rebuild framework, I still don't see files. However, I've checked that all the corresponding commands are received by inserting some more log lines in your code:

```diff
diff --git a/detox/ios/Detox/DetoxManager.m b/detox/ios/Detox/DetoxManager.m
index cd6e7385..9254dc1b 100644
--- a/detox/ios/Detox/DetoxManager.m
+++ b/detox/ios/Detox/DetoxManager.m
@@ -423,16 +423,19 @@ static void detoxConditionalInit()
 		
 		if(launch)
 		{
+			dtx_log_error(@"DTXProfiler continueRecordingAtURL(%@)", absoluteURL);
 			[_recordingManager continueRecordingAtURL:absoluteURL];
 		}
 		else
 		{
+			dtx_log_error(@"DTXProfiler startRecordingAtURL(%@)", absoluteURL);
 			[_recordingManager startRecordingAtURL:absoluteURL];
 		}
 	}
 	else
 	{
 		completionBlocked = YES;
+		dtx_log_error(@"DTXProfiler stopRecordingWithCompletionHandler");
 		[_recordingManager stopRecordingWithCompletionHandler:^(NSError *error) {
 			dispatch_async(dispatch_get_main_queue(), ^{
 				completionHandler();
``` 

In `Console.app` logs I see that `DTXProfiler continueRecordingAtURL` indeed (at least) tries to start recording at the specified file, but then traces are getting lost.

I mean I see that `DTXProfiler` project has also various logging places but none of them gets to the logs I can see in `Console.app`.
