### PR TITLE
Reimplement crash-e2e stabilization

### DIFF
--- a/detox/test/e2e/15.urls.test.js
+++ b/detox/test/e2e/15.urls.test.js
@@ -1,4 +1,12 @@
 describe('Open URLs', () => {
+  afterAll(async () => {
+    await device.launchApp({
+      newInstance: true,
+      url: undefined,
+      launchArgs: undefined,
+    });
+  });
+
   const withDefaultArgs = () => ({
     url: 'detoxtesturlscheme://such-string',
     launchArgs: undefined,

--- a/detox/test/e2e/19.crash-handling.test.js
+++ b/detox/test/e2e/19.crash-handling.test.js
@@ -1,8 +1,6 @@
 describe('Crash Handling', () => {
-  
   it('Should throw error upon app crash', async () => {
-    await device.launchApp({newInstance: true});
-
+    await device.reloadReactNative();
     let failed = false;
 
     try {


### PR DESCRIPTION
**Description:**

This reimplements commit 3e9688dadf6650bb0618178b42e5a5d89f390f27

Instead of relaunching prior to crash handling, relaunch in url tests' `afterAll()` to make solution more generic.

No actual review required, CI results will set the tone here.