### PR TITLE
Refactor apk build path to not include architecture in its flavors #1575

### DIFF
--- a/detox/src/devices/android/APKPath.js
+++ b/detox/src/devices/android/APKPath.js
@@ -3,9 +3,8 @@ const _ = require('lodash');
 const string = require('../../utils/string');
 
 class APKPath {
-
   static getTestApkPath(originalApkPath) {
-    const originalApkPathObj = path.parse(originalApkPath);
+    const originalApkPathObj = path.parse(originalApkPath.replace(/x86\w*-/g, ''));
     let tempPath = originalApkPathObj.dir.split(path.sep);
     const splitFileName = originalApkPathObj.name.split('-');
 
@@ -20,7 +19,13 @@ class APKPath {
       tempPath = _.dropRight(tempPath, 1); //flavorDimensions
     }
 
-    const testApkPath = path.join(tempPath.join(path.sep), 'androidTest', flavorDimensionsPath, buildType, `${originalApkPathObj.name}-androidTest${originalApkPathObj.ext}`);
+    const testApkPath = path.join(
+      tempPath.join(path.sep),
+      'androidTest',
+      flavorDimensionsPath,
+      buildType,
+      `${originalApkPathObj.name}-androidTest${originalApkPathObj.ext}`
+    );
     return testApkPath;
   }
 }

--- a/detox/src/devices/android/APKPath.test.js
+++ b/detox/src/devices/android/APKPath.test.js
@@ -17,14 +17,28 @@ describe('APKPath', () => {
 
   it(`path for a gradle build flavor`, async () => {
     const inputApkPath = path.join(rootPath, 'build/outputs/apk/development/debug/app-development-debug.apk');
-    const expectedTestApkPath = path.join(rootPath, 'build/outputs/apk/androidTest/development/debug/app-development-debug-androidTest.apk');
+    const expectedTestApkPath = path.join(
+      rootPath,
+      'build/outputs/apk/androidTest/development/debug/app-development-debug-androidTest.apk'
+    );
     expect(APKPath.getTestApkPath(inputApkPath)).toEqual(expectedTestApkPath);
   });
 
   it(`path for a gradle build with multiple flavors`, async () => {
     const inputApkPath = path.join(rootPath, 'build/outputs/apk/pocPlayStore/debug/app-poc-playStore-debug.apk');
-    const expectedTestApkPath = path.join(rootPath, 'build/outputs/apk/androidTest/pocPlayStore/debug/app-poc-playStore-debug-androidTest.apk');
+    const expectedTestApkPath = path.join(
+      rootPath,
+      'build/outputs/apk/androidTest/pocPlayStore/debug/app-poc-playStore-debug-androidTest.apk'
+    );
     expect(APKPath.getTestApkPath(inputApkPath)).toEqual(expectedTestApkPath);
   });
 
+  it(`path for a gradle build with specific architecture`, async () => {
+    const inputApkPath = path.join(rootPath, 'build/outputs/apk/development/debug/app-development-x86-debug.apk');
+    const expectedTestApkPath = path.join(
+      rootPath,
+      'build/outputs/apk/androidTest/development/debug/app-development-debug-androidTest.apk'
+    );
+    expect(APKPath.getTestApkPath(inputApkPath)).toEqual(expectedTestApkPath);
+  });
 });


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 

---

**Description:**
Regarding my enhancement request #1575 :
This change allows `getTestApkPath()` in `APKPath.js` to return a correct path when it receives an APK with a specific architecture in it. I also included the corresponding unit test to this PR. You can check all the details in the issue.

Note: I think ESLint formatted some lines apart from line 7 and the added test and that's why they appear as changes too. Feel free to make it as it was before! 

Thanks! 