### PR TITLE
Log reflection errors from looper introspection

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
@@ -222,6 +222,7 @@ public class ReactNativeSupport {
                 looper = Reflect.on(queue).call(METHOD_GET_LOOPER).get();
             }
         } catch (ReflectException e) {
+            Log.i(LOG_TAG, "Could not find looper queue: " + queueName, e.getCause());
             return null;
         }
         return looper;

--- a/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
@@ -222,7 +222,7 @@ public class ReactNativeSupport {
                 looper = Reflect.on(queue).call(METHOD_GET_LOOPER).get();
             }
         } catch (ReflectException e) {
-            Log.i(LOG_TAG, "Could not find looper queue: " + queueName, e.getCause());
+            Log.e(LOG_TAG, "Could not find looper queue: " + queueName, e.getCause());
             return null;
         }
         return looper;


### PR DESCRIPTION
- [ x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

**Description:**
If you are trying to set-up Detox in your app and there is a proguard misconfiguration then this usage of reflection may fail and it will be silent. If this log were here, it would have been a huge clue that would have saved me from having to manually debug Detox to find this thrown exception.