### PR TITLE
Add Support for Biometrics on SimulatorDriver

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -137,26 +137,32 @@ class Device {
 
   async enrollBiometrics() {
     await this.deviceDriver.setBiometricEnrollment(this._deviceId, 'YES');
+    await this.deviceDriver.waitForBackground();
   }
 
   async disenrollBiometrics() {
     await this.deviceDriver.setBiometricEnrollment(this._deviceId, 'NO');
+    await this.deviceDriver.waitForBackground();
   }
 
   async matchFace() {
     await this.deviceDriver.matchBiometric(this._deviceId, 'Face');
+    await this.deviceDriver.waitForBackground();
   }
 
   async unmatchFace() {
     await this.deviceDriver.unmatchBiometric(this._deviceId, 'Face');
+    await this.deviceDriver.waitForBackground();
   }
 
   async matchFinger() {
     await this.deviceDriver.matchBiometric(this._deviceId, 'Finger');
+    await this.deviceDriver.waitForBackground();
   }
 
   async unmatchFinger() {
     await this.deviceDriver.unmatchBiometric(this._deviceId, 'Finger');
+    await this.deviceDriver.waitForBackground();
   }
 
   async shake() {

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -135,6 +135,30 @@ class Device {
     await this.deviceDriver.waitForBackground();
   }
 
+  async enrollBiometrics() {
+    await this.deviceDriver.setBiometricEnrollment(this._deviceId, 'YES');
+  }
+
+  async disenrollBiometrics() {
+    await this.deviceDriver.setBiometricEnrollment(this._deviceId, 'NO');
+  }
+
+  async matchFace() {
+    await this.deviceDriver.matchBiometric(this._deviceId, 'Face');
+  }
+
+  async unmatchFace() {
+    await this.deviceDriver.unmatchBiometric(this._deviceId, 'Face');
+  }
+
+  async matchFinger() {
+    await this.deviceDriver.matchBiometric(this._deviceId, 'Finger');
+  }
+
+  async unmatchFinger() {
+    await this.deviceDriver.unmatchBiometric(this._deviceId, 'Finger');
+  }
+
   async shake() {
     await this.deviceDriver.shake(this._deviceId);
   }

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -136,35 +136,34 @@ class Device {
   }
 
   async enrollBiometrics() {
-    await this.deviceDriver.setBiometricEnrollment(this._deviceId, 'YES');
+    await this.deviceDriver.enrollBiometrics(this._deviceId);
     await this.deviceDriver.waitForBackground();
   }
 
   async disenrollBiometrics() {
-    await this.deviceDriver.setBiometricEnrollment(this._deviceId, 'NO');
+    await this.deviceDriver.disenrollBiometrics(this._deviceId);
     await this.deviceDriver.waitForBackground();
   }
 
-  // async matchFace() {
-  //   await this.deviceDriver.matchBiometric(this._deviceId, 'Face');
-  //   await this.deviceDriver.waitForBackground();
-  // }
+  async matchFace() {
+    await this.deviceDriver.matchFace(this._deviceId);
+    await this.deviceDriver.waitForBackground();
+  }
 
-  // async unmatchFace() {
-  //   console.log('this.deviceDriver ==>', this.deviceDriver)
-  //   await this.deviceDriver.unmatchBiometric(this._deviceId, 'Face');
-  //   await this.deviceDriver.waitForBackground();
-  // }
+  async unmatchFace() {
+    await this.deviceDriver.unmatchFace(this._deviceId);
+    await this.deviceDriver.waitForBackground();
+  }
 
-  // async matchFinger() {
-  //   await this.deviceDriver.matchBiometric(this._deviceId, 'Finger');
-  //   await this.deviceDriver.waitForBackground();
-  // }
+  async matchFinger() {
+    await this.deviceDriver.matchFinger(this._deviceId);
+    await this.deviceDriver.waitForBackground();
+  }
 
-  // async unmatchFinger() {
-  //   await this.deviceDriver.unmatchBiometric(this._deviceId, 'Finger');
-  //   await this.deviceDriver.waitForBackground();
-  // }
+  async unmatchFinger() {
+    await this.deviceDriver.unmatchFinger(this._deviceId);
+    await this.deviceDriver.waitForBackground();
+  }
 
   async shake() {
     await this.deviceDriver.shake(this._deviceId);

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -135,13 +135,9 @@ class Device {
     await this.deviceDriver.waitForBackground();
   }
 
-  async enrollBiometrics() {
-    await this.deviceDriver.enrollBiometrics(this._deviceId);
-    await this.deviceDriver.waitForBackground();
-  }
-
-  async disenrollBiometrics() {
-    await this.deviceDriver.disenrollBiometrics(this._deviceId);
+  async setBiometricEnrollment(toggle) {
+    let yesOrNo = toggle ? 'YES' : 'NO'
+    await this.deviceDriver.setBiometricEnrollment(this._deviceId, yesOrNo);
     await this.deviceDriver.waitForBackground();
   }
 

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -145,26 +145,26 @@ class Device {
     await this.deviceDriver.waitForBackground();
   }
 
-  async matchFace() {
-    await this.deviceDriver.matchBiometric(this._deviceId, 'Face');
-    await this.deviceDriver.waitForBackground();
-  }
+  // async matchFace() {
+  //   await this.deviceDriver.matchBiometric(this._deviceId, 'Face');
+  //   await this.deviceDriver.waitForBackground();
+  // }
 
-  async unmatchFace() {
-    console.log('this.deviceDriver ==>', this.deviceDriver)
-    await this.deviceDriver.unmatchBiometric(this._deviceId, 'Face');
-    await this.deviceDriver.waitForBackground();
-  }
+  // async unmatchFace() {
+  //   console.log('this.deviceDriver ==>', this.deviceDriver)
+  //   await this.deviceDriver.unmatchBiometric(this._deviceId, 'Face');
+  //   await this.deviceDriver.waitForBackground();
+  // }
 
-  async matchFinger() {
-    await this.deviceDriver.matchBiometric(this._deviceId, 'Finger');
-    await this.deviceDriver.waitForBackground();
-  }
+  // async matchFinger() {
+  //   await this.deviceDriver.matchBiometric(this._deviceId, 'Finger');
+  //   await this.deviceDriver.waitForBackground();
+  // }
 
-  async unmatchFinger() {
-    await this.deviceDriver.unmatchBiometric(this._deviceId, 'Finger');
-    await this.deviceDriver.waitForBackground();
-  }
+  // async unmatchFinger() {
+  //   await this.deviceDriver.unmatchBiometric(this._deviceId, 'Finger');
+  //   await this.deviceDriver.waitForBackground();
+  // }
 
   async shake() {
     await this.deviceDriver.shake(this._deviceId);

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -151,6 +151,7 @@ class Device {
   }
 
   async unmatchFace() {
+    console.log('this.deviceDriver ==>', this.deviceDriver)
     await this.deviceDriver.unmatchBiometric(this._deviceId, 'Face');
     await this.deviceDriver.waitForBackground();
   }

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -476,6 +476,48 @@ describe('Device', () => {
     expect(driverMock.driver.sendToHome).toHaveBeenCalledTimes(1);
   });
 
+  it(`enrollBiometrics() should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.enrollBiometrics();
+
+    expect(driverMock.driver.enrollBiometrics).toHaveBeenCalledTimes(1);
+  });
+
+  it(`disenrollBiometrics() should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.disenrollBiometrics();
+
+    expect(driverMock.driver.disenrollBiometrics).toHaveBeenCalledTimes(1);
+  });
+
+  it(`matchFace() should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.matchFace();
+
+    expect(driverMock.driver.matchFace).toHaveBeenCalledTimes(1);
+  });
+
+  it(`unmatchFace() should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.unmatchFace();
+
+    expect(driverMock.driver.unmatchFace).toHaveBeenCalledTimes(1);
+  });
+
+  it(`matchFinger() should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.matchFinger();
+
+    expect(driverMock.driver.matchFinger).toHaveBeenCalledTimes(1);
+  });
+
+  it(`unmatchFinger() should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.unmatchFinger();
+
+    expect(driverMock.driver.unmatchFinger).toHaveBeenCalledTimes(1);
+  });
+
   it(`shake() should pass to device driver`, async () => {
     const device = validDevice();
     await device.shake();

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -490,33 +490,33 @@ describe('Device', () => {
     expect(driverMock.driver.disenrollBiometrics).toHaveBeenCalledTimes(1);
   });
 
-  // it(`matchFace() should pass to device driver`, async () => {
-  //   const device = validDevice();
-  //   await device.matchFace();
+  it(`matchFace() should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.matchFace();
 
-  //   expect(driverMock.driver.matchFace).toHaveBeenCalledTimes(1);
-  // });
+    expect(driverMock.driver.matchFace).toHaveBeenCalledTimes(1);
+  });
 
-  // it(`unmatchFace() should pass to device driver`, async () => {
-  //   const device = validDevice();
-  //   await device.unmatchFace();
+  it(`unmatchFace() should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.unmatchFace();
 
-  //   expect(driverMock.driver.unmatchFace).toHaveBeenCalledTimes(1);
-  // });
+    expect(driverMock.driver.unmatchFace).toHaveBeenCalledTimes(1);
+  });
 
-  // it(`matchFinger() should pass to device driver`, async () => {
-  //   const device = validDevice();
-  //   await device.matchFinger();
+  it(`matchFinger() should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.matchFinger();
 
-  //   expect(driverMock.driver.matchFinger).toHaveBeenCalledTimes(1);
-  // });
+    expect(driverMock.driver.matchFinger).toHaveBeenCalledTimes(1);
+  });
 
-  // it(`unmatchFinger() should pass to device driver`, async () => {
-  //   const device = validDevice();
-  //   await device.unmatchFinger();
+  it(`unmatchFinger() should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.unmatchFinger();
 
-  //   expect(driverMock.driver.unmatchFinger).toHaveBeenCalledTimes(1);
-  // });
+    expect(driverMock.driver.unmatchFinger).toHaveBeenCalledTimes(1);
+  });
 
   it(`shake() should pass to device driver`, async () => {
     const device = validDevice();

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -490,33 +490,33 @@ describe('Device', () => {
     expect(driverMock.driver.disenrollBiometrics).toHaveBeenCalledTimes(1);
   });
 
-  it(`matchFace() should pass to device driver`, async () => {
-    const device = validDevice();
-    await device.matchFace();
+  // it(`matchFace() should pass to device driver`, async () => {
+  //   const device = validDevice();
+  //   await device.matchFace();
 
-    expect(driverMock.driver.matchFace).toHaveBeenCalledTimes(1);
-  });
+  //   expect(driverMock.driver.matchFace).toHaveBeenCalledTimes(1);
+  // });
 
-  it(`unmatchFace() should pass to device driver`, async () => {
-    const device = validDevice();
-    await device.unmatchFace();
+  // it(`unmatchFace() should pass to device driver`, async () => {
+  //   const device = validDevice();
+  //   await device.unmatchFace();
 
-    expect(driverMock.driver.unmatchFace).toHaveBeenCalledTimes(1);
-  });
+  //   expect(driverMock.driver.unmatchFace).toHaveBeenCalledTimes(1);
+  // });
 
-  it(`matchFinger() should pass to device driver`, async () => {
-    const device = validDevice();
-    await device.matchFinger();
+  // it(`matchFinger() should pass to device driver`, async () => {
+  //   const device = validDevice();
+  //   await device.matchFinger();
 
-    expect(driverMock.driver.matchFinger).toHaveBeenCalledTimes(1);
-  });
+  //   expect(driverMock.driver.matchFinger).toHaveBeenCalledTimes(1);
+  // });
 
-  it(`unmatchFinger() should pass to device driver`, async () => {
-    const device = validDevice();
-    await device.unmatchFinger();
+  // it(`unmatchFinger() should pass to device driver`, async () => {
+  //   const device = validDevice();
+  //   await device.unmatchFinger();
 
-    expect(driverMock.driver.unmatchFinger).toHaveBeenCalledTimes(1);
-  });
+  //   expect(driverMock.driver.unmatchFinger).toHaveBeenCalledTimes(1);
+  // });
 
   it(`shake() should pass to device driver`, async () => {
     const device = validDevice();

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -476,18 +476,20 @@ describe('Device', () => {
     expect(driverMock.driver.sendToHome).toHaveBeenCalledTimes(1);
   });
 
-  it(`enrollBiometrics() should pass to device driver`, async () => {
+  it(`setBiometricEnrollment(true) should pass YES to device driver`, async () => {
     const device = validDevice();
-    await device.enrollBiometrics();
+    await device.setBiometricEnrollment(true);
 
-    expect(driverMock.driver.enrollBiometrics).toHaveBeenCalledTimes(1);
+    expect(driverMock.driver.setBiometricEnrollment).toHaveBeenCalledWith(device._deviceId, 'YES');
+    expect(driverMock.driver.setBiometricEnrollment).toHaveBeenCalledTimes(1);
   });
 
-  it(`disenrollBiometrics() should pass to device driver`, async () => {
+  it(`setBiometricEnrollment(false) should pass NO to device driver`, async () => {
     const device = validDevice();
-    await device.disenrollBiometrics();
+    await device.setBiometricEnrollment(false);
 
-    expect(driverMock.driver.disenrollBiometrics).toHaveBeenCalledTimes(1);
+    expect(driverMock.driver.setBiometricEnrollment).toHaveBeenCalledWith(device._deviceId, 'NO');
+    expect(driverMock.driver.setBiometricEnrollment).toHaveBeenCalledTimes(1);
   });
 
   it(`matchFace() should pass to device driver`, async () => {

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -63,11 +63,7 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
-  async enrollBiometrics() {
-    return await Promise.resolve('');
-  }
-
-  async disenrollBiometrics() {
+  async setBiometricEnrollment() {
     return await Promise.resolve('');
   }
 

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -63,6 +63,42 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
+  async sendToHome() {
+    return await Promise.resolve('');
+  }
+
+  async sendToHome() {
+    return await Promise.resolve('');
+  }
+
+  async sendToHome() {
+    return await Promise.resolve('');
+  }
+
+  async enrollBiometrics() {
+    return await Promise.resolve('');
+  }
+
+  async disenrollBiometrics() {
+    return await Promise.resolve('');
+  }
+
+  async matchFace() {
+    return await Promise.resolve('');
+  }
+
+  async unmatchFace() {
+    return await Promise.resolve('');
+  }
+
+  async matchFinger() {
+    return await Promise.resolve('');
+  }
+  
+  async unmatchFinger() {
+    return await Promise.resolve('');
+  }
+
   async shake() {
     return await Promise.resolve('');
   }

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -63,6 +63,10 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
+  async setBiometricEnrollment() {
+    return await Promise.resolve('');
+  }
+
   async enrollBiometrics() {
     return await Promise.resolve('');
   }

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -63,10 +63,6 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
-  async setBiometricEnrollment() {
-    return await Promise.resolve('');
-  }
-
   async enrollBiometrics() {
     return await Promise.resolve('');
   }

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -63,18 +63,6 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
-  async sendToHome() {
-    return await Promise.resolve('');
-  }
-
-  async sendToHome() {
-    return await Promise.resolve('');
-  }
-
-  async sendToHome() {
-    return await Promise.resolve('');
-  }
-
   async enrollBiometrics() {
     return await Promise.resolve('');
   }

--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -83,6 +83,7 @@ class SimulatorDriver extends IosDriver {
   }
 
   async enrollBiometrics(deviceId) {
+    console.log('this.applesimutils ==>', this.applesimutils)
     await this.applesimutils.setBiometricEnrollment(deviceId, 'YES');
   }
 

--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -83,7 +83,6 @@ class SimulatorDriver extends IosDriver {
   }
 
   async enrollBiometrics(deviceId) {
-    console.log('this.applesimutils ==>', this.applesimutils)
     await this.applesimutils.setBiometricEnrollment(deviceId, 'YES');
   }
 

--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -82,6 +82,30 @@ class SimulatorDriver extends IosDriver {
     await this.applesimutils.terminate(deviceId, bundleId);
   }
 
+  async enrollBiometrics(deviceId) {
+    await this.applesimutils.setBiometricEnrollment(deviceId, 'YES');
+  }
+
+  async disenrollBiometrics(deviceId) {
+    await this.applesimutils.setBiometricEnrollment(deviceId, 'NO');
+  }
+
+  async matchFace(deviceId) {
+    await this.applesimutils.matchBiometric(deviceId, 'Face');
+  }
+
+  async unmatchFace(deviceId) {
+    await this.applesimutils.unmatchBiometric(deviceId, 'Face');
+  }
+
+  async matchFinger(deviceId) {
+    await this.applesimutils.matchBiometric(deviceId, 'Finger');
+  }
+
+  async unmatchFinger(deviceId) {
+    await this.applesimutils.unmatchBiometric(deviceId, 'Finger');
+  }
+
   async sendToHome(deviceId) {
     await this.applesimutils.sendToHome(deviceId);
   }

--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -82,12 +82,8 @@ class SimulatorDriver extends IosDriver {
     await this.applesimutils.terminate(deviceId, bundleId);
   }
 
-  async enrollBiometrics(deviceId) {
-    await this.applesimutils.setBiometricEnrollment(deviceId, 'YES');
-  }
-
-  async disenrollBiometrics(deviceId) {
-    await this.applesimutils.setBiometricEnrollment(deviceId, 'NO');
+  async setBiometricEnrollment(deviceId, yesOrNo) {
+    await this.applesimutils.setBiometricEnrollment(deviceId, yesOrNo);
   }
 
   async matchFace(deviceId) {

--- a/detox/src/devices/drivers/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/SimulatorDriver.test.js
@@ -50,12 +50,12 @@ describe('IOS simulator driver', () => {
     });
 
     it('enrolls in biometrics by passing to AppleSimUtils', async () => {
-      await sim.enrollBiometrics(deviceId);
+      await sim.setBiometricEnrollment(deviceId, true);
       expect(sim.applesimutils.setBiometricEnrollment).toHaveBeenCalledWith(deviceId, 'YES');
     })
 
     it('disenrolls in biometrics by passing to AppleSimUtils', async () => {
-      await sim.disenrollBiometrics(deviceId);
+      await sim.setBiometricEnrollment(deviceId, false);
       expect(sim.applesimutils.setBiometricEnrollment).toHaveBeenCalledWith(deviceId, 'NO');
     })
 

--- a/detox/src/devices/drivers/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/SimulatorDriver.test.js
@@ -50,12 +50,12 @@ describe('IOS simulator driver', () => {
     });
 
     it('enrolls in biometrics by passing to AppleSimUtils', async () => {
-      await sim.setBiometricEnrollment(deviceId, true);
+      await sim.setBiometricEnrollment(deviceId, 'YES');
       expect(sim.applesimutils.setBiometricEnrollment).toHaveBeenCalledWith(deviceId, 'YES');
     })
 
     it('disenrolls in biometrics by passing to AppleSimUtils', async () => {
-      await sim.setBiometricEnrollment(deviceId, false);
+      await sim.setBiometricEnrollment(deviceId, 'NO');
       expect(sim.applesimutils.setBiometricEnrollment).toHaveBeenCalledWith(deviceId, 'NO');
     })
 

--- a/detox/src/devices/drivers/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/SimulatorDriver.test.js
@@ -51,7 +51,6 @@ describe('IOS simulator driver', () => {
 
     it('enrolls in biometrics by passing to AppleSimUtils', async () => {
       await sim.enrollBiometrics(deviceId);
-      console.log('sim.applesimutils ==>', sim.applesimutils)
       expect(sim.applesimutils.setBiometricEnrollment).toHaveBeenCalledWith(deviceId, 'YES');
     })
 

--- a/detox/src/devices/drivers/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/SimulatorDriver.test.js
@@ -40,6 +40,45 @@ describe('IOS simulator driver', () => {
       }, '');
     });
   });
+
+  describe('biometrics', () => {
+    beforeEach(() => {
+      languageAndLocale = '';
+
+      const SimulatorDriver = require('./SimulatorDriver');
+      sim = new SimulatorDriver({ client: {} });
+    });
+
+    it('enrolls in biometrics by passing to AppleSimUtils', async () => {
+      await sim.enrollBiometrics(deviceId);
+      expect(sim.applesimutils.setBiometricEnrollment).toHaveBeenCalledWith(deviceId, 'YES');
+    })
+
+    it('disenrolls in biometrics by passing to AppleSimUtils', async () => {
+      await sim.disenrollBiometrics(deviceId);
+      expect(sim.applesimutils.setBiometricEnrollment).toHaveBeenCalledWith(deviceId, 'NO');
+    })
+
+    it('matches a face by passing to AppleSimUtils', async () => {
+      await sim.matchFace(deviceId);
+      expect(sim.applesimutils.matchBiometric).toHaveBeenCalledWith(deviceId, 'Face');
+    })
+
+    it('fails to match a face by passing to AppleSimUtils', async () => {
+      await sim.unmatchFace(deviceId);
+      expect(sim.applesimutils.unmatchBiometric).toHaveBeenCalledWith(deviceId, 'Face');
+    })
+
+    it('matches a face by passing to AppleSimUtils', async () => {
+      await sim.matchFinger(deviceId);
+      expect(sim.applesimutils.matchBiometric).toHaveBeenCalledWith(deviceId, 'Finger');
+    })
+
+    it('fails to match a face by passing to AppleSimUtils', async () => {
+      await sim.unmatchFinger(deviceId);
+      expect(sim.applesimutils.unmatchBiometric).toHaveBeenCalledWith(deviceId, 'Finger');
+    })
+  });
 });
 
 class mockAppleSimUtils {

--- a/detox/src/devices/drivers/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/SimulatorDriver.test.js
@@ -51,6 +51,7 @@ describe('IOS simulator driver', () => {
 
     it('enrolls in biometrics by passing to AppleSimUtils', async () => {
       await sim.enrollBiometrics(deviceId);
+      console.log('sim.applesimutils ==>', sim.applesimutils)
       expect(sim.applesimutils.setBiometricEnrollment).toHaveBeenCalledWith(deviceId, 'YES');
     })
 

--- a/detox/src/devices/drivers/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/SimulatorDriver.test.js
@@ -1,5 +1,5 @@
 describe('IOS simulator driver', () => {
-  let uut;
+  let uut, sim;
 
   const deviceId = 'device-id-mock';
   const bundleId = 'bundle-id-mock';

--- a/detox/src/devices/drivers/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/SimulatorDriver.test.js
@@ -85,5 +85,8 @@ describe('IOS simulator driver', () => {
 class mockAppleSimUtils {
   constructor() {
     this.launch = jest.fn();
+    this.setBiometricEnrollment = jest.fn();
+    this.matchBiometric = jest.fn();
+    this.unmatchBiometric = jest.fn();
   }
 }

--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -137,6 +137,42 @@ class AppleSimUtils {
     await this._execSimctl({ cmd: `launch ${udid} com.apple.springboard`, retries: 10 });
   }
 
+  async matchBiometric(udid, matchType) {
+    if (!['face', 'finger'].include(matchType)) {
+      return;
+    }
+    const statusLogs = {
+      trying: `Trying to match ${matchType}...`,
+      successful: `Matched ${matchType}!`
+    };
+
+    await this._execAppleSimUtils({ args: `--byId ${udid} --${matchType}}` }, statusLogs, 1);
+  }
+
+  async unmatchBiometric(udid, matchType) {
+    if (!['Face', 'Finger'].include(matchType)) {
+      return;
+    }
+    const statusLogs = {
+      trying: `Trying to match ${matchType}...`,
+      successful: `Matched ${matchType}!`
+    };
+
+    await this._execAppleSimUtils({ args: `--byId ${udid} --unmatch${matchType}}` }, statusLogs, 1);
+  }
+
+  async setBiometricEnrollment(udid, yesOrNo) {
+    if (!['YES', 'NO'].include(yesOrNo)) {
+      return;
+    }
+    let toggle = yesOrNo === 'YES'
+    const statusLogs = {
+      trying: `Turning ${toggle ? 'on' : 'off'} biometric enrollment...`,
+      successful: toggle ? 'Activated!' : 'Deactivated!'
+    };
+    await this._execAppleSimUtils({ args: `--byId ${udid} --biometricEnrollment ${yesOrNo}` }, statusLogs, 1);
+  }
+
   async getAppContainer(udid, bundleId) {
     return _.trim((await this._execSimctl({ cmd: `get_app_container ${udid} ${bundleId}` })).stdout);
   }

--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -154,8 +154,8 @@ class AppleSimUtils {
       return;
     }
     const statusLogs = {
-      trying: `Trying to match ${matchType}...`,
-      successful: `Matched ${matchType}!`
+      trying: `Trying to unmatch ${matchType}...`,
+      successful: `Unmatched ${matchType}!`
     };
 
     await this._execAppleSimUtils({ args: `--byId ${udid} --unmatch${matchType}}` }, statusLogs, 1);

--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -138,7 +138,7 @@ class AppleSimUtils {
   }
 
   async matchBiometric(udid, matchType) {
-    if (!['face', 'finger'].include(matchType)) {
+    if (!['Face', 'Finger'].include(matchType)) {
       return;
     }
     const statusLogs = {

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -23,6 +23,11 @@
 - [`device.getPlatform()`](#devicegetplatform)
 - [`device.takeScreenshot(name)`](#devicetakescreenshotname)
 - [`device.shake()` **iOS Only**](#deviceshake-ios-only)
+- [`device.setBiometricEnrollment(bool)` **iOS Only**](#devicesetbiometricenrolmmentbool-ios-only)
+- [`device.matchFace()` **iOS Only**](#devicematchface-ios-only)
+- [`device.unmatchFace()` **iOS Only**](#deviceunmatchface-ios-only)
+- [`device.matchFinger()` **iOS Only**](#devicematchfinger-ios-only)
+- [`device.unmatchFinger()` **iOS Only**](#deviceunmatchfinger-ios-only)
 - [`device.pressBack()` **Android Only**](#devicepressback-android-only)
 - [`device.getUIDevice()` **Android Only**](#devicegetuidevice-android-only)
 
@@ -340,6 +345,27 @@ describe('Menu items', () => {
 
 ### `device.shake()` **iOS Only**
 Simulate shake
+
+### `device.setBiometricEnrollment(bool)` **iOS Only**
+Toggles device enrollment in biometric auth (TouchID or FaceID).
+
+```js
+await device.setBiometricEnrollment(true);
+// or
+await device.setBiometricEnrollment(false);
+```
+
+### `device.matchFace()` **iOS Only**
+Simulates the success of a face match via FaceID
+
+### `device.unmatchFace()` **iOS Only**
+Simulates the failure of face match via FaceID
+
+### `device.matchFinger()` **iOS Only**
+Simulates the success of a finger match via TouchID
+
+### `device.unmatchFinger()` **iOS Only**
+Simulates the failure of a finger match via TouchID
 
 ### `device.pressBack()` **Android Only**
 Simulate press back button.


### PR DESCRIPTION
**Description:**

This is a small change (which was requested in #958).

It adds support for Biometrics by adding the following methods to DeviceDriver:

- `enrollBiometrics` and `disenrollBiometrics` - for setting up biometrics on a Simulator
- `matchFace` and `unmatchFace` - for matching a face on a Simulator
- `matchFinger` and `unmatchFinger` - for matching a finger on a Simulator

It uses an underlying call in `AppleSimUtils.js` to three new methods:

- `setBiometricEnrollment` - which accepts a UDID and either `"YES"` or `"NO"`
- `matchBiometric` - which accepts a UDID and either `"Face"` or `"Finger"`
- `unmatchBiometric` - which accepts a UDID and either `"Face"` or `"Finger"`

I believe I added the appropriate tests so I think this should be good to go - however, I'm happy to change if the core maintainers are not content with my proposed changes. Please provide some suggestions on how it can be improved. Thank you!