### PR TITLE
feat(android): add platform-specific API for clearing package data

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -235,7 +235,7 @@ class Device {
   }
 
   async resetContentAndSettings() {
-    await this.deviceDriver.resetContentAndSettings(this._deviceId);
+    await this.deviceDriver.resetContentAndSettings(this._deviceId, this._bundleId);
   }
 
   getPlatform() {

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -130,6 +130,10 @@ class ADB {
     await this.adbCmd(deviceId, `uninstall ${appId}`);
   }
 
+  async clearStorage(deviceId, packageId) {
+    await this.adbCmd(deviceId, `shell pm clear ${packageId}`)
+  }
+
   async terminate(deviceId, appId) {
     await this.shell(deviceId, `am force-stop ${appId}`);
   }

--- a/detox/src/devices/android/ADB.test.js
+++ b/detox/src/devices/android/ADB.test.js
@@ -98,6 +98,11 @@ describe('ADB', () => {
       undefined, undefined, 1);
   });
 
+  it(`clears storage`, async () => {
+    await adb.clearStorage('com.package');
+    expect(exec).toHaveBeenCalledTimes(1)
+  })
+
   it(`uninstall`, async () => {
     await adb.uninstall('com.package');
     expect(exec).toHaveBeenCalledTimes(1);

--- a/detox/src/devices/drivers/AndroidDriver.js
+++ b/detox/src/devices/drivers/AndroidDriver.js
@@ -110,6 +110,10 @@ class AndroidDriver extends DeviceDriverBase {
     return pid;
   }
 
+  async resetContentAndSettings(deviceId, packageId) {
+    await Promise.all([this.adb.clearStorage(deviceId, packageId), this.adb.clearStorage(deviceId, `${packageId}.test`)])
+  }
+
   async deliverPayload(params) {
     const {delayPayload, url} = params;
 

--- a/detox/src/devices/drivers/AndroidDriver.js
+++ b/detox/src/devices/drivers/AndroidDriver.js
@@ -110,8 +110,11 @@ class AndroidDriver extends DeviceDriverBase {
     return pid;
   }
 
-  async resetContentAndSettings(deviceId, packageId) {
-    await Promise.all([this.adb.clearStorage(deviceId, packageId), this.adb.clearStorage(deviceId, `${packageId}.test`)])
+  async resetContentAndSettings(deviceId, bundleId) {
+    await Promise.all([
+      this.adb.clearStorage(deviceId, bundleId),
+      this.adb.clearStorage(deviceId, `${bundleId}.test`)
+    ]);
   }
 
   async deliverPayload(params) {


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

added clearStorage option to clear app data for android
