### PR TITLE
Fix test runner's hang when spawning Android emulators by new node.js versions (>=10.16.0)

### DIFF
--- a/detox/src/devices/android/Emulator.js
+++ b/detox/src/devices/android/Emulator.js
@@ -41,11 +41,18 @@ class Emulator {
     const tempLog = `./${emulatorName}.log`;
     const stdout = fs.openSync(tempLog, 'a');
     const stderr = fs.openSync(tempLog, 'a');
-    const tail = new Tail(tempLog).on("line", (line) => {
-      if (line.includes('Adb connected, start proxing data')) {
-        childProcessPromise._cpResolve();
-      }
-    });
+    const tailOptions = {
+      useWatchFile: true,
+      fsWatchOptions: {
+        interval: 1500,
+      },
+    };
+    const tail = new Tail(tempLog, tailOptions)
+      .on("line", (line) => {
+        if (line.includes('Adb connected, start proxing data')) {
+          childProcessPromise._cpResolve();
+        }
+      });
 
     function detach() {
       if (childProcessOutput) {


### PR DESCRIPTION
- [x] This is a small change 
- [x] This change has been discussed in issue #1546 and the solution has been agreed upon with maintainers.

---

**Description:**

Fixes #1546 by indirectly switching to `fs.watchFile()` instead of `fs.watch()`, which uses polling and seems to be more stable throughout node.js versions (ref for why `fs.watch()` is unstable: https://github.com/nodejs/node/issues/28882).