### PR TITLE
fix: ensure cleanup cannot be called twice

### DIFF
--- a/detox/src/index.js
+++ b/detox/src/index.js
@@ -60,8 +60,6 @@ async function init(config, params) {
   } catch (err) {
     log.error({ event: 'DETOX_INIT_ERROR' }, '\n', err);
     await cleanup();
-
-    detox = null;
     throw err;
   }
 }
@@ -81,6 +79,7 @@ async function afterEach(testSummary) {
 async function cleanup() {
     if (detox) {
         await detox.cleanup();
+        detox = null;
     }
 }
 

--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -172,6 +172,12 @@ describe('index', () => {
     await detox.cleanup();
   });
 
+  it(`Basic usage, do not throw an error if cleanup is done twice`, async() => {
+    await detox.init(schemes.validOneDeviceNoSession);
+    await detox.cleanup();
+    await detox.cleanup();
+  });
+
   it(`Basic usage, if detox is undefined, do not throw an error`, async() => {
     await detox.cleanup();
   });


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

There's no sense to do the same cleanup twice on the same detox object instance, so why not set it to `null` after the cleanup?