### PR TITLE
feat: allow disabling of post install with env var

### DIFF
--- a/detox/scripts/postinstall.js
+++ b/detox/scripts/postinstall.js
@@ -1,4 +1,4 @@
-if (process.platform === "darwin") {
+if (process.platform === "darwin" && !process.env.DETOX_DISABLE_POSTINSTALL) {
 	require("child_process").execFileSync(`${__dirname}/build_framework.ios.sh`, {
 		stdio: "inherit"
 	});


### PR DESCRIPTION
Resolves #1338

@rotemmiz, what's your opinion on that issue? I understand what problem they might have and indeed there's no other solution so far as I am concerned - that's because `npm install` is not really flexible, and there is a goal to speed up some builds on @haswalt's CI, we should support that from our codebase.

- [x] This is a small change 

