### PR TITLE
(Android) Fix a unidentified non-visibility matching when using waitFor()

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxMatcher.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxMatcher.java
@@ -2,11 +2,8 @@ package com.wix.detox.espresso;
 
 import android.view.View;
 
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
-import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.espresso.matcher.ViewMatchers.Visibility;
 
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
@@ -15,8 +12,11 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.wix.detox.espresso.matcher.ViewMatchersKt.isMatchingAtIndex;
+import static com.wix.detox.espresso.matcher.ViewMatchersKt.isOfClassName;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
@@ -36,15 +36,15 @@ public class DetoxMatcher {
 
     public static Matcher<View> matcherForText(String text) {
         // return anyOf(withText(text), withContentDescription(text));
-        return allOf(withText(text), ViewMatchers.withEffectiveVisibility(Visibility.VISIBLE));
+        return allOf(withText(text), withEffectiveVisibility(Visibility.VISIBLE));
     }
 
     public static Matcher<View> matcherForContentDescription(String contentDescription) {
-        return allOf(withContentDescription(contentDescription), ViewMatchers.withEffectiveVisibility(Visibility.VISIBLE));
+        return allOf(withContentDescription(contentDescription), withEffectiveVisibility(Visibility.VISIBLE));
     }
 
     public static Matcher<View> matcherForTestId(String testId) {
-        return allOf(withTagValue(is((Object) testId)), ViewMatchers.withEffectiveVisibility(Visibility.VISIBLE));
+        return allOf(withTagValue(is((Object) testId)), withEffectiveVisibility(Visibility.VISIBLE));
     }
 
     public static Matcher<View> matcherForAnd(Matcher<View> m1, Matcher<View> m2) {
@@ -67,34 +67,16 @@ public class DetoxMatcher {
         return allOf(m, hasDescendant(descendantMatcher));
     }
 
-    public static Matcher<View> matcherForClass(final String className) {
-        try {
-            Class cls = Class.forName(className);
-            return allOf(isAssignableFrom(cls), ViewMatchers.withEffectiveVisibility(Visibility.VISIBLE));
-        } catch (ClassNotFoundException e) {
-            // empty
-        }
-        return new BaseMatcher<View>() {
-            @Override
-            public boolean matches(Object item) {
-                return false;
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("Class " + className + " not found on classpath. Are you using full class name?");
-            }
-        };
+    public static Matcher<View> matcherForClass(String className) {
+        return isOfClassName(className);
     }
 
     public static Matcher<View> matcherForSufficientlyVisible() {
         return isDisplayingAtLeast(75);
     }
 
-    // Special ViewAssertion is needed for GONE views
-    @Deprecated
     public static Matcher<View> matcherForNotVisible() {
-        return not(isDisplayed());
+        return anyOf(nullValue(), not(isDisplayed()));
     }
 
     public static Matcher<View> matcherForNotNull() {
@@ -106,27 +88,7 @@ public class DetoxMatcher {
     }
 
     public static Matcher<View> matcherForAtIndex(final int index, final Matcher<View> innerMatcher) {
-        return new BaseMatcher<View>() {
-            boolean foundMatch = false;
-            int count = 0;
-
-            @Override
-            public boolean matches(Object item) {
-                if (!innerMatcher.matches(item) || foundMatch) return false;
-
-                if (count == index) {                    
-                    foundMatch = true;
-                    return true;
-                }
-                ++count;
-                return false;
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("matches " + index + "th view.");
-            }
-        };
+        return isMatchingAtIndex(index, innerMatcher);
     }
 
     public static Matcher<View> matcherForAnything() {

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/assertion/ViewAssertions.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/assertion/ViewAssertions.java
@@ -1,0 +1,61 @@
+package com.wix.detox.espresso.assertion;
+
+import android.support.annotation.NonNull;
+import android.view.View;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.espresso.ViewAssertion;
+
+import static androidx.test.espresso.core.internal.deps.guava.base.Preconditions.checkNotNull;
+import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
+
+/**
+ * A custom extension of {@link androidx.test.espresso.assertion.ViewAssertions}.
+ *
+ * <p/>Perhaps in the future we could extend Espresso's using Kotlin's extension functions.
+ */
+public class ViewAssertions {
+
+    /**
+     * An alternative to Espresso's {@link androidx.test.espresso.assertion.ViewAssertions#matches(Matcher)},
+     * which is more suitable for Detox' separated interaction-matcher architecture.
+     * See {@link MatchesViewAssertion} for more details.
+     */
+    public static ViewAssertion matches(final Matcher<? super View> viewMatcher) {
+        return new MatchesViewAssertion(checkNotNull(viewMatcher));
+    }
+
+    /**
+     * Identical to Espresso's {@link androidx.test.espresso.assertion.ViewAssertions}#MatchesViewAssertion
+     * typically created by {@link androidx.test.espresso.assertion.ViewAssertions#matches(Matcher)}, except
+     * that instead of throwing the {@link NoMatchingViewException} (given to the matcher by the <b>interaction</b>
+     * when the view wasn't in the hierarchy), it invokes the matcher nonetheless (i.e. with a <i>null</i> as the item).
+     */
+    private static class MatchesViewAssertion implements ViewAssertion {
+        final Matcher<? super View> viewMatcher;
+
+        private MatchesViewAssertion(final Matcher<? super View> viewMatcher) {
+            this.viewMatcher = viewMatcher;
+        }
+
+        @Override
+        public void check(View view, NoMatchingViewException noViewException) {
+            StringDescription description = new StringDescription();
+            description.appendText("'");
+            viewMatcher.describeTo(description);
+
+            description.appendText("' doesn't match the selected view.");
+
+            assertThat(description.toString(), noViewException != null ? null : view, viewMatcher);
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return String.format("MatchesViewAssertion(Detox){viewMatcher=%s}", viewMatcher);
+        }
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/matcher/NullableTypeSafeMatcher.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/matcher/NullableTypeSafeMatcher.java
@@ -1,0 +1,61 @@
+package com.wix.detox.espresso.matcher;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.internal.ReflectiveTypeFinder;
+
+/**
+ * Identical to Espresso's {@link org.hamcrest.TypeSafeMatcher}, but allows nulls (in which case
+ * the "item" is passed-in into the sub-class nonetheless, as a null).
+ */
+public abstract class NullableTypeSafeMatcher<T> extends BaseMatcher<T> {
+    private static final ReflectiveTypeFinder TYPE_FINDER = new ReflectiveTypeFinder("matchesSafely", 1, 0);
+
+    final private Class<?> expectedType;
+
+    protected NullableTypeSafeMatcher() {
+        this(TYPE_FINDER);
+    }
+
+    protected NullableTypeSafeMatcher(Class<?> expectedType) {
+        this.expectedType = expectedType;
+    }
+
+    private NullableTypeSafeMatcher(ReflectiveTypeFinder typeFinder) {
+      this.expectedType = typeFinder.findExpectedType(getClass());
+    }
+
+    /**
+     * Subclasses should implement this. The item will already have been checked for
+     * the specific type and will never be null.
+     */
+    abstract boolean matchesSafely(T item);
+
+    /**
+     * Subclasses should override this. The item will already have been checked for
+     * the specific type and will never be null.
+     */
+    void describeMismatchSafely(T item, Description mismatchDescription) {
+        super.describeMismatch(item, mismatchDescription);
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public final boolean matches(Object item) {
+        return (item == null || expectedType.isInstance(item)) && matchesSafely((T) item);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    final public void describeMismatch(Object item, Description description) {
+        if (!expectedType.isInstance(item)) {
+            description.appendText("was a ")
+                       .appendText(item.getClass().getName())
+                       .appendText(" (")
+                       .appendValue(item)
+                       .appendText(")");
+        } else {
+            describeMismatchSafely((T) item, description);
+        }
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/matcher/ViewAtIndexMatcher.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/matcher/ViewAtIndexMatcher.kt
@@ -1,0 +1,26 @@
+package com.wix.detox.espresso.matcher
+
+import android.view.View
+import org.hamcrest.BaseMatcher
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+
+class ViewAtIndexMatcher(private val index: Int, private val innerMatcher: Matcher<View>) : BaseMatcher<View>() {
+    private var foundMatch = false
+    private var count = 0
+
+    override fun matches(item: Any): Boolean {
+        if (!innerMatcher.matches(item) || foundMatch) return false
+
+        if (count == index) {
+            foundMatch = true
+            return true
+        }
+        ++count
+        return false
+    }
+
+    override fun describeTo(description: Description) {
+        description.appendText("matches " + index + "th view.")
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/matcher/ViewMatchers.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/matcher/ViewMatchers.kt
@@ -1,0 +1,35 @@
+package com.wix.detox.espresso.matcher
+
+import android.view.View
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.*
+import org.hamcrest.BaseMatcher
+import org.hamcrest.Description
+
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers.*
+
+/*
+ * An extension of [androidx.test.espresso.matcher.ViewMatchers].
+ */
+
+fun isOfClassName(className: String): Matcher<View> {
+    try {
+        val cls = Class.forName(className)
+        return allOf(isAssignableFrom(cls as Class<out View>?), withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))
+    } catch (e: ClassNotFoundException) {
+        // empty
+    }
+
+    return object : BaseMatcher<View>() {
+        override fun matches(item: Any): Boolean {
+            return false
+        }
+
+        override fun describeTo(description: Description) {
+            description.appendText("Class $className not found on classpath. Are you using full class name?")
+        }
+    }
+}
+
+fun isMatchingAtIndex(index: Int, innerMatcher: Matcher<View>): Matcher<View> = ViewAtIndexMatcher(index, innerMatcher)

--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -146,24 +146,23 @@ class MatcherAssertionInteraction extends Interaction {
 }
 
 class WaitForInteraction extends Interaction {
-  constructor(invocationManager, element, matcher) {
+  constructor(invocationManager, element, assertionMatcher) {
     super(invocationManager);
     this._element = element;
-    this._originalMatcher = matcher;
-    // we need to override the original matcher for the element and add matcher to it as well
-    this._element._selectElementWithMatcher(this._element._originalMatcher.and(this._originalMatcher));
+    this._assertionMatcher = assertionMatcher;
+    this._element._selectElementWithMatcher(this._element._originalMatcher);
   }
 
   async withTimeout(timeout) {
     if (typeof timeout !== 'number') throw new Error(`WaitForInteraction withTimeout argument must be a number, got ${typeof timeout}`);
     if (timeout < 0) throw new Error('timeout must be larger than 0');
 
-    this._call = DetoxAssertionApi.waitForAssertMatcher(call(this._element._call), this._originalMatcher._call.value, timeout / 1000);
+    this._call = DetoxAssertionApi.waitForAssertMatcher(call(this._element._call), this._assertionMatcher._call.value, timeout / 1000);
     await this.execute();
   }
 
   whileElement(searchMatcher) {
-    return new WaitForActionInteraction(this._invocationManager, this._element, this._originalMatcher, searchMatcher);
+    return new WaitForActionInteraction(this._invocationManager, this._element, this._assertionMatcher, searchMatcher);
   }
 }
 

--- a/detox/test/e2e/05.waitfor.test.js
+++ b/detox/test/e2e/05.waitfor.test.js
@@ -15,9 +15,19 @@ describe('WaitFor', () => {
   });
 
   it('should wait until an element is removed', async () => {
+    const timeout = 20000;
+
     await expect(element(by.id('deletedFromHierarchyText'))).toBeVisible();
     await element(by.id('GoButton')).tap();
-    await waitFor(element(by.id('deletedFromHierarchyText'))).toBeNotVisible().withTimeout(20000);
+
+    const startTime = new Date().getTime();
+    await waitFor(element(by.id('deletedFromHierarchyText'))).toBeNotVisible().withTimeout(timeout);
+    const endTime = new Date().getTime();
+
+    if (endTime - startTime > timeout) {
+      throw new Error(`Action not expired even after a timeout`);
+    }
+
     await expect(element(by.id('deletedFromHierarchyText'))).toBeNotVisible();
   });
 


### PR DESCRIPTION
- [ ] This is a small change 
- [x] This change has been discussed in issue #1463  and the solution has been agreed upon with maintainers.

---

# Description

Bottom line is - this fixes #1463. Effectively, however, in order to do so, it introduces an essential (mini) overhaul in the way view matching works on Android.

### Overhaul details

A typical (native) Espresso matching test-code looks like this:

```java
onView(withId(R.id.viewId)).check(matches(isDisplayed()))
```
Or to be on the accurate side, since in Detox we don't use native ID's - but testID's, the code should actually like this:
```java
onView(matcherForTestId('someJSElement')).check(matches(isDisplayed())
```
But when trying to compose an equivalent assertion to represent the `waitFor` API (e.g. `waitFor(element(...)).toBeVisible().withTimeout()`), what we accidentally had created, was this:

```java
onView(allOf(matcherForTestId('someJSElement'), isDisplayed())).check(matches(isDisplayed())
```

This is bad, because:
a. `isDisplayed()` is duplicated, unnecessarily.
b. According to [Espresso's basic guide](https://developer.android.com/training/testing/espresso/basics#checking-view-assertions), this is considered bad practice.
c. Most importantly, in the [e2e case](https://github.com/wix/Detox/blob/c5c8a519d36356bacdaafdc2aca3cfcb50e4d85c/detox/test/e2e/05.waitfor.test.js#L17) described by the associated issue (i.e. #1463), this implementation eventually prevents us from breaking the `waitFor()` loop (on the native side) when the view is indeed gone, as we should. Why? because even when the view _is_ gone, the preliminary matcher (to `onView()`) doesn't find an element, nonetheless (!!!), and thus errors keep on being repeatedly thrown (in the [assertion loop](https://github.com/wix/Detox/blob/3ffaaae84e1b6e26c05ebd24934e100ff913841d/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxAssertion.java#L65)) - just like _before_ the view was gone. In other words, the lookup-matcher and assertion-matcher cannot be distinguished, and so the two states (before and after the view is gone) cannot be differentiated.

### Fix

The general idea is to adhere to Espresso's recommendation and separate lookup matchers (e.g. `matcherForTestId()`) from assertion matchers (e.g. visibility, `withText`).

This falls into a few major change blocks:
a. Change on JS-side (`expect.js`):  omitted the _assertion_ matcher from the final one passed in to `onView()`.
b. Introduced an alternative implementation of Espresso's `matches()` -- that _allows_ for nulls to pass on through to matchers (i.e. invokes the matcher even when the view doesn't exist).
c. Introduced an alternative implementation of the not-visible matcher, which short-circuits to true when the view is null.