### PR TITLE
docs: info on contributing to example projects

### DIFF
--- a/docs/Guide.Contributing.md
+++ b/docs/Guide.Contributing.md
@@ -136,13 +136,7 @@ If you add, rename, or delete a test in `detox/test/e2e` suite, you should follo
 	```
 #### 4. Running example projects on Android
 
-To be able to run one of `example/demo-react-*` projects on Android, make sure you downgrade that demo project to `react-native@0.57.8`, e.g.:
-
-```bash
-node scripts/change_react_native_version.js examples/demo-react-native 0.57.8
-```
-
-and also publish `detox-999.999.999.aar` locally (before you start building that demo project):
+Before you build one of `example/demo-react-*` projects for Android, you need to publish `detox-999.999.999.aar` locally:
 
 ```bash
 cd detox/android

--- a/docs/Guide.Contributing.md
+++ b/docs/Guide.Contributing.md
@@ -136,13 +136,13 @@ If you add, rename, or delete a test in `detox/test/e2e` suite, you should follo
 	```
 #### 4. Running example projects on Android
 
-To be able to run `example/demo-react-*` projects on Android, make sure you downgrade the demo project to `react-native@0.57.8`:
+To be able to run one of `example/demo-react-*` projects on Android, make sure you downgrade that demo project to `react-native@0.57.8`, e.g.:
 
 ```bash
 node scripts/change_react_native_version.js examples/demo-react-native 0.57.8
 ```
 
-and publish `detox-999.999.999.aar` locally (before you build the demo project):
+and also publish `detox-999.999.999.aar` locally (before you start building that demo project):
 
 ```bash
 cd detox/android

--- a/docs/Guide.Contributing.md
+++ b/docs/Guide.Contributing.md
@@ -134,8 +134,22 @@ If you add, rename, or delete a test in `detox/test/e2e` suite, you should follo
 	```sh
 	./gradlew test
 	```
+#### 4. Running example projects on Android
 
-#### 4. Code Generation
+To be able to run `example/demo-react-*` projects on Android, make sure you downgrade the demo project to `react-native@0.57.8`:
+
+```bash
+node scripts/change_react_native_version.js examples/demo-react-native 0.57.8
+```
+
+and publish `detox-999.999.999.aar` locally (before you build the demo project):
+
+```bash
+cd detox/android
+./gradlew publish -Dversion=999.999.999 
+```
+
+#### 5. Code Generation
 
 We are using a code generator based on `babel` and `objective-c-parser` to generate a Javascript Interface for `EarlGrey` (the testing library we use on iOS).
 This interface allows us to call Objective-C methods through the WebSocket connection directly on the testing device. 


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

This PR adds missing info in docs on how to run example projects after https://github.com/wix/Detox/commit/331f517328d7ee3ad86406891e0d839da64f4c83 and https://github.com/wix/Detox/commit/9bd9edcc1f211e307947ce1d3e682bc71a846f87 .