### PR TITLE
Introduce restricted support in RN .58+ for Android

### DIFF
--- a/detox/android/build.gradle
+++ b/detox/android/build.gradle
@@ -2,15 +2,15 @@ buildscript {
     ext.isOfficialDetoxLib = true
     ext.kotlinVersion = '1.3.0'
     ext.detoxKotlinVerion = ext.kotlinVersion
-    ext.buildToolsVersion = '27.0.3'
     ext.dokkaVersion = '0.9.18'
+    ext.buildToolsVersion = '28.0.3'
 
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
     }

--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -4,10 +4,10 @@ apply plugin: 'kotlin-android-extensions'
 
 def _ext = rootProject.ext
 
-def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 25
-def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 28
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '28.0.3'
 def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 18
-def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 25
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 28
 def _kotlinVersion = _ext.has('detoxKotlinVersion') ? _ext.detoxKotlinVersion : '1.2.0'
 def _kotlinStdlib = _ext.has('detoxKotlinStdlib') ? _ext.detoxKotlinStdlib : 'kotlin-stdlib-jdk8'
 

--- a/detox/android/gradle/wrapper/gradle-wrapper.properties
+++ b/detox/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 20 14:09:27 IST 2017
+#Sun May 26 15:32:06 IDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/detox/package.json
+++ b/detox/package.json
@@ -34,7 +34,7 @@
     "jest": "24.6.x",
     "mockdate": "^2.0.1",
     "prettier": "1.7.0",
-    "react-native": "0.56.0",
+    "react-native": "0.59.8",
     "wtfnode": "^0.8.0"
   },
   "dependencies": {

--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'com.android.application'
 apply from: "../../node_modules/react-native/react.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId "com.wix.detox.test"
         minSdkVersion 18
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         ndk {
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:appcompat-v7:27.1.1"
+    implementation "com.android.support:appcompat-v7:28.0.0"
 
     fromSourceImplementation(project(path: ":ReactAndroid"))
     // noinspection GradleDynamicVersion

--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -1,8 +1,8 @@
 package com.example;
 
 import android.os.Bundle;
-import android.test.suitebuilder.annotation.LargeTest;
 
+import androidx.test.filters.LargeTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;

--- a/detox/test/android/app/src/main/AndroidManifest.xml
+++ b/detox/test/android/app/src/main/AndroidManifest.xml
@@ -7,16 +7,13 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="22" />
-
     <application
       android:name=".MainApplication"
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme"
+      android:usesCleartextTraffic="true"
     >
 
       <!--

--- a/detox/test/android/app/src/main/java/com/example/MainApplication.java
+++ b/detox/test/android/app/src/main/java/com/example/MainApplication.java
@@ -41,5 +41,4 @@ public class MainApplication extends Application implements ReactApplication {
         super.onCreate();
         SoLoader.init(this, /* native exopackage */ false);
     }
-
 }

--- a/detox/test/android/build.gradle
+++ b/detox/test/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     ext.kotlinVersion = '1.3.0'
-    ext.buildToolsVersion = '27.0.3'
+    ext.detoxKotlinVerion = ext.kotlinVersion
+    ext.buildToolsVersion = '28.0.3'
 
     repositories {
         google()
@@ -9,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'de.undercouch:gradle-download-task:3.4.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }

--- a/detox/test/android/gradle.properties
+++ b/detox/test/android/gradle.properties
@@ -18,4 +18,3 @@
 # org.gradle.parallel=true
 
 android.useDeprecatedNdk=true
-android.enableAapt2=false

--- a/detox/test/android/gradle/wrapper/gradle-wrapper.properties
+++ b/detox/test/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 20 12:00:16 IDT 2017
+#Tue May 21 17:08:37 IDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -1,3 +1,5 @@
+const custom = require('./utils/custom-it');
+
 describe('Actions', () => {
   beforeEach(async () => {
     await device.reloadReactNative();
@@ -61,7 +63,7 @@ describe('Actions', () => {
   });
 
   // directions: 'up'/'down'/'left'/'right'
-  it('should scroll for a small amount in direction', async () => {
+  custom.it.withFailureIf.android.rn58OrNewer('should scroll for a small amount in direction', async () => {
     await expect(element(by.text('Text1'))).toBeVisible();
     await expect(element(by.text('Text4'))).toBeNotVisible();
     await expect(element(by.id('ScrollView161'))).toBeVisible();
@@ -73,7 +75,7 @@ describe('Actions', () => {
     await expect(element(by.text('Text4'))).toBeNotVisible();
   });
 
-  it('should scroll for a large amount in direction', async () => {
+  custom.it.withFailureIf.android.rn58OrNewer('should scroll for a large amount in direction', async () => {
     await expect(element(by.text('Text6'))).toBeNotVisible();
     await element(by.id('ScrollView161')).scroll(220, 'down');
     await expect(element(by.text('Text6'))).toBeVisible();

--- a/detox/test/e2e/03.fs-scroll-actions.test.js
+++ b/detox/test/e2e/03.fs-scroll-actions.test.js
@@ -1,0 +1,53 @@
+/**
+ * A mini suite providing an alternative to tests failing due to issues found in RN 58+ on Android (see
+ * https://github.com/facebook/react-native/issues/23870).
+ * It basically runs similar use cases -- all of which involve visibility and scrolling, but in a
+ * setup where they _can_ pass, so as to assert that the core Detox functionality (waitFor(), scroll())
+ * is valid nevertheless.
+ */
+
+describe('Fullscreen scrolling Actions', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+    await element(by.text('Scroll-Actions')).tap();
+  });
+
+  it('should scroll for a small amount in direction', async () => {
+    await expect(scrollViewDriver.element()).toBeVisible();
+    await expect(scrollViewDriver.firstItem()).toBeVisible();
+    await expect(scrollViewDriver.lastItem()).toBeNotVisible();
+
+    await scrollViewDriver.scrollBy(60);
+    await expect(scrollViewDriver.firstItem()).toBeNotVisible();
+    await expect(scrollViewDriver.secondItem()).toBeVisible();
+    await scrollViewDriver.scrollBy(-60);
+    await expect(scrollViewDriver.firstItem()).toBeVisible();
+    await expect(scrollViewDriver.lastItem()).toBeNotVisible();
+  });
+
+  it('should scroll for a large amount in direction', async () => {
+    await expect(scrollViewDriver.element()).toBeVisible();
+    await expect(scrollViewDriver.firstItem()).toBeVisible();
+    await expect(scrollViewDriver.lastItem()).toBeNotVisible();
+
+    await scrollViewDriver.scrollBy(1000);
+    await expect(scrollViewDriver.firstItem()).toBeNotVisible();
+    await expect(scrollViewDriver.lastItem()).toBeVisible();
+  });
+
+  it('should find element by scrolling until it is visible', async () => {
+    await expect(scrollViewDriver.lastItem()).toBeNotVisible();
+    await waitFor(scrollViewDriver.lastItem()).toBeVisible().whileElement(scrollViewDriver.viewFilter()).scroll(200, 'down');
+    await expect(scrollViewDriver.lastItem()).toBeVisible();
+  });
+});
+
+const scrollViewDriver = {
+  viewFilter: () => by.id('FSScrollActions.scrollView'),
+  element: () => element(scrollViewDriver.viewFilter()),
+  listItem: (index) => element(by.text(`Text${index}`)),
+  firstItem: () => scrollViewDriver.listItem(1),
+  secondItem: () => scrollViewDriver.listItem(2),
+  lastItem: () => scrollViewDriver.listItem(20),
+  scrollBy: (amount) => scrollViewDriver.element().scroll(Math.abs(amount), (amount > 0 ? 'down' : 'up')),
+};

--- a/detox/test/e2e/03.fs-scroll-actions.test.js
+++ b/detox/test/e2e/03.fs-scroll-actions.test.js
@@ -30,7 +30,11 @@ describe('Fullscreen scrolling Actions', () => {
     await expect(scrollViewDriver.firstItem()).toBeVisible();
     await expect(scrollViewDriver.lastItem()).toBeNotVisible();
 
-    await scrollViewDriver.scrollBy(1000);
+    try {
+      await scrollViewDriver.scrollBy(1000);
+    } catch (error) {
+      console.log('Expected error caught: Scrolled the list down to its very end');
+    }
     await expect(scrollViewDriver.firstItem()).toBeNotVisible();
     await expect(scrollViewDriver.lastItem()).toBeVisible();
   });

--- a/detox/test/e2e/05.waitfor.test.js
+++ b/detox/test/e2e/05.waitfor.test.js
@@ -1,3 +1,5 @@
+const custom = require('./utils/custom-it');
+
 describe('WaitFor', () => {
   beforeEach(async() => {
     await device.reloadReactNative();
@@ -11,18 +13,17 @@ describe('WaitFor', () => {
     await expect(element(by.id('createdAndVisibleText'))).toExist();
   });
 
-  it('should wait until an element is removed', async() => {
+  it('should wait until an element is removed', async () => {
     await expect(element(by.id('deletedFromHierarchyText'))).toBeVisible();
     await element(by.id('GoButton')).tap();
     await waitFor(element(by.id('deletedFromHierarchyText'))).toBeNotVisible().withTimeout(20000);
     await expect(element(by.id('deletedFromHierarchyText'))).toBeNotVisible();
   });
 
-  it('should find element by scrolling until it is visible', async() => {
+  custom.it.withFailureIf.android.rn58OrNewer('should find element by scrolling until it is visible', async () => {
     await expect(element(by.text('Text5'))).toBeNotVisible();
     await element(by.id('GoButton')).tap();
     await waitFor(element(by.text('Text5'))).toBeVisible().whileElement(by.id('ScrollView')).scroll(50, 'down');
     await expect(element(by.text('Text5'))).toBeVisible();
   });
-
 });

--- a/detox/test/e2e/utils/custom-it.js
+++ b/detox/test/e2e/utils/custom-it.js
@@ -1,0 +1,40 @@
+const _ = require('lodash');
+const rnMinorVer = require('./rn-consts').rnVersion.minor;
+
+const _it = {
+  withFailureIf: {
+    android: {
+      rn58OrNewer: (spec, specFn) => runOrExpectFailByPredicates(spec, specFn, platformIs('android'), rnVerAtLeast(58)),
+    }
+  },
+};
+
+function runOrExpectFailByPredicates(spec, specFn, ...predicateFuncs) {
+  it(spec, async function() {
+    if (allPredicatesTrue(predicateFuncs)) {
+      await expectSpecFail(specFn);
+    } else {
+      await runSpec(specFn);
+    }
+  });
+}
+
+const platformIs = (platform) => () => (device.getPlatform() === platform);
+const rnVerAtLeast = (rnVer) => () => (rnMinorVer >= rnVer);
+const allPredicatesTrue = (predicateFuncs) => _.reduce(predicateFuncs, (result, predicate) => (result && predicate()), true);
+
+async function expectSpecFail(specFn) {
+  try {
+    await runSpec(specFn);
+  } catch (e) {
+    console.log('Successfully caught an expected error:', e);
+    return;
+  }
+  throw new Error('Ran a spec expecting an error, but no error was thrown');
+}
+
+const runSpec = (specFn) => specFn();
+
+module.exports = {
+  it: _it,
+};

--- a/detox/test/e2e/utils/rn-consts.js
+++ b/detox/test/e2e/utils/rn-consts.js
@@ -1,0 +1,15 @@
+const rnVersion = (function parseRNVersion() {
+  const packageJson = require('react-native/package.json');
+  const raw = packageJson.version;
+  const [major, minor, patch] = raw.split('.');
+  return {
+    major,
+    minor,
+    patch,
+    raw,
+  };
+})();
+
+module.exports = {
+  rnVersion,
+};

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "moment": "^2.24.0",
-    "react": "16.4.1",
-    "react-native": "0.56.0"
+    "react": "16.8.3",
+    "react-native": "0.59.8"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/detox/test/src/Screens/ScrollActionsScreen.js
+++ b/detox/test/src/Screens/ScrollActionsScreen.js
@@ -1,0 +1,25 @@
+import React, { Component } from 'react';
+import {
+  Text,
+  View,
+  ScrollView,
+} from 'react-native';
+
+export default class ScrollActionsScreen extends Component {
+
+  render() {
+    return (
+      <View style={{ flex: 1, justifyContent: 'flex-start', borderColor: '#c0c0c0', borderWidth: 1, backgroundColor: '#f8f8ff' }}>
+        <ScrollView testID='FSScrollActions.scrollView'>
+          {
+            Array.from({length: 20}, (_, index) => this.renderItem(index + 1))
+          }
+        </ScrollView>
+      </View>
+    );
+  }
+
+  renderItem(id) {
+    return <Text key={`listItem.${id}`} style={{ height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 }}>{`Text${id}`}</Text>;
+  }
+}

--- a/detox/test/src/Screens/index.js
+++ b/detox/test/src/Screens/index.js
@@ -1,6 +1,7 @@
 import SanityScreen from './SanityScreen';
 import MatchersScreen from './MatchersScreen';
 import ActionsScreen from './ActionsScreen';
+import ScrollActionsScreen from './ScrollActionsScreen';
 import AssertionsScreen from './AssertionsScreen';
 import WaitForScreen from './WaitForScreen';
 import StressScreen from './StressScreen';
@@ -20,6 +21,7 @@ export {
   SanityScreen,
   MatchersScreen,
   ActionsScreen,
+  ScrollActionsScreen,
   AssertionsScreen,
   WaitForScreen,
   StressScreen,

--- a/detox/test/src/app.js
+++ b/detox/test/src/app.js
@@ -88,6 +88,7 @@ class example extends Component {
           {this.renderScreenButton('Sanity', Screens.SanityScreen)}
           {this.renderScreenButton('Matchers', Screens.MatchersScreen)}
           {this.renderScreenButton('Actions', Screens.ActionsScreen)}
+          {this.renderScreenButton('Scroll-Actions', Screens.ScrollActionsScreen)}
           {this.renderScreenButton('Assertions', Screens.AssertionsScreen)}
           {this.renderScreenButton('WaitFor', Screens.WaitForScreen)}
           {this.renderScreenButton('Stress', Screens.StressScreen)}

--- a/scripts/ci.android.sh
+++ b/scripts/ci.android.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Approve unapproved SDK licenses
+("yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses")
+
 source $(dirname "$0")/ci.sh
 
 pushd detox/android


### PR DESCRIPTION
- [ ] This is a small change 
- [x] This change has been discussed in issue #1181 and the solution has been agreed upon with maintainers.

---

**Description:**

Introduce required changes in order to have our *demo* app test suite successfully run on Android (with the necessary restrictions introduced by the [RN issue](https://github.com/facebook/react-native/issues/23870)).
* Documentation will follow.
* We nevertheless have to upgrade our visibility matcher in order to work around the RN issue, even though it's far from trivial.