### PR TITLE
ci: print node and npm version

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -2,6 +2,12 @@
 
 source $(dirname "$0")/logger.sh
 
+echo "Node version:"
+node --version
+
+echo "NPM version:"
+npm --version
+
 if [ ! -z ${REACT_NATIVE_VERSION} ]; then
   node scripts/change_react_native_version.js "detox/test" ${REACT_NATIVE_VERSION}
 fi


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Makes CI print `node` and `npm` version in use.
It is a part of my investigation of why we keep seeing errors on CI:

```
18:54:43 lerna info Bootstrapping 8 packages
18:54:43 lerna info lifecycle preinstall
18:54:43 lerna info Installing external dependencies
18:55:12 lerna ERR! execute callback with error
18:55:12 lerna ERR! Error: Command failed: npm install
18:55:12 lerna ERR! npm ERR! code ERR_STREAM_WRITE_AFTER_END
18:55:12 lerna ERR! npm ERR! write after end
18:55:12 lerna ERR! 
18:55:12 lerna ERR! npm ERR! A complete log of this run can be found in:
18:55:12 lerna ERR! npm ERR!     /home/jenkins/.npm/_logs/2019-04-29T15_55_04_163Z-debug.log
18:55:12 lerna ERR! 
18:55:12 lerna ERR!     at Promise.all.then.arr (/usr/lib/node_modules/lerna/node_modules/execa/index.js:236:11)
18:55:12 lerna ERR!     at <anonymous>
18:55:12 lerna WARN complete Waiting for 3 child processes to exit. CTRL-C to exit immediately.
18:55:33 { Error: Command failed: npm install
18:55:33 npm ERR! code ERR_STREAM_WRITE_AFTER_END
18:55:33 npm ERR! write after end
```
