### PR TITLE
Revert #1400

### DIFF
--- a/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
+++ b/detox/src/artifacts/instruments/SimulatorInstrumentsPlugin.js
@@ -37,6 +37,11 @@ class SimulatorInstrumentsPlugin extends WholeTestRecorderPlugin {
   async onBeforeLaunchApp(event) {
     await super.onBeforeLaunchApp(event);
 
+    const isInsideRunningTest = !!this.context.testSummary;
+    if (this.enabled && isInsideRunningTest && !this.testRecording) {
+      this.testRecording = this.createTrackedTestRecording();
+    }
+
     if (process.env.DETOX_INSTRUMENTS_PATH) {
       event.launchArgs['instrumentsPath'] = process.env.DETOX_INSTRUMENTS_PATH;
     }

--- a/detox/test/e2e/01.sanity.test.js
+++ b/detox/test/e2e/01.sanity.test.js
@@ -1,6 +1,10 @@
 describe('Sanity', () => {
+  beforeAll(async () => {
+    await device.launchApp({newInstance: true, delete: true, permissions: {notifications: 'YES'}});
+  });
+
   beforeEach(async () => {
-    await device.reloadReactNative();
+    await device.launchApp({newInstance: true});
     await element(by.text('Sanity')).tap();
   });
 


### PR DESCRIPTION
I suggest reverting the revert https://github.com/wix/Detox/commit/1c76b5ac7c8cd91ff0240bb6d3b3597656090e8e from PR https://github.com/wix/Detox/pull/1400.

My pull request reproduces the situation in the description and it does not result into any crashes.

Let's think what was wrong in the original situation, and fix the original issue without throwing away essential parts of `SimulatorInstrumentsPlugin`. As the saying goes, the baby should not be thrown out with the bath water.