### PR TITLE
Removed triggering of instruments recording  (--record-performance) for apps launched in before/beforeApp scopes

### DIFF
--- a/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
+++ b/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
@@ -37,11 +37,6 @@ class SimulatorInstrumentsPlugin extends WholeTestRecorderPlugin {
   async onBeforeLaunchApp(event) {
     await super.onBeforeLaunchApp(event);
 
-    const isInsideRunningTest = !!this.context.testSummary;
-    if (this.enabled && isInsideRunningTest && !this.testRecording) {
-      this.testRecording = this.createTrackedTestRecording();
-    }
-
     if (process.env.DETOX_INSTRUMENTS_PATH) {
       event.launchArgs['-instrumentsPath'] = process.env.DETOX_INSTRUMENTS_PATH;
     }


### PR DESCRIPTION
**Description:**

Removed triggering of instruments recording  (--record-performance) for apps launched in before/beforeApp scopes

```js
  before(async () => {
    await device.launchApp({newInstance: true, permissions: {notifications: 'YES'}});
  });
```

In that case, the beforeEach scope handles starting of a recording on an already launched app, and instruments will crash on an invalid state.


```
Suppressed error inside function call: SimulatorInstrumentsPlugin.onBeforeEach({ title: 'Launch logged in app from dead state',
  fullName:
   'Open installed app - logged in Launch logged in app from dead state',
  status: 'running' })
  err: A recording is already in progress
  (
      0   CoreFoundation                      0x00000001101421bb __exceptionPreprocess + 331
      1   libobjc.A.dylib                     0x000000010e076735 objc_exception_throw + 48
      2   CoreFoundation                      0x0000000110142015 +[NSException raise:format:] + 197
      3   DTXProfiler                         0x000000010afeef72 -[DTXProfiler _startProfilingWithConfiguration:deleteExisting:] + 875
      4   Detox                               0x000000010af5dca1 -[DetoxInstrumentsManager startRecordingAtURL:] + 149
      5   Detox                               0x000000010af5c567 -[DetoxManager _handlePerformanceRecording:isFromLaunch:completionHandler:] + 413
      6   Detox                               0x000000010af5ad28 -[DetoxManager websocket:didReceiveAction:withParams:withMessageId:] + 266
      7   Detox                               0x000000010af4fa97 -[WebSocket receiveAction:] + 457
      8   SocketRocket                        0x000000012f522508 __43-[SRWebSocket _handleFrameWithData:opCode:]_block_invoke.295 + 214
      9   EarlGrey                            0x000000012f375b32 __60-[GREYDispatchQueueTracker grey_dispatchAsyncCallWithBlock:]_block_invoke + 50
      10  libdispatch.dylib                   0x00000001153224e1 _dispatch_call_block_and_release + 12
      11  libdispatch.dylib                   0x000000011532354b _dispatch_client_callout + 8
      12  libdispatch.dylib                   0x000000011532f380 _dispatch_main_queue_callback_4CF + 1290
      13  CoreFoundation                      0x00000001100a73e9 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
      14  CoreFoundation                      0x00000001100a1a76 __CFRunLoopRun + 2342
      15  CoreFoundation                      0x00000001100a0e11 CFRunLoopRunSpecific + 625
      16  GraphicsServices                    0x00000001164ca1dd GSEventRunModal + 62
      17  Detox                               0x000000010af53c73 __detox_run + 284
      18  DTXProfiler                         0x000000010afe9e60 __dtxinst_UIApplication_run + 171
      19  UIKitCore                           0x0000000116f5881d UIApplicationMain + 140
      20  WixOneAppDev                        0x000000010975aec2 main + 80
      21  libdyld.dylib                       0x0000000115393575 start + 1
      22  ???                                 0x0000000000000008 0x0 + 8
```
