### PR TITLE
use --byId instead of --simulator

### DIFF
--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -14,7 +14,7 @@ class AppleSimUtils {
       permissions.push(permission + '=' + shouldAllow);
     });
     await this._execAppleSimUtils({
-      args: `--simulator ${udid} --bundle ${bundleId} --restartSB --setPermissions ${_.join(permissions, ',')}`
+      args: `--byId ${udid} --bundle ${bundleId} --restartSB --setPermissions ${_.join(permissions, ',')}`
     }, statusLogs, 1);
   }
 


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

fixes usage with newest applesimutils https://github.com/wix/AppleSimulatorUtils/releases

tested in CI

before:
```
detox[15997] INFO:  [DetoxServer.js] server listening on localhost:52500...
detox[15997] ERROR: [exec.js/EXEC_FAIL, #6] "applesimutils --simulator 14B76F33-6E7F-4F0F-9079-B75A57BD0B41 --bundle com.some.company--restartSB --setPermissions notifications=YES" failed with code = 253, stdout and stderr:

detox[15997] ERROR: [exec.js/EXEC_FAIL, #6] A collection of utils for Apple simulators.

Usage Examples:
    applesimutils --byId <simulator identifier> --bundle <bundle identifier> --setPermissions "<permission1>, <permission2>, ..."
    applesimutils --byName <simulator name> --byOS <simulator OS version> --bundle <bundle identifier> --setPermissions "<permission1>, <permission2>, ..."
    applesimutils --list [--byName <simulator name>] [--byOS <simulator OS version>] [--byType <simulator OS version>] [--maxResults <int>]
    applesimutils --byId <simulator identifier> --biometricEnrollment <YES/NO>
    applesimutils --byId <simulator identifier> --matchFace

Options:
    --byId                       Filters simulators by identifier
    --byName                     Filters simulators by name
    --byType                     Filters simulators by device type
    --byOS                       Filters simulators by operating system
    --list                       Lists available simulators
    --setPermissions             Sets the specified permissions and restarts SpringBoard for the changes to take effect
    --clearKeychain              Clears the simulator's keychain
    --restartSB                  Restarts SpringBoard
    --biometricEnrollment        Enables or disables biometric (Face ID/Touch ID) enrollment.
    --matchFace                  Approves Face ID authentication request with a matching face
    --unmatchFace                Fails Face ID authentication request with a non-matching face
    --matchFinger                Approves Touch ID authentication request with a matching finger
    --unmatchFinger              Fails Touch ID authentication request with a non-matching finger
    --bundle                     The app bundle identifier
    --maxResults                 Limits the number of results returned from --list
    --version, -v                Prints version
    --help, -h                   Prints usage

Available Permissions:
    calendar=YES|NO|unset
    camera=YES|NO|unset
    contacts=YES|NO|unset
    health=YES|NO|unset
    homekit=YES|NO|unset
    location=always|inuse|never|unset
    medialibrary=YES|NO|unset
    microphone=YES|NO|unset
    motion=YES|NO|unset
    notifications=YES|NO|unset
    photos=YES|NO|unset
    reminders=YES|NO|unset
    siri=YES|NO|unset
    speech=YES|NO|unset


For more features, open an issue at https://github.com/wix/AppleSimulatorUtils
Pull-requests are always welcome!
```

after the change, there is no crash