### PR TITLE
(Android) Fix issue with taps being ignored if made right after scrolling

### DIFF
--- a/detox/test/e2e/03.scroll-actions.test.js
+++ b/detox/test/e2e/03.scroll-actions.test.js
@@ -1,0 +1,19 @@
+const {scrollViewDriver} = require('./drivers/fs-scroll-driver');
+
+describe('Fullscreen actions', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+    await element(by.text('Scroll-Actions')).tap();
+  });
+
+  /**
+   * This use case refers to this issue: https://github.com/wix/Detox/issues/1485
+   */
+  it(':android: Scrolling & tapping', async () => {
+    const expectedAlertText = `Alert(Item #${scrollViewDriver.secondPageItemIndex()})`;
+
+    await waitFor(scrollViewDriver.secondPageItem()).toBeVisible().whileElement(scrollViewDriver.byId()).scroll(100, 'down');
+    await scrollViewDriver.secondPageItem().tap();
+    await expect(element(by.text(expectedAlertText))).toBeVisible();
+  });
+});

--- a/detox/test/e2e/03.visibility-workaround-actions.test.js
+++ b/detox/test/e2e/03.visibility-workaround-actions.test.js
@@ -1,14 +1,14 @@
+const {scrollViewDriver} = require('./drivers/fs-scroll-driver');
+const {expectToThrow} = require('./utils/custom-expects');
+
 /**
  * A mini suite providing an alternative to tests failing due to issues found in RN 58+ on Android (see
  * https://github.com/facebook/react-native/issues/23870).
  * It basically runs similar use cases -- all of which involve visibility and scrolling, but in a
- * setup where they _can_ pass, so as to assert that the core Detox functionality (waitFor(), scroll())
+ * setup where they <i>can</i> pass, so as to assert that the core Detox functionality (waitFor(), scroll())
  * is valid nevertheless.
  */
-
-const {expectToThrow} = require('./utils/custom-expects');
-
-describe('Fullscreen scroll-view', () => {
+describe('Visibility-bug workaround', () => {
   beforeEach(async () => {
     await device.reloadReactNative();
     await element(by.text('Scroll-Actions')).tap();
@@ -23,6 +23,7 @@ describe('Fullscreen scroll-view', () => {
       await scrollViewDriver.scrollBy(60);
       await expect(scrollViewDriver.firstItem()).toBeNotVisible();
       await expect(scrollViewDriver.secondItem()).toBeVisible();
+
       await scrollViewDriver.scrollBy(-60);
       await expect(scrollViewDriver.firstItem()).toBeVisible();
       await expect(scrollViewDriver.lastItem()).toBeNotVisible();
@@ -55,14 +56,3 @@ describe('Fullscreen scroll-view', () => {
     });
   });
 });
-
-const scrollViewDriver = {
-  byId: () => by.id('FSScrollActions.scrollView'),
-  element: () => element(scrollViewDriver.byId()),
-  listItem: (index) => element(by.text(`Text${index}`)),
-  firstItem: () => scrollViewDriver.listItem(1),
-  secondItem: () => scrollViewDriver.listItem(2),
-  lastItem: () => scrollViewDriver.listItem(20),
-  fakeItem: () => scrollViewDriver.listItem(1000),
-  scrollBy: (amount) => scrollViewDriver.element().scroll(Math.abs(amount), (amount > 0 ? 'down' : 'up')),
-};

--- a/detox/test/e2e/drivers/fs-scroll-driver.js
+++ b/detox/test/e2e/drivers/fs-scroll-driver.js
@@ -1,0 +1,16 @@
+const scrollViewDriver = {
+  byId: () => by.id('FSScrollActions.scrollView'),
+  element: () => element(scrollViewDriver.byId()),
+  listItem: (index) => element(by.text(`Text${index}`)),
+  firstItem: () => scrollViewDriver.listItem(1),
+  secondItem: () => scrollViewDriver.listItem(2),
+  secondPageItemIndex: () => 16,
+  secondPageItem: () => scrollViewDriver.listItem(scrollViewDriver.secondPageItemIndex()),
+  lastItem: () => scrollViewDriver.listItem(20),
+  fakeItem: () => scrollViewDriver.listItem(1000),
+  scrollBy: (amount) => scrollViewDriver.element().scroll(Math.abs(amount), (amount > 0 ? 'down' : 'up')),
+};
+
+module.exports = {
+  scrollViewDriver
+};

--- a/detox/test/src/Screens/ScrollActionsScreen.js
+++ b/detox/test/src/Screens/ScrollActionsScreen.js
@@ -3,6 +3,8 @@ import {
   Text,
   View,
   ScrollView,
+  TouchableOpacity,
+  Alert,
 } from 'react-native';
 
 export default class ScrollActionsScreen extends Component {
@@ -20,6 +22,11 @@ export default class ScrollActionsScreen extends Component {
   }
 
   renderItem(id) {
-    return <Text key={`listItem.${id}`} style={{ height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 }}>{`Text${id}`}</Text>;
+    const key = `listItem.${id}`;
+    return (
+      <TouchableOpacity key={key} testID={key} onPress={() => Alert.alert('Alert', `Alert(Item #${id})`)}>
+        <Text style={{ height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 }}>{`Text${id}`}</Text>
+      </TouchableOpacity>
+    );
   }
 }


### PR DESCRIPTION
- [x] This is a small change 
- [x] This change has been discussed in issue #1485 and the solution has been agreed upon with maintainers.

---

**Description:**

Fix #1485. The core here is to wait until all scroll-view children leave the on-press state, which becomes in-effect since, presumably, the parent scroll-view is pressed-on and it propagates it to the children (see `ViewGroup`'s impl of `dispatchSetPressed()`). This adds up to 3 lines, really.

The fix was taken from Espresso's original implementation -- much like Detox's entire implementation of scrolling, except that is was probably "lost in translation" beforehand.