### PR TITLE
code: print a warning instead of an error if artifact files are not found

### DIFF
--- a/detox/src/artifacts/templates/artifact/Artifact.js
+++ b/detox/src/artifacts/templates/artifact/Artifact.js
@@ -107,7 +107,7 @@ class Artifact {
       logger.debug({ event: 'MOVE_FILE' }, `moving "${source}" to ${destination}`);
       await fs.move(source, destination);
     } else {
-      logger.error({ event: 'MOVE_FILE_ERROR'} , `did not find temporary file: ${source}`);
+      logger.warn({ event: 'MOVE_FILE_MISSING'} , `did not find temporary file: ${source}`);
     }
   }
 }

--- a/detox/src/artifacts/templates/artifact/Artifact.test.js
+++ b/detox/src/artifacts/templates/artifact/Artifact.test.js
@@ -502,7 +502,7 @@ describe(Artifact.name, () => {
       it('should log error if source file does not exist', async () => {
         await Artifact.moveTemporaryFile(logger, source, destination = tempfile('.dest'));
         expect(await fs.exists(destination)).toBe(false);
-        expect(logger.error).toHaveBeenCalledWith({ event: 'MOVE_FILE_ERROR' }, expect.any(String));
+        expect(logger.warn).toHaveBeenCalledWith({ event: 'MOVE_FILE_MISSING' }, expect.any(String));
       });
     });
   });


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Instead of red error lines in the log, Detox will be printing warnings — to not confuse the users who might attribute the "errors" to a cause of why their tests are failing.

<img width="640" alt="image" src="https://user-images.githubusercontent.com/1962469/56847764-12e1cc80-68e8-11e9-9788-5efe6be9986e.png">
