### PR TITLE
fix(jest): allow passing --maxWorkers as a percent value

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -116,7 +116,8 @@ module.exports.builder = {
     group: 'Execution:',
     describe:
       '[iOS Only] Specifies the number of workers the test runner should spawn, requires a test runner with parallel execution support (Detox CLI currently supports Jest)',
-    default: "1"
+    string: true,
+    default: '1'
   },
   'jest-report-specs': {
     group: 'Execution:',
@@ -209,7 +210,7 @@ module.exports.handler = async function test(program) {
   }
 
   function runMocha() {
-    if (program.workers.toString() !== "1") {
+    if (program.workers !== '1') {
       log.warn('Can not use -w, --workers. Parallel test execution is only supported with iOS and Jest');
     }
 
@@ -239,7 +240,7 @@ module.exports.handler = async function test(program) {
   }
 
   function runJest() {
-    const hasMultipleWorkers = (program.workers.toString() !== "1");
+    const hasMultipleWorkers = program.workers !== '1';
     if (platform === 'android') {
       program.readOnlyEmu = false;
       if (hasMultipleWorkers) {

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -209,7 +209,7 @@ module.exports.handler = async function test(program) {
   }
 
   function runMocha() {
-    if (program.workers !== "1") {
+    if (program.workers.toString() !== "1") {
       log.warn('Can not use -w, --workers. Parallel test execution is only supported with iOS and Jest');
     }
 
@@ -239,7 +239,7 @@ module.exports.handler = async function test(program) {
   }
 
   function runJest() {
-    const hasMultipleWorkers = (program.workers !== "1");
+    const hasMultipleWorkers = (program.workers.toString() !== "1");
     if (platform === 'android') {
       program.readOnlyEmu = false;
       if (hasMultipleWorkers) {

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -115,9 +115,25 @@ module.exports.builder = {
     alias: 'workers',
     group: 'Execution:',
     describe:
-      '[iOS Only] Specifies number of workers the test runner should spawn, requires a test runner with parallel execution support (Detox CLI currently supports Jest)',
-    default: 1,
-    number: true
+      '[iOS Only] Specifies the number of workers the test runner should spawn, requires a test runner with parallel execution support (Detox CLI currently supports Jest)',
+    coerce(param) {
+      let workers = 1;
+      if (param) {
+        const workersStr = param.trim();
+        const workersInt = Number.parseInt(workersStr, 10);
+
+        if (workersStr.endsWith('%')) {
+          const percentValue = workersStr.substring(0, workersStr.length - 1);
+          if (percentValue == Number.parseInt(percentValue, 10)) {
+            workers = workersStr;
+          }
+        } else if (workersStr == workersInt) {
+          workers = workersInt;
+        }
+      }
+      return workers;
+    },
+    default: "1"
   },
   'jest-report-specs': {
     group: 'Execution:',
@@ -240,7 +256,7 @@ module.exports.handler = async function test(program) {
   }
 
   function runJest() {
-    const hasMultipleWorkers = (program.workers > 1);
+    const hasMultipleWorkers = (program.workers !== 1);
     if (platform === 'android') {
       program.readOnlyEmu = false;
       if (hasMultipleWorkers) {

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -116,23 +116,6 @@ module.exports.builder = {
     group: 'Execution:',
     describe:
       '[iOS Only] Specifies the number of workers the test runner should spawn, requires a test runner with parallel execution support (Detox CLI currently supports Jest)',
-    coerce(param) {
-      let workers = 1;
-      if (param) {
-        const workersStr = param.trim();
-        const workersInt = Number.parseInt(workersStr, 10);
-
-        if (workersStr.endsWith('%')) {
-          const percentValue = workersStr.substring(0, workersStr.length - 1);
-          if (percentValue == Number.parseInt(percentValue, 10)) {
-            workers = workersStr;
-          }
-        } else if (workersStr == workersInt) {
-          workers = workersInt;
-        }
-      }
-      return workers;
-    },
     default: "1"
   },
   'jest-report-specs': {
@@ -226,7 +209,7 @@ module.exports.handler = async function test(program) {
   }
 
   function runMocha() {
-    if (program.workers !== 1) {
+    if (program.workers !== "1") {
       log.warn('Can not use -w, --workers. Parallel test execution is only supported with iOS and Jest');
     }
 
@@ -256,7 +239,7 @@ module.exports.handler = async function test(program) {
   }
 
   function runJest() {
-    const hasMultipleWorkers = (program.workers !== 1);
+    const hasMultipleWorkers = (program.workers !== "1");
     if (platform === 'android') {
       program.readOnlyEmu = false;
       if (hasMultipleWorkers) {

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -117,27 +117,22 @@ describe('test', () => {
 
       it('should use one worker', async () => {
         await callCli('./test', 'test');
-        expectWorkersArg({value: 1});
+        expectWorkersArg({value: '1'});
       });
 
       it('should still use one worker', async () => {
         await callCli('./test', 'test --workers 1');
-        expectWorkersArg({value: 1});
+        expectWorkersArg({value: '1'});
       });
 
       it('should still use two workers', async () => {
         await callCli('./test', 'test --workers 2');
-        expectWorkersArg({value: 2});
+        expectWorkersArg({value: '2'});
       });
 
       it('should use 100% workers', async () => {
         await callCli('./test', 'test --workers 100%');
         expectWorkersArg({value: '100%'});
-      });
-
-      it('should use 1 worker', async () => {
-        await callCli('./test', 'test --workers a%');
-        expectWorkersArg({value: '1'});
       });
 
       it('should be enabled for a single worker', async () => {

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -107,8 +107,38 @@ describe('test', () => {
       })
     );
 
+    const expectWorkersArg = ({value}) => expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining(`--maxWorkers=${value}`),
+      expect.anything(),
+    );
+
     describe('ios', () => {
       beforeEach(mockIOSJestConfiguration);
+
+      it('should use one worker', async () => {
+        await callCli('./test', 'test');
+        expectWorkersArg({value: 1});
+      });
+
+      it('should still use one worker', async () => {
+        await callCli('./test', 'test --workers 1');
+        expectWorkersArg({value: 1});
+      });
+
+      it('should still use two workers', async () => {
+        await callCli('./test', 'test --workers 2');
+        expectWorkersArg({value: 2});
+      });
+
+      it('should use 100% workers', async () => {
+        await callCli('./test', 'test --workers 100%');
+        expectWorkersArg({value: '100%'});
+      });
+
+      it('should use 1 worker', async () => {
+        await callCli('./test', 'test --workers a%');
+        expectWorkersArg({value: '1'});
+      });
 
       it('should be enabled for a single worker', async () => {
         await callCli('./test', 'test --workers 1');


### PR DESCRIPTION
Jest allows percent values for `--maxWorkers`.
This is a small change to allow this same behavior.
Currently `--workers 100%` will become `--maxWorkers NaN`

I added some tests but I believe the naming should be reviewed