### PR TITLE
code: logging fixes in detox init

### DIFF
--- a/detox/local-cli/init.js
+++ b/detox/local-cli/init.js
@@ -5,8 +5,6 @@ const mochaTemplates = require('./templates/mocha');
 const jestTemplates = require('./templates/jest');
 const log = require('../src/utils/logger').child({ __filename });
 
-const PREFIX = 'detox-init';
-
 module.exports.command = 'init';
 module.exports.desc = 'Scaffold initial E2E test folder structure for a specified test runner';
 module.exports.builder = {
@@ -24,11 +22,15 @@ module.exports.handler = async function init(argv) {
   switch (runner) {
     case 'mocha':
       createMochaFolderE2E();
-      patchTestRunnerFieldInPackageJSON('mocha');
+      patchDetoxConfigInPackageJSON({
+        runner: 'mocha',
+      });
       break;
     case 'jest':
       createJestFolderE2E();
-      patchTestRunnerFieldInPackageJSON('jest');
+      patchDetoxConfigInPackageJSON({
+        runner: 'jest',
+      });
       break;
     default:
       throw new Error([
@@ -43,25 +45,29 @@ module.exports.handler = async function init(argv) {
 };
 
 function createFolder(dir, files) {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir);
+  if (fs.existsSync(dir)) {
+    return log.error(`Failed to create ${dir} folder, because it already exists at path: ${path.resolve(dir)}`);
+  }
 
-    for (const entry of Object.entries(files)) {
-      const [filename, content] = entry;
-      createFile(path.join(dir, filename), content);
-    }
-  } else {
-    log.error(PREFIX, `./e2e folder already exists at path: ${path.resolve(dir)}`);
+  try {
+    fs.mkdirSync(dir);
+  } catch (err) {
+    return log.error({ err }, `Failed to create ${dir} folder due to an error:`);
+  }
+
+  for (const entry of Object.entries(files)) {
+    const [filename, content] = entry;
+    createFile(path.join(dir, filename), content);
   }
 }
 
 function createFile(filename, content) {
   try {
     fs.writeFileSync(filename, content);
-    log.info(PREFIX, `A file was created in: ${filename}`);
+    log.info(`Created a file at path: ${filename}`);
   } catch (e) {
-    log.error(PREFIX, `Failed to create file in: ${filename}`);
-    log.error(PREFIX, e);
+    log.error(`Failed to create a file at path: ${filename}`);
+    log.error(e);
   }
 }
 
@@ -85,31 +91,36 @@ function parsePackageJson(filepath) {
   try {
     return require(filepath);
   } catch (err) {
-    log.error(PREFIX, `Failed to parse ./package.json due to the error:\n${err.message}`);
+    log.error(`Failed to parse package.json due to an error:\n${err.message}`);
   }
 }
 
-function patchPackageJson(packageJson, runnerName) {
-  _.set(packageJson, ['detox', 'test-runner'], runnerName);
+function loggedSet(obj, path, value) {
+  _.set(obj, path, value);
 
-  log.info(PREFIX, 'Patched ./package.json with commands:');
-  log.info(PREFIX, `_.set(packageJson, ['detox', 'test-runner'], "${runnerName}")`);
+  const pathString = path.map(segment => `[${JSON.stringify(segment)}]`).join('');
+  log.info(`  json${pathString} = ${JSON.stringify(value)};`);
 }
 
 function savePackageJson(filepath, json) {
   try {
     fs.writeFileSync(filepath, JSON.stringify(json, null, 2) + '\n');
   } catch (err) {
-    log.error(PREFIX, `Failed to write changes into ./package.json due to the error:\n${err.message}`);
+    log.error(`Failed to write changes back into package.json due to an error:\n${err.message}`);
   }
 }
 
-function patchTestRunnerFieldInPackageJSON(runnerName) {
+function patchDetoxConfigInPackageJSON({ runner }) {
   const packageJsonPath = path.join(process.cwd(), 'package.json');
-  const packageJson = parsePackageJson(packageJsonPath);
 
-  if (packageJson) {
-    patchPackageJson(packageJson, runnerName);
+  if (fs.existsSync(packageJsonPath)) {
+    log.info(`Patching package.json at path: ${packageJsonPath}`);
+
+    const packageJson = parsePackageJson(packageJsonPath);
+    loggedSet(packageJson, ['detox', 'test-runner'], runner);
+
     savePackageJson(packageJsonPath, packageJson);
+  } else {
+    log.error(`Failed to find package.json at path: ${packageJsonPath}`);
   }
 }


### PR DESCRIPTION
**Description:**

1. Remove redundant PREFIX in logs, because `require('../src/utils/logger').child({ __filename });` already gives the logger a prefix.
2. As @d4vidi suggested in his PR #1351, to explicitly specify `runner-config` field in package.json (and that's an additional parameter to a scaffolding function), so to be on the safe side, I refactored `patchDetoxConfigInPackageJSON` function to accept named parameters (via destructuring). As a result, we have here a more generic `loggedSet` instead of a crafted-once log message.
3. `createFolder` log message has been fixed (interpolated `${dir}` instead of a constant `./e2e`).
4. `createFolder` won't throw an unhandled exception if creating a folder fails - instead, it will log an error with an explanation and go to the next step. 
5. `patchDetoxConfigInPackageJSON` now prints a comprehensible error if it does not find `package.json`. 
6. Fixed wording in error messages.