### PR TITLE
chore(npmignore): exclude extra files in npm package

### DIFF
--- a/detox/.npmignore
+++ b/detox/.npmignore
@@ -6,8 +6,13 @@ DerivedData/
 DetoxBuild/
 Detox.framework/
 
+.eslintrc
+.nvmrc
+.vscode
+jsconfig.json
 
 src/**/*.test.js
+/__tests__
 __snapshots__
 ios_src
 

--- a/detox/.npmignore
+++ b/detox/.npmignore
@@ -12,7 +12,8 @@ Detox.framework/
 jsconfig.json
 
 src/**/*.test.js
-/__tests__
+__tests__
+__mocks__
 __snapshots__
 ios_src
 

--- a/detox/.npmignore
+++ b/detox/.npmignore
@@ -12,6 +12,9 @@ Detox.framework/
 jsconfig.json
 
 src/**/*.test.js
+src/**/*.mock.js
+src/**/*.mock.json
+
 __tests__
 __mocks__
 __snapshots__

--- a/detox/.npmignore
+++ b/detox/.npmignore
@@ -10,14 +10,15 @@ Detox.framework/
 .nvmrc
 .vscode
 jsconfig.json
-
-src/**/*.test.js
-src/**/*.mock.js
-src/**/*.mock.json
+wallaby.js
 
 __tests__
 __mocks__
 __snapshots__
+src/**/*.test.js
+src/**/*.mock.js
+src/**/*.mock.json
+
 ios_src
 
 #################


### PR DESCRIPTION
Just small extension of npmignore, to save npm traffic and npminstall time.