### PR TITLE
Add option to keep simulator lock file to cli

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -134,7 +134,7 @@ module.exports.builder = {
   },
   keepLockFile:{
     group: 'Configuration:',
-    describe:'Keep Simulators lock file when running detox test'
+    describe:'Keep the device lock file when running Detox tests'
   },
   n: {
     alias: 'device-name',

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -126,11 +126,11 @@ module.exports.builder = {
   H: {
     alias: 'headless',
     group: 'Execution:',
-    describe: '[Android Only] Launch Emulator in headless mode. Useful when running on CI.'
+    describe: '[Android Only] Launch emulator in headless mode. Useful when running on CI.'
   },
   gpu: {
     group: 'Execution:',
-    describe: '[Android Only] Launch Emulator with the specific -gpu [gpu mode] parameter.'
+    describe: '[Android Only] Launch emulator with the specific -gpu [gpu mode] parameter.'
   },
   keepLockFile:{
     group: 'Configuration:',

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -148,7 +148,7 @@ const collectExtraArgs = require('./utils/collectExtraArgs')(module.exports.buil
 module.exports.handler = async function test(program) {
   program.artifactsLocation = buildDefaultArtifactsRootDirpath(program.configuration, program.artifactsLocation);
   
-  if(program.keepsimlock){
+  if(!program.keepsimlock){
     clearDeviceRegistryLockFile();
   }
 

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -134,7 +134,7 @@ module.exports.builder = {
   },
   keepLockFile:{
     group: 'Configuration:',
-    describe:'keep simulators lock file when running detox test'
+    describe:'Keep Simulators lock file when running detox test'
   },
   n: {
     alias: 'device-name',

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -132,9 +132,9 @@ module.exports.builder = {
     group: 'Execution:',
     describe: '[Android Only] Launch Emulator with the specific -gpu [gpu mode] parameter.'
   },
-  keepsimlock:{
+  keepLockFile:{
     group: 'Configuration:',
-    describe:'keep simulator lock file when running detox test'
+    describe:'keep simulators lock file when running detox test'
   },
   n: {
     alias: 'device-name',
@@ -148,7 +148,7 @@ const collectExtraArgs = require('./utils/collectExtraArgs')(module.exports.buil
 module.exports.handler = async function test(program) {
   program.artifactsLocation = buildDefaultArtifactsRootDirpath(program.configuration, program.artifactsLocation);
   
-  if(!program.keepsimlock){
+  if(!program.keepLockFile){
     clearDeviceRegistryLockFile();
   }
 

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -132,6 +132,10 @@ module.exports.builder = {
     group: 'Execution:',
     describe: '[Android Only] Launch Emulator with the specific -gpu [gpu mode] parameter.'
   },
+  keepsimlock:{
+    group: 'Configuration:',
+    describe:'keep simulator lock file when running detox test'
+  },
   n: {
     alias: 'device-name',
     group: 'Configuration:',
@@ -143,8 +147,10 @@ const collectExtraArgs = require('./utils/collectExtraArgs')(module.exports.buil
 
 module.exports.handler = async function test(program) {
   program.artifactsLocation = buildDefaultArtifactsRootDirpath(program.configuration, program.artifactsLocation);
-
-  clearDeviceRegistryLockFile();
+  
+  if(program.keepsimlock){
+    clearDeviceRegistryLockFile();
+  }
 
   const config = getDetoxSection();
 

--- a/docs/Guide.ParallelTestExecution.md
+++ b/docs/Guide.ParallelTestExecution.md
@@ -3,31 +3,34 @@ Detox can leverage multi worker support of JS test runners ([Jest](http://jestjs
 
 By default `detox test` will run the test runner with one worker (it will pass `--maxWorkers=1` to Jest cli, Mocha is unaffected). Worker count can be controlled by adding `--workers n` to `detox test`, read more in [detox-cli section](APIRef.DetoxCLI.md#test).
 
-#### Lock file
+## Device Creation
+While running with multiple workers, Detox might not have an available simulator for every worker.
+If no simulator is available for that worker, the worker will create one with the name `{name}-Detox`.
+
+## Lock File
 Simulators/emulators run on a different process, outside of node, and require some sort of lock mechanism to make sure only one process controlls a simulator in a given time. Therefore, Detox 7.4.0 introduced `device.registry.state.lock`, a lock file controlled by Detox, that registers all in-use simulators.
+
+> **Note:** Each worker is responsible of removing the deviceId from the list in `device.registry.state.lock`. Exiting a test runner abruptly (using ctrl+c / ⌘+c) will not give the worker a chance to deregister the device from the lock file, resulting in an inconsistent state, which can result in creation of unnecessary new simulators. 
+>
+>* detox-cli makes sure `device.registry.state.lock` is cleaned whenever it executes.
+>* If you use Detox without detox-cli make sure you delete or reset the lock file before running tests.
+>
+>	```sh
+>	echo "[]" > ~/Library/Detox/device.registry.state.lock
+>	```
+>
 
 The lock file location is determined by the OS, and [defined here](https://github.com/wix/detox/blob/master/detox/src/utils/appdatapath.js).
 
-##### MacOS
+#### MacOS
 `~/Library/Detox/device.registry.state.lock`
-##### Linux
+#### Linux
 `~/.local/share/Detox/device.registry.state.lock`
-##### Windows
+#### Windows
 `$LOCALAPPDATA/data/Detox/device.registry.state.lock`
 or
 `$USERPROFILE/Application Data/Detox/device.registry.state.lock`
 
-#### Device creation
-While running with multiple workers, Detox might not have an available simulator for every worker.
-If no simulator is available for that worker, the worker will create one with the name `{name}-Detox`.
+#### Persisting the Lock File
 
-### IMPORTANT NOTE
-Each worker is responsible of removing the deviceId from the list in `device.registry.state.lock`. Exiting a test runner abruptly (using ctrl+c / ⌘+c) will not give the worker a chance to deregister the device from the lock file, resulting in an inconsistent state, which ca result in creation of unnecessary new simulators. 
-
-* detox-cli makes sure `device.registry.state.lock` is cleaned whenever it executes.
-* If you use Detox without detox-cli make sure you delete or reset the lock file before running tests.
-
-	```sh
-	echo "[]" > ~/Library/Detox/device.registry.state.lock
-	```
-
+By default, once all workers finish their test runs, Detox will delete the lock file. Under certain conditions, you may want to persist the lock file. Use the `--keepLockFile` flag to disable automatic deletion.

--- a/docs/Guide.ParallelTestExecution.md
+++ b/docs/Guide.ParallelTestExecution.md
@@ -31,6 +31,6 @@ The lock file location is determined by the OS, and [defined here](https://githu
 or
 `$USERPROFILE/Application Data/Detox/device.registry.state.lock`
 
-#### Persisting the Lock File
+### Persisting the Lock File
 
 By default, once all workers finish their test runs, Detox will delete the lock file. Under certain conditions, you may want to persist the lock file. Use the `--keepLockFile` flag to disable automatic deletion.


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
when running detox test, the devices lock file is removed, detox test -keepsimlock will not delete the lock file.
it will be manually managed.