### PR TITLE
fix(init) exits on error before erasing package.json

### DIFF
--- a/detox/local-cli/init.js
+++ b/detox/local-cli/init.js
@@ -44,6 +44,11 @@ module.exports.handler = async function init(argv) {
   }
 };
 
+function hasError(...args) {
+  log.error(...args);
+  process.exit(1);
+}
+
 function createFolder(dir, files) {
   if (fs.existsSync(dir)) {
     return log.error(`Failed to create ${dir} folder, because it already exists at path: ${path.resolve(dir)}`);
@@ -52,7 +57,7 @@ function createFolder(dir, files) {
   try {
     fs.mkdirSync(dir);
   } catch (err) {
-    return log.error({ err }, `Failed to create ${dir} folder due to an error:`);
+    return hasError({ err }, `Failed to create ${dir} folder due to an error:`);
   }
 
   for (const entry of Object.entries(files)) {
@@ -91,7 +96,7 @@ function parsePackageJson(filepath) {
   try {
     return require(filepath);
   } catch (err) {
-    log.error(`Failed to parse package.json due to an error:\n${err.message}`);
+    hasError(`Failed to parse package.json due to an error:\n${err.message}`);
   }
 }
 
@@ -106,7 +111,7 @@ function savePackageJson(filepath, json) {
   try {
     fs.writeFileSync(filepath, JSON.stringify(json, null, 2) + '\n');
   } catch (err) {
-    log.error(`Failed to write changes back into package.json due to an error:\n${err.message}`);
+    hasError(`Failed to write changes back into package.json due to an error:\n${err.message}`);
   }
 }
 
@@ -121,6 +126,6 @@ function patchDetoxConfigInPackageJSON({ runner }) {
 
     savePackageJson(packageJsonPath, packageJson);
   } else {
-    log.error(`Failed to find package.json at path: ${packageJsonPath}`);
+    hasError(`Failed to find package.json at path: ${packageJsonPath}`);
   }
 }

--- a/detox/local-cli/init.js
+++ b/detox/local-cli/init.js
@@ -5,6 +5,8 @@ const mochaTemplates = require('./templates/mocha');
 const jestTemplates = require('./templates/jest');
 const log = require('../src/utils/logger').child({ __filename });
 
+let exitCode = 0;
+
 module.exports.command = 'init';
 module.exports.desc = 'Scaffold initial E2E test folder structure for a specified test runner';
 module.exports.builder = {
@@ -42,22 +44,19 @@ module.exports.handler = async function init(argv) {
         'HINT: Try running one of the commands above, look what it does, and take similar steps for your use case.',
       ].join('\n'));
   }
-};
 
-function hasError(...args) {
-  log.error(...args);
-  process.exit(1);
-}
+  process.exit(exitCode); // eslint-disable-line
+};
 
 function createFolder(dir, files) {
   if (fs.existsSync(dir)) {
-    return log.error(`Failed to create ${dir} folder, because it already exists at path: ${path.resolve(dir)}`);
+    return reportError(`Failed to create ${dir} folder, because it already exists at path: ${path.resolve(dir)}`);
   }
 
   try {
     fs.mkdirSync(dir);
   } catch (err) {
-    return hasError({ err }, `Failed to create ${dir} folder due to an error:`);
+    return reportError({ err }, `Failed to create ${dir} folder due to an error:`);
   }
 
   for (const entry of Object.entries(files)) {
@@ -70,9 +69,8 @@ function createFile(filename, content) {
   try {
     fs.writeFileSync(filename, content);
     log.info(`Created a file at path: ${filename}`);
-  } catch (e) {
-    log.error(`Failed to create a file at path: ${filename}`);
-    log.error(e);
+  } catch (err) {
+    reportError({ err }, `Failed to create a file at path: ${filename}`);
   }
 }
 
@@ -96,7 +94,7 @@ function parsePackageJson(filepath) {
   try {
     return require(filepath);
   } catch (err) {
-    hasError(`Failed to parse package.json due to an error:\n${err.message}`);
+    reportError(`Failed to parse package.json due to an error:\n${err.message}`);
   }
 }
 
@@ -111,7 +109,7 @@ function savePackageJson(filepath, json) {
   try {
     fs.writeFileSync(filepath, JSON.stringify(json, null, 2) + '\n');
   } catch (err) {
-    hasError(`Failed to write changes back into package.json due to an error:\n${err.message}`);
+    reportError(`Failed to write changes back into package.json due to an error:\n${err.message}`);
   }
 }
 
@@ -122,10 +120,16 @@ function patchDetoxConfigInPackageJSON({ runner }) {
     log.info(`Patching package.json at path: ${packageJsonPath}`);
 
     const packageJson = parsePackageJson(packageJsonPath);
-    loggedSet(packageJson, ['detox', 'test-runner'], runner);
-
-    savePackageJson(packageJsonPath, packageJson);
+    if (packageJson) {
+      loggedSet(packageJson, ['detox', 'test-runner'], runner);
+      savePackageJson(packageJsonPath, packageJson);
+    }
   } else {
-    hasError(`Failed to find package.json at path: ${packageJsonPath}`);
+    reportError(`Failed to find package.json at path: ${packageJsonPath}`);
   }
+}
+
+function reportError(...args) {
+  log.error(...args);
+  exitCode = 1;
 }


### PR DESCRIPTION
init now exits and sets an error status of 1 if it can't compelte a
task. This prevents it from overwrite `package.json`.
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [X] This is a small change 
- [ ] This change has been discussed in issue #1692 and the solution has been agreed upon with maintainers.

---

**Description:**

There are two ways to close #1692:
1. to test the returned object representing the package is defined, or
2. fail fast at the point where the package raises a `SyntaxError`.

I'd suggest 2, but am more than happy to implement 1 as it has the fewest number of changes.  Dealers choice.
