### PR TITLE
More helpful error message if Detox.init() fails

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -88,6 +88,7 @@
       "src/devices/ios/AppleSimUtils.js",
       "src/server/DetoxServer.js",
       ".*Driver.js",
+      "MissingDetox.js",
       "EmulatorTelnet.js",
       "Emulator.js",
       "DeviceDriverBase.js",

--- a/detox/runners/jest/WorkerAssignReporterImpl.js
+++ b/detox/runners/jest/WorkerAssignReporterImpl.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const chalk = require('chalk').default;
 const ReporterBase = require('./ReporterBase');
 const log = require('../../src/utils/logger').child();
@@ -9,7 +10,12 @@ class WorkerAssignReporterImpl extends ReporterBase {
   }
 
   report(workerName) {
-    log.info({event: 'WORKER_ASSIGN'}, `${chalk.whiteBright(workerName)} assigned to ${chalk.blueBright(this.device.name)}`);
+    const deviceName = _.attempt(() => this.device.name);
+    const formattedDeviceName = _.isError(deviceName)
+      ? chalk.redBright('undefined')
+      : chalk.blueBright(deviceName);
+
+    log.info({event: 'WORKER_ASSIGN'}, `${chalk.whiteBright(workerName)} is assigned to ${formattedDeviceName}`);
   }
 }
 

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -9,6 +9,7 @@ const EmulatorDriver = require('./devices/drivers/EmulatorDriver');
 const AttachedAndroidDriver = require('./devices/drivers/AttachedAndroidDriver');
 const DetoxRuntimeError = require('./errors/DetoxRuntimeError');
 const argparse = require('./utils/argparse');
+const MissingDetox = require('./utils/MissingDetox');
 const configuration = require('./configuration');
 const Client = require('./client/Client');
 const DetoxServer = require('./server/DetoxServer');
@@ -176,5 +177,7 @@ class Detox {
     return session;
   }
 }
+
+Detox.none = new MissingDetox();
 
 module.exports = Detox;

--- a/detox/src/DetoxExportWrapper.js
+++ b/detox/src/DetoxExportWrapper.js
@@ -29,6 +29,10 @@ class DetoxExportWrapper {
   }
 
   async init(config, params) {
+    if (!params || params.initGlobals !== false) {
+      Detox.none.initContext(global);
+    }
+
     this[_detox] = await DetoxExportWrapper._initializeInstance(config, params);
     return this[_detox];
   }

--- a/detox/src/DetoxExportWrapper.js
+++ b/detox/src/DetoxExportWrapper.js
@@ -38,6 +38,8 @@ class DetoxExportWrapper {
   }
 
   async cleanup() {
+    Detox.none.cleanupContext(global);
+
     if (this[_detox] !== Detox.none) {
       await this[_detox].cleanup();
       this[_detox] = Detox.none;
@@ -58,6 +60,8 @@ class DetoxExportWrapper {
     let instance = null;
 
     try {
+      Detox.none.setError(null);
+
       if (!detoxConfig) {
         throw new Error(`No configuration was passed to detox, make sure you pass a detoxConfig when calling 'detox.init(detoxConfig)'`);
       }

--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -28,6 +28,7 @@ describe('index', () => {
       .mock('./Detox', () => {
         const MissingDetox = require('./utils/MissingDetox');
         const none = new MissingDetox();
+        none.cleanupContext = () => {}; // avoid ruining global state
 
         return Object.assign(jest.fn(() => mockDetox), { none });
       });
@@ -43,6 +44,14 @@ describe('index', () => {
       .unmock('./devices/Device')
       .unmock('./client/Client')
       .unmock('./Detox')
+  });
+
+  it(`constructs detox without globals if initGlobals = false`, async () => {
+    const Detox = require('./Detox');
+
+    await detox.init(schemes.validOneDeviceNoSession, { initGlobals: false });
+
+    expect('by' in global).toBe(false);
   });
 
   it(`throws if there was no config passed`, async () => {

--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -1,4 +1,5 @@
 const schemes = require('./configurations.mock');
+
 describe('index', () => {
   let detox;
   let mockDevice;
@@ -24,7 +25,12 @@ describe('index', () => {
       .mock('./devices/Device')
       .mock('./utils/logger')
       .mock('./client/Client')
-      .mock('./Detox', () => jest.fn(() => mockDetox))
+      .mock('./Detox', () => {
+        const MissingDetox = require('./utils/MissingDetox');
+        const none = new MissingDetox();
+
+        return Object.assign(jest.fn(() => mockDetox), { none });
+      });
 
     process.env.DETOX_UNIT_TEST = true;
     detox = require('./index');
@@ -185,8 +191,9 @@ describe('index', () => {
   it(`Basic usage with memorized exported objects`, async() => {
     const { device, by } = detox;
 
-    expect(device.launchApp).toBe(undefined);
-    expect(by.id).toBe(undefined);
+    expect(() => { device, by }).not.toThrowError();
+    expect(() => { device.launchApp }).toThrowError();
+    expect(() => { by.id }).toThrowError();
 
     await detox.init(schemes.validOneDeviceNoSession);
 
@@ -195,8 +202,9 @@ describe('index', () => {
 
     await detox.cleanup();
 
-    expect(device.launchApp).toBe(undefined);
-    expect(by.id).toBe(undefined);
+    expect(() => { device, by }).not.toThrowError();
+    expect(() => { device.launchApp }).toThrowError();
+    expect(() => { by.id }).toThrowError();
   });
 
   it(`Basic usage, do not throw an error if cleanup is done twice`, async() => {
@@ -221,7 +229,14 @@ describe('index', () => {
   });
 
   it(`beforeEach() should be covered - with detox not initialized`, async() => {
-    await detox.beforeEach();
+    await expect(detox.beforeEach()).rejects.toThrow(/Make sure to call/);
+  });
+
+  it(`error message should be covered - with detox failed to initialize`, async() => {
+    mockDetox.init.mockReturnValue(Promise.reject(new Error('Test error')));
+
+    await expect(detox.init(schemes.validOneDeviceNoSession)).rejects.toThrow(/Test error/);
+    await expect(detox.beforeEach()).rejects.toThrow(/There was an error/);
   });
 
   it(`afterEach() should be covered - with detox initialized`, async() => {
@@ -230,7 +245,6 @@ describe('index', () => {
   });
 
   it(`afterEach() should be covered - with detox not initialized`, async() => {
-    await detox.afterEach();
+    await expect(detox.afterEach()).rejects.toThrow(/Make sure to call/);
   });
-
 });

--- a/detox/src/utils/MissingDetox.js
+++ b/detox/src/utils/MissingDetox.js
@@ -1,0 +1,45 @@
+const DetoxRuntimeError = require('../errors/DetoxRuntimeError');
+
+class MissingDetox {
+  constructor(invocationManager) {
+    this.throwError = this._throwError.bind(this);
+
+    this.by = {
+      accessibilityLabel: this.throwError,
+      label: this.throwError,
+      id: this.throwError,
+      type: this.throwError,
+      traits: this.throwError,
+      value: this.throwError,
+      text: this.throwError,
+    };
+
+    this.element = this.throwError;
+    this.expect = this.throwError;
+    this.waitFor = this.throwError;
+  }
+
+  get device() {
+    this.throwError();
+  }
+
+  get by() {
+    this.throwError();
+  }
+
+  setError(err) {
+    this._lastError = err;
+  }
+
+  _throwError() {
+    throw new DetoxRuntimeError({
+      message: 'Detox instance has not been initialized',
+      hint: this._lastError
+        ? 'There was an error on attempt to call detox.init()'
+        : 'Make sure to call detox.init() before your test begins',
+      debugInfo: this._lastError && this._lastError.stack || '',
+    });
+  }
+}
+
+module.exports = MissingDetox;

--- a/detox/src/utils/MissingDetox.js
+++ b/detox/src/utils/MissingDetox.js
@@ -19,6 +19,20 @@ class MissingDetox {
     this._defineRequiredProperty(context, 'waitFor', this.throwError, readonly);
   }
 
+  cleanupContext(context) {
+    this._cleanupProperty(context, 'by');
+    this._cleanupProperty(context, 'device');
+    this._cleanupProperty(context, 'element');
+    this._cleanupProperty(context, 'expect');
+    this._cleanupProperty(context, 'waitFor');
+  }
+
+  _cleanupProperty(context, name) {
+    if (context.hasOwnProperty(name)) {
+      context[name] = undefined;
+    }
+  }
+
   _defineRequiredProperty(context, name, initialValue, readonly) {
     if (context.hasOwnProperty(name)) {
       return;


### PR DESCRIPTION
I am very tired of user reports that tell `device (or element) is not defined` and so on.
Let's solve it.

The goal of this pull request to transform those errors:

![Old errors](https://user-images.githubusercontent.com/1962469/67159143-83beea00-f349-11e9-86c9-4dcde5d1fda4.png)

To these, telling that there was an error in detox.init():

![New errors](https://user-images.githubusercontent.com/1962469/67159141-7a358200-f349-11e9-81bc-495a4b258428.png)