### PR TITLE
proposal to PR adbdevices inspection logs

### DIFF
--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -5,6 +5,7 @@ const {escape} = require('../../utils/pipeCommands');
 const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
 const EmulatorTelnet = require('./EmulatorTelnet');
 const Environment = require('../../utils/environment');
+const {encodeBase64} = require('../../utils/encoding');
 
 class ADB {
   constructor() {
@@ -67,7 +68,7 @@ class ADB {
       if (this.isEmulator(deviceAdbName)) {
         const port = _.split(deviceAdbName, '-')[1];
         if (!port) {
-          _reportTelnetPortResolutionError(input, devicesList, deviceAdbName, port);
+          _reportTelnetPortResolutionError(input, deviceAdbName);
         }
 
         const telnet = new EmulatorTelnet();
@@ -287,17 +288,17 @@ class ADB {
   }
 }
 
-function _reportTelnetPortResolutionError(input, devicesList, deviceAdbName, port) {
-  const log = require('../../utils/logger').child({ __filename });
-  const {encodeBase64} = require('../../utils/encoding');
-  log.error({event: 'DEVICE_NAME_ERROR'}, `Failed to determine port for emulator device '${deviceAdbName}!!!`);
-  log.error({event: 'DEVICE_NAME_ERROR'}, `Please help us out by reporting all DEVICE_NAME_ERROR logs in: https://github.com/wix/Detox/issues/1427`);
-  log.error({event: 'DEVICE_NAME_ERROR'}, `State dump ==>`);
-  log.error({event: 'DEVICE_NAME_ERROR'}, `adb devices: ${input}`);
-  log.error({event: 'DEVICE_NAME_ERROR'}, `adb devices (base64): '${encodeBase64(input)}'`);
-  log.error({event: 'DEVICE_NAME_ERROR'}, `devicesList: ${devicesList}`);
-  log.error({event: 'DEVICE_NAME_ERROR'}, `port: ${port}`);
-  throw new Error(`Unable to determine port for emulator device '${deviceAdbName}'!`);
+function _reportTelnetPortResolutionError(input, deviceAdbName) {
+  const errorMessage = [
+    `Failed to determine port for emulator device "${deviceAdbName}"`,
+    `Please help us out by reporting dump below in: https://github.com/wix/Detox/issues/1427`,
+    `The dump below just contains base64-encoded output of "adb devices"`,
+    `------BEGIN DUMP------`,
+    encodeBase64(input),
+    `------END DUMP------`,
+  ].join('\n');
+
+  throw new Error(errorMessage);
 }
 
 module.exports = ADB;

--- a/detox/src/devices/android/ADB.test.js
+++ b/detox/src/devices/android/ADB.test.js
@@ -65,7 +65,7 @@ describe('ADB', () => {
         fail('Expected an error');
       } catch (error) {
         expect(mockEmulatorTelnet.connect).not.toHaveBeenCalled();
-        expect(error.message).toEqual(`Unable to determine port for emulator device 'emulator-'!`);
+        expect(error.message).toMatchSnapshot();
       }
     });
 

--- a/detox/src/devices/android/__snapshots__/ADB.test.js.snap
+++ b/detox/src/devices/android/__snapshots__/ADB.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ADB devices should abort if port can't be parsed 1`] = `
+"Failed to determine port for emulator device \\"emulator-\\"
+Please help us out by reporting dump below in: https://github.com/wix/Detox/issues/1427
+The dump below just contains base64-encoded output of \\"adb devices\\"
+------BEGIN DUMP------
+TGlzdCBvZiBkZXZpY2VzIGF0dGFjaGVkCmVtdWxhdG9yLQlkZXZpY2UK
+------END DUMP------"
+`;


### PR DESCRIPTION
@d4vidi, I think that it is safer just to format an error and throw it. 
![Screenshot from 2019-06-25 10-34-47](https://user-images.githubusercontent.com/1962469/60079396-852f2b80-9736-11e9-8328-ea343b1bab24.png)

Then there are fewer chances that users will skip the message - they will see it two times - at the end of the mocha/jest test run, and inside logs.

Also, I don't see any sense to include so much extraneous info, as currently in the PR.
Let's look together. This logic looks absolutely deterministic:

```js
  async parseAdbDevicesConsoleOutput(input) {
    const outputToList = input.trim().split('\n'); // string functions
    const devicesList = _.takeRight(outputToList, outputToList.length - 1); // lodash collection functions
    const devices = []; // array init
    for (const deviceString of devicesList) { // iterator for-of
      const deviceParams = deviceString.split('\t'); // string function
      const deviceAdbName = deviceParams[0]; // array index
      let device;
      if (this.isEmulator(deviceAdbName)) { // only uses .includes() built-in function
        const port = _.split(deviceAdbName, '-')[1]; // string function, array index
        if (!port) {
          _reportTelnetPortResolutionError(input, deviceAdbName);
        }
```

So, base64 encoded string should absolutely suffice.
