### PR TITLE
Allow valid Android AVDs to run (#1157)

### DIFF
--- a/detox/src/devices/drivers/EmulatorDriver.js
+++ b/detox/src/devices/drivers/EmulatorDriver.js
@@ -18,24 +18,6 @@ class EmulatorDriver extends AndroidDriver {
     this.emulator = new Emulator();
   }
 
-  async _fixEmulatorConfigIniSkinName(name) {
-    const configFile = `${os.homedir()}/.android/avd/${name}.avd/config.ini`;
-    const config = ini.parse(fs.readFileSync(configFile, 'utf-8'));
-
-    if (!config['skin.name']) {
-      const width = config['hw.lcd.width'];
-      const height = config['hw.lcd.height'];
-
-      if (width === undefined || height === undefined) {
-        throw new Error(`Emulator with name ${name} has a corrupt config.ini file (${configFile}), try fixing it by recreating an emulator.`);
-      }
-
-      config['skin.name'] = `${width}x${height}`;
-      fs.writeFileSync(configFile, ini.stringify(config));
-    }
-    return config;
-  }
-
   async boot(avdName) {
     let adbName = await this._findADBNameByAVDName(avdName, { strict: false });
     const coldBoot = adbName == null;
@@ -87,8 +69,6 @@ class EmulatorDriver extends AndroidDriver {
       throw new Error(`Can not boot Android Emulator with the name: '${avdName}',
       make sure you choose one of the available emulators: ${avds.toString()}`);
     }
-
-    await this._fixEmulatorConfigIniSkinName(avdName);
 
     const adbName = await this.boot(avdName);
     await this.adb.apiLevel(adbName);


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
This is a proposal to fix https://github.com/wix/Detox/issues/1157 (I sent a PR instead of commenting on the issue as it is locked).

- `git blame` shows that the problematic code dates back to https://github.com/wix/Detox/commit/419d356506f0c1751072b8c44bfc663bece4a856
- `skin.name` (or even `skin`) does not appear anywhere else in the `detox` code base (as of tag `13.0.2`)
- the added `skin.name` in `config.ini` does not seem required, as emulators created and launched by the latest android SDK function well without this added line.
- detox works well on my app with this patch applied, although I've not been able to run the e2e part of the test suite (JS tests were fine)

I hope it's ok to propose this PR before having discussed it in the issues. If not, please reopen #1157 :)