### PR TITLE
Reimplemented SimulatorLogPlugin to use log stream

### DIFF
--- a/detox/src/artifacts/log/LogArtifactPlugin.js
+++ b/detox/src/artifacts/log/LogArtifactPlugin.js
@@ -23,7 +23,7 @@ class LogArtifactPlugin extends StartupAndTestRecorderPlugin {
   }
 
   async preparePathForTestArtifact(testSummary) {
-    return this.api.preparePathForArtifact('test.log', testSummary);
+    return this.api.preparePathForArtifact('process.log', testSummary);
   }
 }
 

--- a/detox/src/artifacts/log/ios/SimulatorLogPlugin.js
+++ b/detox/src/artifacts/log/ios/SimulatorLogPlugin.js
@@ -11,52 +11,39 @@ class SimulatorLogPlugin extends LogArtifactPlugin {
 
   async onBeforeShutdownDevice(event) {
     await super.onBeforeShutdownDevice(event);
-    await this._tryStopCurrentRecording();
+    await this._tryToStopCurrentRecording();
   }
 
-  async onBeforeUninstallApp(event) {
-    await super.onBeforeUninstallApp(event);
-    await this._tryStopCurrentRecording();
+  async onBeforeLaunchApp(event) {
+    await super.onBeforeLaunchApp(event);
+    await this._tryToLaunchCurrentRecording();
   }
 
-  async onBeforeTerminateApp(event) {
-    await super.onBeforeTerminateApp(event);
-    await this._tryStopCurrentRecording();
-  }
-
-  async onLaunchApp(event) {
-    await super.onLaunchApp(event);
-
+  async _tryToLaunchCurrentRecording() {
     if (this.currentRecording) {
       await this.currentRecording.start({
-        readFromBeginning: true,
+        udid: this.context.deviceId,
+        bundleId: this.context.bundleId,
       });
     }
   }
 
-  async _tryStopCurrentRecording() {
+  async _tryToStopCurrentRecording() {
     if (this.currentRecording) {
       await this.currentRecording.stop();
     }
   }
 
   createStartupRecording() {
-    return this._createRecording(true);
+    return this.createTestRecording();
   }
 
   createTestRecording() {
-    return this._createRecording(false);
-  }
-
-  _createRecording(readFromBeginning) {
-    const udid = this.context.deviceId;
-    const { stdout, stderr } = this.appleSimUtils.getLogsPaths(udid);
-
     return new SimulatorLogRecording({
+      udid: this.context.deviceId,
+      bundleId: this.context.bundleId,
+      appleSimUtils: this.appleSimUtils,
       temporaryLogPath: tempfile('.log'),
-      logStderr: stderr,
-      logStdout: stdout,
-      readFromBeginning,
     });
   }
 }

--- a/detox/src/artifacts/log/ios/SimulatorLogRecording.js
+++ b/detox/src/artifacts/log/ios/SimulatorLogRecording.js
@@ -1,106 +1,67 @@
-const _ = require('lodash');
 const fs = require('fs-extra');
 const log = require('../../../utils/logger').child({ __filename });
 const sleep = require('../../../utils/sleep');
-const { Tail } = require('tail');
+const exec = require('../../../utils/exec');
 const Artifact = require('../../templates/artifact/Artifact');
 
 class SimulatorLogRecording extends Artifact {
   constructor({
-    logStderr,
-    logStdout,
-    readFromBeginning,
+    udid,
+    bundleId,
+    appleSimUtils,
     temporaryLogPath,
   }) {
     super();
 
-    this._readFromBeginning = readFromBeginning;
+    this._udid = udid;
+    this._bundleId = bundleId;
+    this._appleSimUtils = appleSimUtils;
     this._logPath = temporaryLogPath;
-    this._stdoutPath = logStdout;
-    this._stderrPath = logStderr;
-
-    this._logStream = null;
-    this._stdoutTail = null;
-    this._stderrTail = null;
+    this._logContext = null;
   }
 
-  async doStart({ readFromBeginning } = {}) {
-    if (readFromBeginning !== void 0) {
-      this._readFromBeginning = readFromBeginning;
-    }
+  async doStart({ udid, bundleId } = {}) {
+    if (udid) {this._udid = udid; }
+    if (bundleId) {this._bundleId = bundleId; }
 
-    this._logStream = this._logStream || this._openWriteableStream();
-    this._stdoutTail = await this._createTail(this._stdoutPath, 'stdout');
-    this._stderrTail = await this._createTail(this._stderrPath, 'stderr');
+    await fs.ensureFile(this._logPath);
+    const fileHandle = await fs.open(this._logPath, 'a');
+
+    this._logContext = {
+      fileHandle,
+      throttle: sleep(100),
+      process: this._appleSimUtils.logStream({
+        udid: this._udid,
+        processImagePath: await this._getProcessImagePath(),
+        stdout: fileHandle,
+        level: 'debug',
+        style: 'compact',
+      }),
+    };
   }
 
   async doStop() {
-    await this._unwatch();
+    if (this._logContext) {
+      const { fileHandle, throttle, process } = this._logContext;
+      await throttle;
+      await exec.interruptProcess(process, 'SIGTERM');
+      await fs.close(fileHandle);
+      this._logContext = null;
+    }
   }
 
   async doSave(artifactPath) {
-    await this._closeWriteableStream();
     await Artifact.moveTemporaryFile(log, this._logPath, artifactPath);
   }
 
   async doDiscard() {
-    await this._closeWriteableStream();
     await fs.remove(this._logPath);
   }
 
-  _openWriteableStream() {
-    log.trace({ event: 'CREATE_STREAM '}, `creating append-only stream to: ${this._logPath}`);
-    return fs.createWriteStream(this._logPath, { flags: 'a' });
-  }
-
-  async _unwatch() {
-    await Promise.all([this._unwatchTail('stdout'), this._unwatchTail('stderr')]);
-  }
-
-  async _unwatchTail(stdxxx) {
-    const stdTail = `_${stdxxx}Tail`;
-    const logPath = this[`_${stdxxx}Path`];
-    const tail = this[stdTail];
-
-    if (tail) {
-      log.trace({ event: 'TAIL_UNWATCH' }, `unwatching ${stdxxx} log: ${logPath}`);
-      tail.watch = _.noop; // HACK: suppress race condition: https://github.com/lucagrulla/node-tail/blob/3791355a0ddcc5de72e1ad64ea2f0d6e78e2c9c5/src/tail.coffee#L102
-      tail.unwatch();
-      await new Promise((resolve) => setImmediate(resolve));
-    }
-
-    this[stdTail] = null;
-  }
-
-  async _closeWriteableStream() {
-    log.trace({ event: 'CLOSING_STREAM '}, `closing stream to: ${this._logPath}`);
-
-    const stream = this._logStream;
-    this._logStream = null;
-    await new Promise(resolve => stream.end(resolve));
-  }
-
-  async _createTail(file, prefix) {
-    if (!fs.existsSync(file)) {
-      log.warn({ event: 'LOG_MISSING' }, `simulator ${prefix} log is missing at path: ${file}`);
-      return null;
-    }
-
-    log.trace({ event: 'TAIL_CREATE' }, `starting to watch ${prefix} log: ${file}`);
-
-    const tail = new Tail(file, { fromBeginning: this._readFromBeginning })
-      .on('line', (line) => { this._appendLine(prefix, line); })
-      .on('error', (err) => { log.warn({ event: 'TAIL_ERROR' }, err); });
-
-    return tail;
-  }
-
-  _appendLine(prefix, line) {
-    if (this._logStream) {
-      this._logStream.write(`${prefix}: ${line}\n`);
-    } else {
-      log.warn({ event: 'LOG_WRITE_ERROR' }, 'failed to add line to log:\n' + line);
-    }
+  async _getProcessImagePath() {
+    return this._bundleId
+      ? this._appleSimUtils.getAppContainer(this._udid, this._bundleId)
+      : '';
   }
 }
 

--- a/detox/src/utils/exec.js
+++ b/detox/src/utils/exec.js
@@ -114,8 +114,10 @@ function spawnAndLog(command, flags, options) {
     log.error({ event: 'SPAWN_ERROR' }, `${cmd} failed with code = ${exitCode}`);
   }
 
-  stdout.on('data', (chunk) => log.trace({ stdout: true, event: 'SPAWN_STDOUT' }, chunk.toString()));
-  stderr.on('data', (chunk) => log.error({ stderr: true, event: 'SPAWN_STDERR' }, chunk.toString()));
+  if (!options || !options.silent) {
+    stdout && stdout.on('data', (chunk) => log.trace({ stdout: true, event: 'SPAWN_STDOUT' }, chunk.toString()));
+    stderr && stderr.on('data', (chunk) => log.error({ stderr: true, event: 'SPAWN_STDERR' }, chunk.toString()));
+  }
 
   function onEnd(e) {
     const signal = e.childProcess.signalCode || '';

--- a/detox/src/utils/exec.test.js
+++ b/detox/src/utils/exec.test.js
@@ -197,6 +197,16 @@ describe('spawn', () => {
     expect(log.error).toBeCalledWith(expect.objectContaining({ event: 'SPAWN_STDERR', stderr: true }), 'world');
   });
 
+  it('should not log output if silent: true', async () => {
+    await exec.spawnAndLog('command', [], { silent: true });
+    await nextCycle();
+
+    expect(log.debug).toBeCalledWith(expect.objectContaining({ event: 'SPAWN_CMD' }), '[pid=2018] command');
+    expect(log.trace).toBeCalledWith(expect.objectContaining({ event: 'SPAWN_END' }), 'command finished with code = 0');
+    expect(log.trace).not.toBeCalledWith(expect.objectContaining({ event: 'SPAWN_STDOUT', stdout: true }), expect.any(String));
+    expect(log.error).not.toBeCalledWith(expect.objectContaining({ event: 'SPAWN_STDERR', stderr: true }), expect.any(String));
+  });
+
   it('should log erroneously finished spawns', async () => {
     const childProcess = {
       pid: 8102,


### PR DESCRIPTION
**Description:**

The existing `SimulatorLogPlugin` implementation appears to be **not informative** (does not include various NSLog messages, etc) and **hacky** (relies on tailing two temporary files which contain piped output from a simulator launched in a special way).

The suggested reimplementation is based on two extra commands:

```
/usr/bin/xcrun simctl spawn ${udid} log stream --level debug --style compact --predicate '${predicate}
```
, where the predicate is built via:
```
/usr/bin/xcrun simctl get_app_container ${udid} ${bundleId}
```
and looks like:

```
processImagePath beginsWith "${appContainer}"
```

Ultimately, the plugin now is able to produce logs like these:

```
2019-06-04 14:01:49.918 E  example[59318:22c78e] [com.wix.Detox:DetoxManager] Web socket failed to connect with error: Error Domain=NSPOSIXErrorDomain Code=61 "Connection refused" UserInfo={_kCFStreamErrorCodeKey=61, _kCFStreamErrorDomainKey=1}
2019-06-04 14:01:49.917 Df example[59318:22c7d0] [com.apple.network:] [C2 localhost:51820 tcp, legacy-socket] cancel
2019-06-04 14:01:49.920 Df example[59318:22c7d0] [com.apple.network:] [C2 localhost:51820 tcp, legacy-socket] cancelled
```

That should be helpful in troubleshooting various issues, including the one that blocks us from merging  [dinstruments-demoapp](https://github.com/wix/Detox/tree/dinstruments-demoapp) branch to *master*.