### PR TITLE
Call userNotificationCenter:willPresentNotification:withCompletionHandler: as part of user notification sending to active apps

### DIFF
--- a/detox/ios/Detox.xcodeproj/project.pbxproj
+++ b/detox/ios/Detox.xcodeproj/project.pbxproj
@@ -571,10 +571,9 @@
 			};
 			buildConfigurationList = 394767911DBF985400D72256 /* Build configuration list for PBXProject "Detox" */;
 			compatibilityVersion = "Xcode 10.0";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 			);
 			mainGroup = 3947678D1DBF985400D72256;
@@ -795,6 +794,11 @@
 			baseConfigurationReference = 390D1C981E3A2893007F5F46 /* Detox.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					arm64,
+					arm64e,
+					x86_64,
+				);
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -849,7 +853,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "arm64 arm64e";
+				VALID_ARCHS = "arm64 arm64e x86_64";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -860,6 +864,11 @@
 			baseConfigurationReference = 390D1C981E3A2893007F5F46 /* Detox.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					arm64,
+					arm64e,
+					x86_64,
+				);
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -910,7 +919,7 @@
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "arm64 arm64e";
+				VALID_ARCHS = "arm64 arm64e x86_64";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/detox/ios/Detox/DetoxAppDelegateProxy.m
+++ b/detox/ios/Detox/DetoxAppDelegateProxy.m
@@ -314,7 +314,7 @@ static void __copyMethods(Class orig, Class target)
 	return rv;
 }
 
-- (void)applicationWillEnterForeground:(UIApplication *)application
+- (void)applicationDidBecomeActive:(UIApplication *)application
 {
 	if([class_getSuperclass(object_getClass(self)) instancesRespondToSelector:_cmd])
 	{
@@ -323,24 +323,22 @@ static void __copyMethods(Class orig, Class target)
 		super_class(&super, _cmd, application);
 	}
 	
-	dispatch_async(dispatch_get_main_queue(), ^{
-		[_pendingOpenURLs enumerateObjectsUsingBlock:^(NSDictionary * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-			[self __dtx_actualDispatchOpenURL:obj];
-		}];
-		[_pendingOpenURLs removeAllObjects];
-		
-		[_pendingUserNotificationDispatchers enumerateObjectsUsingBlock:^(DetoxUserNotificationDispatcher * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-			[self __dtx_actualDispatchUserNotificationWithDispatcher:obj];
-		}];
-		[_pendingUserNotificationDispatchers removeAllObjects];
-		
+	[_pendingOpenURLs enumerateObjectsUsingBlock:^(NSDictionary * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+		[self __dtx_actualDispatchOpenURL:obj];
+	}];
+	[_pendingOpenURLs removeAllObjects];
+	
+	[_pendingUserNotificationDispatchers enumerateObjectsUsingBlock:^(DetoxUserNotificationDispatcher * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+		[self __dtx_actualDispatchUserNotificationWithDispatcher:obj];
+	}];
+	[_pendingUserNotificationDispatchers removeAllObjects];
+	
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_10_3
-		[_pendingUserActivityDispatchers enumerateObjectsUsingBlock:^(DetoxUserActivityDispatcher * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-			[self __dtx_actualDispatchUserActivityWithDispatcher:obj];
-		}];
-		[_pendingUserActivityDispatchers removeAllObjects];
+	[_pendingUserActivityDispatchers enumerateObjectsUsingBlock:^(DetoxUserActivityDispatcher * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+		[self __dtx_actualDispatchUserActivityWithDispatcher:obj];
+	}];
+	[_pendingUserActivityDispatchers removeAllObjects];
 #endif
-	});
 }
 
 - (BOOL)touchVisualizerWindowShouldAlwaysShowFingertip:(COSTouchVisualizerWindow *)window

--- a/detox/ios/DetoxUserNotificationTests/TestableAppDelegate.swift
+++ b/detox/ios/DetoxUserNotificationTests/TestableAppDelegate.swift
@@ -66,8 +66,8 @@ class TestableAppDelegate: NSObject, UIApplicationDelegate {
 
 @available(iOS 10.0, *)
 extension TestableAppDelegate {
-	class func triggerType(from response: UNNotificationResponse) -> TestableAppDelegateNotifcationTriggerType {
-		switch response.notification.request.trigger {
+	class func triggerType(from notification: UNNotification) -> TestableAppDelegateNotifcationTriggerType {
+		switch notification.request.trigger {
 		case is UNPushNotificationTrigger:
 			return .push
 		case is UNTimeIntervalNotificationTrigger:

--- a/detox/ios/DetoxUserNotificationTests/UNApiAppDelegate.swift
+++ b/detox/ios/DetoxUserNotificationTests/UNApiAppDelegate.swift
@@ -11,15 +11,35 @@ import UserNotifications
 
 @available(iOS 10.0, *)
 class UNApiAppDelegate: LegacyApiAppDelegate, UNUserNotificationCenterDelegate {
+	var userNotificationWillPresentWasCalled = false
+	var userNotificationdidReceiveWasCalled = false
+	var swallowActiveUserNotification = false
+	
 	override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]?) -> Bool {
 		UNUserNotificationCenter.current().delegate = self
 		
 		return super.application(application, didFinishLaunchingWithOptions: launchOptions)
 	}
 	
-	func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Swift.Void) {
+	private func markUNApiCalled(notification: UNNotification) {
 		userNotificationAPIWasCalled = true
-		userNotificationTriggerType = TestableAppDelegate.triggerType(from: response)
-		userNotificationTitle = response.notification.request.content.title
+		userNotificationTriggerType = TestableAppDelegate.triggerType(from: notification)
+		userNotificationTitle = notification.request.content.title
+	}
+	
+	func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+		userNotificationWillPresentWasCalled = true
+		markUNApiCalled(notification: notification)
+		
+		if swallowActiveUserNotification {
+			completionHandler([])
+		} else {
+			completionHandler([.alert, .badge, .sound])
+		}
+	}
+	
+	func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Swift.Void) {
+		userNotificationdidReceiveWasCalled = true
+		markUNApiCalled(notification: response.notification)
 	}
 }

--- a/detox/test/ios/example.xcodeproj/xcshareddata/xcschemes/example.xcscheme
+++ b/detox/test/ios/example.xcodeproj/xcshareddata/xcschemes/example.xcscheme
@@ -84,7 +84,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-detoxUserNotificationDataURL /Users/lnatan/Desktop/user_notification.json"
+            argument = "-detoxUserNotificationDataURL /Users/lnatan/Desktop/Code/Detox/detox/ios/DetoxUserNotificationTests/user_notification_push_trigger.json"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument

--- a/detox/test/ios/example.xcodeproj/xcshareddata/xcschemes/example.xcscheme
+++ b/detox/test/ios/example.xcodeproj/xcshareddata/xcschemes/example.xcscheme
@@ -99,6 +99,10 @@
             argument = "-detoxPrintBusyIdleResources YES"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-detoxUserActivityDataURL /Users/lnatan/Desktop/user-activity.json"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction

--- a/detox/test/ios/example/AppDelegate.m
+++ b/detox/test/ios/example/AppDelegate.m
@@ -2,7 +2,6 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTRootView.h>
-#import <React/RCTPushNotificationManager.h>
 #import <React/RCTLinkingManager.h>
 @import CoreSpotlight;
 
@@ -149,10 +148,14 @@ RCT_EXPORT_MODULE();
 	jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
 	
+	//RN 🤦‍♂️
+	NSMutableDictionary* opts = launchOptions.mutableCopy;
+	opts[UIApplicationLaunchOptionsRemoteNotificationKey] = nil;
+	
 	RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
 														moduleName:@"example"
 												 initialProperties:nil
-													 launchOptions:launchOptions];
+													 launchOptions:opts];
 	rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 	
 	self.window = [[AnnoyingWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
@@ -210,11 +213,6 @@ RCT_EXPORT_MODULE();
 		[someLabel.centerXAnchor constraintEqualToAnchor:self.window.centerXAnchor],
 		[someLabel.topAnchor constraintEqualToAnchor:self.window.annoyingLabel.bottomAnchor],
 	]];
-}
-
-- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
-{
-	[RCTPushNotificationManager didReceiveLocalNotification:notification];
 }
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void(^)(NSArray<id<UIUserActivityRestoring>> * __nullable restorableObjects))restorationHandler

--- a/detox/test/ios/example/AppDelegate.m
+++ b/detox/test/ios/example/AppDelegate.m
@@ -24,8 +24,27 @@ extern void __dtx_send_external_log(const char* log) __attribute__((weak));
 	if(self)
 	{
 		_annoyingLabel = [UILabel new];
+		_annoyingLabel.translatesAutoresizingMaskIntoConstraints = NO;
 		
 		[self addSubview:_annoyingLabel];
+		
+		NSLayoutYAxisAnchor* topAnchor;
+		if (@available(iOS 11.0, *))
+		{
+			topAnchor = self.safeAreaLayoutGuide.topAnchor;
+		}
+		else
+		{
+			topAnchor = self.topAnchor;
+		}
+		
+		NSLayoutConstraint* topConstraint = [_annoyingLabel.topAnchor constraintEqualToAnchor:topAnchor constant:-14];
+		topConstraint.priority = UILayoutPriorityRequired - 1;
+		[NSLayoutConstraint activateConstraints:@[
+			[_annoyingLabel.centerXAnchor constraintEqualToAnchor:self.centerXAnchor],
+			topConstraint,
+			[_annoyingLabel.topAnchor constraintGreaterThanOrEqualToAnchor:self.topAnchor],
+		]];
 	}
 	
 	return self;
@@ -41,13 +60,6 @@ extern void __dtx_send_external_log(const char* log) __attribute__((weak));
 	[super layoutSubviews];
 	
 	[self bringSubviewToFront:_annoyingLabel];
-	
-	UIEdgeInsets insets;
-	if (@available(iOS 11.0, *)) {
-		insets = self.safeAreaInsets;
-	}
-	
-	_annoyingLabel.center = CGPointMake(self.center.x, insets.top);
 }
 
 @end
@@ -175,9 +187,29 @@ RCT_EXPORT_MODULE();
 	return rv;
 }
 
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-	[RCTPushNotificationManager didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+	completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionSound);
+}
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
+{
+	UILabel* someLabel = [UILabel new];
+	someLabel.translatesAutoresizingMaskIntoConstraints = NO;
+	
+	someLabel.text = response.notification.request.content.title;
+	someLabel.backgroundColor = UIColor.blackColor;
+	someLabel.textColor = UIColor.whiteColor;
+	someLabel.font = [UIFont systemFontOfSize:40];
+	
+	RCTRootView* rv = (id)self.window.rootViewController.view;
+	//Add to the content view so that reloadReactNative() removes this label.
+	[[rv valueForKey:@"contentView"] addSubview:someLabel];
+	
+	[NSLayoutConstraint activateConstraints:@[
+		[someLabel.centerXAnchor constraintEqualToAnchor:self.window.centerXAnchor],
+		[someLabel.topAnchor constraintEqualToAnchor:self.window.annoyingLabel.bottomAnchor],
+	]];
 }
 
 - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
@@ -185,7 +217,7 @@ RCT_EXPORT_MODULE();
 	[RCTPushNotificationManager didReceiveLocalNotification:notification];
 }
 
-- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(id)restorationHandler
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void(^)(NSArray<id<UIUserActivityRestoring>> * __nullable restorableObjects))restorationHandler
 {
 	if([userActivity.activityType isEqualToString:CSSearchableItemActionType])
 	{
@@ -194,8 +226,8 @@ RCT_EXPORT_MODULE();
 		//Fake it here as if it is a URL, but actually it's a searchable item identifier.
 		return [RCTLinkingManager application:application
 									  openURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@", identifier]]
-							sourceApplication:nil
-								   annotation:nil];
+							sourceApplication:@""
+								   annotation:@{}];
 	}
 	
 	return [RCTLinkingManager application:application continueUserActivity:userActivity restorationHandler:restorationHandler];


### PR DESCRIPTION
Move sample app to use UN API, rather than legacy API
Drop usage of terribly outdated RCTPushNotificationManager
Closes #1509