### PR TITLE
Fix matchBiometric and unmatchBiometric commands

### DIFF
--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -146,7 +146,7 @@ class AppleSimUtils {
       successful: `Matched ${matchType}!`
     };
 
-    await this._execAppleSimUtils({ args: `--byId ${udid} --${matchType}}` }, statusLogs, 1);
+    await this._execAppleSimUtils({ args: `--byId ${udid} --match${matchType}` }, statusLogs, 1);
   }
 
   async unmatchBiometric(udid, matchType) {
@@ -158,7 +158,7 @@ class AppleSimUtils {
       successful: `Unmatched ${matchType}!`
     };
 
-    await this._execAppleSimUtils({ args: `--byId ${udid} --unmatch${matchType}}` }, statusLogs, 1);
+    await this._execAppleSimUtils({ args: `--byId ${udid} --unmatch${matchType}` }, statusLogs, 1);
   }
 
   async setBiometricEnrollment(udid, yesOrNo) {


### PR DESCRIPTION
- The matchBiometric and unmatchBiometric commands failed because of an incorrect parenthesis.
- The correct commands are --matchFace or --matchFinger, see https://github.com/wix/AppleSimulatorUtils

The biometrics functionality was introduced with https://github.com/wix/Detox/pull/1554 and https://github.com/wix/Detox/pull/1547

<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

Using the biometrics commands caused errors on my computer. I fixed them with this PR.

Fyi, using `await device.matchFinger();` still fails on my computer with the timeout below. I could not yet find the reason why. There may be additional errors that need fixing.
```
    1) with his matching finger
detox[71526] WARN:  [Client.js/PENDING_REQUESTS] App has not responded to the network requests below:
  (id = 12) waitForBackground: {}

That might be the reason why the test "Login with the correct fingerprint with his matching finger" has timed out.

  1 passing (6m)
  1 failing

  1) Login with the correct fingerprint
       with his matching finger:
     Error: Timeout of 280000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (e2e/tests/login.test.js)
```