### PR TITLE
test: remove jest workaround in e2e

### DIFF
--- a/detox/test/e2e/init.js
+++ b/detox/test/e2e/init.js
@@ -3,13 +3,7 @@ const config = require('../package.json').detox;
 const adapter = require('detox/runners/mocha/adapter');
 
 before(async () => {
-  try {
-    await detox.init(config);
-  } catch (e) {
-    await detox.cleanup();
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    process.exit(1);
-  }
+  await detox.init(config);
 });
 
 beforeEach(async function () {


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

1. The code in `detox/test/e2e/init.js`, inside `before` statement is historically inherited from my workaround to Jest issues (buffered console logs) which are being addressed in @d4vidi's PR #1351.

2. Moreover, currently, we don't use Jest in the e2e test suite, but Mocha. The code there is not relevant.

3. There's even more to it. Given `try {} catch {}` statement performs a redundant `detox.cleanup()`. Why? If you check the code of `detox.init()` implementation, it already has `try {} catch { cleanup() }` logic, so this is obviously extraneous.