### PR TITLE
Change Expo guide to recommend `.bin` folder prefixed by a dot

### DIFF
--- a/docs/Guide.Expo.md
+++ b/docs/Guide.Expo.md
@@ -9,7 +9,7 @@
 "detox": {
   "configurations": {
     "ios.sim": {
-      "binaryPath": "bin/Exponent.app",
+      "binaryPath": ".bin/Exponent.app",
       "type": "ios.simulator",
       "name": "iPhone 7"
     }
@@ -19,7 +19,7 @@
 
 - Download the Expo Client iOS App from [Expo.io/tools](https://expo.io/tools#client).
 - Unzip the iOS IPA and **rename the folder** to `Exponent.app`. It'll have a file icon but will still be a folder.
-- Create `bin` folder and put `Exponent.app` inside so it matches the binaryPath set above.
+- Create `.bin` folder and put `Exponent.app` inside so it matches the binaryPath set above.
 - Create an `e2e` and copy over the settings from [the example app](https://github.com/expo/with-detox-tests/tree/master/e2e)
 
 The most important piece of this the `reloadApp` from `detox-expo-helpers`. Don't forget this.


### PR DESCRIPTION
- [x] This is a small change 

---

When following the previous instructions of naming the folder `bin`, Expo sees assets within `bin/Exponent.app` as assets to be included in the published bundle. It gives the following warning upon launch:

```
Warning: This project contains unoptimized assets. Please run `expo optimize` in your project directory.
```

The app still runs locally and Detox succeeds, but when attempting to publish, a long sequence of `bin/Exponent.app` assets are optimized:

```
Optimizing /Users/josh/apps/ribbons/native/bin/Exponent.app/AppIcon20x20@2x.png
Compressed version of /Users/josh/apps/ribbons/native/bin/Exponent.app/AppIcon20x20@2x.png same size as original. Using original instead.
Optimizing /Users/josh/apps/ribbons/native/bin/Exponent.app/AppIcon20x20@3x.png
Compressed version of /Users/josh/apps/ribbons/native/bin/Exponent.app/AppIcon20x20@3x.png same size as original. Using original instead.
```

Eventually for me the optimization process hangs. Preventing it from hanging isn't the fix, though--we don't want these assets included in the published build, whether optimized or unoptimized.

I tried a few options to configure Expo to exclude `bin` from the build without success. But simply naming the folder to `.bin` seems to work as well--we do not get the "unoptimized assets" warning upon launch, and the publish operation succeeds without attempting to include `bin/Exponent.app` assets.
