### PR TITLE
Increase log-level for result of 'adb devices' command

### DIFF
--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -13,7 +13,7 @@ class ADB {
   }
 
   async devices() {
-    const output = (await this.adbCmd('', 'devices')).stdout;
+    const output = (await this.adbCmd('', 'devices', { verbosity: 'high' })).stdout;
     return this.parseAdbDevicesConsoleOutput(output);
   }
 

--- a/detox/src/devices/android/ADB.test.js
+++ b/detox/src/devices/android/ADB.test.js
@@ -1,4 +1,6 @@
 describe('ADB', () => {
+  const mockAndroidSDKPath = '/Android/sdk-mock';
+
   let ADB;
   let adb;
   let EmulatorTelnet;
@@ -7,7 +9,7 @@ describe('ADB', () => {
   beforeEach(() => {
     jest.mock('../../utils/logger');
     jest.mock('../../utils/environment', () => ({
-      getAndroidSDKPath: () => '/dev/null',
+      getAndroidSDKPath: () => mockAndroidSDKPath,
     }));
 
     jest.mock('./EmulatorTelnet');
@@ -27,6 +29,7 @@ describe('ADB', () => {
 
   it(`devices`, async () => {
     await adb.devices();
+    expect(exec).toHaveBeenCalledWith(`${mockAndroidSDKPath}/platform-tools/adb  devices`, { verbosity: 'high' }, undefined, 1);
     expect(exec).toHaveBeenCalledTimes(1);
   });
 

--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -219,7 +219,8 @@ class AppleSimUtils {
   }
 
   async _execSimctl({ cmd, statusLogs = {}, retries = 1, silent = false }) {
-    return await exec.execWithRetriesAndLogs(`/usr/bin/xcrun simctl ${cmd}`, { silent }, statusLogs, retries);
+    const verbosity = silent ? 'low' : 'normal';
+    return await exec.execWithRetriesAndLogs(`/usr/bin/xcrun simctl ${cmd}`, { verbosity }, statusLogs, retries);
   }
 
   _parseResponseFromAppleSimUtils(response) {

--- a/detox/src/utils/__snapshots__/exec.test.js.snap
+++ b/detox/src/utils/__snapshots__/exec.test.js.snap
@@ -26,13 +26,19 @@ Array [
 ]
 `;
 
-exports[`exec exec command and fail with timeout 1`] = `
+exports[`exec exec command and fail with error code, report only to debug log if verbosity is low 1`] = `
 Array [
+  Array [
+    Object {
+      "event": "EXEC_CMD",
+    },
+    "bin",
+  ],
   Array [
     Object {
       "event": "EXEC_FAIL",
     },
-    "\\"bin\\" failed with timeout = 1ms, stdout and stderr:
+    "\\"bin\\" failed with code = undefined, stdout and stderr:
 ",
   ],
   Array [
@@ -52,19 +58,13 @@ Array [
 ]
 `;
 
-exports[`exec exec command and silently fail with error code, report only to debug log 1`] = `
+exports[`exec exec command and fail with timeout 1`] = `
 Array [
-  Array [
-    Object {
-      "event": "EXEC_CMD",
-    },
-    "bin",
-  ],
   Array [
     Object {
       "event": "EXEC_FAIL",
     },
-    "\\"bin\\" failed with code = undefined, stdout and stderr:
+    "\\"bin\\" failed with timeout = 1ms, stdout and stderr:
 ",
   ],
   Array [


### PR DESCRIPTION
- [x] This is a small change 
- [x] This change has been discussed in issue #1427 and the solution has been agreed upon with maintainers.

---

**Description:**

Since we don't know what the root cause is for the sporadic failures of #1427, for now we'll have to settle on getting more info. With this PR, we'll `debug`-log the result of each `adb devices` instead of just `trace`-ing it. This will give us high visibility the next time this happens.