### PR TITLE
fix(ws): explicit error handling

### DIFF
--- a/detox/src/server/DetoxServer.js
+++ b/detox/src/server/DetoxServer.js
@@ -45,6 +45,10 @@ class DetoxServer {
         }
       });
 
+      ws.on('error', (e) => {
+        this.log.warn({ event: 'WEBSOCKET_ERROR', role, sessionId }, `${e && e.message} (role=${role}, session=${sessionId})`);
+      });
+
       ws.on('close', () => {
         if (sessionId && role) {
           this.log.debug({ event: 'DISCONNECT' }, `role=${role}, sessionId=${sessionId}`);


### PR DESCRIPTION
Fixes the issue we began getting after bumping `ws` to `^3.3.1`.
 
- [x] This is a small change 

---

**Description:**

Private builds on TeamCity began failing with unhandled `read ECONNRESET` error in logs, and the domino effect led to failures in consequent tests.

To my great displeasure, I could not reproduce it consistently in Detox e2e suite, but the fix has been verified locally on the private build.

More details here: https://github.com/websockets/ws/issues/1256