### PR TITLE
Move away from swizzling the app delegate

### DIFF
--- a/detox/ios/Detox.xcodeproj/project.pbxproj
+++ b/detox/ios/Detox.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		394767F61DBF994200D72256 /* SocketRocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 394767E71DBF992400D72256 /* SocketRocket.framework */; };
 		394767F71DBF994500D72256 /* EarlGrey.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 394767DC1DBF991E00D72256 /* EarlGrey.framework */; };
 		394D589C1E50B59400556DB9 /* NSBundle+TestsFix.m in Sources */ = {isa = PBXBuildFile; fileRef = 394D589B1E50B59400556DB9 /* NSBundle+TestsFix.m */; };
+		396EA67A22E0AE7D0087E4D4 /* DTXAddressInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 396EA67222E0AE7C0087E4D4 /* DTXAddressInfo.h */; };
+		396EA67B22E0AE7D0087E4D4 /* DTXAddressInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 396EA67922E0AE7C0087E4D4 /* DTXAddressInfo.mm */; };
 		397EC9B51E7EDE0B00D5F2BB /* EarlGreyStatistics.h in Headers */ = {isa = PBXBuildFile; fileRef = 397EC9B31E7EDE0B00D5F2BB /* EarlGreyStatistics.h */; };
 		397EC9B61E7EDE0B00D5F2BB /* EarlGreyStatistics.m in Sources */ = {isa = PBXBuildFile; fileRef = 397EC9B41E7EDE0B00D5F2BB /* EarlGreyStatistics.m */; };
 		398260E8220CC9530061E83E /* GREYActions+Detox.m in Sources */ = {isa = PBXBuildFile; fileRef = 398260D4220CA56D0061E83E /* GREYActions+Detox.m */; };
@@ -233,6 +235,8 @@
 		394767DD1DBF992400D72256 /* SocketRocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SocketRocket.xcodeproj; path = SocketRocket/SocketRocket.xcodeproj; sourceTree = "<group>"; };
 		394D589A1E50B59400556DB9 /* NSBundle+TestsFix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSBundle+TestsFix.h"; sourceTree = "<group>"; };
 		394D589B1E50B59400556DB9 /* NSBundle+TestsFix.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+TestsFix.m"; sourceTree = "<group>"; };
+		396EA67222E0AE7C0087E4D4 /* DTXAddressInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DTXAddressInfo.h; sourceTree = "<group>"; };
+		396EA67922E0AE7C0087E4D4 /* DTXAddressInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DTXAddressInfo.mm; sourceTree = "<group>"; };
 		3975C78220272ED500C59ED8 /* src */ = {isa = PBXFileReference; lastKnownFileType = folder; name = src; path = ../src; sourceTree = "<group>"; };
 		397EC9B31E7EDE0B00D5F2BB /* EarlGreyStatistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EarlGreyStatistics.h; sourceTree = "<group>"; };
 		397EC9B41E7EDE0B00D5F2BB /* EarlGreyStatistics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EarlGreyStatistics.m; sourceTree = "<group>"; };
@@ -375,6 +379,8 @@
 				394767A41DBF987E00D72256 /* DetoxManager.h */,
 				394767A51DBF987E00D72256 /* DetoxManager.m */,
 				39FFD9451FD730A600C97030 /* DetoxCrashHandler.mm */,
+				396EA67222E0AE7C0087E4D4 /* DTXAddressInfo.h */,
+				396EA67922E0AE7C0087E4D4 /* DTXAddressInfo.mm */,
 				39A34C6F1E30F10D00BEBB59 /* DetoxAppDelegateProxy.h */,
 				39A34C701E30F10D00BEBB59 /* DetoxAppDelegateProxy.m */,
 				39CEFCDA1E34E91B00A09124 /* DetoxUserNotificationDispatcher.swift */,
@@ -485,6 +491,7 @@
 				394767D21DBF98D900D72256 /* WXJSTimerObservationIdlingResource.h in Headers */,
 				390D1C691E3A14EF007F5F46 /* UNNotificationResponse+PrivateHeaders.h in Headers */,
 				391FA5E91E7FD96D0056F82F /* GREYIdlingResourcePrettyPrint.h in Headers */,
+				396EA67A22E0AE7D0087E4D4 /* DTXAddressInfo.h in Headers */,
 				39A34C711E30F10D00BEBB59 /* DetoxAppDelegateProxy.h in Headers */,
 				39F642281FDD5EB100468FED /* DTXLogging.h in Headers */,
 				397EC9B51E7EDE0B00D5F2BB /* EarlGreyStatistics.h in Headers */,
@@ -714,6 +721,7 @@
 				39BCE599224BDBF000B0D357 /* ReactNativeSupportNoARC.m in Sources */,
 				397EC9B61E7EDE0B00D5F2BB /* EarlGreyStatistics.m in Sources */,
 				399BF36921933F0C00F96D50 /* ExternalLogging.m in Sources */,
+				396EA67B22E0AE7D0087E4D4 /* DTXAddressInfo.mm in Sources */,
 				391FA5EA1E7FD96D0056F82F /* GREYIdlingResourcePrettyPrint.m in Sources */,
 				394767CF1DBF98D900D72256 /* ReactNativeSupport.m in Sources */,
 				394767B51DBF987E00D72256 /* TestRunner.m in Sources */,

--- a/detox/ios/Detox/DTXAddressInfo.h
+++ b/detox/ios/Detox/DTXAddressInfo.h
@@ -1,0 +1,23 @@
+//
+//  DTXAddressInfo.h
+//  DTXProfiler
+//
+//  Created by Leo Natan (Wix) on 07/07/2017.
+//  Copyright © 2017-2019 Wix. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface DTXAddressInfo : NSObject
+
+- (instancetype)initWithAddress:(NSUInteger)address;
+
+@property (nonatomic, readonly) NSUInteger address;
+@property (nonatomic, copy, readonly) NSString* image;
+@property (nonatomic, copy, readonly) NSString* symbol;
+@property (nonatomic, readonly) NSUInteger offset;
+
+- (NSString*)formattedDescriptionForIndex:(NSUInteger)index;
+
+
+@end

--- a/detox/ios/Detox/DTXAddressInfo.mm
+++ b/detox/ios/Detox/DTXAddressInfo.mm
@@ -1,0 +1,120 @@
+//
+//  DTXAddressInfo.m
+//  DTXProfiler
+//
+//  Created by Leo Natan (Wix) on 07/07/2017.
+//  Copyright © 2017-2019 Wix. All rights reserved.
+//
+
+#import "DTXAddressInfo.h"
+#include <dlfcn.h>
+#include <cxxabi.h>
+
+static char* (*__dtx_swift_demangle)(const char *mangledName,
+									 size_t mangledNameLength,
+									 char *outputBuffer,
+									 size_t *outputBufferSize,
+									 uint32_t flags);
+
+@implementation DTXAddressInfo
+{
+	Dl_info _info;
+}
+
+@synthesize image, symbol, offset, address;
+
++ (void)load
+{
+	__dtx_swift_demangle = (char*(*)(const char *, size_t, char *, size_t *, uint32_t))dlsym(RTLD_DEFAULT, "swift_demangle");
+}
+
+- (instancetype)initWithAddress:(NSUInteger)_address
+{
+	self = [super init];
+	
+	if(self)
+	{
+		address = _address;
+		dladdr((void*)address, &_info);
+	}
+	
+	return self;
+}
+
+- (NSString *)image
+{
+	if(_info.dli_fname != NULL)
+	{
+		NSString* potentialImage = [NSString stringWithUTF8String:_info.dli_fname];
+		
+		if([potentialImage containsString:@"/"])
+		{
+			return potentialImage.lastPathComponent;
+		}
+	}
+	
+	return @"???";
+}
+
+- (NSString *)symbol
+{
+	if(_info.dli_sname != NULL)
+	{
+		int status = -1;
+		char* demangled = nullptr;
+		BOOL shouldFree = NO;
+		
+		if((demangled = abi::__cxa_demangle(_info.dli_sname, nullptr, nullptr, &status)) != nullptr ||
+		   (__dtx_swift_demangle && (demangled = __dtx_swift_demangle(_info.dli_sname, strlen(_info.dli_sname), nullptr, nullptr, 0)) != nullptr))
+		{
+			shouldFree = YES;
+		}
+		
+		if(demangled == nullptr)
+		{
+			demangled = (char *)_info.dli_sname;
+			shouldFree = NO;
+		}
+		
+		NSString* tmpSymbol = [NSString stringWithUTF8String:demangled];
+		
+		if(shouldFree)
+		{
+			free(demangled);
+		}
+		
+		return tmpSymbol;
+	}
+	else if(_info.dli_fname != NULL)
+	{
+		return self.image;
+	}
+	
+	return [NSString stringWithFormat:@"0x%1lx", (unsigned long)_info.dli_saddr];
+}
+
+- (NSUInteger)offset
+{
+	NSString* str = nil;
+	if(_info.dli_sname != NULL && (str = [NSString stringWithUTF8String:_info.dli_sname]) != nil)
+	{
+		return address - (NSUInteger)_info.dli_saddr;
+	}
+	else if(_info.dli_fname != NULL && (str = [NSString stringWithUTF8String:_info.dli_fname]) != nil)
+	{
+		return address - (NSUInteger)_info.dli_fbase;
+	}
+	
+	return address - (NSUInteger)_info.dli_saddr;
+}
+
+- (NSString*)formattedDescriptionForIndex:(NSUInteger)index;
+{
+#if __LP64__
+	return [NSString stringWithFormat:@"%-4ld%-35s 0x%016llx %@ + %ld", index, self.image.UTF8String, (uint64_t)address, self.symbol, self.offset];
+#else
+	return [NSString stringWithFormat:@"%-4d%-35s 0x%08lx %@ + %d", index, self.image.UTF8String, (unsigned long)address, self.symbol, self.offset];
+#endif
+}
+
+@end

--- a/detox/ios/Detox/Detox.pch
+++ b/detox/ios/Detox/Detox.pch
@@ -11,4 +11,14 @@
 
 #import "DTXLogging.h"
 
+#define dtx_defer_block_name_with_prefix(prefix, suffix) prefix ## suffix
+#define dtx_defer_block_name(suffix) dtx_defer_block_name_with_prefix(defer_, suffix)
+#define dtx_defer __strong void(^dtx_defer_block_name(__LINE__))(void) __attribute__((cleanup(defer_cleanup_block), unused)) = ^
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+static void defer_cleanup_block(__strong void(^*block)(void)) {
+	(*block)();
+}
+#pragma clang diagnostic pop
+
 #endif /* Detox_pch */

--- a/detox/ios/Detox/DetoxAppDelegateProxy.h
+++ b/detox/ios/Detox/DetoxAppDelegateProxy.h
@@ -9,14 +9,14 @@
 @import Foundation;
 @import UIKit;
 
-@interface DetoxAppDelegateProxyPrototype : NSObject <UIApplicationDelegate>
+@interface DetoxAppDelegateProxy : NSObject <UIApplicationDelegate>
 
-@property (class, nonatomic, strong, readonly) DetoxAppDelegateProxyPrototype* __dtx_currentAppDelegateProxy;
+@property (class, nonatomic, strong, readonly) DetoxAppDelegateProxy* sharedAppDelegateProxy;
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_10_3
-- (void)__dtx_dispatchUserActivityFromDataURL:(NSURL*)userActivityDataURL delayUntilActive:(BOOL)delay;
+- (void)_dispatchUserActivityFromDataURL:(NSURL*)userActivityDataURL delayUntilActive:(BOOL)delay;
 #endif
-- (void)__dtx_dispatchUserNotificationFromDataURL:(NSURL*)userNotificationDataURL delayUntilActive:(BOOL)delay;
-- (void)__dtx_dispatchOpenURL:(NSURL*)URL options:(NSDictionary*)options delayUntilActive:(BOOL)delay;
+- (void)_dispatchUserNotificationFromDataURL:(NSURL*)userNotificationDataURL delayUntilActive:(BOOL)delay;
+- (void)_dispatchOpenURL:(NSURL*)URL options:(NSDictionary*)options delayUntilActive:(BOOL)delay;
 
 @end

--- a/detox/ios/Detox/DetoxAppDelegateProxy.h
+++ b/detox/ios/Detox/DetoxAppDelegateProxy.h
@@ -9,9 +9,9 @@
 @import Foundation;
 @import UIKit;
 
-@interface DetoxAppDelegateProxy : NSObject <UIApplicationDelegate>
+@interface DetoxAppDelegateProxyPrototype : NSObject <UIApplicationDelegate>
 
-@property (class, nonatomic, strong, readonly) DetoxAppDelegateProxy* currentAppDelegateProxy;
+@property (class, nonatomic, strong, readonly) DetoxAppDelegateProxyPrototype* __dtx_currentAppDelegateProxy;
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_10_3
 - (void)__dtx_dispatchUserActivityFromDataURL:(NSURL*)userActivityDataURL delayUntilActive:(BOOL)delay;

--- a/detox/ios/Detox/DetoxManager.m
+++ b/detox/ios/Detox/DetoxManager.m
@@ -282,7 +282,7 @@ static void detoxConditionalInit()
 			}
 			
 			block = ^{
-				[DetoxAppDelegateProxy.currentAppDelegateProxy __dtx_dispatchOpenURL:URLToOpen options:options delayUntilActive:delay];
+				[DetoxAppDelegateProxyPrototype.__dtx_currentAppDelegateProxy __dtx_dispatchOpenURL:URLToOpen options:options delayUntilActive:delay];
 				
 				sendDoneAction(self.webSocket, messageId);
 			};
@@ -294,7 +294,7 @@ static void detoxConditionalInit()
 			NSParameterAssert(userNotificationDataURL != nil);
 			
 			block = ^{
-				[DetoxAppDelegateProxy.currentAppDelegateProxy __dtx_dispatchUserNotificationFromDataURL:userNotificationDataURL delayUntilActive:delay];
+				[DetoxAppDelegateProxyPrototype.__dtx_currentAppDelegateProxy __dtx_dispatchUserNotificationFromDataURL:userNotificationDataURL delayUntilActive:delay];
 				
 				sendDoneAction(self.webSocket, messageId);
 			};
@@ -307,7 +307,7 @@ static void detoxConditionalInit()
 			NSParameterAssert(userActivityDataURL != nil);
 			
 			block = ^{
-				[DetoxAppDelegateProxy.currentAppDelegateProxy __dtx_dispatchUserActivityFromDataURL:userActivityDataURL delayUntilActive:delay];
+				[DetoxAppDelegateProxyPrototype.__dtx_currentAppDelegateProxy __dtx_dispatchUserActivityFromDataURL:userActivityDataURL delayUntilActive:delay];
 				
 				sendDoneAction(self.webSocket, messageId);
 			};

--- a/detox/ios/Detox/DetoxManager.m
+++ b/detox/ios/Detox/DetoxManager.m
@@ -282,7 +282,7 @@ static void detoxConditionalInit()
 			}
 			
 			block = ^{
-				[DetoxAppDelegateProxyPrototype.__dtx_currentAppDelegateProxy __dtx_dispatchOpenURL:URLToOpen options:options delayUntilActive:delay];
+				[DetoxAppDelegateProxy.sharedAppDelegateProxy _dispatchOpenURL:URLToOpen options:options delayUntilActive:delay];
 				
 				sendDoneAction(self.webSocket, messageId);
 			};
@@ -294,7 +294,7 @@ static void detoxConditionalInit()
 			NSParameterAssert(userNotificationDataURL != nil);
 			
 			block = ^{
-				[DetoxAppDelegateProxyPrototype.__dtx_currentAppDelegateProxy __dtx_dispatchUserNotificationFromDataURL:userNotificationDataURL delayUntilActive:delay];
+				[DetoxAppDelegateProxy.sharedAppDelegateProxy _dispatchUserNotificationFromDataURL:userNotificationDataURL delayUntilActive:delay];
 				
 				sendDoneAction(self.webSocket, messageId);
 			};
@@ -307,7 +307,7 @@ static void detoxConditionalInit()
 			NSParameterAssert(userActivityDataURL != nil);
 			
 			block = ^{
-				[DetoxAppDelegateProxyPrototype.__dtx_currentAppDelegateProxy __dtx_dispatchUserActivityFromDataURL:userActivityDataURL delayUntilActive:delay];
+				[DetoxAppDelegateProxy.sharedAppDelegateProxy _dispatchUserActivityFromDataURL:userActivityDataURL delayUntilActive:delay];
 				
 				sendDoneAction(self.webSocket, messageId);
 			};

--- a/detox/test/ios/example.xcodeproj/xcshareddata/xcschemes/example.xcscheme
+++ b/detox/test/ios/example.xcodeproj/xcshareddata/xcschemes/example.xcscheme
@@ -103,6 +103,10 @@
             argument = "-detoxUserActivityDataURL /Users/lnatan/Desktop/user-activity.json"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-enableAppDelegateVerboseLogging YES"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction


### PR DESCRIPTION
Instead, swizzle the `UIApplication` delegate accessor to do magic and provide a proxy delegate to UIKit/UIKitCore, while still returning the user app delegate when user code requests it.

Fixes #1525