### PR TITLE
Add rebuild-framework-cache command to local CLI

### DIFF
--- a/detox/local-cli/rebuild-framework-cache.js
+++ b/detox/local-cli/rebuild-framework-cache.js
@@ -1,13 +1,17 @@
+const fs = require('fs-extra');
 const path = require('path');
 const cp = require('child_process');
 const os = require('os');
 const log = require('../src/utils/logger').child({ __filename });
 
-module.exports.command = 'build-framework-cache';
-module.exports.desc = 'MacOS only. Build Detox.framework to ~/Library/Detox. The framework cache is specific for each combination of Xcode and Detox versions';
+module.exports.command = 'rebuild-framework-cache';
+module.exports.desc = 'MacOS only. Rebuilds Detox.framework into ~/Library/Detox. The framework cache is specific for each combination of Xcode and Detox versions.';
 
 module.exports.handler = async function buildFrameworkCache() {
   if (os.platform() === 'darwin') {
+    const frameworkPath = path.join(os.homedir(), '/Library/Detox');
+    log.info(`Removing framework binaries from ${frameworkPath}`);
+    await fs.remove(frameworkPath);
     cp.execSync(path.join(__dirname, '../scripts/build_framework.ios.sh'), {stdio: 'inherit'});
   } else {
     log.info(`The command is supported only on MacOS, skipping the execution.`);


### PR DESCRIPTION
In most cases, `clean-framework-cache` and `build-framework-cache` are called together. This PR adds `rebuild-framework-cache` to local CLI so that these two steps are easier to accomplish.

Right now, it doesn't replace the existing ones. I don't think `clean-framework-cache` should be removed, but `build-framework-cache` may be unnecessary.

One caveat here is that `rebuild-framework-cache` cleans all cache but only builds for the current Detox. Not sure how bad this is, considering the use-cases.