### PR TITLE
Add explicit note about React Native 0.60 and workspace

### DIFF
--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -100,7 +100,7 @@ The basic configuration for Detox should be in your `package.json` file under th
 
 In the above configuration example, change `example` to your actual project name. Under the key `"binaryPath"`, `example.app` should be `<your_project_name>.app`. Under the key `"build"`, `example.xcodeproj` should be `<your_project_name>.xcodeproj` and `-scheme example` should be `-scheme <your_project_name>`.
 
-For iOS apps in a workspace (eg: CocoaPods) use `-workspace ios/example.xcworkspace` instead of `-project`.
+For React Native 0.60 or above, or any other iOS apps in a workspace (eg: CocoaPods) use `-workspace ios/example.xcworkspace` instead of `-project`.
 
 Also make sure the simulator model specified under the key `"name"` (`iPhone 7` above) is actually available on your machine (it was installed by Xcode). Check this by typing `xcrun simctl list` in terminal to display all available simulators.
 


### PR DESCRIPTION
- [x] This is a small change 

---

As mentioned in [the React Native 0.60 announcement blog post](https://facebook.github.io/react-native/blog/2019/07/03/version-60#cocoapods-by-default), React Native now uses Cocoapods, and therefore `.xcworkspace` files, by default.

To make the Getting Started instructions easier for users who aren't familiar with Cocoapods, this PR explicitly says that the `-workspace` option is needed for React Native 0.60 and above.

I've confirmed in [a tutorial project](https://github.com/learn-tdd-in/react-native) that in RN 0.60 Detox does not work with the `-project` flag but does work with this change applied.