### PR TITLE
Add support for okhttpVersion, okioVersion and reactNativeVersion gradle root-project extra properties.

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -10,6 +10,9 @@ def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 18
 def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 25
 def _kotlinVersion = _ext.has('detoxKotlinVersion') ? _ext.detoxKotlinVersion : '1.2.0'
 def _kotlinStdlib = _ext.has('detoxKotlinStdlib') ? _ext.detoxKotlinStdlib : 'kotlin-stdlib-jdk8'
+def _okhttpVersion = _ext.has('okhttpVersion') ? _ext.okhttpVersion : '3.14.1';
+def _okioVersion = _ext.has('okioVersion') ? _ext.okioVersion : '2.2.2';
+def _reactNativeVersion = _ext.has('reactNativeVersion') ? _ext.reactNativeVersion : '+';
 
 android {
     compileSdkVersion _compileSdkVersion
@@ -62,11 +65,11 @@ dependencies {
     implementation "org.jetbrains.kotlin:$_kotlinStdlib:$_kotlinVersion"
 
     // noinspection GradleDynamicVersion
-    compileOnly 'com.facebook.react:react-native:+'
+    compileOnly "com.facebook.react:react-native:${_reactNativeVersion}"
     // noinspection GradleDynamicVersion
-    compileOnly 'com.squareup.okhttp3:okhttp:+'
+    compileOnly "com.squareup.okhttp3:okhttp:${_okhttpVersion}"
     // noinspection GradleDynamicVersion
-    compileOnly 'com.squareup.okio:okio:+'
+    compileOnly "com.squareup.okio:okio:${okioVersion}"
 
     implementation 'org.apache.commons:commons-lang3:3.4'
 
@@ -90,7 +93,7 @@ dependencies {
     testImplementation 'org.apache.commons:commons-io:1.3.2'
     testImplementation 'com.nhaarman:mockito-kotlin:1.4.0'
     // noinspection GradleDynamicVersion
-    testImplementation 'com.facebook.react:react-native:+'
+    testImplementation "com.facebook.react:react-native:${_reactNativeVersion}"
 }
 
 if (rootProject.hasProperty('isOfficialDetoxLib')) {

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -280,13 +280,15 @@ Detox should work with `kotlin-stdlib-jdk7`, as well.
 
 Detox requires the Kotlin standard-library as it's own dependency. Due to the [many flavours](https://kotlinlang.org/docs/reference/using-gradle.html#configuring-dependencies) by which Kotlin has been released, multiple dependencies often create a conflict.
 
-For that, Detox allows for the exact specification of the standard library to use using two Gradle globals: `detoxKotlinVerion` and `detoxKotlinStdlib`. You can define both in your  root build-script file (i.e.`android/build.gradle`):
+For that, Detox allows for the exact specification of the standard library to use using some Gradle globals: `detoxKotlinVerion` and `detoxKotlinStdlib`. You can define both in your root build-script file (i.e.`android/build.gradle`):
 
 ```groovy
 buildscript {
     // ...
     ext.detoxKotlinVersion = '1.3.0' // Detox' default is 1.2.0
     ext.detoxKotlinStdlib = 'kotlin-stdlib-jdk7' // Detox' default is kotlin-stdlib-jdk8
+    // ext.okioVersion and ext.okhttpVersion are available too.
 }
 ```
+
 


### PR DESCRIPTION


<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [ ] This is a small change 
- [ ] This change has been discussed in issue #1380 and the solution has been agreed upon with maintainers.

---

**Description:**

The aim is to allow version conflicts to be overridden if override the kotlin version. It's also following the standard pattern that most other projects use for reactNativeVersion. I've just picked the latest non-alpha/beta version for okhttp and okio. I don't know if they work with kotlin 1.2.0.

I've not tested this in any way yet.