### PR TITLE
Look for emulators in ANDROID_SDK_HOME or os.homedir()

### DIFF
--- a/detox/src/devices/drivers/EmulatorDriver.js
+++ b/detox/src/devices/drivers/EmulatorDriver.js
@@ -19,7 +19,8 @@ class EmulatorDriver extends AndroidDriver {
   }
 
   async _fixEmulatorConfigIniSkinName(name) {
-    const configFile = `${os.homedir()}/.android/avd/${name}.avd/config.ini`;
+    const sdkHome = process.env.ANDROID_SDK_HOME || os.homedir();
+    const configFile = path.normalize(`${sdkHome}/.android/avd/${name}.avd/config.ini`);
     const config = ini.parse(fs.readFileSync(configFile, 'utf-8'));
 
     if (!config['skin.name']) {


### PR DESCRIPTION
- [x] This is a small change 
---

Fixes the issue https://github.com/wix/Detox/issues/1255#issuecomment-510211996 where the emulator path is incorrect in certain environments.