### PR TITLE
Allow specifying the simulator name or UDID as a device name for iOS simulators

### DIFF
--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -30,7 +30,10 @@ class AppleSimUtils {
 
     let type;
     let os;
-    if (_.includes(query, ',')) {
+    if (query.match(/[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/i)) {
+      return [query]
+    }
+    else if (_.includes(query, ',')) {
       const parts = _.split(query, ',');
       type = parts[0].trim();
       os = parts[1].trim();


### PR DESCRIPTION
- [x] This is a small change 

**Description:**

This PR allows specifying a UDID as the --device-name option, which allows targeting a specific simulator instance rather than just one that matches the device type/OS.

This is very useful when the test environment contains multiple of the same device types that are pre-configured for different locales for example.
