### PR TITLE
feat(ios): add method device.clearKeychain()

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -210,6 +210,10 @@ class Device {
     await this.deviceDriver.setLocation(this._deviceId, lat, lon);
   }
 
+  async clearKeychain() {
+    await this.deviceDriver.clearKeychain(this._deviceId);
+  }
+
   async _sendPayload(key, params) {
     const payloadFilePath = this.deviceDriver.createPayloadFile(params);
     let payload = {};

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -677,6 +677,14 @@ describe('Device', () => {
     expect(driverMock.driver.pressBack).toHaveBeenCalledWith(device._deviceId);
   });
 
+  it(`clearKeychain() should invoke driver's clearKeychain()`, async () => {
+    const device = validDevice();
+
+    await device.clearKeychain();
+
+    expect(driverMock.driver.clearKeychain).toHaveBeenCalledWith(device._deviceId);
+  });
+
   describe('get ui device', () => {
     it(`getUiDevice should invoke driver's getUiDevice`, async () => {
       const device = validDevice();

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -103,6 +103,10 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
+  async clearKeychain(_udid) {
+    return await Promise.resolve('')
+  }
+
   async waitUntilReady() {
     return await this.client.waitUntilReady();
   }

--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -128,6 +128,10 @@ class SimulatorDriver extends IosDriver {
     await this.applesimutils.setPermissions(deviceId, bundleId, permissions);
   }
 
+  async clearKeychain(deviceId) {
+    await this.applesimutils.clearKeychain(deviceId)
+  }
+
   async resetContentAndSettings(deviceId) {
     await this.shutdown(deviceId);
     await this.applesimutils.resetContentAndSettings(deviceId);

--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -150,6 +150,15 @@ class AppleSimUtils {
     await this._execAppleSimUtils({ args: `--byId ${udid} --biometricEnrollment ${yesOrNo}` }, statusLogs, 1);
   }
 
+  async clearKeychain(udid) {
+    const statusLogs = {
+      trying: `Clearing Keychain...`,
+      successful: 'Cleared Keychain!'
+    };
+
+    await this._execAppleSimUtils({ args: `--byId ${udid} --clearKeychain` }, statusLogs, 1);
+  }
+
   async getAppContainer(udid, bundleId) {
     return _.trim((await this._execSimctl({ cmd: `get_app_container ${udid} ${bundleId}` })).stdout);
   }

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -28,6 +28,7 @@
 - [`device.unmatchFace()` **iOS Only**](#deviceunmatchface-ios-only)
 - [`device.matchFinger()` **iOS Only**](#devicematchfinger-ios-only)
 - [`device.unmatchFinger()` **iOS Only**](#deviceunmatchfinger-ios-only)
+- [`device.clearKeychain()` **iOS Only**](#deviceclearkeychain-ios-only)
 - [`device.pressBack()` **Android Only**](#devicepressback-android-only)
 - [`device.getUIDevice()` **Android Only**](#devicegetuidevice-android-only)
 

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -367,6 +367,9 @@ Simulates the success of a finger match via TouchID
 ### `device.unmatchFinger()` **iOS Only**
 Simulates the failure of a finger match via TouchID
 
+### `device.clearKeychain()` **iOS Only**
+Cleares the device keychain
+
 ### `device.pressBack()` **Android Only**
 Simulate press back button.
 

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -368,7 +368,7 @@ Simulates the success of a finger match via TouchID
 Simulates the failure of a finger match via TouchID
 
 ### `device.clearKeychain()` **iOS Only**
-Cleares the device keychain
+Clears the device keychain
 
 ### `device.pressBack()` **Android Only**
 Simulate press back button.


### PR DESCRIPTION
- [x] This is a small change 
- [x] This change has been discussed in issue https://github.com/wix/Detox/issues/1371

---

**Description:**

Adds the ability to delete the iOS Keychain by adding `clearKeychain` to `Device`.

I opted to not add a new e2e test as a dependency would need to be added, but will if you guys think it's needed.