### PR TITLE
fix: include launch args that come from artifact plugin

### DIFF
--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -70,10 +70,8 @@ class SimulatorDriver extends IosDriver {
   }
 
   async launchApp(deviceId, bundleId, launchArgs, languageAndLocale) {
-    const _launchArgs = this._transformLaunchArgs(launchArgs);
-
     await this.emitter.emit('beforeLaunchApp', {bundleId, deviceId, launchArgs});
-    const pid = await this.applesimutils.launch(deviceId, bundleId, _launchArgs, languageAndLocale);
+    const pid = await this.applesimutils.launch(deviceId, bundleId, launchArgs, languageAndLocale);
     await this.emitter.emit('launchApp', {bundleId, deviceId, launchArgs, pid});
 
     return pid;
@@ -128,13 +126,6 @@ class SimulatorDriver extends IosDriver {
 
   async waitForBackground() {
     return await this.client.waitForBackground();
-  }
-
-  _transformLaunchArgs(launchArgs) {
-    return _.reduce(launchArgs, (result, value, key) => {
-      result[`-${key}`] = value;
-      return result;
-    }, {});
   }
 }
 

--- a/detox/src/devices/drivers/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/SimulatorDriver.test.js
@@ -30,13 +30,13 @@ describe('IOS simulator driver', () => {
 
     it('should be passed to AppleSimUtils even if some of them were received from `beforeLaunchApp` phase', async () => {
       uut.emitter.on('beforeLaunchApp', ({ launchArgs }) => {
-        launchArgs.dog3 = 'from-plugin';
+        launchArgs.dog3 = 'Chika, from plugin';
       });
 
       await uut.launchApp(deviceId, bundleId, launchArgs, languageAndLocale);
       expect(uut.applesimutils.launch).toHaveBeenCalledWith(deviceId, bundleId, {
         ...launchArgs,
-        dog3: 'from-plugin',
+        dog3: 'Chika, from plugin',
       }, '');
     });
   });

--- a/detox/src/devices/drivers/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/SimulatorDriver.test.js
@@ -1,34 +1,43 @@
 describe('IOS simulator driver', () => {
+  let uut;
 
   const deviceId = 'device-id-mock';
   const bundleId = 'bundle-id-mock';
 
+  beforeEach(() => {
+    jest.mock('../ios/AppleSimUtils', () => mockAppleSimUtils);
+  });
+
   describe('launch args', () => {
+    let launchArgs, languageAndLocale;
 
-    let uut;
     beforeEach(() => {
-      jest.mock('../ios/AppleSimUtils', () => mockAppleSimUtils);
-
-      const SimulatorDriver = require('./SimulatorDriver');
-      uut = new SimulatorDriver({
-        client: {},
-      });
-    });
-
-    it('should inject a prefix to arg keys', async () => {
-      const launchArgs = {
+      launchArgs = {
         'dog1': 'dharma',
         'dog2': 'karma',
       };
 
-      await uut.launchApp(deviceId, bundleId, launchArgs, '');
+      languageAndLocale = '';
 
-      const simUtilsLaunchAllArgs = uut.applesimutils.launch.mock.calls[0];
-      const simUtilsLaunchArgs = simUtilsLaunchAllArgs[2];
-      expect(simUtilsLaunchArgs).toEqual({
-        '-dog1': 'dharma',
-        '-dog2': 'karma',
+      const SimulatorDriver = require('./SimulatorDriver');
+      uut = new SimulatorDriver({ client: {} });
+    });
+
+    it('should be passed to AppleSimUtils', async () => {
+      await uut.launchApp(deviceId, bundleId, launchArgs, languageAndLocale);
+      expect(uut.applesimutils.launch).toHaveBeenCalledWith(deviceId, bundleId, launchArgs, languageAndLocale);
+    });
+
+    it('should be passed to AppleSimUtils even if some of them were received from `beforeLaunchApp` phase', async () => {
+      uut.emitter.on('beforeLaunchApp', ({ launchArgs }) => {
+        launchArgs.dog3 = 'from-plugin';
       });
+
+      await uut.launchApp(deviceId, bundleId, launchArgs, languageAndLocale);
+      expect(uut.applesimutils.launch).toHaveBeenCalledWith(deviceId, bundleId, {
+        ...launchArgs,
+        dog3: 'from-plugin',
+      }, '');
     });
   });
 });

--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -248,7 +248,7 @@ class AppleSimUtils {
   }
 
   _joinLaunchArgs(launchArgs) {
-    return _.map(launchArgs, (v, k) => `${k} "${v}"`).join(' ').trim();
+    return _.map(launchArgs, (v, k) => `-${k} "${v}"`).join(' ').trim();
   }
 
   async _launchMagically(frameworkPath, logsInfo, udid, bundleId, args, languageAndLocale) {


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

This is a hotfix for https://github.com/wix/Detox/pull/1385.

There is a not very obvious logic in `SimulatorInstrumentsPlugin` that mutates `launchArgs` in order to be able to launch the app with Detox Instruments recording enabled from the very beginning. Also, it can specify `detoxInstrumentsPath` via that specific mutation.

This particular oversight had two implications:

1. You can’t override Detox Instruments Path when launching an app.
2. And you can’t collect profiling if you launch an app inside `it()`.

This fix moves all the command-line argument manipulation logic of launchApp to `AppleSimUtils` class.
