### PR TITLE
feat: --device-launch-args passthrough parameter

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -243,6 +243,7 @@ module.exports.handler = async function test(program) {
     const detoxEnvironmentVariables = _.pick(program, [
       'deviceLaunchArgs',
     ]);
+
     launchTestRunner(command, detoxEnvironmentVariables);
   }
 
@@ -291,6 +292,7 @@ module.exports.handler = async function test(program) {
       'readOnlyEmu',
       'deviceLaunchArgs',
     ]);
+
     launchTestRunner(command, detoxEnvironmentVariables);
   }
 

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -140,6 +140,10 @@ module.exports.builder = {
     alias: 'device-name',
     group: 'Configuration:',
     describe: 'Override the device name specified in a configuration. Useful for running a single build configuration on multiple devices.'
+  },
+  'device-launch-args': {
+    group: 'Execution:',
+    describe: 'Custom arguments to pass (through) onto the device (emulator/simulator) binary when launched.'
   }
 };
 
@@ -235,8 +239,19 @@ module.exports.handler = async function test(program) {
       ...getPassthroughArguments(),
     ]).join(' ');
 
-    log.info(command);
-    cp.execSync(command, { stdio: 'inherit' });
+
+    const detoxEnvironmentVariables = _.pick(program, [
+      'deviceLaunchArgs',
+    ]);
+
+    log.info(printEnvironmentVariables(detoxEnvironmentVariables) + command);
+    cp.execSync(command, {
+        stdio: 'inherit',
+        env: {
+          ...process.env,
+          ...detoxEnvironmentVariables
+        }
+      });
   }
 
   function runJest() {
@@ -282,6 +297,7 @@ module.exports.handler = async function test(program) {
       'deviceName',
       'reportSpecs',
       'readOnlyEmu',
+      'deviceLaunchArgs',
     ]);
 
     log.info(printEnvironmentVariables(detoxEnvironmentVariables) + command);

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -243,15 +243,7 @@ module.exports.handler = async function test(program) {
     const detoxEnvironmentVariables = _.pick(program, [
       'deviceLaunchArgs',
     ]);
-
-    log.info(printEnvironmentVariables(detoxEnvironmentVariables) + command);
-    cp.execSync(command, {
-        stdio: 'inherit',
-        env: {
-          ...process.env,
-          ...detoxEnvironmentVariables
-        }
-      });
+    launchTestRunner(command, detoxEnvironmentVariables);
   }
 
   function runJest() {
@@ -299,15 +291,7 @@ module.exports.handler = async function test(program) {
       'readOnlyEmu',
       'deviceLaunchArgs',
     ]);
-
-    log.info(printEnvironmentVariables(detoxEnvironmentVariables) + command);
-    cp.execSync(command, {
-      stdio: 'inherit',
-      env: {
-        ...process.env,
-        ...detoxEnvironmentVariables
-      }
-    });
+    launchTestRunner(command, detoxEnvironmentVariables);
   }
 
   function printEnvironmentVariables(envObject) {
@@ -345,6 +329,17 @@ module.exports.handler = async function test(program) {
     const lockFilePath = platform === 'ios' ? environment.getDeviceLockFilePathIOS() : environment.getDeviceLockFilePathAndroid();
     fs.ensureFileSync(lockFilePath);
     fs.writeFileSync(lockFilePath, '[]');
+  }
+
+  function launchTestRunner(command, detoxEnvironmentVariables) {
+    log.info(printEnvironmentVariables(detoxEnvironmentVariables) + command);
+    cp.execSync(command, {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        ...detoxEnvironmentVariables
+      }
+    });
   }
 
   run();

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -60,8 +60,22 @@ describe('test', () => {
       await callCli('./test', 'test --specs e2e');
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('migration guide'));
     });
-  });
 
+    it('should pass in device-launch-args as an environment variable', async () => {
+      mockAndroidMochaConfiguration();
+
+      await callCli('./test', 'test --device-launch-args="-mocked -launched -args"');
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          env: expect.objectContaining({
+            deviceLaunchArgs: '-mocked -launched -args',
+          }),
+        }),
+      );
+    });
+  });
 
   describe('jest', () => {
     it('runs successfully', async () => {
@@ -87,6 +101,21 @@ describe('test', () => {
             artifactsLocation: expect.stringContaining(normalize('artifacts/only.')),
           }),
         })
+      );
+    });
+
+    it('should pass in device-launch-args as an environment variable', async () => {
+      mockAndroidJestConfiguration();
+
+      await callCli('./test', 'test --device-launch-args="-mocked -launched -args"');
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          env: expect.objectContaining({
+            deviceLaunchArgs: '-mocked -launched -args',
+          }),
+        }),
       );
     });
   });

--- a/detox/src/devices/android/Emulator.js
+++ b/detox/src/devices/android/Emulator.js
@@ -24,6 +24,7 @@ class Emulator {
   }
 
   async boot(emulatorName, options = {port: undefined}) {
+    const userLaunchArgs = (argparse.getArgValue('deviceLaunchArgs') || '').split(/\s+/);
     const emulatorArgs = _.compact([
       '-verbose',
       '-no-audio',
@@ -32,11 +33,12 @@ class Emulator {
       argparse.getArgValue('readOnlyEmu') ? '-read-only' : '',
       options.port ? `-port` : '',
       options.port ? `${options.port}` : '',
+      ...userLaunchArgs,
       `@${emulatorName}`
     ]);
 
     const gpuMethod = this.gpuMethod();
-    if(gpuMethod) {
+    if (gpuMethod) {
       emulatorArgs.push('-gpu', gpuMethod);
     }
 
@@ -96,7 +98,7 @@ class Emulator {
 
   gpuMethod() {
     const gpuArgument = argparse.getArgValue('gpu');
-    if(gpuArgument) {
+    if (gpuArgument) {
       return gpuArgument;
     }
 

--- a/detox/src/devices/android/Emulator.js
+++ b/detox/src/devices/android/Emulator.js
@@ -24,7 +24,7 @@ class Emulator {
   }
 
   async boot(emulatorName, options = {port: undefined}) {
-    const userLaunchArgs = (argparse.getArgValue('deviceLaunchArgs') || '').split(/\s+/);
+    const deviceLaunchArgs = (argparse.getArgValue('deviceLaunchArgs') || '').split(/\s+/);
     const emulatorArgs = _.compact([
       '-verbose',
       '-no-audio',
@@ -33,7 +33,7 @@ class Emulator {
       argparse.getArgValue('readOnlyEmu') ? '-read-only' : '',
       options.port ? `-port` : '',
       options.port ? `${options.port}` : '',
-      ...userLaunchArgs,
+      ...deviceLaunchArgs,
       `@${emulatorName}`
     ]);
 

--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -6,6 +6,7 @@ const IosDriver = require('./IosDriver');
 const configuration = require('../../configuration');
 const environment = require('../../utils/environment');
 const DeviceRegistry = require('../DeviceRegistry');
+const argparse = require('../../utils/argparse');
 
 class SimulatorDriver extends IosDriver {
 
@@ -64,7 +65,8 @@ class SimulatorDriver extends IosDriver {
   }
 
   async _boot(deviceId) {
-    const coldBoot = await this.applesimutils.boot(deviceId);
+    const deviceLaunchArgs = argparse.getArgValue('deviceLaunchArgs');
+    const coldBoot = await this.applesimutils.boot(deviceId, deviceLaunchArgs);
     await this.emitter.emit('bootDevice', { coldBoot, deviceId });
   }
 

--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const exec = require('../../utils/exec');
 const log = require('../../utils/logger').child({ __filename });
 const environment = require('../../utils/environment');
+const argparse = require('../../utils/argparse');
 
 class AppleSimUtils {
   async setPermissions(udid, bundleId, permissionsObj) {
@@ -70,8 +71,9 @@ class AppleSimUtils {
     const isBooted = await this.isBooted(udid);
 
     if (!isBooted) {
+      const userLaunchArgs = (argparse.getArgValue('deviceLaunchArgs') || '');
       const statusLogs = { trying: `Booting device ${udid}` };
-      await this._execSimctl({ cmd: `boot ${udid}`, statusLogs, retries: 10 });
+      await this._execSimctl({ cmd: `boot ${udid} ${userLaunchArgs}`, statusLogs, retries: 10 });
       await this._execSimctl({ cmd: `bootstatus ${udid}`, retries: 1 });
       return true;
     }

--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const exec = require('../../utils/exec');
 const log = require('../../utils/logger').child({ __filename });
 const environment = require('../../utils/environment');
-const argparse = require('../../utils/argparse');
 
 class AppleSimUtils {
   async setPermissions(udid, bundleId, permissionsObj) {
@@ -67,13 +66,12 @@ class AppleSimUtils {
    * @param {String} udid - device id
    * @returns {Promise<boolean>} true, if device has been booted up from the shutdown state
    */
-  async boot(udid) {
+  async boot(udid, deviceLaunchArgs = '') {
     const isBooted = await this.isBooted(udid);
 
     if (!isBooted) {
-      const userLaunchArgs = (argparse.getArgValue('deviceLaunchArgs') || '');
-      const statusLogs = { trying: `Booting device ${udid}` };
-      await this._execSimctl({ cmd: `boot ${udid} ${userLaunchArgs}`, statusLogs, retries: 10 });
+      const statusLogs = { trying: `Booting device ${udid}...` };
+      await this._execSimctl({ cmd: `boot ${udid} ${deviceLaunchArgs}`, statusLogs, retries: 10 });
       await this._execSimctl({ cmd: `bootstatus ${udid}`, retries: 1 });
       return true;
     }

--- a/docs/APIRef.DetoxCLI.md
+++ b/docs/APIRef.DetoxCLI.md
@@ -80,6 +80,7 @@ Initiating your test suite. <sup>[[1]](#notice-passthrough)</sup>
 | --jest-report-specs | [Jest Only] Whether to output logs per each running spec, in real-time. By default, disabled with multiple workers. |
 | -H, --headless                                | [Android Only] Launch Emulator in headless mode. Useful when running on CI. |
 | --gpu                                         | [Android Only] Launch Emulator with the specific -gpu [gpu mode] parameter. |
+| --device-launch-args | A list of passthrough-arguments to use when (if) devices (Android emulator / iOS simulator) are launched by Detox.<br />**Note: the value must be specified after an equal size (`=`) and inside quotes.** Usage example:<br />`--device-launch-args="-http-proxy http://1.1.1.1:8000 -no-snapshot-load"` |
 | --no-color                                    | Disable colors in log output |
 | --help                                        | Show help |
 


### PR DESCRIPTION
Resolves #1669.

- [x] This is a small change 
- [x] This change has been discussed in issue #1669 and the solution has been agreed upon with maintainers.

---

**Description:**

Allows users to provide custom args in CLI that would be passed-through onto the device (Android emulator / iOS simulator) when (if) launched by Detox.

@swabbass @silyevsk 