### PR TITLE
fix(artifacts): more precise log recording on iOS and Android

### DIFF
--- a/detox/src/artifacts/log/LogArtifactPlugin.js
+++ b/detox/src/artifacts/log/LogArtifactPlugin.js
@@ -15,6 +15,14 @@ class LogArtifactPlugin extends StartupAndTestRecorderPlugin {
     this.keepOnlyFailedTestsArtifacts = recordLogs === 'failing';
   }
 
+  async onBeforeShutdownDevice(event) {
+    await super.onBeforeShutdownDevice(event);
+
+    if (this.currentRecording) {
+      await this.currentRecording.stop();
+    }
+  }
+
   async preparePathForStartupArtifact() {
     const deviceId = this.context.deviceId;
     const timestamp = getTimeStampString();

--- a/detox/src/artifacts/log/android/ADBLogcatPlugin.js
+++ b/detox/src/artifacts/log/android/ADBLogcatPlugin.js
@@ -17,6 +17,7 @@ class ADBLogcatPlugin extends LogArtifactPlugin {
 
   async onLaunchApp(event) {
     await super.onLaunchApp(event);
+    await this.onReadyToRecord();
 
     if (this.currentRecording) {
       await this.currentRecording.start();

--- a/detox/src/artifacts/log/android/ADBLogcatPlugin.js
+++ b/detox/src/artifacts/log/android/ADBLogcatPlugin.js
@@ -7,13 +7,19 @@ class ADBLogcatPlugin extends LogArtifactPlugin {
 
     this._adb = config.adb;
     this._devicePathBuilder = config.devicePathBuilder;
+    this._lastTimestamp = '';
+  }
+
+  async onBeforeLaunchApp(event) {
+    await super.onBeforeLaunchApp(event);
+    this._lastTimestamp = await this._adb.now(event.deviceId);
   }
 
   async onLaunchApp(event) {
     await super.onLaunchApp(event);
 
     if (this.currentRecording) {
-      await this.currentRecording.start({ pid: event.pid });
+      await this.currentRecording.start();
     }
   }
 
@@ -28,7 +34,13 @@ class ADBLogcatPlugin extends LogArtifactPlugin {
       adb: this._adb,
       deviceId,
       bundleId,
-      pid,
+      pid: {
+        get: () => this.context.pid,
+      },
+      since: {
+        get: () => this._lastTimestamp,
+        set: (value) => { this._lastTimestamp = value; },
+      },
       pathToLogOnDevice: this._devicePathBuilder.buildTemporaryArtifactPath('.log'),
     });
   }

--- a/detox/src/artifacts/log/android/ADBLogcatRecording.js
+++ b/detox/src/artifacts/log/android/ADBLogcatRecording.js
@@ -1,6 +1,7 @@
 const Artifact = require('../../templates/artifact/Artifact');
 const DetoxRuntimeError = require('../../../errors/DetoxRuntimeError');
 const { interruptProcess } = require('../../../utils/exec');
+const log = require('../../../utils/logger').child({ __filename });
 const retry = require('../../../utils/retry');
 const sleep = require('../../../utils/sleep');
 
@@ -9,6 +10,7 @@ class ADBLogcatRecording extends Artifact {
     adb,
     deviceId,
     pid,
+    since,
     pathToLogOnDevice,
   }) {
     super();
@@ -16,56 +18,63 @@ class ADBLogcatRecording extends Artifact {
 
     this.deviceId = deviceId;
     this.pid = pid;
+    this.since = since;
 
     this.pathToLogOnDevice = pathToLogOnDevice;
     this.processPromise = null;
 
     this._waitUntilLogFileIsCreated = null;
-    this._waitWhileLogIsOpenedByLogcat = null;
   }
 
-  async doStart({ pid } = {}) {
-    if (pid) {
-      this.pid = pid;
+  get hasRecordedFile() {
+    return !!this._waitUntilLogFileIsCreated;
+  }
+
+  async doStart() {
+    const pid = this.pid.get();
+
+    if (pid > 0) {
+      this.processPromise = this.adb.logcat(this.deviceId, {
+        file: this.pathToLogOnDevice,
+        time: this.since.get(),
+        pid,
+      });
+
+      this._waitUntilLogFileIsCreated = sleep(300).then(() => {
+        return retry(() => this._assertLogIsCreated());
+      });
+    } else {
+      log.debug('Ignoring a command to start recording, because PID of the app is missing');
     }
-
-    const now = await this.adb.now(this.deviceId);
-
-    await this._waitWhileLogIsOpenedByLogcat; // in case if log recording restarted
-    this.processPromise = this.adb.logcat(this.deviceId, {
-      file: this.pathToLogOnDevice,
-      pid: this.pid,
-      time: now,
-    });
-
-    this._waitUntilLogFileIsCreated = sleep(300).then(() => {
-      return retry(() => this._assertLogIsCreated());
-    });
   }
 
   async doStop() {
     try {
       await this._waitUntilLogFileIsCreated;
+      this.since.set(await this.adb.now(this.deviceId));
     } finally {
       if (this.processPromise) {
-        const processPromise = this.processPromise;
-
-        this._waitWhileLogIsOpenedByLogcat = sleep(300)
-          .then(() => interruptProcess(processPromise))
-          .then(() => { this.processPromise = null; });
+        await interruptProcess(this.processPromise);
+        this.processPromise = null;
       }
     }
   }
 
   async doSave(artifactPath) {
-    await this._waitWhileLogIsOpenedByLogcat;
-    await this.adb.pull(this.deviceId, this.pathToLogOnDevice, artifactPath);
-    await this.adb.rm(this.deviceId, this.pathToLogOnDevice);
+    if (this.hasRecordedFile) {
+      await this.adb.pull(this.deviceId, this.pathToLogOnDevice, artifactPath);
+      await this.adb.rm(this.deviceId, this.pathToLogOnDevice);
+    } else {
+      log.debug(`Skipping saving artifact because the recording has not started: ${artifactPath}`);
+    }
   }
 
   async doDiscard() {
-    await this._waitWhileLogIsOpenedByLogcat;
-    await this.adb.rm(this.deviceId, this.pathToLogOnDevice);
+    if (this.hasRecordedFile) {
+      await this.adb.rm(this.deviceId, this.pathToLogOnDevice);
+    } else {
+      log.debug(`Skipping discarding artifact due to a not started recording: ${this.pathToLogOnDevice}`);
+    }
   }
 
   async _assertLogIsCreated() {

--- a/detox/src/artifacts/log/ios/SimulatorLogPlugin.js
+++ b/detox/src/artifacts/log/ios/SimulatorLogPlugin.js
@@ -7,6 +7,7 @@ class SimulatorLogPlugin extends LogArtifactPlugin {
     super(config);
 
     this.appleSimUtils = config.appleSimUtils;
+    this.priority = 8;
   }
 
   async onBeforeShutdownDevice(event) {

--- a/detox/src/artifacts/log/ios/SimulatorLogPlugin.js
+++ b/detox/src/artifacts/log/ios/SimulatorLogPlugin.js
@@ -6,7 +6,6 @@ const SimulatorLogRecording = require('./SimulatorLogRecording');
 class SimulatorLogPlugin extends LogArtifactPlugin {
   constructor(config) {
     super(config);
-    this.onBeforeAll = _.once(this.onBeforeAll.bind(this));
 
     this.appleSimUtils = config.appleSimUtils;
     this.priority = 8;
@@ -14,7 +13,7 @@ class SimulatorLogPlugin extends LogArtifactPlugin {
 
   async onBeforeLaunchApp(event) {
     await super.onBeforeLaunchApp(event);
-    await this.onBeforeAll();
+    await this.onReadyToRecord();
 
     if (this.currentRecording) {
       await this.currentRecording.start({

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
@@ -14,6 +14,7 @@ class ArtifactPlugin {
     this.context = {};
     this.enabled = false;
     this.keepOnlyFailedTestsArtifacts = false;
+    this.priority = 16;
     this._disableReason = '';
   }
 


### PR DESCRIPTION
**Description:**

This issue popped up when we tried to debug why `*.dtxrec` are not being recorded on CI.

This PR addresses some of them, specifically:

1) the log plugin starts recording first and ends recording last (`priority` field);
2) the log plugin for iOS gracefully terminates the spawned logging process (to save more logs);
3) the log plugin for Android requests logs from a more correct timestamp (either from "before the app was launched" or "before the last recording was stopped").
4) to reflect the recent `process.log` naming, Android log plugin will not record logs if no PID is specified.