### PR TITLE
Make crash e2e more stable

### DIFF
--- a/detox/test/e2e/19.crash-handling.test.js
+++ b/detox/test/e2e/19.crash-handling.test.js
@@ -1,7 +1,7 @@
 describe('Crash Handling', () => {
-
   it('Should throw error upon app crash', async () => {
-    await device.reloadReactNative();
+    await device.launchApp({newInstance: true});
+
     let failed = false;
 
     try {


### PR DESCRIPTION
**Description:**

Currently, crash e2e's start by reloading RN instead of restarting from scratch. This means the test doesn't really begin fresh, from scratch - as some native state properties can leak in. Not just theoretical -- on Android, this made the app load inside a different activity that's related to url launch checking (previous test was urls related).