### PR TITLE
Upgrade Gradle to 5.1.1

### DIFF
--- a/detox/android/build.gradle
+++ b/detox/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.isOfficialDetoxLib = true
-    ext.kotlinVersion = '1.3.0'
+    ext.kotlinVersion = '1.3.41'
     ext.detoxKotlinVerion = ext.kotlinVersion
     ext.dokkaVersion = '0.9.18'
     ext.buildToolsVersion = '28.0.3'
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
 

--- a/detox/android/gradle.properties
+++ b/detox/android/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# Not ready for this yet
+android.enableR8=false

--- a/detox/android/gradle/wrapper/gradle-wrapper.properties
+++ b/detox/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun May 26 15:32:06 IDT 2019
+#Sun Sep 15 22:36:02 IDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/detox/test/android/build.gradle
+++ b/detox/test/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.isOfficialDetoxApp = true
-    ext.kotlinVersion = '1.3.0'
+    ext.kotlinVersion = '1.3.41'
     ext.detoxKotlinVerion = ext.kotlinVersion
     ext.buildToolsVersion = '28.0.3'
 
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'de.undercouch:gradle-download-task:3.4.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 

--- a/detox/test/android/gradle.properties
+++ b/detox/test/android/gradle.properties
@@ -17,4 +17,5 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-android.useDeprecatedNdk=true
+# Not ready for this yet
+android.enableR8=false

--- a/detox/test/android/gradle/wrapper/gradle-wrapper.properties
+++ b/detox/test/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 21 17:08:37 IDT 2019
+#Sun Sep 15 22:36:02 IDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/examples/demo-native-android/build.gradle
+++ b/examples/demo-native-android/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/demo-native-android/gradle.properties
+++ b/examples/demo-native-android/gradle.properties
@@ -15,3 +15,5 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.enableR8=false

--- a/examples/demo-native-android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/demo-native-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 26 11:45:06 IST 2016
+#Sun Sep 15 23:01:02 IDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/examples/demo-react-native/android/build.gradle
+++ b/examples/demo-react-native/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.3.0'
+    ext.kotlinVersion = '1.3.41'
     ext.detoxKotlinVersion = ext.kotlinVersion
 
     repositories {
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/examples/demo-react-native/android/gradle.properties
+++ b/examples/demo-react-native/android/gradle.properties
@@ -17,4 +17,5 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-android.useDeprecatedNdk=true
+# Not ready for this yet
+android.enableR8=false

--- a/examples/demo-react-native/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/demo-react-native/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 03 11:38:02 IDT 2019
+#Sun Sep 15 22:51:43 IDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #0 and the solution has been agreed upon with maintainers.

---

**Description:**

Upgrade Gradle to `5.1.1` and the Android gradle-plugin to equivalent version `3.4.1` in all demo apps. Biggest motivation for doing this is the [HTTP retries](https://docs.gradle.org/5.0/release-notes.html#http-retries-during-dependency-resolution) feature.

Disclaimer: the feature may not be fully functional as described [in this report to gradle](https://github.com/gradle/gradle/issues/8264). I hope it'd be ok for us nevertheless.