### PR TITLE
Update APIRef.ActionsOnElement.md

### DIFF
--- a/docs/APIRef.ActionsOnElement.md
+++ b/docs/APIRef.ActionsOnElement.md
@@ -78,6 +78,10 @@ Use the builtin keyboard to type text into a text field.
 await element(by.id('textField')).typeText('passcode');
 ```
 
+> **Note:** Make sure to toggle the software keyboard on text fields.
+>
+> To do this, open the simulator, tap any text field in your app, then select **Hardware** -> **Keyboard** -> **Toggle Software Keyboard** (⌘K) to automatically toggle the builtin keyboard on each time a text field is tapped in your tests.
+
 > **Note:** Make sure hardware keyboard is disconnected. Otherwise, Detox may fail when attempting to type text.
 >
 > To make sure hardware keyboard is disconnected, open the simulator from Xcode and make sure **Hardware** -> **Keyboard** -> **Connect Hardware Keyboard** is deselected (or press ⇧⌘K).


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

This appears to be an important pre-requisite to successfully calling `typeText`, because it uses the builtin keyboard in all text fields.

To use the builtin keyboard, it must be toggled on first in the simulator in any text field, otherwise this error will be thrown in the terminal:

```sh
Detox _ Failed to type string because keyboard was not shown on screen
```

One can achieve this by tapping on any app text field, then selecting *Hardware -> Keyboard -> Toggle Software Keyboard (⌘K)*.

This will now automatically toggle the builtin keyboard on during tests.