### PR TITLE
Improve overall accuracy of native android scrolling

### DIFF
--- a/detox/test/e2e/03.integ-actions.test.js
+++ b/detox/test/e2e/03.integ-actions.test.js
@@ -43,7 +43,7 @@ describe(':android: Integrative actions', () => {
    * This use case is a nearly identical reproduction of https://github.com/wix/Detox/issues/1495
    */
   it('should scroll various distances accurately, and type text into text fields', async () => {
-    const iterations = 9; // TODO See why this tends to fail when #iterations=10
+    const iterations = 10;
     const inputHeightDP = 40;
     const baseMarginDP = 20;
 

--- a/detox/test/e2e/drivers/integ-actions-drivers.js
+++ b/detox/test/e2e/drivers/integ-actions-drivers.js
@@ -1,7 +1,12 @@
+// This isn't ideal, but native scrolling is never entirely accurate, compared the exact amount we pass in in DP.
+// This is an approximation based on experiments (over the current native impl.), AND IS IN NO WAY A MAGIC NUMBER (!!!),
+// especially since the inaccuracy is not linear as we assume here.
+const SCROLL_ADJ_FACTOR = 1.035;
+
 const scrollingTextsDriver = {
   scrollView: () => element(by.id('integActions.textsScrollView')),
   scrollDown: async (amount) => {
-    await scrollingTextsDriver.scrollView().scroll(amount + 15.5, 'down'); // Adjustment is experiments-based, not a magic number!
+    await scrollingTextsDriver.scrollView().scroll(amount * SCROLL_ADJ_FACTOR, 'down'); // Adjustment is experiments-based, not a magic number!
   },
   tapOnText: async (id) => {
     const elementId = scrollingTextsDriver._elementId(id);
@@ -18,7 +23,7 @@ const scrollingTextsDriver = {
 const scrollingTextInputsDriver = {
   scrollView: () => element(by.id('integActions.inputsScrollView')),
   scrollDown: async (amount) => {
-    await scrollingTextInputsDriver.scrollView().scroll(amount + 16, 'down'); // Adjustment is experiments-based, not a magic number!
+    await scrollingTextInputsDriver.scrollView().scroll(amount * SCROLL_ADJ_FACTOR, 'down');
   },
   typeInField: async (fieldId) => {
     const elementId = scrollingTextInputsDriver._elementId(fieldId);


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #0000 and the solution has been agreed upon with maintainers.

---

**Description:**

Improves native-scrolling accuracy (Android), in terms of how close the effective scrolling will be on the device, compared to the scrolling amount provided in DIP in Detox tests.
As a result, it should stabilize currently flaky integration-actions tests that involve intense scrolling scenarios.