### PR TITLE
feat(configuration): name string -> device object

### DIFF
--- a/detox/src/DetoxExportWrapper.js
+++ b/detox/src/DetoxExportWrapper.js
@@ -95,16 +95,15 @@ class DetoxExportWrapper {
                         ${Object.keys(configurations)}`);
     }
 
-    if (deviceOverride) {
-      deviceConfig.name = deviceOverride;
-    }
-
     if (!deviceConfig.type) {
       configuration.throwOnEmptyType();
     }
 
-    if (!deviceConfig.name) {
-      configuration.throwOnEmptyName();
+    deviceConfig.device = deviceOverride || deviceConfig.device || deviceConfig.name;
+    delete deviceConfig.name;
+
+    if (_.isEmpty(deviceConfig.device)) {
+      configuration.throwOnEmptyDevice();
     }
 
     return deviceConfig;

--- a/detox/src/configuration.js
+++ b/detox/src/configuration.js
@@ -23,12 +23,12 @@ function validateSession(session) {
   }
 }
 
-function throwOnEmptyName() {
-  throw new DetoxConfigError(`'name' property is missing, should hold the device name to run on (e.g. "iPhone 11 Pro", "iPhone 11 Pro, iOS 13.0"`);
+function throwOnEmptyDevice() {
+  throw new DetoxConfigError(`'device' property is empty, should hold the device query to run on (e.g. { "type": "iPhone 11 Pro" }, { "avdName": "Nexus_5X_API_29" })`);
 }
 
 function throwOnEmptyType() {
-  throw new DetoxConfigError(`'type' property is missing, should hold the device type to test on (currently only simulator is supported: ios.simulator or ios.none)`);
+  throw new DetoxConfigError(`'type' property is missing, should hold the device type to test on (e.g. "ios.simulator" or "android.emulator")`);
 }
 
 function throwOnEmptyBinaryPath() {
@@ -38,7 +38,7 @@ function throwOnEmptyBinaryPath() {
 module.exports = {
   defaultSession,
   validateSession,
-  throwOnEmptyName,
+  throwOnEmptyDevice,
   throwOnEmptyType,
   throwOnEmptyBinaryPath
 };

--- a/detox/src/configurations.mock.js
+++ b/detox/src/configurations.mock.js
@@ -171,6 +171,31 @@ const validOneEmulator = {
   }
 };
 
+const deviceObjectSimulator = {
+  "configurations": {
+    "ios.sim.release": {
+      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
+      "type": "ios.simulator",
+      "device": {
+        "name": "iPhone 7 Plus",
+        "os": "iOS 10.2"
+      }
+    }
+  }
+};
+
+const deviceObjectEmulator = {
+  "configurations": {
+    "android.emu.release": {
+      "binaryPath": "android/app/build/outputs/apk/app-debug.apk",
+      "type": "android.emulator",
+      "device": {
+        "avdName": "Nexus 5X"
+      }
+    }
+  }
+};
+
 module.exports = {
   validOneDeviceNoSession,
   validOneIosNoneDeviceNoSession,
@@ -186,5 +211,7 @@ module.exports = {
   sessionPerConfiguration,
   sessionInCommonAndInConfiguration,
   validOneEmulator,
-  pathsTests
+  pathsTests,
+  deviceObjectEmulator,
+  deviceObjectSimulator,
 };

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -17,7 +17,7 @@ class Device {
   async prepare(params = {}) {
     this._binaryPath = this._getAbsolutePath(this._deviceConfig.binaryPath);
     this._testBinaryPath = this._deviceConfig.testBinaryPath ? this._getAbsolutePath(this._deviceConfig.testBinaryPath) : null;
-    this._deviceId = await this.deviceDriver.acquireFreeDevice(this._deviceConfig.name);
+    this._deviceId = await this.deviceDriver.acquireFreeDevice(this._deviceConfig.device || this._deviceConfig.name);
     this._bundleId = await this.deviceDriver.getBundleIdFromBinary(this._binaryPath);
 
     await this.deviceDriver.prepare();

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -644,19 +644,12 @@ describe('Device', () => {
   });
 
   it(`new Device() with invalid device config (no binary) should throw`, () => {
+    // TODO: this is an invalid test, because it will pass only on SimulatorDriver
     expect(() => new Device({
       deviceConfig: invalidDeviceNoBinary.configurations['ios.sim.release'],
       deviceDriver: new SimulatorDriver(client),
       sessionConfig: validScheme.session,
     })).toThrowError(/binaryPath.* is missing/);
-  });
-
-  it(`new Device() with invalid device config (no device name) should throw`, () => {
-    expect(() => new Device({
-      deviceConfig: invalidDeviceNoDeviceName.configurations['ios.sim.release'],
-      deviceDriver: new SimulatorDriver(client),
-      sessionConfig: validScheme.session,
-    })).toThrowError(/name.* is missing/);
   });
 
   it(`should accept absolute path for binary`, async () => {

--- a/detox/src/devices/drivers/AttachedAndroidDriver.js
+++ b/detox/src/devices/drivers/AttachedAndroidDriver.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const AndroidDriver = require('./AndroidDriver');
 const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
 
@@ -12,7 +13,8 @@ class AttachedAndroidDriver extends AndroidDriver {
     return this._name;
   }
 
-  async acquireFreeDevice(adbName) {
+  async acquireFreeDevice(deviceQuery) {
+    const adbName = _.isPlainObject(deviceQuery) ? deviceQuery.adbName : deviceQuery;
     const { devices, stdout } = await this.adb.devices();
 
     if (!devices.some(d => d.adbName === adbName)) {

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -40,7 +40,7 @@ class DeviceDriverBase {
     return {};
   }
 
-  async acquireFreeDevice(name) {
+  async acquireFreeDevice(deviceQuery) {
     await Promise.resolve('');
   }
 

--- a/detox/src/devices/drivers/EmulatorDriver.js
+++ b/detox/src/devices/drivers/EmulatorDriver.js
@@ -32,7 +32,9 @@ class EmulatorDriver extends AndroidDriver {
     return this._name
   }
 
-  async acquireFreeDevice(avdName) {
+  async acquireFreeDevice(deviceQuery) {
+    const avdName = _.isPlainObject(deviceQuery) ? deviceQuery.avdName : deviceQuery;
+
     await this._validateAvd(avdName);
     await this._fixEmulatorConfigIniSkinNameIfNeeded(avdName);
 

--- a/detox/src/devices/drivers/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/SimulatorDriver.test.js
@@ -79,6 +79,72 @@ describe('IOS simulator driver', () => {
       expect(sim.applesimutils.unmatchBiometric).toHaveBeenCalledWith(deviceId, 'Finger');
     })
   });
+
+  describe('acquireFreeDevice', () => {
+    let applesimutils;
+
+    beforeEach(() => {
+      const SimulatorDriver = require('./SimulatorDriver');
+      uut = new SimulatorDriver({ client: {} });
+      jest.spyOn(uut.deviceRegistry, 'isDeviceBusy').mockReturnValue(false);
+      applesimutils = uut.applesimutils;
+      applesimutils.list.mockImplementation(async () => require('../ios/applesimutils.mock')['--list']);
+    });
+
+    it('should accept string as device type', async () => {
+      await uut.acquireFreeDevice('iPhone X');
+
+      expect(applesimutils.list).toHaveBeenCalledWith(
+        { byType: 'iPhone X' },
+        'Searching for device by type = "iPhone X" ...'
+      );
+    });
+
+    it('should accept string with comma as device type and OS version', async () => {
+      await uut.acquireFreeDevice('iPhone X, iOS 12.0');
+
+      expect(applesimutils.list).toHaveBeenCalledWith(
+        { byType: 'iPhone X', byOS: 'iOS 12.0' },
+        'Searching for device by type = "iPhone X" and by OS = "iOS 12.0" ...'
+      );
+    });
+
+    it('should accept { byId } as matcher', async () => {
+      await uut.acquireFreeDevice({ id: 'C6EC2279-A6EB-40BE-99D2-5F11949F25E5' });
+
+      expect(applesimutils.list).toHaveBeenCalledWith(
+        { byId: 'C6EC2279-A6EB-40BE-99D2-5F11949F25E5' },
+        'Searching for device by UDID = "C6EC2279-A6EB-40BE-99D2-5F11949F25E5" ...'
+      );
+    });
+
+    it('should accept { byName } as matcher', async () => {
+      await uut.acquireFreeDevice({ name: 'Chika' });
+
+      expect(applesimutils.list).toHaveBeenCalledWith(
+        { byName: 'Chika' },
+        'Searching for device by name = "Chika" ...'
+      );
+    });
+
+    it('should accept { byType } as matcher', async () => {
+      await uut.acquireFreeDevice({ type: 'iPad Air' });
+
+      expect(applesimutils.list).toHaveBeenCalledWith(
+        { byType: 'iPad Air' },
+        'Searching for device by type = "iPad Air" ...'
+      );
+    });
+
+    it('should accept { byType, byOS } as matcher', async () => {
+      await uut.acquireFreeDevice({ type: 'iPad 2', os: 'iOS 9.3.6' });
+
+      expect(applesimutils.list).toHaveBeenCalledWith(
+        { byType: 'iPad 2', byOS: 'iOS 9.3.6' },
+        'Searching for device by type = "iPad 2" and by OS = "iOS 9.3.6" ...'
+      );
+    });
+  });
 });
 
 class mockAppleSimUtils {
@@ -87,5 +153,7 @@ class mockAppleSimUtils {
     this.setBiometricEnrollment = jest.fn();
     this.matchBiometric = jest.fn();
     this.unmatchBiometric = jest.fn();
+    this.boot = jest.fn();
+    this.list = jest.fn();
   }
 }

--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -109,7 +109,7 @@ describe('index', () => {
 
     const expectedConfig = {
       ...schemes.validOneDeviceNoSession.configurations['ios.sim.release'],
-      name: 'iPhone X'
+      device: 'iPhone X'
     }
 
     expect(Detox).toHaveBeenCalledWith({

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -48,18 +48,24 @@
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
         "build": "set -o pipefail && xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example_ci -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
-        "name": "iPhone 11 Pro"
+        "device": {
+          "type": "iPhone 11 Pro"
+        }
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
         "build": "set -o pipefail && export CODE_SIGNING_REQUIRED=NO && export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -project ios/example.xcodeproj  -UseNewBuildSystem=NO -scheme example_ci -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
-        "name": "iPhone 11 Pro"
+        "device": {
+          "type": "iPhone 11 Pro"
+        }
       },
       "ios.none": {
         "binaryPath": "ios",
         "type": "ios.none",
-        "name": "iPhone 11 Pro",
+        "device": {
+          "type": "iPhone 11 Pro"
+        },
         "session": {
           "server": "ws://localhost:8099",
           "sessionId": "com.wix.detox-example"
@@ -69,19 +75,25 @@
         "binaryPath": "android/app/build/outputs/apk/fromBin/debug/app-fromBin-debug.apk",
         "build": "cd android && ./gradlew assembleFromBinDebug assembleFromBinDebugAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
-        "name": "Nexus_5X_API_26"
+        "device": {
+          "avdName": "Nexus_5X_API_26"
+        }
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/fromBin/release/app-fromBin-release.apk",
         "build": "cd android && ./gradlew assembleFromBinRelease assembleFromBinReleaseAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
-        "name": "Nexus_5X_API_26"
+        "device": {
+          "avdName": "Nexus_5X_API_26"
+        }
       },
       "android.emu.debug.fromSource": {
         "binaryPath": "android/app/build/outputs/apk/fromSource/debug/app-fromSource-debug.apk",
         "build": "cd android && ./gradlew assembleFromSourceDebug assembleFromSourceDebugAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
-        "name": "Nexus_5X_API_26"
+        "device": {
+          "avdName": "Nexus_5X_API_26"
+        }
       }
     }
   },

--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -11,23 +11,47 @@
 |`type`| Device type, available options are `ios.simulator`, `ios.none`, `android.emulator`, and `android.attached`. |
 |`binaryPath`| Relative path to the ipa/app due to be  tested (make sure you build the app in a project relative path)|
 |`testBinaryPath`| (optional, Android only): relative path to the test app (apk) |
-|`name`| Device name, aligns to the device list avaliable through `xcrun simctl list` for example, this is one line of the output of `xcrun simctl list`: `A3C93900-6D17-4830-8FBE-E102E4BBCBB9  iPhone 7  Shutdown  iPhone 7  iOS 10.2`, in order to choose the first `iPhone 7` regardless of OS version, use `iPhone 7`. To be OS specific use `iPhone 7, iOS 10.2`|
+|`device`| Device query, e.g. `{ "byType": "iPhone 11 Pro" }` for iOS simulator or `{ "avdName": "Nexus_5X_API_29" }` |
 |`build`| **[optional]** Build command (either `xcodebuild`, `react-native run-ios`, etc...), will be later available through detox CLI tool.|
 	
 **Example:**
 
-```json
+```js
+{
+  // ...
   "detox": {
-	...
+    // ...
     "configurations": {
       "ios.sim.debug": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
         "build": "xcodebuild -project ios/example.xcodeproj -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
-        "name": "iPhone 7 Plus"
-      }
+        "device": { /* one of these or a combination of them */
+          "id": "D53474CF-7DD1-4673-8517-E75DAD6C34D6",
+          "type": "iPhone 11 Pro",
+          "name": "MySim",
+          "os": "iOS 13.0",
+        }
+      },
+      "android.emu.release": {
+        "binaryPath": "...",
+        "build": "...",
+        "type": "android.emulator",
+        "device": {
+          "avdName": "Nexus_5X_API_29",
+        }
+      },
+      "android.att.release": {
+        "binaryPath": "...",
+        "build": "...",
+        "type": "android.attached",
+        "device": {
+          "adbName": "YOGAA1BBB412",
+        }
+      },
     }
   }
+}
 ```	
 	
 ### Server Configuration
@@ -52,7 +76,7 @@ Session can also be set per configuration:
     "configurations": {
       "ios.sim.debug": {
         ...
-	"session": {
+        "session": {
           "server": "ws://localhost:8099",
           "sessionId": "YourProjectSessionId"
         }

--- a/docs/Guide.DebuggingInXcode.md
+++ b/docs/Guide.DebuggingInXcode.md
@@ -16,13 +16,15 @@ Edit the Detox section in `package.json` to add the following configuration:
 
 ```json
 "ios.none": {
-    "binaryPath": "ios",
-    "type": "ios.none",
-    "name": "iPhone 8 Plus",
-    "session": {
-        "server": "ws://localhost:8099",
-        "sessionId": "<your app's bundle identifier>"
-    }
+  "binaryPath": "ios",
+  "type": "ios.none",
+  "device": {
+    "type": "iPhone 8 Plus"
+  },
+  "session": {
+    "server": "ws://localhost:8099",
+    "sessionId": "<your app's bundle identifier>"
+  }
 }
 ```
 

--- a/docs/Guide.Migration.md
+++ b/docs/Guide.Migration.md
@@ -2,6 +2,56 @@
 
 We are improving detox API as we go along, sometimes these changes require us to break the API in order for it to make more sense. These migration guides refer to breaking changes. If a newer version has no entries in this document, it means it does not require special migration steps. Refer to the release notes of the later builds to learn about their improvements and changes.
 
+## 14.5.0
+
+It is recommended to change "name" string to "device" object in your configurations, like shown below:
+
+Before:
+```json
+{
+  "ios.sim.debug": {
+    "type": "ios.simulator",
+    "name": "iPhone 11 Pro"
+  },
+  "android.emu.release": {
+    "type": "android.emulator",
+    "name": "Nexus_5X_API_29"
+  },
+  "android.att.release": {
+    "type": "android.attached",
+    "name": "YOGAA1BBB412"
+  }
+}
+```
+
+After:
+
+```js
+{
+  "ios.sim.debug": {
+    "type": "ios.simulator",
+    "device": { // one of these or a combination of them
+      "id": "D53474CF-7DD1-4673-8517-E75DAD6C34D6",
+      "type": "iPhone 11 Pro",
+      "name": "MySim",
+      "os": "iOS 13.0",
+    }
+  },
+  "android.emu.release": {
+    "type": "android.emulator",
+    "device": { // only avdName is supported at the moment
+      "avdName": "Nexus_5X_API_29",
+    }
+  },
+  "android.att.release": {
+    "type": "android.attached",
+    "device": { // only adbName is supported at the moment
+      "adbName": "YOGAA1BBB412",
+    }
+  }
+}
+```
+
 ## 14.0.0
 
 Detox 14.0.0 drops support for iOS 9.x simulators, and thus it also drops support for any API that is deprecated in iOS 10 and above. This includes legacy [remote](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application?language=objc) and [local](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622930-application?language=objc) notifications handling API. These APIs have been deprecated since iOS 10, and we believe we've given app developers enough time to use the modern APIs. Make sure you transition to the [UserNotifications framework](https://developer.apple.com/documentation/usernotifications?language=objc) as soon as possible.

--- a/docs/Guide.RunningOnCI.md
+++ b/docs/Guide.RunningOnCI.md
@@ -19,7 +19,9 @@ We will need to create a [release device configuration for Detox](/docs/APIRef.C
       "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
       "build": "xcodebuild -project ios/example.xcodeproj -scheme example -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
       "type": "ios.simulator",
-      "name": "iPhone 7"
+      "device": {
+        "type": "iPhone 11 Pro"
+      }
     }
   }
 }

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -120,14 +120,17 @@ Add this part to your `package.json`:
             "build":
             "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
             "type": "android.emulator",
-            "name": "Nexus_5X_API_24"
+            "device": {
+              "avdName": "Nexus_5X_API_24"
+            }
         },
         "android.emu.release": {
             "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
-            "build":
-            "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
+            "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
             "type": "android.emulator",
-            "name": "Nexus_5X_API_26"
+            "device": {
+              "avdName": "Nexus_5X_API_26"
+            }
         }
     }
 }

--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -92,7 +92,9 @@ The basic configuration for Detox should be in your `package.json` file under th
       "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
       "build": "xcodebuild -project ios/example.xcodeproj -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
       "type": "ios.simulator",
-      "name": "iPhone 7"
+      "device": {
+        "type": "iPhone 11 Pro"
+      }
     }
   }
 }
@@ -102,7 +104,7 @@ In the above configuration example, change `example` to your actual project name
 
 For React Native 0.60 or above, or any other iOS apps in a workspace (eg: CocoaPods) use `-workspace ios/example.xcworkspace` instead of `-project`.
 
-Also make sure the simulator model specified under the key `"name"` (`iPhone 7` above) is actually available on your machine (it was installed by Xcode). Check this by typing `xcrun simctl list` in terminal to display all available simulators.
+Also make sure the simulator model specified under the key `device.type` (e.g. `iPhone 11 Pro` above) is actually available on your machine (it was installed by Xcode). Check this by typing `applesimutils --list` in terminal to display all available simulators.
 
 > TIP: To test a release version, replace 'Debug' with 'Release' in the binaryPath and build properties. For full configuration options see Configuration under the API Reference.
 

--- a/docs/More.AndroidSupportStatus.md
+++ b/docs/More.AndroidSupportStatus.md
@@ -62,7 +62,9 @@ To utilize Genymotion you should use 'android.attached' as configuration type pa
     "binaryPath": "./android/app/build/outputs/apk/app-debug.apk",
     "build": "pushd ./android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && popd",
     "type": "android.attached",
-    "name": "192.168.57.101:5555"
+    "device": {
+      "adbName": "192.168.57.101:5555"
+    }
 }
 ```
 

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -23,12 +23,16 @@
       "ios.sim.release": {
         "binaryPath": "../demo-react-native/ios/build/Build/Products/Release-iphonesimulator/example.app",
         "type": "ios.simulator",
-        "name": "iPhone 11 Pro"
+        "device": {
+          "type": "iPhone 11 Pro"
+        }
       },
       "android.emu.release": {
         "binaryPath": "../demo-react-native/android/app/build/outputs/apk/release/app-release.apk",
         "type": "android.emulator",
-        "name": "Nexus_5X_API_26"
+        "device": {
+          "avdName": "Nexus_5X_API_26"
+        }
       }
     }
   }

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -31,19 +31,25 @@
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
         "build": "export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet",
         "type": "ios.simulator",
-        "name": "iPhone 11 Pro"
+        "device": {
+          "type": "iPhone 11 Pro"
+        }
       },
       "ios.sim.debug": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
         "build": "xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
-        "name": "iPhone 11 Pro"
+        "device": {
+          "type": "iPhone 11 Pro"
+        }
       },
       "ios.none": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
         "build": "xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.none",
-        "name": "iPhone 11 Pro",
+        "device": {
+          "type": "iPhone 11 Pro"
+        },
         "session": {
           "server": "ws://localhost:8099",
           "sessionId": "com.wix.demo.react.native"
@@ -53,13 +59,17 @@
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
         "build": "cd android ; ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug ; cd -",
         "type": "android.emulator",
-        "name": "Nexus_5X_API_26"
+        "device": {
+          "avdName": "Nexus_5X_API_26"
+        }
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
         "build": "cd android ; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release ; cd -",
         "type": "android.emulator",
-        "name": "Nexus_5X_API_26"
+        "device": {
+          "avdName": "Nexus_5X_API_26"
+        }
       }
     }
   }


### PR DESCRIPTION
- [x] This change has been discussed in issues #853  and pull requests #905, #1404 .

### Issues resolved

Resolves #853 (to query a simulator specifically by name, use appropriately):

```
"device": { name: "Simulator name" }
```

### Summary
It is recommended to change `"name"` string to `"device"` object in your configurations, like shown below:

Before:
```json
{
  "ios.sim.debug": {
    "type": "ios.simulator",
    "name": "iPhone 11 Pro"
  },
  "android.emu.release": {
    "type": "android.emulator",
    "name": "Nexus_5X_API_29"
  },
  "android.att.release": {
    "type": "android.attached",
    "name": "YOGAA1BBB412"
  }
}
```

After:

```js
{
  "ios.sim.debug": {
    "type": "ios.simulator",
    "device": { // one of these or a combination of them
      "id": "D53474CF-7DD1-4673-8517-E75DAD6C34D6",
      "type": "iPhone 11 Pro",
      "name": "MySim",
      "os": "iOS 13.0",
    }
  },
  "android.emu.release": {
    "type": "android.emulator",
    "device": { // only avdName is supported at the moment
      "avdName": "Nexus_5X_API_29",
    }
  },
  "android.att.release": {
    "type": "android.attached",
    "device": { // only adbName is supported at the moment
      "adbName": "YOGAA1BBB412",
    }
  }
}
```