### PR TITLE
Android parallelism (WIP)

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -240,9 +240,13 @@ module.exports.handler = async function test(program) {
   }
 
   function runJest() {
-    if (platform === 'android' && program.workers !== 1) {
-      log.warn('Can not use -w, --workers. Parallel test execution is only supported on iOS currently');
-      program.w = program.workers = 1;
+    if (platform === 'android') {
+      program.readOnlyEmu = false;
+      if ((program.workers || 0) > 1) {
+        program.readOnlyEmu = true;
+        log.warn('Multiple workers is an experimental feature on Android and requires an emulator binary of version 28.0.1 or higher. ' +
+          'Check your version by running: $ANDROID_HOME/tools/bin/sdkmanager --list');
+      }
     }
 
     const jestReportSpecsArg = program['jest-report-specs'];
@@ -276,6 +280,7 @@ module.exports.handler = async function test(program) {
       'recordPerformance',
       'deviceName',
       'reportSpecs',
+      'readOnlyEmu',
     ]);
 
     log.info(printEnvironmentVariables(detoxEnvironmentVariables) + command);

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -147,7 +147,7 @@ const collectExtraArgs = require('./utils/collectExtraArgs')(module.exports.buil
 
 module.exports.handler = async function test(program) {
   program.artifactsLocation = buildDefaultArtifactsRootDirpath(program.configuration, program.artifactsLocation);
-  
+
   if(!program.keepLockFile){
     clearDeviceRegistryLockFile();
   }
@@ -320,9 +320,13 @@ module.exports.handler = async function test(program) {
   }
 
   function clearDeviceRegistryLockFile() {
-    const lockFilePath = environment.getDeviceLockFilePath();
-    fs.ensureFileSync(lockFilePath);
-    fs.writeFileSync(lockFilePath, '[]');
+    const lockFilePathIOS = environment.getDeviceLockFilePathIOS();
+    fs.ensureFileSync(lockFilePathIOS);
+    fs.writeFileSync(lockFilePathIOS, '[]');
+
+    const lockFilePathAndroid = environment.getDeviceLockFilePathAndroid();
+    fs.ensureFileSync(lockFilePathAndroid);
+    fs.writeFileSync(lockFilePathAndroid, '[]');
   }
 
   run();

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -240,20 +240,22 @@ module.exports.handler = async function test(program) {
   }
 
   function runJest() {
+    const hasMultipleWorkers = ((program.workers || 0) > 1);
     if (platform === 'android') {
       program.readOnlyEmu = false;
-      if ((program.workers || 0) > 1) {
+      if (hasMultipleWorkers) {
         program.readOnlyEmu = true;
         log.warn('Multiple workers is an experimental feature on Android and requires an emulator binary of version 28.0.1 or higher. ' +
           'Check your version by running: $ANDROID_HOME/tools/bin/sdkmanager --list');
       }
     }
+    program.reportWorkerAssign = hasMultipleWorkers;
 
     const jestReportSpecsArg = program['jest-report-specs'];
     if (!_.isUndefined(jestReportSpecsArg)) {
       program.reportSpecs = (jestReportSpecsArg.toString() === 'true');
     } else {
-      program.reportSpecs = (program.workers === 1);
+      program.reportSpecs = !hasMultipleWorkers;
     }
 
     const command = _.compact([
@@ -280,6 +282,7 @@ module.exports.handler = async function test(program) {
       'recordPerformance',
       'deviceName',
       'reportSpecs',
+      'reportWorkerAssign',
       'readOnlyEmu',
     ]);
 

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -150,6 +150,29 @@ describe('test', () => {
     });
   });
 
+  describe('Jest worker-device assignment reporting (propagated) switch', () => {
+    const expectWorkerAssignArg = ({value}) => expect(mockExec).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          reportWorkerAssign: value,
+        }),
+      })
+    );
+
+    it('should be enabled if more than 1 worker is set', async () => {
+      mockAndroidJestConfiguration();
+      await callCli('./test', 'test --workers 2');
+      expectWorkerAssignArg({value: true});
+    });
+
+    it('should be disabled by default', async () => {
+      mockAndroidJestConfiguration();
+      await callCli('./test', 'test');
+      expectWorkerAssignArg({value: false});
+    });
+  });
+
   describe('Jest read-only mode for emulators (propagated) switch', () => {
     const expectReadOnlyEmulatorsArg = ({value}) => expect(mockExec).toHaveBeenCalledWith(
       expect.anything(),

--- a/detox/runners/jest/JasmineWorkerAssignReporter.js
+++ b/detox/runners/jest/JasmineWorkerAssignReporter.js
@@ -1,0 +1,21 @@
+const detox = require('detox');
+const chalk = require('chalk').default;
+const path = require('path');
+
+class JasmineWorkerAssignReporter {
+  suiteStarted(suiteInfo) {
+    const fileName = path.basename(suiteInfo.testPath);
+    this._traceln(`${chalk.whiteBright(fileName)} assigned to ${chalk.blueBright(detox.deviceName())}`);
+    this._traceln('');
+  }
+
+  _trace(message) {
+    process.stdout.write(message);
+  }
+
+  _traceln(message) {
+    this._trace(message);
+    process.stdout.write('\n');
+  }
+}
+module.exports = JasmineWorkerAssignReporter;

--- a/detox/runners/jest/JasmineWorkerAssignReporter.js
+++ b/detox/runners/jest/JasmineWorkerAssignReporter.js
@@ -1,4 +1,4 @@
-const detox = require('detox');
+const detox = require('detox'); // eslint-disable-line node/no-missing-require
 const chalk = require('chalk').default;
 const path = require('path');
 

--- a/detox/runners/jest/assignReporter.js
+++ b/detox/runners/jest/assignReporter.js
@@ -1,0 +1,8 @@
+const argparse = require('../../src/utils/argparse');
+
+if (argparse.getArgValue('reportWorkerAssign') === 'true') {
+  const Reporter = require('./JasmineWorkerAssignReporter');
+  module.exports = new Reporter();
+} else {
+  module.exports = {};
+}

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -127,6 +127,10 @@ class Detox {
     });
   }
 
+  deviceName() {
+    return this.device.name();
+  }
+
   _logTestRunCheckpoint(event, { status, fullName }) {
     log.trace({ event, status }, `${status} test: ${JSON.stringify(fullName)}`);
   }

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -187,6 +187,18 @@ describe('Detox', () => {
     expect(detox._client.dumpPendingRequests).toHaveBeenCalled();
   });
 
+  it('should return the device\'s name', async () => {
+    const deviceMock = require('./devices/Device');
+    deviceMock.prototype.name = jest.fn().mockReturnValue('mock-device-name');
+
+    Detox = require('./Detox');
+    detox = new Detox({deviceConfig: validDeviceConfig});
+
+    await detox.init();
+    expect(detox.deviceName()).toEqual('mock-device-name');
+    expect(deviceMock.prototype.name).toHaveBeenCalled();
+  });
+
   describe('.artifactsManager', () => {
     let artifactsManager;
 

--- a/detox/src/DetoxExportWrapper.js
+++ b/detox/src/DetoxExportWrapper.js
@@ -40,6 +40,13 @@ class DetoxExportWrapper {
     }
   }
 
+  deviceName() {
+    if (this[_detox]) {
+      return this[_detox].deviceName();
+    }
+    return '';
+  }
+
   _definePassthroughMethod(name) {
     this[name] = (...args) => {
       if (this[_detox]) {

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -96,6 +96,10 @@ class Device {
     }
   }
 
+  name() {
+    return this.deviceDriver.name();
+  }
+
   async takeScreenshot(name) {
     if (!name) {
       throw new Error('Cannot take a screenshot with an empty name.');

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -90,6 +90,14 @@ describe('Device', () => {
     return schemeDevice(validScheme, 'ios.sim.release');
   }
 
+  it('should return the name from the driver', async () => {
+    driverMock.driver.name.mockReturnValue('mock-device-name');
+
+    const device = validDevice();
+    expect(device.name()).toEqual('mock-device-name');
+    expect(driverMock.driver.name).toHaveBeenCalled();
+  });
+
   describe('prepare()', () => {
     it(`valid scheme, no binary, should throw`, async () => {
       const device = validDevice();

--- a/detox/src/devices/DeviceRegistry.js
+++ b/detox/src/devices/DeviceRegistry.js
@@ -2,16 +2,15 @@ const _ = require('lodash');
 const fs = require('fs-extra');
 const plockfile = require('proper-lockfile');
 const retry = require('../utils/retry');
-const environment = require('../utils/environment');
-const DEVICE_LOCK_FILE_PATH = environment.getDeviceLockFilePath();
 
 const LOCK_RETRY_OPTIONS = {retries: 10000, interval: 5};
 
 class DeviceRegistry {
 
-  constructor({getDeviceIdsByType, createDevice}) {
+  constructor({getDeviceIdsByType, createDevice, lockfile}) {
     this.getDeviceIdsByType = getDeviceIdsByType;
     this.createDevice = createDevice;
+    this.lockfile = lockfile;
     this._createEmptyLockFileIfNeeded();
   }
 
@@ -39,11 +38,11 @@ class DeviceRegistry {
   }
 
   async _lock() {
-    await retry(LOCK_RETRY_OPTIONS, () => plockfile.lockSync(DEVICE_LOCK_FILE_PATH));
+    await retry(LOCK_RETRY_OPTIONS, () => plockfile.lockSync(this.lockfile));
   }
 
   async _unlock() {
-    await plockfile.unlockSync(DEVICE_LOCK_FILE_PATH);
+    await plockfile.unlockSync(this.lockfile);
   }
 
   clear() {
@@ -59,19 +58,19 @@ class DeviceRegistry {
   }
 
   _createEmptyLockFileIfNeeded() {
-    if (!fs.existsSync(DEVICE_LOCK_FILE_PATH)) {
-      fs.ensureFileSync(DEVICE_LOCK_FILE_PATH);
+    if (!fs.existsSync(this.lockfile)) {
+      fs.ensureFileSync(this.lockfile);
       this._writeBusyDevicesToLockFile([]);
     }
   }
 
   _writeBusyDevicesToLockFile(lockedDevices) {
-    fs.writeFileSync(DEVICE_LOCK_FILE_PATH, JSON.stringify(lockedDevices));
+    fs.writeFileSync(this.lockfile, JSON.stringify(lockedDevices));
   }
 
   _getBusyDevices() {
     this._createEmptyLockFileIfNeeded();
-    const lockFileContent = fs.readFileSync(DEVICE_LOCK_FILE_PATH, 'utf-8');
+    const lockFileContent = fs.readFileSync(this.lockfile, 'utf-8');
     return JSON.parse(lockFileContent);
   }
 

--- a/detox/src/devices/DeviceRegistry.test.js
+++ b/detox/src/devices/DeviceRegistry.test.js
@@ -16,10 +16,6 @@ describe('DeviceRegistry', () => {
 
     jest.mock('proper-lockfile');
 
-    jest.mock('../utils/environment', () => ({
-      getDeviceLockFilePath: jest.fn().mockReturnValue('lockfile-path/mock'),
-    }));
-
     createDevice = jest.fn();
     getDeviceIdsByType = jest.fn();
   });
@@ -31,7 +27,11 @@ describe('DeviceRegistry', () => {
 
   function deviceRegistry() {
     const DeviceRegistry = require('./DeviceRegistry');
-    const registry = new DeviceRegistry({getDeviceIdsByType, createDevice});
+    const registry = new DeviceRegistry({
+      getDeviceIdsByType,
+      createDevice,
+      lockfile: 'lockfile-path/mock'
+    });
     registry.clear();
     return registry;
   }
@@ -73,7 +73,7 @@ describe('DeviceRegistry', () => {
     it(`should create a lockfile if none exists`, async () => {
       fs.existsSync.mockReturnValue(false);
 
-      const registry = deviceRegistry();
+      deviceRegistry();
 
       expect(fs.ensureFileSync).toHaveBeenCalledWith('lockfile-path/mock');
       expect(fs.writeFileSync).toHaveBeenCalledWith('lockfile-path/mock', "[]");

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -13,8 +13,22 @@ class ADB {
   }
 
   async devices() {
-    const output = (await this.adbCmd('', 'devices', { verbosity: 'high' })).stdout;
-    return this.parseAdbDevicesConsoleOutput(output);
+    const parser = await this._adbDevices();
+    const devices = [];
+    for (let device = await parser.parseNext(); device; device = await parser.parseNext()) {
+      devices.push(device);
+    }
+    return devices;
+  }
+
+  async findDevice(matcher) {
+    const parser = await this._adbDevices();
+    for (let device = await parser.parseNext(); device; device = await parser.parseNext()) {
+      if (await matcher(device)) {
+        return device;
+      }
+    }
+    return undefined;
   }
 
   async unlockScreen(deviceId) {
@@ -54,43 +68,6 @@ class ADB {
 
   async _sendKeyEvent(deviceId, keyevent) {
     await this.shell(deviceId, `input keyevent ${keyevent}`);
-  }
-
-  async parseAdbDevicesConsoleOutput(input) {
-    const outputToList = input.trim().split('\n');
-    const devicesList = _.takeRight(outputToList, outputToList.length - 1);
-    const devices = [];
-    for (const deviceString of devicesList) {
-      const deviceParams = deviceString.split('\t');
-      const deviceAdbName = deviceParams[0];
-      let device;
-      if (this.isEmulator(deviceAdbName)) {
-        const port = _.split(deviceAdbName, '-')[1];
-        if (!port) {
-          _reportTelnetPortResolutionError(input, devicesList, deviceAdbName, port);
-        }
-
-        const telnet = new EmulatorTelnet();
-        await telnet.connect(port);
-        const name = await telnet.avdName();
-        device = {type: 'emulator', name: name, adbName: deviceAdbName, port: port};
-        await telnet.quit();
-      } else if (this.isGenymotion(deviceAdbName)) {
-        device = {type: 'genymotion', name: deviceAdbName, adbName: deviceAdbName};
-      } else {
-        device = {type: 'device', name: deviceAdbName, adbName: deviceAdbName};
-      }
-      devices.push(device);
-    }
-    return devices;
-  }
-
-  isEmulator(deviceAdbName) {
-    return _.includes(deviceAdbName, 'emulator-');
-  }
-
-  isGenymotion(string) {
-    return (/^((1?\d?\d|25[0-5]|2[0-4]\d)(\.|:)){4}[0-9]{4}/.test(string));
   }
 
   async now(deviceId) {
@@ -269,6 +246,11 @@ class ADB {
     return (await this.adbCmd(deviceId, `shell "${escape.inQuotedString(cmd)}"`, options)).stdout.trim();
   }
 
+  async _adbDevices() {
+    const output = (await this.adbCmd('', 'devices', { verbosity: 'high' })).stdout;
+    return new AdbDevicesParser(output);
+  }
+
   async adbCmd(deviceId, params, options) {
     const serial = `${deviceId ? `-s ${deviceId}` : ''}`;
     const cmd = `${this.adbBin} ${serial} ${params}`;
@@ -285,6 +267,59 @@ class ADB {
     const serial = deviceId ? ['-s', deviceId] : [];
     return spawnAndLog(this.adbBin, [...serial, ...params]);
   }
+}
+
+class AdbDevicesParser {
+  constructor(adbDevicesOutput) {
+    this.rawInput = adbDevicesOutput;
+    this.devicesList = this._extractDeviceNamesFromAdbDevicesOutput(adbDevicesOutput);
+    this.index = 0;
+  }
+
+  async parseNext() {
+    if (this.index < this.devicesList.length) {
+      return await this._parseAdbDevice(this.devicesList[this.index++]);
+    }
+    return undefined;
+  }
+
+  _extractDeviceNamesFromAdbDevicesOutput(input) {
+    const outputToList = input.trim().split('\n');
+    const devicesList = _.takeRight(outputToList, outputToList.length - 1);
+    return devicesList;
+  }
+
+  async _parseAdbDevice(deviceString) {
+    const deviceParams = deviceString.split('\t');
+    const adbName = deviceParams[0];
+
+    let device;
+    if (isEmulator(adbName)) {
+      const port = _.split(adbName, '-')[1];
+      if (!port) {
+        _reportTelnetPortResolutionError(this.rawInput, this.devicesList, adbName, port);
+      }
+
+      const telnet = new EmulatorTelnet();
+      await telnet.connect(port);
+      const name = await telnet.avdName();
+      device = {type: 'emulator', name: name, adbName, port};
+      await telnet.quit();
+    } else if (isGenymotion(adbName)) {
+      device = {type: 'genymotion', name: adbName, adbName};
+    } else {
+      device = {type: 'device', name: adbName, adbName};
+    }
+    return device;
+  }
+}
+
+function isEmulator(deviceAdbName) {
+  return _.includes(deviceAdbName, 'emulator-');
+}
+
+function isGenymotion(adbName) {
+  return (/^((1?\d?\d|25[0-5]|2[0-4]\d)(\.|:)){4}[0-9]{4}/.test(adbName));
 }
 
 function _reportTelnetPortResolutionError(input, devicesList, deviceAdbName, port) {

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -47,8 +47,7 @@ class ADB {
   }
 
   async _getPowerStatus(deviceId) {
-    const stdout = await this.shell(deviceId, `dumpsys power | grep "^[ ]*m[UW].*="`);
-
+    const stdout = await this.shell(deviceId, `dumpsys power | grep "^[ ]*m[UW].*="`, { retries: 5 });
     return stdout
       .split('\n')
       .map(s => s.trim().split('='))
@@ -146,7 +145,7 @@ class ADB {
       return this._cachedApiLevels.get(deviceId);
     }
 
-    const lvl = Number(await this.shell(deviceId, `getprop ro.build.version.sdk`));
+    const lvl = Number(await this.shell(deviceId, `getprop ro.build.version.sdk`, { retries: 5 }));
     this._cachedApiLevels.set(deviceId, lvl);
 
     return lvl;

--- a/detox/src/devices/android/ADB.test.js
+++ b/detox/src/devices/android/ADB.test.js
@@ -50,13 +50,38 @@ describe('ADB', () => {
       expect(exec).toHaveBeenCalledTimes(1);
     });
 
-    it(`should parse emulator devices`, async () => {
+    it(`should query emulator devices' name via telnet`, async () => {
       exec.mockReturnValue({
-        stdout: 'List of devices attached\nemulator-5554\tdevice\nemulator-5555\tdevice\n'
+        stdout: 'List of devices attached\n'
+          + 'emulator-5554\tdevice\n'
+          + 'emulator-5555\tdevice\n'
+          + '\n',
       });
 
       await adb.devices();
       expect(mockEmulatorTelnet.connect).toHaveBeenCalledWith("5554");
+      expect(mockEmulatorTelnet.connect).toHaveBeenCalledWith("5555");
+    });
+
+    it(`Parse 'adb device' output with devices of all kinds`, async () => {
+      const adbDevicesConsoleOutput = "List of devices attached\n"
+        + "192.168.60.101:5555\tdevice\n"
+        + "emulator-5556\tdevice\n"
+        + "emulator-5554\tdevice\n"
+        + "sx432wsds\tdevice\n"
+        + "\n";
+      exec.mockReturnValue({
+        stdout: adbDevicesConsoleOutput
+      });
+
+      const parsedDevices = [
+        { "adbName": "192.168.60.101:5555", "name": "192.168.60.101:5555", "type": "genymotion" },
+        { "adbName": "emulator-5556", "name": undefined, "port": "5556", "type": "emulator" },
+        { "adbName": "emulator-5554", "name": undefined, "port": "5554", "type": "emulator" },
+        { "adbName": "sx432wsds", "name": "sx432wsds", "type": "device" }];
+
+      const actual = await adb.devices();
+      expect(actual).toEqual(parsedDevices);
     });
 
     it(`should abort if port can't be parsed`, async () => {
@@ -82,6 +107,30 @@ describe('ADB', () => {
 
       await adb.devices();
       expect(mockEmulatorTelnet.connect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('lookup device', () => {
+    it('should look up a device by matcher', async () => {
+      const adbDevices = 'List of devices attached\n'
+        + 'MOCK_SERIAL\tdevice\n'
+        + '192.168.60.101:6666\tdevice\n'
+        + 'emulator-5554\tdevice\n'
+        + 'emulator-5556\tdevice\n'
+        + '\n';
+      const matcher = jest.fn()
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+
+      exec.mockReturnValue({
+        stdout: adbDevices,
+      });
+
+      const result = await adb.findDevice(matcher);
+
+      expect(result.adbName).toEqual('emulator-5554');
+      expect(matcher).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -186,27 +235,6 @@ describe('ADB', () => {
     await adb.listInstrumentation(deviceId);
 
     expect(adb.shell).toBeCalledWith(deviceId, 'pm list instrumentation');
-  });
-
-  it(`Parse 'adb device' output`, async () => {
-    const adbDevicesConsoleOutput = "List of devices attached\n"
-      + "192.168.60.101:5555\tdevice\n"
-      + "emulator-5556\tdevice\n"
-      + "emulator-5554\tdevice\n"
-      + "sx432wsds\tdevice\n"
-      + "\n";
-
-    const spyDevices = jest.spyOn(adb, 'devices');
-    spyDevices.mockReturnValue(Promise.resolve(adbDevicesConsoleOutput));
-
-    const parsedDevices = [
-      { "adbName": "192.168.60.101:5555", "name": "192.168.60.101:5555", "type": "genymotion" },
-      { "adbName": "emulator-5556", "name": undefined, "port": "5556", "type": "emulator" },
-      { "adbName": "emulator-5554", "name": undefined, "port": "5554", "type": "emulator" },
-      { "adbName": "sx432wsds", "name": "sx432wsds", "type": "device" }];
-
-    const actual = await adb.parseAdbDevicesConsoleOutput(adbDevicesConsoleOutput);
-    expect(actual).toEqual(parsedDevices);
   });
 
   it(`getInstrumentationRunner parses the correct runner for the package`, async () => {

--- a/detox/src/devices/android/Emulator.js
+++ b/detox/src/devices/android/Emulator.js
@@ -23,15 +23,15 @@ class Emulator {
     return (await exec(`${this.emulatorBin} ${cmd}`)).stdout;
   }
 
-  async boot(emulatorName, options = {port: undefined, readOnly: false}) {
+  async boot(emulatorName, options = {port: undefined}) {
     const emulatorArgs = _.compact([
       '-verbose',
       '-no-audio',
       '-no-boot-anim',
       argparse.getArgValue('headless') ? '-no-window' : '',
+      argparse.getArgValue('readOnlyEmu') ? '-read-only' : '',
       options.port ? `-port` : '',
       options.port ? `${options.port}` : '',
-      options.readOnly ? '-read-only' : '',
       `@${emulatorName}`
     ]);
 
@@ -41,7 +41,7 @@ class Emulator {
     }
 
     let childProcessOutput;
-    const tempLog = `./${emulatorName}.log`;
+    const tempLog = `./${emulatorName}-${options.port}.log`;
     const stdout = fs.openSync(tempLog, 'a');
     const stderr = fs.openSync(tempLog, 'a');
     const tailOptions = {

--- a/detox/src/devices/android/Emulator.js
+++ b/detox/src/devices/android/Emulator.js
@@ -1,12 +1,11 @@
-const path = require('path');
-const exec = require('../../utils/exec').execWithRetriesAndLogs;
-const spawn = require('child-process-promise').spawn;
 const _ = require('lodash');
-const unitLogger = require('../../utils/logger').child({ __filename });
 const fs = require('fs');
 const os = require('os');
-const Environment = require('../../utils/environment');
+const spawn = require('child-process-promise').spawn;
 const Tail = require('tail').Tail;
+const exec = require('../../utils/exec').execWithRetriesAndLogs;
+const unitLogger = require('../../utils/logger').child({ __filename });
+const Environment = require('../../utils/environment');
 const argparse = require('../../utils/argparse');
 
 class Emulator {
@@ -24,11 +23,15 @@ class Emulator {
     return (await exec(`${this.emulatorBin} ${cmd}`)).stdout;
   }
 
-  async boot(emulatorName) {
+  async boot(emulatorName, options = {port: undefined, readOnly: false}) {
     const emulatorArgs = _.compact([
       '-verbose',
       '-no-audio',
+      '-no-boot-anim',
       argparse.getArgValue('headless') ? '-no-window' : '',
+      options.port ? `-port` : '',
+      options.port ? `${options.port}` : '',
+      options.readOnly ? '-read-only' : '',
       `@${emulatorName}`
     ]);
 

--- a/detox/src/devices/drivers/AttachedAndroidDriver.js
+++ b/detox/src/devices/drivers/AttachedAndroidDriver.js
@@ -7,12 +7,18 @@ class AttachedAndroidDriver extends AndroidDriver {
     super(config);
 
     this.emulator = new Emulator();
+    this._name = 'Unspecified Device';
+  }
+
+  name() {
+    return this._name;
   }
 
   async acquireFreeDevice(name) {
     const deviceId = await this.findDeviceId({adbName: name});
     await this.adb.apiLevel(name);
     await this.adb.unlockScreen(deviceId);
+    this._name = `${deviceId} (${name})`;
     return deviceId;
   }
 }

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -44,10 +44,6 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
-  async boot() {
-    return await Promise.resolve('');
-  }
-
   async launchApp() {
     return await Promise.resolve('');
   }
@@ -78,7 +74,7 @@ class DeviceDriverBase {
   async matchFinger() {
     return await Promise.resolve('');
   }
-  
+
   async unmatchFinger() {
     return await Promise.resolve('');
   }

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -24,6 +24,10 @@ class DeviceDriverBase {
     });
   }
 
+  name() {
+    return 'UNKNOWN_DEVICE';
+  }
+
   off(event, listener) {
     this.emitter.off(event, listener);
   }

--- a/detox/src/devices/drivers/EmulatorDriver.js
+++ b/detox/src/devices/drivers/EmulatorDriver.js
@@ -77,7 +77,7 @@ class EmulatorDriver extends AndroidDriver {
   }
 
   async _waitForBootToComplete(deviceId) {
-    await retry({ retries: 120, interval: 5000 }, async () => {
+    await retry({ retries: 240, interval: 2500 }, async () => {
       const isBootComplete = await this.adb.isBootComplete(deviceId);
 
       if (!isBootComplete) {

--- a/detox/src/devices/drivers/EmulatorDriver.js
+++ b/detox/src/devices/drivers/EmulatorDriver.js
@@ -27,6 +27,11 @@ class EmulatorDriver extends AndroidDriver {
       lockfile: environment.getDeviceLockFilePathAndroid(),
     });
     this.pendingBoots = {};
+    this._name = 'Unspecified Emulator';
+  }
+
+  name() {
+    return this._name
   }
 
   async acquireFreeDevice(avdName) {
@@ -39,12 +44,13 @@ class EmulatorDriver extends AndroidDriver {
     await this.adb.apiLevel(adbName);
     await this.adb.unlockScreen(adbName);
 
+    this._name = `${adbName} (${avdName})`;
     return adbName;
   }
 
-  async cleanup(deviceId, bundleId) {
-    await this.deviceRegistry.freeDevice(deviceId);
-    await super.cleanup(deviceId, bundleId);
+  async cleanup(adbName, bundleId) {
+    await this.deviceRegistry.freeDevice(adbName);
+    await super.cleanup(adbName, bundleId);
   }
 
   async _boot(avdName, adbName) {

--- a/detox/src/devices/drivers/EmulatorDriver.js
+++ b/detox/src/devices/drivers/EmulatorDriver.js
@@ -1,85 +1,72 @@
 const _ = require('lodash');
 const path = require('path');
-const Emulator = require('../android/Emulator');
-const EmulatorTelnet = require('../android/EmulatorTelnet');
-const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
-const Environment = require('../../utils/environment');
-const retry = require('../../utils/retry');
-const sleep = require('../../utils/sleep');
-const AndroidDriver = require('./AndroidDriver');
 const ini = require('ini');
 const fs = require('fs');
 const os = require('os');
+const Emulator = require('../android/Emulator');
+const EmulatorTelnet = require('../android/EmulatorTelnet');
+const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
+const environment = require('../../utils/environment');
+const retry = require('../../utils/retry');
+const AndroidDriver = require('./AndroidDriver');
+const DeviceRegistry = require('../DeviceRegistry');
+
+const DetoxEmulatorsPortRange = {
+  min: 10000,
+  max: 20000
+};
 
 class EmulatorDriver extends AndroidDriver {
   constructor(config) {
     super(config);
 
     this.emulator = new Emulator();
+    this.deviceRegistry = new DeviceRegistry({
+      getDeviceIdsByType: this._getDeviceIdsByType.bind(this),
+      createDevice: this._createDevice.bind(this),
+      lockfile: environment.getDeviceLockFilePathAndroid(),
+    });
+    this.pendingBoots = {};
   }
 
-  async _fixEmulatorConfigIniSkinName(name) {
-    const configFile = `${os.homedir()}/.android/avd/${name}.avd/config.ini`;
-    const config = ini.parse(fs.readFileSync(configFile, 'utf-8'));
+  async acquireFreeDevice(avdName) {
+    await this._validateAvd(avdName);
+    await this._fixEmulatorConfigIniSkinNameIfNeeded(avdName);
 
-    if (!config['skin.name']) {
-      const width = config['hw.lcd.width'];
-      const height = config['hw.lcd.height'];
+    const adbName = await this.deviceRegistry.getDevice(avdName);
+    await this._boot(avdName, adbName);
 
-      if (width === undefined || height === undefined) {
-        throw new Error(`Emulator with name ${name} has a corrupt config.ini file (${configFile}), try fixing it by recreating an emulator.`);
-      }
-
-      config['skin.name'] = `${width}x${height}`;
-      fs.writeFileSync(configFile, ini.stringify(config));
-    }
-    return config;
-  }
-
-  async boot(avdName) {
-    let adbName = await this._findADBNameByAVDName(avdName, { strict: false });
-    const coldBoot = adbName == null;
-
-    // If it's not already running, start it now.
-    if (coldBoot) {
-      await this.emulator.boot(avdName);
-      adbName = await this._findADBNameByAVDName(avdName, { strict: true });
-    }
-
-    await this._waitForBootToComplete(adbName);
-    await this.emitter.emit('bootDevice', { coldBoot, deviceId: adbName });
+    await this.adb.apiLevel(adbName);
+    await this.adb.unlockScreen(adbName);
 
     return adbName;
   }
 
-  async _findADBNameByAVDName(avdName, { strict }) {
-    const adbDevices = await this.adb.devices();
-    const filteredDevices = _.filter(adbDevices, {type: 'emulator', name: avdName});
-
-    if (filteredDevices.length === 1) {
-      return filteredDevices[0].adbName;
-    }
-
-    if (filteredDevices.length > 1) {
-      throw new Error(`Got more than one device corresponding to the name: ${avdName}`);
-    }
-
-    if (strict) {
-      throw new Error(`Could not find '${avdName}' on the currently ADB attached devices, 
-      try restarting adb 'adb kill-server && adb start-server'`);
-    }
-
-    return null;
+  async cleanup(deviceId, bundleId) {
+    await this.deviceRegistry.freeDevice(deviceId);
+    await super.cleanup(deviceId, bundleId);
   }
 
-  async acquireFreeDevice(avdName) {
-    const avds = await this.emulator.listAvds();
+  async _boot(avdName, adbName) {
+    const coldBoot = !!this.pendingBoots[adbName];
 
+    if (coldBoot) {
+      const port = this.pendingBoots[adbName];
+      await this.emulator.boot(avdName, {port});
+      delete this.pendingBoots[adbName];
+    }
+
+    await this._waitForBootToComplete(adbName);
+    await this.emitter.emit('bootDevice', { coldBoot, deviceId: adbName });
+  }
+
+  async _validateAvd(avdName) {
+    const avds = await this.emulator.listAvds();
     if (!avds) {
-      const avdmanagerPath = path.join(Environment.getAndroidSDKPath(), 'tools', 'bin', 'avdmanager');
+      const avdmanagerPath = path.join(environment.getAndroidSDKPath(), 'tools', 'bin', 'avdmanager');
 
       throw new Error(`Could not find any configured Android Emulator. 
-      Try creating a device first, example: ${avdmanagerPath} create avd --force --name Nexus_5X_API_24 --abi x86 --package 'system-images;android-24;google_apis_playstore;x86' --device "Nexus 5X"
+      Try creating a device first, example: ${avdmanagerPath} create avd --force --name Pixel_2_API_26 --abi x86 --package 'system-images;android-26;google_apis_playstore;x86' --device "Pixel 2"
       or go to https://developer.android.com/studio/run/managing-avds.html for details on how to create an Emulator.`);
     }
 
@@ -87,14 +74,6 @@ class EmulatorDriver extends AndroidDriver {
       throw new Error(`Can not boot Android Emulator with the name: '${avdName}',
       make sure you choose one of the available emulators: ${avds.toString()}`);
     }
-
-    await this._fixEmulatorConfigIniSkinName(avdName);
-
-    const adbName = await this.boot(avdName);
-    await this.adb.apiLevel(adbName);
-    await this.adb.unlockScreen(adbName);
-
-    return adbName;
   }
 
   async _waitForBootToComplete(deviceId) {
@@ -116,6 +95,55 @@ class EmulatorDriver extends AndroidDriver {
     await telnet.connect(port);
     await telnet.kill();
     await this.emitter.emit('shutdownDevice', { deviceId });
+  }
+
+  async _fixEmulatorConfigIniSkinNameIfNeeded(avdName) {
+    const configFile = `${os.homedir()}/.android/avd/${avdName}.avd/config.ini`;
+    const config = ini.parse(fs.readFileSync(configFile, 'utf-8'));
+
+    if (!config['skin.name']) {
+      const width = config['hw.lcd.width'];
+      const height = config['hw.lcd.height'];
+
+      if (width === undefined || height === undefined) {
+        throw new Error(`Emulator with name ${avdName} has a corrupt config.ini file (${configFile}), try fixing it by recreating an emulator.`);
+      }
+
+      config['skin.name'] = `${width}x${height}`;
+      fs.writeFileSync(configFile, ini.stringify(config));
+    }
+    return config;
+  }
+
+  async _getDeviceIdsByType(name) {
+    const device = await this.adb.findDevice(async (candidate) => {
+      const isEmulator = candidate.type === 'emulator';
+      const isMatchingName = candidate.name === name;
+      if (!(isEmulator && isMatchingName)) {
+        return false;
+      }
+
+      // Note: though not entirely pure, this is an important optimization so as to avoid preparsing of all
+      // potentially fit emulators, which can be time consuming - mostly because of the telnet.
+      const isBusy = await this.deviceRegistry._getBusyDevices().includes(candidate.adbName);
+      return !isBusy;
+    });
+
+    const devices = [];
+    if (device) {
+      devices.push(device.adbName);
+    }
+    return devices;
+  }
+
+  async _createDevice() {
+    const {min, max} = DetoxEmulatorsPortRange;
+    let port = Math.random() * (max - min) + min;
+    port = port & (~0 - 1);
+
+    const adbName = `emulator-${port}`;
+    this.pendingBoots[adbName] = port;
+    return adbName;
   }
 }
 

--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -17,6 +17,12 @@ class SimulatorDriver extends IosDriver {
       createDevice: type => this.applesimutils.create(type),
       lockfile: environment.getDeviceLockFilePathIOS(),
     });
+
+    this._name = 'Unspecified Simulator';
+  }
+
+  name() {
+    return this._name;
   }
 
   async prepare() {
@@ -36,10 +42,11 @@ class SimulatorDriver extends IosDriver {
   async acquireFreeDevice(name) {
     const deviceId = await this.deviceRegistry.getDevice(name);
     if (deviceId) {
-      await this.boot(deviceId);
+      await this._boot(deviceId);
     } else {
       console.error('Unable to acquire free device ', name);
     }
+    this._name = `${deviceId || 'UNKNOWN_DEVICE_ID'} (${name})`;
     return deviceId;
   }
 

--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -15,6 +15,7 @@ class SimulatorDriver extends IosDriver {
     this.deviceRegistry = new DeviceRegistry({
       getDeviceIdsByType: async type => await this.applesimutils.findDevicesUDID(type),
       createDevice: type => this.applesimutils.create(type),
+      lockfile: environment.getDeviceLockFilePathIOS(),
     });
   }
 
@@ -55,7 +56,7 @@ class SimulatorDriver extends IosDriver {
     }
   }
 
-  async boot(deviceId) {
+  async _boot(deviceId) {
     const coldBoot = await this.applesimutils.boot(deviceId);
     await this.emitter.emit('bootDevice', { coldBoot, deviceId });
   }
@@ -123,7 +124,7 @@ class SimulatorDriver extends IosDriver {
   async resetContentAndSettings(deviceId) {
     await this.shutdown(deviceId);
     await this.applesimutils.resetContentAndSettings(deviceId);
-    await this.boot(deviceId);
+    await this._boot(deviceId);
   }
 
   validateDeviceConfig(deviceConfig) {

--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -13,6 +13,7 @@ describe('index', () => {
           id: jest.fn(),
         };
       }),
+      deviceName: jest.fn(),
       cleanup: jest.fn(),
       beforeEach: jest.fn(),
       afterEach: jest.fn(),
@@ -199,6 +200,17 @@ describe('index', () => {
     expect(mockDetox.cleanup).toHaveBeenCalled();
   });
 
+  it(`should return name from detox`, async () => {
+    mockDetox.deviceName.mockReturnValue('mock-device-name');
+    await detox.init(schemes.validOneDeviceNoSession);
+    expect(detox.deviceName()).toEqual('mock-device-name');
+  });
+
+  it(`should fallback to empty name before init`, async () => {
+    mockDetox.deviceName.mockReturnValue('mock-device-name');
+    expect(detox.deviceName()).toEqual('');
+  });
+
   it(`beforeEach() should be covered - with detox initialized`, async() => {
     await detox.init(schemes.validOneDeviceNoSession);
     await detox.beforeEach();
@@ -216,4 +228,5 @@ describe('index', () => {
   it(`afterEach() should be covered - with detox not initialized`, async() => {
     await detox.afterEach();
   });
+
 });

--- a/detox/src/utils/environment.js
+++ b/detox/src/utils/environment.js
@@ -5,7 +5,8 @@ const exec = require('child-process-promise').exec;
 const appdatapath = require('./appdatapath');
 
 const DETOX_LIBRARY_ROOT_PATH = path.join(appdatapath.appDataPath(), 'Detox');
-const DEVICE_LOCK_FILE_PATH = path.join(DETOX_LIBRARY_ROOT_PATH, 'device.registry.state.lock');
+const DEVICE_LOCK_FILE_PATH_IOS = path.join(DETOX_LIBRARY_ROOT_PATH, 'device.registry.state.lock');
+const DEVICE_LOCK_FILE_PATH_ANDROID = path.join(DETOX_LIBRARY_ROOT_PATH, 'android-device.registry.state.lock');
 
 function getAndroidSDKPath() {
   let sdkPath = process.env.ANDROID_SDK_ROOT || process.env.ANDROID_HOME;
@@ -39,8 +40,12 @@ function getDetoxLibraryRootPath() {
   return DETOX_LIBRARY_ROOT_PATH;
 }
 
-function getDeviceLockFilePath() {
-  return DEVICE_LOCK_FILE_PATH;
+function getDeviceLockFilePathIOS() {
+  return DEVICE_LOCK_FILE_PATH_IOS;
+}
+
+function getDeviceLockFilePathAndroid() {
+  return DEVICE_LOCK_FILE_PATH_ANDROID;
 }
 
 function getHomeDir() {
@@ -53,6 +58,7 @@ module.exports = {
   getAndroidSDKPath,
   getAndroidEmulatorPath,
   getDetoxLibraryRootPath,
-  getDeviceLockFilePath,
+  getDeviceLockFilePathIOS,
+  getDeviceLockFilePathAndroid,
   getHomeDir,
 };

--- a/detox/test/e2e/23.flows.test.js
+++ b/detox/test/e2e/23.flows.test.js
@@ -1,6 +1,7 @@
 describe('Flows', () => {
+
   it('should exit without timeouts if app was terminated inside test', async () => {
-    await device.launchApp();
+    await device.launchApp({newInstance: true});
     await device.terminateApp();
   });
 });

--- a/detox/test/e2e/init.js
+++ b/detox/test/e2e/init.js
@@ -2,12 +2,17 @@ const detox = require('detox');
 const config = require('../package.json').detox;
 const adapter = require('detox/runners/jest/adapter');
 const specReporter = require('detox/runners/jest/specReporter');
+const assignReporter = require('detox/runners/jest/assignReporter');
 
 jasmine.getEnv().addReporter(adapter);
 
 // This takes care of generating status logs on a per-spec basis. By default, jest only reports at file-level.
 // This is strictly optional.
 jasmine.getEnv().addReporter(specReporter);
+
+// This will post which device has assigned to run a suite, in a multiple-worker test session.
+// This is strictly optional.
+jasmine.getEnv().addReporter(assignReporter);
 
 // Set the default timeout
 jest.setTimeout(300000);

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -13,7 +13,7 @@
     "e2e:ios-ci": "detox test --configuration ios.sim.release --workers 3 --debug-synchronization --take-screenshots all --record-logs all -- --coverage",
     "e2e:android": "detox test --configuration android.emu.release",
     "e2e:android-debug": "detox test --configuration android.emu.debug",
-    "e2e:android-ci": "detox test e2e --configuration android.emu.release --workers 4 --take-screenshots all --record-logs all --headless --loglevel verbose -- --coverage",
+    "e2e:android-ci": "detox test e2e --configuration android.emu.release --workers 3 --take-screenshots all --record-logs all --headless --loglevel verbose -- --coverage",
     "build:ios": "detox build --configuration ios.sim.release",
     "build:android": "detox build --configuration android.emu.release",
     "build:android-debug": "detox build --configuration android.emu.debug",

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -13,7 +13,7 @@
     "e2e:ios-ci": "detox test --configuration ios.sim.release --workers 3 --debug-synchronization --take-screenshots all --record-logs all -- --coverage",
     "e2e:android": "detox test --configuration android.emu.release",
     "e2e:android-debug": "detox test --configuration android.emu.debug",
-    "e2e:android-ci": "detox test e2e --configuration android.emu.release --workers 3 --take-screenshots all --record-logs all --headless --loglevel verbose -- --coverage",
+    "e2e:android-ci": "detox test e2e --configuration android.emu.release --workers 5 --take-screenshots all --record-logs all --headless --loglevel verbose -- --coverage",
     "build:ios": "detox build --configuration ios.sim.release",
     "build:android": "detox build --configuration android.emu.release",
     "build:android-debug": "detox build --configuration android.emu.debug",

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -13,7 +13,7 @@
     "e2e:ios-ci": "detox test --configuration ios.sim.release --workers 3 --debug-synchronization --take-screenshots all --record-logs all -- --coverage",
     "e2e:android": "detox test --configuration android.emu.release",
     "e2e:android-debug": "detox test --configuration android.emu.debug",
-    "e2e:android-ci": "detox test e2e --configuration android.emu.release --take-screenshots all --record-logs all --headless --loglevel verbose -- --coverage",
+    "e2e:android-ci": "detox test e2e --configuration android.emu.release --workers 4 --take-screenshots all --record-logs all --headless --loglevel verbose -- --coverage",
     "build:ios": "detox build --configuration ios.sim.release",
     "build:android": "detox build --configuration android.emu.release",
     "build:android-debug": "detox build --configuration android.emu.debug",


### PR DESCRIPTION
- [ ] This is a small change 
- [x] This change has been discussed in issue #1572 and the solution has been agreed upon with maintainers.

---

**Description:**

The first step towards officially introducing parallel testing on Android (multiple jest workers).
Reasons for this being beta:
- Uses a feature of the android emulator's binary which is still in beta (`-read-only`). It was introduced [~1 year ago](https://androidstudio.googleblog.com/2018/07/emulator-2800-canary.html), and looks stable - but many versions have been released since then and I couldn't test all of them.
- Some error-logs show when using 3 workers or more (though everything works fine).
- The whole feature hasn't been documented yet.
- Worker-device assignment reporter doesn't seem completely stable yet, and it hasn't been documented.