### PR TITLE
fix: conduct cleanup even if app has been already terminated

### DIFF
--- a/detox/src/client/Client.test.js
+++ b/detox/src/client/Client.test.js
@@ -110,6 +110,16 @@ describe('Client', () => {
     expect(client.ws.send).toHaveBeenCalledTimes(3);
   });
 
+  it(`cleanup() - if connected should accept testeeDisconnected action too`, async () => {
+    await connect();
+    client.ws.send.mockReturnValueOnce(response("ready", {}, 1));
+    await client.waitUntilReady();
+    client.ws.send.mockReturnValueOnce(response("testeeDisconnected", {}, 2));
+    await client.cleanup();
+
+    expect(client.ws.send).toHaveBeenCalledTimes(3);
+  });
+
   it(`cleanup() - if not connected should do nothing`, async () => {
     client = new Client(config);
     client.ws.send.mockReturnValueOnce(response("cleanupDone", {}, 1));

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -83,14 +83,14 @@ class ReloadReactNative extends Action {
 
 class Cleanup extends Action {
   constructor(stopRunner) {
-    const params = {
-      stopRunner: stopRunner
-    };
-    super('cleanup', params);
+    super('cleanup', { stopRunner });
+    this.messageId = -0xc1ea;
   }
 
   async handle(response) {
-    this.expectResponseOfType(response, 'cleanupDone');
+    if (response.type !== 'testeeDisconnected') {
+      this.expectResponseOfType('cleanupDone');
+    }
   }
 }
 

--- a/detox/src/server/DetoxServer.js
+++ b/detox/src/server/DetoxServer.js
@@ -49,6 +49,10 @@ class DetoxServer {
         if (sessionId && role) {
           this.log.debug({ event: 'DISCONNECT' }, `role=${role}, sessionId=${sessionId}`);
 
+          if (role === ROLE_TESTEE) {
+            this.sendToOtherRole(sessionId, role, { type: 'testeeDisconnected', messageId: -0xc1ea });
+          }
+
           if (this.standalone && role === ROLE_TESTER) {
             this.sendToOtherRole(sessionId, role, { type: 'testerDisconnected', messageId: -1 });
           }
@@ -70,6 +74,13 @@ class DetoxServer {
       this.sendAction(ws, action);
     } else {
       this.log.debug({ event: 'CANNOT_FORWARD' }, `role=${otherRole} not connected, cannot fw action (sessionId=${sessionId})`);
+
+      if (role === ROLE_TESTER && action.type === 'cleanup') {
+        this.sendToOtherRole(sessionId, otherRole, {
+          type: 'testeeDisconnected',
+          messageId: action.messageId,
+        });
+      }
     }
   }
 

--- a/detox/test/e2e/23.flows.test.js
+++ b/detox/test/e2e/23.flows.test.js
@@ -1,0 +1,6 @@
+describe('Flows', () => {
+  it('should exit without timeouts if app was terminated inside test', async () => {
+    await device.launchApp();
+    await device.terminateApp();
+  });
+});


### PR DESCRIPTION
- [x] This change has been discussed in issue #1460 and the solution has been agreed upon with maintainers.