### PR TITLE
feat: DETOX_INSTRUMENTS_PATH environment variable

### DIFF
--- a/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
+++ b/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
@@ -43,7 +43,7 @@ class SimulatorInstrumentsPlugin extends WholeTestRecorderPlugin {
     }
 
     if (process.env.DETOX_INSTRUMENTS_PATH) {
-      event.launchArgs['-detoxInstrumentsPath'] = event.launchArgs['-detoxInstrumentsPath'] || process.env.DETOX_INSTRUMENTS_PATH;
+      event.launchArgs['-instrumentsPath'] = event.launchArgs['-instrumentsPath'] || process.env.DETOX_INSTRUMENTS_PATH;
     }
 
     if (this.testRecording) {

--- a/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
+++ b/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
@@ -71,6 +71,4 @@ class SimulatorInstrumentsPlugin extends WholeTestRecorderPlugin {
   }
 }
 
-SimulatorInstrumentsPlugin.DEFAULT_INSTRUMENTS_PATH = '/Applications/Detox Instruments.app';
-
 module.exports = SimulatorInstrumentsPlugin;

--- a/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
+++ b/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
@@ -43,7 +43,7 @@ class SimulatorInstrumentsPlugin extends WholeTestRecorderPlugin {
     }
 
     if (process.env.DETOX_INSTRUMENTS_PATH) {
-      event.launchArgs['-instrumentsPath'] = event.launchArgs['-instrumentsPath'] || process.env.DETOX_INSTRUMENTS_PATH;
+      event.launchArgs['-instrumentsPath'] = process.env.DETOX_INSTRUMENTS_PATH;
     }
 
     if (this.testRecording) {

--- a/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
+++ b/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
@@ -10,8 +10,7 @@ class SimulatorInstrumentsPlugin extends WholeTestRecorderPlugin {
     super(config);
 
     this.client = config.client;
-    this.enabled = false;
-    this.shouldRecord = argparse.getArgValue('record-performance') === 'all';
+    this.enabled = argparse.getArgValue('record-performance') === 'all';
   }
 
   async onBeforeUninstallApp(event) {
@@ -38,14 +37,13 @@ class SimulatorInstrumentsPlugin extends WholeTestRecorderPlugin {
   async onBeforeLaunchApp(event) {
     await super.onBeforeLaunchApp(event);
 
-    if (!this.enabled && this.shouldRecord) {
-      const isInstalled = await this._assertDetoxInstrumentsInstalled(event.launchArgs['-instrumentsPath']);
-      this.enabled = this.shouldRecord = isInstalled;
-    }
-
     const isInsideRunningTest = !!this.context.testSummary;
     if (this.enabled && isInsideRunningTest && !this.testRecording) {
       this.testRecording = this.createTrackedTestRecording();
+    }
+
+    if (process.env.DETOX_INSTRUMENTS_PATH) {
+      event.launchArgs['-detoxInstrumentsPath'] = event.launchArgs['-detoxInstrumentsPath'] || process.env.DETOX_INSTRUMENTS_PATH;
     }
 
     if (this.testRecording) {
@@ -59,22 +57,6 @@ class SimulatorInstrumentsPlugin extends WholeTestRecorderPlugin {
     if (this.testRecording) {
       await this.testRecording.start({ dry: true }); // start nominally, to set a correct recording state
     }
-  }
-
-  async _assertDetoxInstrumentsInstalled(customInstrumentsPath) {
-    const instrumentsPath = customInstrumentsPath || SimulatorInstrumentsPlugin.DEFAULT_INSTRUMENTS_PATH;
-    if (await fs.exists(instrumentsPath)) {
-      return true;
-    }
-
-    const hint = customInstrumentsPath
-      ? `Please verify that -instrumentsPath argument points to the existing Detox Instruments installation.`
-      : `To enable recording performance profiles, please follow: https://github.com/wix/DetoxInstruments#installation`;
-
-    log.warn({ event: 'INSTRUMENTS_NOT_FOUND' },
-      `Failed to find Detox Instruments app at path: ${instrumentsPath}\n${hint}`);
-
-    return false;
   }
 
   createTestRecording() {

--- a/detox/src/artifacts/instruments/SimulatorInstrumentsRecording.js
+++ b/detox/src/artifacts/instruments/SimulatorInstrumentsRecording.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const log = require('../../utils/logger').child({ __filename });
 const Artifact = require('../templates/artifact/Artifact');
 
@@ -33,7 +34,10 @@ class SimulatorInstrumentsRecording extends Artifact {
   }
 
   async doSave(artifactPath) {
-    await Artifact.moveTemporaryFile(log, this.temporaryRecordingPath, artifactPath);
+    const success = await Artifact.moveTemporaryFile(log, this.temporaryRecordingPath, artifactPath);
+    if (!success) {
+      SimulatorInstrumentsRecording.hintAboutDetoxInstruments();
+    }
   }
 
   async doDiscard() {
@@ -44,5 +48,15 @@ class SimulatorInstrumentsRecording extends Artifact {
     return this._client.isConnected && !this._client.pandingAppCrash;
   }
 }
+
+SimulatorInstrumentsRecording.hintAboutDetoxInstruments = _.once(() => {
+  log.warn(`Make sure either:
+1. You have installed Detox Instruments:
+   https://github.com/wix/DetoxInstruments#installation 
+2. You have integrated Detox Instruments in your app:
+   https://github.com/wix/DetoxInstruments/blob/master/Documentation/XcodeIntegrationGuide.md 
+3. You have set the environment variable with your custom Detox Instruments location:
+   export DETOX_INSTRUMENTS_PATH="/path/to/Detox Instruments.app"`);
+});
 
 module.exports = SimulatorInstrumentsRecording;

--- a/detox/src/artifacts/templates/artifact/Artifact.js
+++ b/detox/src/artifacts/templates/artifact/Artifact.js
@@ -106,8 +106,10 @@ class Artifact {
     if (await fs.exists(source)) {
       logger.debug({ event: 'MOVE_FILE' }, `moving "${source}" to ${destination}`);
       await fs.move(source, destination);
+      return true;
     } else {
       logger.error({ event: 'MOVE_FILE_ERROR'} , `did not find temporary file: ${source}`);
+      return false;
     }
   }
 }

--- a/docs/APIRef.Artifacts.md
+++ b/docs/APIRef.Artifacts.md
@@ -69,11 +69,27 @@ Make sure you have `detox.beforeEach(testSummary)` and `detox.afterEach(testSumm
 
 For iOS, you might be getting errors on CI similar to this:
 
-```Error: Error Domain=NSPOSIXErrorDomain Code=22 "Invalid argument" UserInfo={NSLocalizedDescription=Video recording requires hardware Metal capability.}.```
+```
+Error: Error Domain=NSPOSIXErrorDomain Code=22 "Invalid argument" UserInfo={NSLocalizedDescription=Video recording requires hardware Metal capability.}.
+```
 
 Unfortunately, this error is beyond our reach. To fix it, you have to enable hardware acceleration on your build machine, or just disable video recording on CI if it is not possible to turn on the acceleration.
 
 There might be a similar issue on Android when the screenrecording process exits with an error on CI. While the solution might be identical to the one above, also you might try to experiment with other emulator devices and Android OS versions to see if it helps.
+
+### Detox Instruments is installed in a custom location
+
+If you have to use [Detox Instruments](https://github.com/wix/DetoxInstruments)
+installed in a custom location (e.g., inside `node_modules`), you can point Detox
+to it with the `DETOX_INSTRUMENTS_PATH` environment variable, as shown below:
+
+```bash
+DETOX_INSTRUMENTS_PATH="/path/to/Detox Instruments.app" detox test ...
+```
+
+Please mind that if **Detox Instruments** had been [integrated into
+your app](https://github.com/wix/DetoxInstruments/blob/master/Documentation/XcodeIntegrationGuide.md) (usually, that is in development builds), then the built-in version of [Detox Profiler framework](https://github.com/wix/DetoxInstruments/tree/master/Profiler) will always take priority over any custom path to Detox Instruments installation.
+
 
 ### Ctrl+C does not terminate Detox+Jest tests correctly
 


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

To enable using Detox on CI agents where it is not easily possible to install Detox Instruments in a default location `/Applications/Detox Instruments.app`, here we add a way to define the default path via environment variable:

```bash
DETOX_INSTRUMENTS_PATH="/path/to/Detox Instruments.app" detox test ...
```