### PR TITLE
Scroll start position android

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxAction.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxAction.java
@@ -106,8 +106,12 @@ public class DetoxAction {
      *
      * @param direction Direction to scroll (see {@link MotionDir})
      * @param amountInDP Density Independent Pixels
+     * @param startOffsetPercentX Percentage denoting where X-swipe should start, with respect to the scrollable view.
+     * @param startOffsetPercentY Percentage denoting where Y-swipe should start, with respect to the scrollable view.
      */
-    public static ViewAction scrollInDirection(final int direction, final double amountInDP) {
+    public static ViewAction scrollInDirection(final int direction, final double amountInDP, double startOffsetPercentX, double startOffsetPercentY) {
+        final Float _startOffsetPercentX = startOffsetPercentX < 0 ? null : (float) startOffsetPercentX;
+        final Float _startOffsetPercentY = startOffsetPercentY < 0 ? null : (float) startOffsetPercentY;
         return actionWithAssertions(new ViewAction() {
             @Override
             public Matcher<View> getConstraints() {
@@ -122,7 +126,7 @@ public class DetoxAction {
             @Override
             public void perform(UiController uiController, View view) {
                 try {
-                    ScrollHelper.perform(uiController, view, direction, amountInDP);
+                    ScrollHelper.perform(uiController, view, direction, amountInDP, _startOffsetPercentX, _startOffsetPercentY);
                 } catch (Exception e) {
                     throw new DetoxRuntimeException(e);
                 }
@@ -132,14 +136,18 @@ public class DetoxAction {
 
     /**
      * Scroll the view in a direction by a specified amount (DP units).
-     * <br/>Similar to {@link #scrollInDirection(int, double)}, but stops <b>gracefully</b> in the case
+     * <br/>Similar to {@link #scrollInDirection(int, double, double, double)}, but stops <b>gracefully</b> in the case
      * where the scrolling-edge is reached, by throwing the {@link StaleActionException} exception (i.e.
      * so as to make this use case manageable by the user).
      *
      * @param direction Direction to scroll (see {@link MotionDir})
      * @param amountInDP Density Independent Pixels
+     * @param startOffsetPercentX Percentage denoting where X-swipe should start, with respect to the scrollable view.
+     * @param startOffsetPercentY Percentage denoting where Y-swipe should start, with respect to the scrollable view.
      */
-    public static ViewAction scrollInDirectionStaleAtEdge(final int direction, final double amountInDP) {
+    public static ViewAction scrollInDirectionStaleAtEdge(final int direction, final double amountInDP, double startOffsetPercentX, double startOffsetPercentY) {
+        final Float _startOffsetPercentX = startOffsetPercentX < 0 ? null : (float) startOffsetPercentX;
+        final Float _startOffsetPercentY = startOffsetPercentY < 0 ? null : (float) startOffsetPercentY;
         return actionWithAssertions(new ViewAction() {
             @Override
             public Matcher<View> getConstraints() {
@@ -154,7 +162,7 @@ public class DetoxAction {
             @Override
             public void perform(UiController uiController, View view) {
                 try {
-                    ScrollHelper.perform(uiController, view, direction, amountInDP);
+                    ScrollHelper.perform(uiController, view, direction, amountInDP, _startOffsetPercentX, _startOffsetPercentY);
                 } catch (ScrollEdgeException exScrollAtEdge) {
                     throw new StaleActionException(exScrollAtEdge);
                 }

--- a/detox/src/android/espressoapi/DetoxAction.js
+++ b/detox/src/android/espressoapi/DetoxAction.js
@@ -83,9 +83,11 @@ class DetoxAction {
     };
   }
 
-  static scrollInDirection(direction, amountInDP) {
+  static scrollInDirection(direction, amountInDP, startOffsetPercentX, startOffsetPercentY) {
     if (typeof direction !== "string") throw new Error("direction should be a string, but got " + (direction + (" (" + (typeof direction + ")"))));
     if (typeof amountInDP !== "number") throw new Error("amountInDP should be a number, but got " + (amountInDP + (" (" + (typeof amountInDP + ")"))));
+    if (typeof startOffsetPercentX !== "number") throw new Error("startOffsetPercentX should be a number, but got " + (startOffsetPercentX + (" (" + (typeof startOffsetPercentX + ")"))));
+    if (typeof startOffsetPercentY !== "number") throw new Error("startOffsetPercentY should be a number, but got " + (startOffsetPercentY + (" (" + (typeof startOffsetPercentY + ")"))));
     return {
       target: {
         type: "Class",
@@ -98,13 +100,21 @@ class DetoxAction {
       }, {
         type: "Double",
         value: amountInDP
+      }, {
+        type: "Double",
+        value: startOffsetPercentX
+      }, {
+        type: "Double",
+        value: startOffsetPercentY
       }]
     };
   }
 
-  static scrollInDirectionStaleAtEdge(direction, amountInDP) {
+  static scrollInDirectionStaleAtEdge(direction, amountInDP, startOffsetPercentX, startOffsetPercentY) {
     if (typeof direction !== "string") throw new Error("direction should be a string, but got " + (direction + (" (" + (typeof direction + ")"))));
     if (typeof amountInDP !== "number") throw new Error("amountInDP should be a number, but got " + (amountInDP + (" (" + (typeof amountInDP + ")"))));
+    if (typeof startOffsetPercentX !== "number") throw new Error("startOffsetPercentX should be a number, but got " + (startOffsetPercentX + (" (" + (typeof startOffsetPercentX + ")"))));
+    if (typeof startOffsetPercentY !== "number") throw new Error("startOffsetPercentY should be a number, but got " + (startOffsetPercentY + (" (" + (typeof startOffsetPercentY + ")"))));
     return {
       target: {
         type: "Class",
@@ -117,6 +127,12 @@ class DetoxAction {
       }, {
         type: "Double",
         value: amountInDP
+      }, {
+        type: "Double",
+        value: startOffsetPercentX
+      }, {
+        type: "Double",
+        value: startOffsetPercentY
       }]
     };
   }

--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -83,16 +83,16 @@ class ClearTextAction extends Action {
 }
 
 class ScrollAmountAction extends Action {
-  constructor(direction, amount) {
+  constructor(direction, amount, startPositionX = -1.0, startPositionY = -1.0) {
     super();
-    this._call = invoke.callDirectly(DetoxActionApi.scrollInDirection(direction, amount));
+    this._call = invoke.callDirectly(DetoxActionApi.scrollInDirection(direction, amount, startPositionX, startPositionY));
   }
 }
 
 class ScrollAmountStopAtEdgeAction extends Action {
-  constructor(direction, amount) {
+  constructor(direction, amount, startPositionX = -1.0, startPositionY = -1.0) {
     super();
-    this._call = invoke.callDirectly(DetoxActionApi.scrollInDirectionStaleAtEdge(direction, amount));
+    this._call = invoke.callDirectly(DetoxActionApi.scrollInDirectionStaleAtEdge(direction, amount, startPositionX, startPositionY));
   }
 }
 
@@ -191,8 +191,8 @@ class WaitForActionInteractionBase extends Interaction {
 }
 
 class WaitForActionInteraction extends WaitForActionInteractionBase {
-  async scroll(amount, direction = 'down') {
-    this._prepare(new ScrollAmountStopAtEdgeAction(direction, amount));
+  async scroll(amount, direction = 'down', scrollPositionX, scrollPositionY) {
+    this._prepare(new ScrollAmountStopAtEdgeAction(direction, amount, scrollPositionX, scrollPositionY));
     await this.execute();
   }
 }
@@ -243,10 +243,10 @@ class Element {
   async clearText() {
     return await new ActionInteraction(this._invocationManager, this, new ClearTextAction()).execute();
   }
-  async scroll(amount, direction = 'down') {
+  async scroll(amount, direction = 'down', startPositionX, startPositionY) {
     // override the user's element selection with an extended matcher that looks for UIScrollView children
     // this._selectElementWithMatcher(this._originalMatcher._extendToDescendantScrollViews());
-    return await new ActionInteraction(this._invocationManager, this, new ScrollAmountAction(direction, amount)).execute();
+    return await new ActionInteraction(this._invocationManager, this, new ScrollAmountAction(direction, amount, startPositionX, startPositionY)).execute();
   }
   async scrollTo(edge) {
     // override the user's element selection with an extended matcher that looks for UIScrollView children

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -85,7 +85,6 @@ describe('Actions', () => {
     await expect(element(by.text('Replace Working!!!'))).toBeVisible();
   });
 
-  // directions: 'up'/'down'/'left'/'right'
   custom.it.withFailureIf.android.rn58OrNewer('should scroll for a small amount in direction', async () => {
     await expect(element(by.text('Text1'))).toBeVisible();
     await expect(element(by.text('Text4'))).toBeNotVisible();
@@ -98,22 +97,10 @@ describe('Actions', () => {
     await expect(element(by.text('Text4'))).toBeNotVisible();
   });
 
-  it('should scroll for a large amount in direction', async () => {
+  custom.it.withFailureIf.android.rn58OrNewer('should scroll for a large amount in direction', async () => {
     await expect(element(by.text('Text6'))).toBeNotVisible();
     await element(by.id('ScrollView161')).scroll(220, 'down');
     await expect(element(by.text('Text6'))).toBeVisible();
-  });
-
-  it('should scroll for a small amount in horizontal direction', async () => {
-    await expect(element(by.text('HText1'))).toBeVisible();
-    await expect(element(by.text('HText6'))).toBeNotVisible();
-    await expect(element(by.id('ScrollViewH'))).toBeVisible();
-    await element(by.id('ScrollViewH')).scroll(100, 'right');
-    await expect(element(by.text('HText1'))).toBeNotVisible();
-    await expect(element(by.text('HText6'))).toBeVisible();
-    await element(by.id('ScrollViewH')).scroll(100, 'left');
-    await expect(element(by.text('HText1'))).toBeVisible();
-    await expect(element(by.text('HText6'))).toBeNotVisible();
   });
 
   it('should scroll for a large amount in horizontal direction', async () => {
@@ -122,7 +109,6 @@ describe('Actions', () => {
     await expect(element(by.text('HText7'))).toBeVisible();
   });
 
-  // edges: 'top'/'bottom'/'left'/'right'
   it('should scroll to edge', async () => {
     await expect(element(by.text('Text8'))).toBeNotVisible();
     await element(by.id('ScrollView161')).scrollTo('bottom');
@@ -131,13 +117,50 @@ describe('Actions', () => {
     await expect(element(by.text('Text1'))).toBeVisible();
   });
 
-
   it('should scroll horizontally to edge', async () => {
     await expect(element(by.text('HText8'))).toBeNotVisible();
     await element(by.id('ScrollViewH')).scrollTo('right');
     await expect(element(by.text('HText8'))).toBeVisible();
     await element(by.id('ScrollViewH')).scrollTo('left');
     await expect(element(by.text('HText1'))).toBeVisible();
+  });
+
+  it('should scroll from a custom start-position ratio', async () => {
+    await expect(element(by.text('Text8'))).toBeNotVisible();
+    await element(by.id('toggleScrollOverlays')).tap();
+    try {
+      await element(by.id('ScrollView161')).scroll(310, 'down', 0.8, 0.6);
+    } catch (err) {
+    }
+    await element(by.id('toggleScrollOverlays')).tap();
+    await expect(element(by.text('Text8'))).toBeVisible();
+
+    await element(by.id('toggleScrollOverlays')).tap();
+    try {
+      await element(by.id('ScrollView161')).scroll(310, 'up', 0.2, 0.4);
+    } catch (err) {
+    }
+    await element(by.id('toggleScrollOverlays')).tap();
+    await expect(element(by.text('Text8'))).toBeNotVisible();
+  });
+
+  it('should scroll horizontally from a custom start-position ratio', async () => {
+    await expect(element(by.text('HText6'))).toBeNotVisible();
+    await element(by.id('toggleScrollOverlays')).tap();
+    try {
+      await element(by.id('ScrollViewH')).scroll(220, 'right', 0.8, 0.6);
+    } catch (err) {
+    }
+    await element(by.id('toggleScrollOverlays')).tap();
+    await expect(element(by.text('HText6'))).toBeVisible();
+
+    await element(by.id('toggleScrollOverlays')).tap();
+    try {
+      await element(by.id('ScrollViewH')).scroll(220, 'left', 0.2, 0.4);
+    } catch (err) {
+    }
+    await element(by.id('toggleScrollOverlays')).tap();
+    await expect(element(by.text('HText6'))).toBeNotVisible();
   });
 
   // TODO - swipe is not good enough for triggering pull to refresh. need to come up with something better

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -42,7 +42,7 @@ describe('Actions', () => {
     await element(by.id('UniqueId937_wrapper')).typeText(typedText);
     await expect(element(by.text(typedText))).toBeVisible();
   });
-  
+
   it(':ios: should fail typing in a view without text element', async () => {
     const typedText = 'Won\'t be typed at all';
     let failed = false;
@@ -52,7 +52,7 @@ describe('Actions', () => {
     catch(ex) {
       failed = true;
     }
-    
+
     if(failed === false) {
       throw new Error('Test should have thrown an error, but did not');
     }
@@ -98,10 +98,28 @@ describe('Actions', () => {
     await expect(element(by.text('Text4'))).toBeNotVisible();
   });
 
-  custom.it.withFailureIf.android.rn58OrNewer('should scroll for a large amount in direction', async () => {
+  it('should scroll for a large amount in direction', async () => {
     await expect(element(by.text('Text6'))).toBeNotVisible();
     await element(by.id('ScrollView161')).scroll(220, 'down');
     await expect(element(by.text('Text6'))).toBeVisible();
+  });
+
+  it('should scroll for a small amount in horizontal direction', async () => {
+    await expect(element(by.text('HText1'))).toBeVisible();
+    await expect(element(by.text('HText6'))).toBeNotVisible();
+    await expect(element(by.id('ScrollViewH'))).toBeVisible();
+    await element(by.id('ScrollViewH')).scroll(100, 'right');
+    await expect(element(by.text('HText1'))).toBeNotVisible();
+    await expect(element(by.text('HText6'))).toBeVisible();
+    await element(by.id('ScrollViewH')).scroll(100, 'left');
+    await expect(element(by.text('HText1'))).toBeVisible();
+    await expect(element(by.text('HText6'))).toBeNotVisible();
+  });
+
+  it('should scroll for a large amount in horizontal direction', async () => {
+    await expect(element(by.text('HText7'))).toBeNotVisible();
+    await element(by.id('ScrollViewH')).scroll(220, 'right');
+    await expect(element(by.text('HText7'))).toBeVisible();
   });
 
   // edges: 'top'/'bottom'/'left'/'right'
@@ -111,6 +129,15 @@ describe('Actions', () => {
     await expect(element(by.text('Text8'))).toBeVisible();
     await element(by.id('ScrollView161')).scrollTo('top');
     await expect(element(by.text('Text1'))).toBeVisible();
+  });
+
+
+  it('should scroll horizontally to edge', async () => {
+    await expect(element(by.text('HText8'))).toBeNotVisible();
+    await element(by.id('ScrollViewH')).scrollTo('right');
+    await expect(element(by.text('HText8'))).toBeVisible();
+    await element(by.id('ScrollViewH')).scrollTo('left');
+    await expect(element(by.text('HText1'))).toBeVisible();
   });
 
   // TODO - swipe is not good enough for triggering pull to refresh. need to come up with something better

--- a/detox/test/src/Screens/ActionsScreen.js
+++ b/detox/test/src/Screens/ActionsScreen.js
@@ -33,6 +33,7 @@ export default class ActionsScreen extends Component {
       numTaps: 0,
       isRefreshing: false,
       backPressed: false,
+      showScrollOverlays: false,
     };
   }
 
@@ -93,6 +94,12 @@ export default class ActionsScreen extends Component {
           testID='UniqueId006'
         />
 
+        <View style={{ height: 20, borderColor: '#c0c0c0', borderWidth: 1, flexDirection: 'row', justifyContent: 'space-evenly', alignItems: 'center' }}>
+          <TouchableOpacity onPress={this.onToggleScrollViewVisibility.bind(this)}>
+            <Text testID='toggleScrollOverlays' style={{ color: 'blue' }}>Toggle scroll overlays</Text>
+          </TouchableOpacity>
+        </View>
+
         <View style={{ height: 100, borderColor: '#c0c0c0', borderWidth: 1, backgroundColor: '#f8f8ff' }}>
           <ScrollView testID='ScrollView161'>
             <Text style={styles.item}>Text1</Text>
@@ -104,9 +111,11 @@ export default class ActionsScreen extends Component {
             <Text style={styles.item}>Text7</Text>
             <Text style={styles.item}>Text8</Text>
           </ScrollView>
+          { this.state.showScrollOverlays ? <View style={{ height: 55, width: width * 0.75, backgroundColor: 'deepskyblue', position: 'absolute', bottom: 0 }} /> : null }
+          { this.state.showScrollOverlays ? <View style={{ height: 55, width: width * 0.75, backgroundColor: 'goldenrod', position: 'absolute', right: 0 }} /> : null }
         </View>
 
-        <View style={{ height: 50, borderColor: '#c0c0c0', borderWidth: 1, backgroundColor: '#f8f8ff', marginBottom: 20 }}>
+        <View style={{ height: 50, borderColor: '#c0c0c0', borderWidth: 1, backgroundColor: '#f8f8ff' }}>
           <ScrollView testID='ScrollViewH' horizontal>
             <Text style={styles.horizItem}>HText1</Text>
             <Text style={styles.horizItem}>HText2</Text>
@@ -117,6 +126,8 @@ export default class ActionsScreen extends Component {
             <Text style={styles.horizItem}>HText7</Text>
             <Text style={styles.horizItem}>HText8</Text>
           </ScrollView>
+          { this.state.showScrollOverlays ? <View style={{ height: 28, width: width * 0.75, backgroundColor: 'goldenrod', position: 'absolute', bottom: 0 }} /> : null }
+          { this.state.showScrollOverlays ? <View style={{ height: 28, width: width * 0.75, backgroundColor: 'deepskyblue', position: 'absolute', right: 0 }} /> : null }
         </View>
 
         <View style={{ height: 100, borderColor: '#c0c0c0', borderWidth: 1, backgroundColor: '#f8f8ff', marginBottom: 20 }}>
@@ -227,6 +238,12 @@ export default class ActionsScreen extends Component {
         greeting: 'PullToReload Working'
       });
     }, 500);
+  }
+
+  onToggleScrollViewVisibility() {
+    this.setState({
+      showScrollOverlays: !this.state.showScrollOverlays,
+    })
   }
 
   backHandler() {

--- a/detox/test/src/Screens/ActionsScreen.js
+++ b/detox/test/src/Screens/ActionsScreen.js
@@ -6,8 +6,21 @@ import {
   TouchableOpacity,
   ScrollView,
   RefreshControl,
+  Platform,
+  Dimensions,
+  StyleSheet,
 } from 'react-native';
 import TextInput from '../Views/TextInput';
+
+const { width } = Dimensions.get('window');
+
+// Calc horizontal item size to have exactly 5 items visible
+const hItemWidth = (width / 5) - 20;
+
+const styles = StyleSheet.create({
+  item: { height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 },
+  horizItem: { width: hItemWidth, backgroundColor: '#e8e8f8', margin: 10, textAlign: 'center', textAlignVertical: 'center' },
+});
 
 export default class ActionsScreen extends Component {
 
@@ -30,6 +43,7 @@ export default class ActionsScreen extends Component {
   render() {
     if (this.state.greeting) return this.renderAfterButton();
     if (this.state.backPressed) return this.renderPopupBackPressedDetected();
+
     return (
       <View testID='View7990' style={{ flex: 1, paddingTop: 40, justifyContent: 'flex-start' }}>
 
@@ -55,7 +69,7 @@ export default class ActionsScreen extends Component {
           <Text style={{ color: 'blue', marginBottom: 20, textAlign: 'center' }}
             testID='UniqueId819'>Taps: {this.state.numTaps}</Text>
         </TouchableOpacity>
-          
+
         <View testID='UniqueId937_wrapper'>
           <TextInput style={{ height: 40, borderColor: 'gray', borderWidth: 1, marginBottom: 20, marginHorizontal: 20, padding: 5 }}
             onChangeText={this.onChangeTypeText.bind(this)}
@@ -64,7 +78,7 @@ export default class ActionsScreen extends Component {
             onSubmitEditing={this.onReturn.bind(this)}
             />
         </View>
-  
+
         {Platform.OS === 'ios' && <TouchableOpacity style={{ height: 40, borderColor: 'gray', borderWidth: 1, marginBottom: 20, marginHorizontal: 20, padding: 5 }} testID='NoTextInputInside' />}
 
         <TextInput style={{ height: 40, borderColor: 'gray', borderWidth: 1, marginBottom: 20, marginHorizontal: 20, padding: 5 }}
@@ -79,16 +93,29 @@ export default class ActionsScreen extends Component {
           testID='UniqueId006'
         />
 
-        <View style={{ height: 100, borderColor: '#c0c0c0', borderWidth: 1, backgroundColor: '#f8f8ff', marginBottom: 20 }}>
+        <View style={{ height: 100, borderColor: '#c0c0c0', borderWidth: 1, backgroundColor: '#f8f8ff' }}>
           <ScrollView testID='ScrollView161'>
-            <Text style={{ height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 }}>Text1</Text>
-            <Text style={{ height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 }}>Text2</Text>
-            <Text style={{ height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 }}>Text3</Text>
-            <Text style={{ height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 }}>Text4</Text>
-            <Text style={{ height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 }}>Text5</Text>
-            <Text style={{ height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 }}>Text6</Text>
-            <Text style={{ height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 }}>Text7</Text>
-            <Text style={{ height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 }}>Text8</Text>
+            <Text style={styles.item}>Text1</Text>
+            <Text style={styles.item}>Text2</Text>
+            <Text style={styles.item}>Text3</Text>
+            <Text style={styles.item}>Text4</Text>
+            <Text style={styles.item}>Text5</Text>
+            <Text style={styles.item}>Text6</Text>
+            <Text style={styles.item}>Text7</Text>
+            <Text style={styles.item}>Text8</Text>
+          </ScrollView>
+        </View>
+
+        <View style={{ height: 50, borderColor: '#c0c0c0', borderWidth: 1, backgroundColor: '#f8f8ff', marginBottom: 20 }}>
+          <ScrollView testID='ScrollViewH' horizontal>
+            <Text style={styles.horizItem}>HText1</Text>
+            <Text style={styles.horizItem}>HText2</Text>
+            <Text style={styles.horizItem}>HText3</Text>
+            <Text style={styles.horizItem}>HText4</Text>
+            <Text style={styles.horizItem}>HText5</Text>
+            <Text style={styles.horizItem}>HText6</Text>
+            <Text style={styles.horizItem}>HText7</Text>
+            <Text style={styles.horizItem}>HText8</Text>
           </ScrollView>
         </View>
 


### PR DESCRIPTION
- [ ] This is a small change 
- [ ] This change has been discussed in issue #0000 and the solution has been agreed upon with maintainers.

---

**Description:**

Adds support for `scroll()`'s `startPosition[XY]` params on Android - [docs ref](https://github.com/wix/Detox/blob/master/docs/APIRef.ActionsOnElement.md#scrollpixels-direction-startpositionxnan-startpositionynan).

Effectively, this should fix #1593.
