### PR TITLE
Update expect.js to include swipe() action on whileElement() method

### DIFF
--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -195,6 +195,11 @@ class WaitForActionInteraction extends WaitForActionInteractionBase {
     this._prepare(new ScrollAmountStopAtEdgeAction(direction, amount));
     await this.execute();
   }
+  
+  async swipe(direction, speed = 'fast') {
+    this._prepare(new SwipeAction(direction, speed));
+    await this.execute();
+  }
 }
 
 class Element {

--- a/detox/src/ios/expect.js
+++ b/detox/src/ios/expect.js
@@ -271,6 +271,11 @@ class WaitForActionInteraction extends Interaction {
     this._searchMatcher = this._searchMatcher._extendToDescendantScrollViews();
     await this._execute(new ScrollAmountAction(direction, amount, startScrollX, startScrollY));
   }
+  async swipe(direction, speed = 'fast') {
+    // override the user's element selection with an extended matcher that avoids RN issues with RCTScrollView
+    this._searchMatcher = this._searchMatcher._avoidProblematicReactNativeElements();
+    await this.execute(new SwipeAction(direction, speed));
+  }
 }
 
 class Element {

--- a/detox/test/e2e/05.waitfor.test.js
+++ b/detox/test/e2e/05.waitfor.test.js
@@ -47,4 +47,11 @@ describe('WaitFor', () => {
     await expectToThrow(() => waitFor(element(by.text('Text1000'))).toBeVisible().whileElement(by.id('ScrollView')).scroll(50, 'down'));
     await expect(element(by.text('Text1000'))).toBeNotVisible();
   });
+  
+  
+  it('should abort swiping if element was not found', async () => {
+    await element(by.id('GoButton')).tap();
+    await expectToThrow(() => waitFor(element(by.text('Text1000'))).toBeVisible().whileElement(by.id('ScrollView')).swipe('up', 'fast'));
+    await expect(element(by.text('Text1000'))).toBeNotVisible();
+  });
 });


### PR DESCRIPTION
Allow the `.swipe()` action to be used when using the `whileElement()` method on the `waitFor()` manual synchronization.

<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
