### PR TITLE
fix(attached-android): reverse port forwarding, and screen unlocking

### DIFF
--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -23,7 +23,7 @@ class ADB {
       mUserActivityTimeoutOverrideFromWindowManager,
     } = await this._getPowerStatus(deviceId);
 
-    if (mWakefulness === 'Asleep') {
+    if (mWakefulness === 'Asleep' || mWakefulness === 'Dozing') {
       await this.pressPowerDevice(deviceId);
     }
 

--- a/detox/src/devices/android/ADB.js
+++ b/detox/src/devices/android/ADB.js
@@ -269,6 +269,14 @@ class ADB {
     return (await this.adbCmd(deviceId, `shell "${escape.inQuotedString(cmd)}"`, options)).stdout.trim();
   }
 
+  async reverse(deviceId, port) {
+    return this.adbCmd(deviceId, `reverse tcp:${port} tcp:${port}`);
+  }
+
+  async reverseRemove(deviceId, port) {
+    return this.adbCmd(deviceId, `reverse --remove tcp:${port}`);
+  }
+
   async adbCmd(deviceId, params, options) {
     const serial = `${deviceId ? `-s ${deviceId}` : ''}`;
     const cmd = `${this.adbBin} ${serial} ${params}`;

--- a/detox/src/devices/drivers/AndroidDriver.test.js
+++ b/detox/src/devices/drivers/AndroidDriver.test.js
@@ -27,7 +27,11 @@ describe('Android driver', () => {
   beforeEach(() => {
     const AndroidDriver = require('./AndroidDriver');
     uut = new AndroidDriver({
-      client: {}
+      client: {
+        configuration: {
+          server: 'ws://localhost:1234'
+        }
+      }
     });
   });
 
@@ -72,6 +76,8 @@ describe('Android driver', () => {
 class mockADBClass {
   constructor() {
     this.getInstrumentationRunner = jest.fn();
+    this.reverse = jest.fn();
+    this.reverseRemove = jest.fn();
   }
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 

---

**Description:**
This PR addresses 2 things for testing on android devices:
- Automatic reverse port forwarding for `DetoxServer` to connect back to the host machine. Relevant issues: #1174 #1200 #968 
- Screen unlocking from `'Dozing'` state