### PR TITLE
Fix biometric matching timeout

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -142,22 +142,18 @@ class Device {
 
   async matchFace() {
     await this.deviceDriver.matchFace(this._deviceId);
-    await this.deviceDriver.waitForBackground();
   }
 
   async unmatchFace() {
     await this.deviceDriver.unmatchFace(this._deviceId);
-    await this.deviceDriver.waitForBackground();
   }
 
   async matchFinger() {
     await this.deviceDriver.matchFinger(this._deviceId);
-    await this.deviceDriver.waitForBackground();
   }
 
   async unmatchFinger() {
     await this.deviceDriver.unmatchFinger(this._deviceId);
-    await this.deviceDriver.waitForBackground();
   }
 
   async shake() {

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -142,18 +142,22 @@ class Device {
 
   async matchFace() {
     await this.deviceDriver.matchFace(this._deviceId);
+    await this.deviceDriver.waitForActive();
   }
 
   async unmatchFace() {
     await this.deviceDriver.unmatchFace(this._deviceId);
+    await this.deviceDriver.waitForActive();
   }
 
   async matchFinger() {
     await this.deviceDriver.matchFinger(this._deviceId);
+    await this.deviceDriver.waitForActive();
   }
 
   async unmatchFinger() {
     await this.deviceDriver.unmatchFinger(this._deviceId);
+    await this.deviceDriver.waitForActive();
   }
 
   async shake() {


### PR DESCRIPTION
- [x ] This is a small change 

Attempting to match biometrics always times out. These functions call 'waitForBackground' which is unnecessary as far as I can tell. The app does not background after matching a face or finger and this causes the test to always time out.

I believe there is still an issue with biometrics where `waitForActive` will always time out when a Face ID or Touch ID dialog is opened upon app launch. However that may be a broader issue.