### PR TITLE
Cancel explicit deps in okio and okhttp

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -63,10 +63,6 @@ dependencies {
 
     // noinspection GradleDynamicVersion
     compileOnly 'com.facebook.react:react-native:+'
-    // noinspection GradleDynamicVersion
-    compileOnly 'com.squareup.okhttp3:okhttp:+'
-    // noinspection GradleDynamicVersion
-    compileOnly 'com.squareup.okio:okio:+'
 
     implementation 'org.apache.commons:commons-lang3:3.4'
 


### PR DESCRIPTION
**Description:**

Fixes #1380 and similar problems in some projects that _compile_ Detox, typically running RN-59, maybe 58.

This explains the fix in a nutshell:
- Using gradle's `+` wildcard for auto version resolution - which in facts yields the _newest available version_, works for react native as a dep, because RN gets resolved strictly from the synthetic `node_modules/react-native/android` "repo". The "newest" version is simply the one that's installed there.
- This isn't the case for `okhttp` and `okio`, which are found at the `google` and/or `jcenter` repos. In the current setting, that basically gives Detox the mandate to claim it relies on new, perhaps incompatible versions (e.g. `okhttp` 4), while really it can work with anything not too old.

Luckily, `okhttp` and `okio` eventually directly and indirectly come from the dep in react native itself (e.g. via fresco), so explicitly declaring them has been rendered useless now. Example from the Detox test app:
```
fromBinReleaseCompileClasspath - Resolved configuration for compilation for variant: fromBinRelease
+--- com.facebook.react:react-native:+ -> 0.56.0
|    +--- javax.inject:javax.inject:1
|    +--- com.android.support:appcompat-v7:26.1.0 -> 27.1.1
|    |    +--- com.android.support:support-annotations:27.1.1
|    |    +--- com.android.support:support-core-utils:27.1.1
|    |    |    +--- com.android.support:support-annotations:27.1.1
|    |    |    \--- com.android.support:support-compat:27.1.1
|    |    |         +--- com.android.support:support-annotations:27.1.1
|    |    |         \--- android.arch.lifecycle:runtime:1.1.0
|    |    |              +--- android.arch.lifecycle:common:1.1.0
|    |    |              \--- android.arch.core:common:1.1.0
...
|    +--- com.facebook.fresco:imagepipeline-okhttp3:1.9.0
|    |    +--- com.squareup.okhttp3:okhttp:3.10.0
|    |    |    \--- com.squareup.okio:okio:1.14.0
|    |    +--- com.facebook.fresco:fbcore:1.9.0
|    |    \--- com.facebook.fresco:imagepipeline:1.9.0 (*)
|    +--- com.facebook.soloader:soloader:0.3.0
|    +--- com.google.code.findbugs:jsr305:3.0.0
|    +--- com.squareup.okhttp3:okhttp:3.10.0 (*)
|    +--- com.squareup.okhttp3:okhttp-urlconnection:3.10.0
|    |    \--- com.squareup.okhttp3:okhttp:3.10.0 (*)
|    +--- com.squareup.okio:okio:1.14.0
|    \--- org.webkit:android-jsc:r174650
```