### PR TITLE
Corrects React Native version specifier in Mocking

### DIFF
--- a/docs/Guide.Mocking.md
+++ b/docs/Guide.Mocking.md
@@ -21,7 +21,7 @@ This replacement mechanism provides a lot of flexibility to change implementatio
 
 #### Configuration
 0. For RN < 0.55, setup `react-native-repackager` in your library.
-1. For case 0.55 <= RN < 0.59 create a file called `rn-cli.config.js` in the root folder. If you use RN > 0.59 (which in turn uses Metro with breaking changes introduced in 0.43 - https://github.com/facebook/metro/releases/tag/v0.43.0) file should have name `metro.config.js` or `metro.config.json` (or define metro field in `package.json`) to root dir. Then set up `resolver.sourceExts` to prioritize any given source extension over the default one:
+1. For case 0.55 <= RN < 0.59 create a file called `rn-cli.config.js` in the root folder. If you use RN >= 0.59 (which in turn uses Metro with breaking changes introduced in 0.43 - https://github.com/facebook/metro/releases/tag/v0.43.0) file should have name `metro.config.js` or `metro.config.json` (or define metro field in `package.json`) to root dir. Then set up `resolver.sourceExts` to prioritize any given source extension over the default one:
 
     ```js
     const defaultSourceExts = require('metro-config/src/defaults/defaults').sourceExts


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
The two scenarios for the different React Native version ranges misses 0.59. This corrects the latter range.