### PR TITLE
lint: fix intellisense warning

### DIFF
--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -2,6 +2,9 @@
   "name": "detox-test",
   "version": "12.6.1",
   "private": true,
+  "engines": {
+    "node": ">=8.3.0"
+  },
   "scripts": {
     "test": ":",
     "packager": "react-native start",


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Currently, `eslint` takes `.eslintrc` configuration from the parent project - `detox`. And there is a `node` preset there:

https://github.com/wix/Detox/blob/bb61030b68986ddd3f3265ba8c76c54597ea5957/detox/.eslintrc#L1-L3

It takes into consideration a field (`engines.node`) in `package.json`, so to get rid of lint warnings in `detox/test` project, I specify this non-harmful property explicitly.