### PR TITLE
correcting to install wix/brew/applesimutils, instead of applesimutil…

### DIFF
--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -237,7 +237,7 @@ class AppleSimUtils {
 
     } catch (ex) {
       throw new Error(`Could not parse response from applesimutils, please update applesimutils and try again.
-      'brew uninstall applesimutils && brew tap wix/brew && brew install applesimutils'`);
+      'brew uninstall applesimutils && brew tap wix/brew && brew install wix/brew/applesimutils'`);
     }
     return parsed;
   }

--- a/docs/Guide.RunningOnCI.md
+++ b/docs/Guide.RunningOnCI.md
@@ -69,7 +69,7 @@ env:
 
 install:
 - brew tap wix/brew
-- brew install applesimutils
+- brew install wix/brew/applesimutils
 - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
 - export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 - nvm install $NODE_VERSION
@@ -137,7 +137,7 @@ workflows:
             #!/bin/bash
 
             brew tap wix/brew
-            brew install applesimutils
+            brew install wix/brew/applesimutils
         title: Install Detox Utils
     - script:
         inputs:

--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -48,7 +48,7 @@ A collection of utils for Apple simulators, Detox uses it to communicate with th
 
 ```sh
 brew tap wix/brew
-brew install applesimutils
+brew install wix/brew/applesimutils
 ```
 
 > TIP: Verify it works by typing in terminal `applesimutils` to output the tool help screen

--- a/scripts/install.ios.sh
+++ b/scripts/install.ios.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-$(dirname "$0")/install.sh
+"$(dirname "$0")/install.sh"
 
 export CODE_SIGNING_REQUIRED=NO
 brew tap wix/brew
-brew install applesimutils --HEAD
+brew install wix/brew/applesimutils --HEAD


### PR DESCRIPTION
The documentation and scripts are incorrect as we are getting errors now trying to `brew install applesimutils` instead of `brew install wix/brew/applesimutils`



- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Changed documentation, and scripts in addition to a minor shellcheck error.
