### PR TITLE
(Android) Fix undesired turning of typeText() taps into long taps over InputText components

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxViewActions.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxViewActions.java
@@ -1,47 +1,22 @@
 package com.wix.detox.espresso;
 
-import android.view.View;
+import com.wix.detox.espresso.action.DetoxTypeTextAction;
+import com.wix.detox.espresso.action.RNClickAction;
 
-import com.wix.detox.ReactNativeSupport;
-
-import org.hamcrest.Matcher;
-
-import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
 import androidx.test.espresso.action.ViewActions;
+
+import static androidx.test.espresso.action.ViewActions.actionWithAssertions;
 
 /**
  * An alternative to {@link ViewActions} - providing alternative implementations, where needed.
  */
 public class DetoxViewActions {
-    private static class BusyViewActionWrapper implements ViewAction {
-        private final ViewAction espressoViewAction;
-
-        BusyViewActionWrapper(ViewAction clickAction) {
-            this.espressoViewAction = clickAction;
-        }
-
-        @Override
-        public Matcher<View> getConstraints() {
-            return espressoViewAction.getConstraints();
-        }
-
-        @Override
-        public String getDescription() {
-            return espressoViewAction.getDescription();
-        }
-
-        @Override
-        public void perform(UiController uiController, View view) {
-            ReactNativeSupport.pauseRNTimersIdlingResource();
-            espressoViewAction.perform(uiController, view);
-            ReactNativeSupport.resumeRNTimersIdlingResource();
-            uiController.loopMainThreadUntilIdle();
-        }
+    public static ViewAction click() {
+        return actionWithAssertions(new RNClickAction());
     }
 
-    public static ViewAction click() {
-        final ViewAction clickAction = ViewActions.click();
-        return new BusyViewActionWrapper(clickAction);
+    public static ViewAction typeText(String text) {
+        return actionWithAssertions(new DetoxTypeTextAction(text));
     }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxTypeTextAction.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxTypeTextAction.java
@@ -1,0 +1,39 @@
+package com.wix.detox.espresso.action;
+
+import android.view.View;
+
+import org.hamcrest.Matcher;
+
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.action.TypeTextAction;
+
+import static org.hamcrest.Matchers.allOf;
+
+public class DetoxTypeTextAction implements ViewAction {
+    private final String text;
+    private final RNClickAction clickAction;
+    private final TypeTextAction typeTextAction;
+
+    public DetoxTypeTextAction(String text) {
+        this.text = text;
+        clickAction = new RNClickAction();
+        typeTextAction = new TypeTextAction(text, false);
+    }
+
+    @Override
+    public Matcher<View> getConstraints() {
+        return allOf(clickAction.getConstraints(), new TypeTextAction("", true).getConstraints());
+    }
+
+    @Override
+    public String getDescription() {
+        return "Click to focus & type text ("+text+")";
+    }
+
+    @Override
+    public void perform(UiController uiController, View view) {
+        clickAction.perform(uiController, view);
+        typeTextAction.perform(uiController, view);
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/RNClickAction.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/RNClickAction.java
@@ -1,0 +1,47 @@
+package com.wix.detox.espresso.action;
+
+import android.view.InputDevice;
+import android.view.MotionEvent;
+import android.view.View;
+
+import com.wix.detox.ReactNativeSupport;
+
+import org.hamcrest.Matcher;
+
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.action.GeneralClickAction;
+import androidx.test.espresso.action.GeneralLocation;
+import androidx.test.espresso.action.Press;
+import androidx.test.espresso.action.Tap;
+
+public class RNClickAction implements ViewAction {
+    private final ViewAction clickAction =
+            new GeneralClickAction(
+                Tap.SINGLE,
+                GeneralLocation.VISIBLE_CENTER,
+                Press.FINGER,
+                InputDevice.SOURCE_UNKNOWN,
+                MotionEvent.BUTTON_PRIMARY);
+
+    @Override
+    public Matcher<View> getConstraints() {
+        return clickAction.getConstraints();
+    }
+
+    @Override
+    public String getDescription() {
+        return clickAction.getDescription();
+    }
+
+    @Override
+    public void perform(UiController uiController, View view) {
+        ReactNativeSupport.pauseRNTimersIdlingResource();
+        try {
+            clickAction.perform(uiController, view);
+        } finally {
+            ReactNativeSupport.resumeRNTimersIdlingResource();
+        }
+        uiController.loopMainThreadUntilIdle();
+    }
+}

--- a/detox/src/android/espressoapi/DetoxViewActions.js
+++ b/detox/src/android/espressoapi/DetoxViewActions.js
@@ -7,22 +7,6 @@
 
 
 class DetoxViewActions {
-  static getConstraints(element) {
-    return {
-      target: element,
-      method: "getConstraints",
-      args: []
-    };
-  }
-
-  static getDescription(element) {
-    return {
-      target: element,
-      method: "getDescription",
-      args: []
-    };
-  }
-
   static click() {
     return {
       target: {
@@ -31,6 +15,18 @@ class DetoxViewActions {
       },
       method: "click",
       args: []
+    };
+  }
+
+  static typeText(text) {
+    if (typeof text !== "string") throw new Error("text should be a string, but got " + (text + (" (" + (typeof text + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.espresso.DetoxViewActions"
+      },
+      method: "typeText",
+      args: [text]
     };
   }
 

--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -64,7 +64,7 @@ class PressKeyAction extends Action {
 class TypeTextAction extends Action {
   constructor(value) {
     super();
-    this._call = invoke.callDirectly(ViewActionsApi.typeText(value));
+    this._call = invoke.callDirectly(DetoxViewActionsApi.typeText(value));
   }
 }
 

--- a/detox/test/android/app/src/main/java/com/example/NativeModule.java
+++ b/detox/test/android/app/src/main/java/com/example/NativeModule.java
@@ -6,6 +6,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 import android.view.Gravity;
+import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.TextView;
@@ -17,6 +18,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 public class NativeModule extends ReactContextBaseJavaModule {
 
@@ -100,5 +102,33 @@ public class NativeModule extends ReactContextBaseJavaModule {
             }
         }
         promise.resolve(Arguments.createMap());
+    }
+
+    @ReactMethod
+    public void spyLongTaps(final String testID) {
+        ReactFindViewUtil.addViewListener(new ReactFindViewUtil.OnViewFoundListener() {
+            @Override
+            public String getNativeId() {
+                return testID;
+            }
+
+            @Override
+            public void onViewFound(View view) {
+                final ReactFindViewUtil.OnViewFoundListener onViewFoundListener = this;
+                view.setOnLongClickListener(new View.OnLongClickListener() {
+                    @Override
+                    public boolean onLongClick(View v) {
+                        throw new IllegalStateException("Validation failed: component \"" + testID + "\" was long-tapped!!!");
+                    }
+                });
+
+                view.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        ReactFindViewUtil.removeViewListener(onViewFoundListener);
+                    }
+                });
+            }
+        });
     }
 }

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -32,34 +32,46 @@ describe('Actions', () => {
   });
 
   it('should type in an element', async () => {
-    let typedText = device.getPlatform() === 'ios' ? 'Type Working 123 אֱבּג абв!!!' : "Type Working!!!";
-    await element(by.id('UniqueId937')).tap();
+    const typedText = device.getPlatform() === 'ios' ? 'Type Working 123 אֱבּג абв!!!' : "Type Working!!!";
+
+    if (device.getPlatform() === 'ios') {
+      await element(by.id('UniqueId937')).tap();
+    }
     await element(by.id('UniqueId937')).typeText(typedText);
     await expect(element(by.text(typedText))).toBeVisible();
   });
 
   it('should press the backspace key on an element', async () => {
-    let typedText = 'test';
-    await element(by.id('UniqueId937')).tap();
+    const typedText = 'test';
+
+    if (device.getPlatform() === 'ios') { // TODO remove tap() for iOS
+      await element(by.id('UniqueId937')).tap();
+    }
     await element(by.id('UniqueId937')).typeText(typedText + 'x');
     await element(by.id('UniqueId937')).tapBackspaceKey();
     await expect(element(by.text(typedText))).toBeVisible();
   });
 
   it('should press the return key on an element', async () => {
-    await element(by.id('UniqueId937')).tap();
+    if (device.getPlatform() === 'ios') { // TODO remove tap() for iOS
+      await element(by.id('UniqueId937')).tap();
+    }
     await element(by.id('UniqueId937')).tapReturnKey();
     await expect(element(by.text('Return Working!!!'))).toBeVisible();
   });
 
   it('should clear text in an element', async () => {
-    await element(by.id('UniqueId005')).tap();
+    if (device.getPlatform() === 'ios') { // TODO remove tap() for iOS
+      await element(by.id('UniqueId005')).tap();
+    }
     await element(by.id('UniqueId005')).clearText();
     await expect(element(by.text('Clear Working!!!'))).toBeVisible();
   });
 
   it('should replace text in an element', async () => {
-    await element(by.id('UniqueId006')).tap();
+    if (device.getPlatform() === 'ios') { // TODO remove tap() for iOS
+      await element(by.id('UniqueId006')).tap();
+    }
     await element(by.id('UniqueId006')).replaceText('replaced_text');
     await expect(element(by.text('Replace Working!!!'))).toBeVisible();
   });

--- a/detox/test/src/Screens/ActionsScreen.js
+++ b/detox/test/src/Screens/ActionsScreen.js
@@ -4,10 +4,10 @@ import {
   BackHandler,
   View,
   TouchableOpacity,
-  TextInput,
   ScrollView,
-  RefreshControl
+  RefreshControl,
 } from 'react-native';
+import TextInput from '../Views/TextInput';
 
 export default class ActionsScreen extends Component {
 

--- a/detox/test/src/Views/TextInput.js
+++ b/detox/test/src/Views/TextInput.js
@@ -1,0 +1,21 @@
+import React, {Component} from 'react';
+import { TextInput, NativeModules, Platform } from 'react-native';
+
+const { NativeModule } = NativeModules;
+
+class AndroidTextInput extends Component {
+  constructor(props) {
+    super(props);
+    NativeModule.spyLongTaps(props.testID);
+  }
+
+  render() {
+    return <TextInput {...this.props} nativeID={this.props.testID} />
+  }
+}
+
+if (Platform.OS === 'android') {
+  module.exports = AndroidTextInput;
+} else {
+  module.exports = TextInput;
+}


### PR DESCRIPTION
- [x] This is a small change 
- [x] This change has been discussed in issue #1462 and the solution has been agreed upon with maintainers.

---

**Description:**

Fix #1462 by replacing Espresso's implementation of `typeText()` with a custom one that manages the pre-tap in a way that is safe for RN apps (just like detox does for standard clicks).

As a side note, the challenge here was not in fixing the issue (except for researching it), but in having associated use cases tested. This isn't trivial since `TextInput` components cannot be set a long-press callback from the JS side.