### PR TITLE
refactor: device selection revisited

### DIFF
--- a/detox/src/devices/drivers/AndroidDriver.js
+++ b/detox/src/devices/drivers/AndroidDriver.js
@@ -148,27 +148,6 @@ class AndroidDriver extends DeviceDriverBase {
     return this.uiDevice;
   }
 
-  async findDeviceId(filter) {
-    const adbDevices = await this.adb.devices();
-    const filteredDevices = _.filter(adbDevices, filter);
-
-    let adbName;
-    switch (filteredDevices.length) {
-      case 1:
-        const adbDevice = filteredDevices[0];
-        adbName = adbDevice.adbName;
-        break;
-      case 0:
-        throw new Error(`Could not find '${filter.name}' on the currently ADB attached devices: '${JSON.stringify(adbDevices)}', 
-      try restarting adb 'adb kill-server && adb start-server'`);
-        break;
-      default:
-        throw new Error(`Got more than one device corresponding to the name: ${filter.name}. Current ADB attached devices: ${JSON.stringify(adbDevices)}`);
-    }
-
-    return adbName;
-  }
-
   async setURLBlacklist(urlList) {
     const call = EspressoDetoxApi.setURLBlacklist(urlList);
     await this.invocationManager.execute(call);

--- a/detox/src/devices/drivers/AttachedAndroidDriver.js
+++ b/detox/src/devices/drivers/AttachedAndroidDriver.js
@@ -1,4 +1,5 @@
 const AndroidDriver = require('./AndroidDriver');
+const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
 
 class AttachedAndroidDriver extends AndroidDriver {
 
@@ -11,12 +12,23 @@ class AttachedAndroidDriver extends AndroidDriver {
     return this._name;
   }
 
-  async acquireFreeDevice(name) {
-    const deviceId = await this.findDeviceId({adbName: name});
-    await this.adb.apiLevel(name);
-    await this.adb.unlockScreen(deviceId);
-    this._name = `${deviceId} (${name})`;
-    return deviceId;
+  async acquireFreeDevice(adbName) {
+    const { devices, stdout } = await this.adb.devices();
+
+    if (!devices.some(d => d.adbName === adbName)) {
+      throw new DetoxRuntimeError({
+        message: `Could not find '${adbName}' on the currently ADB attached devices:`,
+        debugInfo: stdout,
+        hint: `Make sure your device is connected.\n` +
+              `You can also try restarting adb with 'adb kill-server && adb start-server'.`
+      });
+    }
+
+    await this.adb.apiLevel(adbName);
+    await this.adb.unlockScreen(adbName);
+    this._name = adbName;
+
+    return adbName;
   }
 }
 

--- a/detox/src/devices/ios/applesimutils.mock.json
+++ b/detox/src/devices/ios/applesimutils.mock.json
@@ -1,0 +1,24 @@
+{
+  "--list": [
+    {
+      "deviceType" : {
+        "name" : "iPhone X",
+        "bundlePath" : "\/Applications\/Xcode.app\/Contents\/Developer\/Platforms\/iPhoneOS.platform\/Developer\/Library\/CoreSimulator\/Profiles\/DeviceTypes\/iPhone X.simdevicetype",
+        "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-X"
+      },
+      "state" : "Shutdown",
+      "isAvailable" : true,
+      "name" : "iPhone X",
+      "udid" : "FBA6D413-0A3D-466F-BF40-ECC019133E43",
+      "os" : {
+        "buildversion" : "16B91",
+        "bundlePath" : "\/Applications\/Xcode.app\/Contents\/Developer\/Platforms\/iPhoneOS.platform\/Developer\/Library\/CoreSimulator\/Profiles\/Runtimes\/iOS.simruntime",
+        "isAvailable" : true,
+        "name" : "iOS 12.1",
+        "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-12-1",
+        "version" : "12.1"
+      }
+    }
+  ]
+}
+

--- a/detox/src/utils/ExclusiveLockfile.js
+++ b/detox/src/utils/ExclusiveLockfile.js
@@ -1,0 +1,140 @@
+const _ = require('lodash');
+const fs = require('fs');
+const plockfile = require('proper-lockfile');
+const retry = require('./retry');
+
+const DEFAULT_OPTIONS = {
+  retry: {retries: 10000, interval: 5},
+  read: { encoding: 'utf8' },
+  getInitialState: _.constant(null),
+};
+
+class ExclusiveLockfile {
+  constructor(lockfile, options) {
+    if (!lockfile) {
+      throw new Error('Path to the lockfile should be a non-empty string');
+    }
+
+    this._lockFilePath = lockfile;
+    this._options = _.defaultsDeep(options, DEFAULT_OPTIONS);
+
+    this._isLocked = false;
+    this._invalidate();
+  }
+
+  get options() {
+    return this._options;
+  }
+
+  /***
+   * @async
+   * @param {Function} fn
+   * @returns {Promise<any>}
+   */
+  async exclusively(fn) {
+    await this._lock();
+
+    try {
+      return (await fn());
+    } finally {
+      this._unlock();
+    }
+  }
+
+  /***
+   * @returns {any}
+   */
+  read() {
+    if (!this._isLocked) {
+      throw new Error('Forbidden to read in unlocked mode');
+    }
+
+    if (!this._hasValue) {
+      this._value = this._doRead();
+      this._hasValue = true;
+    }
+
+    return this._value;
+  }
+
+  /***
+   * @param {any} value
+   */
+  write(value) {
+    if (!this._isLocked) {
+      throw new Error('Forbidden to write in unlocked mode');
+    }
+
+    this._value = value;
+    this._hasValue = true;
+  }
+
+  /***
+   * @private
+   */
+  _invalidate() {
+    this._hasValue = false;
+    this._value = null;
+  }
+
+  /***
+   * @returns {any}
+   * @private
+   */
+  _doRead() {
+    const contents = fs.readFileSync(this._lockFilePath, this._options.read);
+    return JSON.parse(contents);
+  }
+
+  /***
+   * @param value
+   * @private
+   */
+  _doWrite(value) {
+    const contents = JSON.stringify(value);
+    fs.writeFileSync(this._lockFilePath, contents);
+  }
+
+  /***
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _lock() {
+    this._ensureFileExists();
+
+    await retry(this._options.retry, () => {
+      const operationResult = plockfile.lockSync(this._lockFilePath);
+
+      this._isLocked = true;
+      this._invalidate();
+
+      return operationResult;
+    });
+  }
+
+  /***
+   * @private
+   */
+  _ensureFileExists() {
+    if (!fs.existsSync(this._lockFilePath)) {
+      const initialState = this._options.getInitialState();
+      this._doWrite(initialState);
+    }
+  }
+
+  /***
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _unlock() {
+    if (this._hasValue) {
+      this._doWrite(this._value);
+    }
+
+    plockfile.unlockSync(this._lockFilePath);
+    this._isLocked = false;
+    this._invalidate();
+  }
+}
+
+module.exports = ExclusiveLockfile;

--- a/detox/src/utils/ExclusiveLockfile.test.js
+++ b/detox/src/utils/ExclusiveLockfile.test.js
@@ -1,0 +1,104 @@
+jest.mock('proper-lockfile');
+
+const plock = require('proper-lockfile');
+const fs = require('fs-extra');
+const tempfile = require('tempfile');
+const ExclusiveLockFile = require('./ExclusiveLockfile');
+
+describe('ExclusiveLockFile', () => {
+  let filePath;
+
+  beforeEach(() => {
+    filePath = tempfile('.test');
+  });
+
+  afterEach(async () => {
+    await fs.remove(filePath);
+  });
+
+  it('should execute an arbitrary function inside an exclusive lock', async () => {
+    const lockfile = new ExclusiveLockFile(filePath, {
+      getInitialState: () => 42,
+    });
+
+    expect(plock.lockSync).not.toHaveBeenCalled();
+    const result = await lockfile.exclusively(async () => {
+      expect(plock.lockSync).toHaveBeenCalled();
+
+      expect(lockfile.read()).toBe(42);
+      lockfile.write(84);
+      expect(lockfile.read()).toBe(84);
+
+      expect(plock.unlockSync).not.toHaveBeenCalled();
+      return "result";
+    });
+
+    expect(plock.unlockSync).toHaveBeenCalled();
+    expect(result).toBe('result');
+  });
+
+  it('should unlock after an exception inside the function', async () => {
+    const lockfile = new ExclusiveLockFile(filePath);
+
+    await expect(lockfile.exclusively(async () => {
+      throw new Error('synthetic error');
+    })).rejects.toThrow(/synthetic error/);
+
+    expect(plock.unlockSync).toHaveBeenCalled();
+  });
+
+  it('should forbid reading and writting outside of exclusive access', async () => {
+    const lockfile = new ExclusiveLockFile(filePath);
+
+    expect(() => lockfile.read()).toThrowError(/Forbidden.*to read/);
+    expect(() => lockfile.write(0)).toThrowError(/Forbidden.*to write/);
+  });
+
+  it('should create a lockfile if it does not exist', async () => {
+    const lockfile = new ExclusiveLockFile(filePath, {
+      getInitialState: () => 1000,
+    });
+
+    expect(fs.existsSync(filePath)).toBe(false);
+    await lockfile.exclusively(() => {});
+    expect(fs.readFileSync(filePath, 'utf8')).toBe('1000');
+  });
+
+  it('should not overwrite a lockfile if it exists', async () => {
+    const lockfile = new ExclusiveLockFile(filePath);
+
+    await lockfile.exclusively(() => lockfile.write('DETOX'));
+    await lockfile.exclusively(() => {});
+
+    expect(fs.readFileSync(filePath, 'utf8')).toBe('"DETOX"');
+  });
+
+  describe('constructor', () => {
+    it('should have 1 required arg', () => {
+      expect(() => new ExclusiveLockFile()).toThrowError(/non-empty string/);
+    });
+
+    it('should have default options', () => {
+      const lockfile = new ExclusiveLockFile(filePath);
+
+      expect(lockfile.options).toEqual({
+        retry: expect.objectContaining({}),
+        read: { encoding: 'utf8' },
+        getInitialState: expect.any(Function),
+      });
+    });
+
+    it('should have allow customizing options', () => {
+      const getInitialState = () => {};
+      const lockfile = new ExclusiveLockFile(filePath, {
+        getInitialState,
+      });
+
+      expect(lockfile.options).toEqual({
+        retry: expect.objectContaining({}),
+        read: { encoding: 'utf8' },
+        getInitialState,
+      });
+    });
+  });
+});

--- a/detox/src/utils/argparse.js
+++ b/detox/src/utils/argparse.js
@@ -1,4 +1,6 @@
+const _ = require('lodash');
 const argv = require('minimist')(process.argv.slice(2));
+const {escape} = require('./pipeCommands');
 
 function getArgValue(key) {
   let value;
@@ -23,7 +25,43 @@ function getFlag(key) {
   return false;
 }
 
+const DEFAULT_JOIN_ARGUMENTS_OPTIONS = {
+  prefix: '--',
+  joiner: ' ',
+};
+
+function joinArgs(keyValues, options = DEFAULT_JOIN_ARGUMENTS_OPTIONS) {
+  const {prefix, joiner} = options === DEFAULT_JOIN_ARGUMENTS_OPTIONS
+    ? options
+    : { ...DEFAULT_JOIN_ARGUMENTS_OPTIONS, ...options };
+
+  const argArray = [];
+
+  for (const [key, value] of Object.entries(keyValues)) {
+    if (value == null) {
+      continue;
+    }
+
+    let arg = (!key.startsWith('-') ? prefix : '') + key;
+
+    if (value !== true) {
+      arg += joiner;
+
+      if (_.isString(value) && value.includes(' ')) {
+        arg += `"${escape.inQuotedString(value)}"`;
+      } else {
+        arg += value;
+      }
+    }
+
+    argArray.push(arg)
+  }
+
+  return argArray.join(' ');
+}
+
 module.exports = {
   getArgValue,
-  getFlag
+  getFlag,
+  joinArgs,
 };

--- a/detox/src/utils/argparse.test.js
+++ b/detox/src/utils/argparse.test.js
@@ -66,4 +66,33 @@ describe('argparse', () => {
       expect(argparse.getFlag('flag-missing')).toBe(false);
     });
   });
+
+  describe('joinArgs()', () => {
+    let argparse;
+
+    beforeEach(() => {
+      argparse = require('./argparse');
+    });
+
+    it('should convert key-values to args string', () => {
+      expect(argparse.joinArgs({
+        optional: undefined,
+        debug: true,
+        timeout: 3000,
+        logLevel: 'verbose',
+        '-w': 1,
+        'device-name': 'iPhone X'
+      })).toBe('--debug --timeout 3000 --logLevel verbose -w 1 --device-name "iPhone X"');
+    });
+
+    it('should accept options', () => {
+      const options = { prefix: '-', joiner: '=' };
+      const argsObject = {
+        'version': 100,
+        '--help': true
+      };
+
+      expect(argparse.joinArgs(argsObject, options)).toBe('-version=100 --help');
+    });
+  })
 });

--- a/detox/src/utils/safeAsync.js
+++ b/detox/src/utils/safeAsync.js
@@ -1,0 +1,11 @@
+async function safeAsync(fnOrValue) {
+  if (typeof fnOrValue === 'function') {
+    const fn = fnOrValue;
+    return (await fn());
+  } else {
+    return fnOrValue;
+  }
+}
+
+module.exports = safeAsync;
+

--- a/detox/src/utils/safeAsync.test.js
+++ b/detox/src/utils/safeAsync.test.js
@@ -1,0 +1,19 @@
+const safeAsync = require('./safeAsync');
+
+describe('safeAsync', () => {
+  it(`should wrap value into a promise`, async() => {
+    await expect(safeAsync(5)).resolves.toEqual(5);
+  });
+
+  it(`should call sync function and return its result as a promise`, async() => {
+    await expect(safeAsync(() => 5)).resolves.toEqual(5);
+  });
+
+  it(`should call async function into a promise`, async() => {
+    await expect(safeAsync(async () => 5)).resolves.toEqual(5);
+  });
+
+  it(`should handle sync function errors in the async way`, async() => {
+    await expect(safeAsync( () => { throw 'error'; })).rejects.toEqual('error');
+  });
+});


### PR DESCRIPTION
- [x] This change has been discussed in issues #853, #1103,  #1565 and pull requests #905, #1404 .

This pull request prepares the ground to finally deal with #853 and also should potentially resolve #1565. 

The consequent PR will add `device` property to a configuration, which can be configured in a more powerful way.

**Changes:**

1. **AppleSimUtils**: make it thinner and more explicit, therefore the search method is called now `list` (similar to the CLI). The query handler logic (`iPhone X, iOS 12.0`) is moved 1 layer upwards, to SimulatorDriver.

2. **SimulatorDriver**: logic of search remains intact - device type (+ device os, if specified via comma).

3. **AppleSimUtils**: remove the dependency on a heavy and non-maintainable direct call `xcrun simctl list -j`, by allowing `new AppleSimUtils().create(device)` to accept a "prototype" for a device you want to create. I pick it from the result the `list()` method returns as-is, and pass it to `create()`.

4. **SimulatorDriver**: remove redundant calls to applesimutils, querying the same things twice when creating a device. **Important:** *now, when creating a device, it takes an OS version of the first matching but a busy device.*

5. **AndroidDriver**: remove redundant Telnet queries to busy devices. That can happen, because getting a name now done explicitly, via `queryName()` method, so we can postpone it till the very last moment.

6. **ADB**: recompose an async-iterator-like ADB output parser to lazy DeviceHandle classes, to allow bullet (5) to happen.

7. **DeviceRegistry**: refactor to accommodate changes to `SimulatorDriver` and `AndroidDriver`. API was simplified to just `allocateDevice` and `disposeDevice`. This way, we remove 2-way connecting between *Driver -> DeviceRegistry -> injected methods of *Driver, therefore we have better maintainability.

TODO(@noomorph): conduct some more manual QA.