### PR TITLE
Avoid crash due to iOS createTimer API change

### DIFF
--- a/detox/ios/Detox/WXJSTimerObservationIdlingResource.m
+++ b/detox/ios/Detox/WXJSTimerObservationIdlingResource.m
@@ -118,38 +118,56 @@ DTX_CREATE_LOG(WXJSTimerObservationIdlingResource)
 		Class cls = NSClassFromString(@"RCTTiming");
 		SEL createTimerSel = NSSelectorFromString(@"createTimer:duration:jsSchedulingTime:repeats:");
 		Method m = class_getInstanceMethod(cls, createTimerSel);
-		
-		void (*orig_createTimer)(id, SEL, NSNumber*, NSTimeInterval, NSDate*, BOOL) = (void(*)(id, SEL, NSNumber*, NSTimeInterval, NSDate*, BOOL))method_getImplementation(m);
-		method_setImplementation(m, imp_implementationWithBlock(^(id _self, NSNumber* timerID, NSTimeInterval duration, NSDate* jsDate, BOOL repeats) {
-			__strong __typeof(weakSelf) strongSelf = weakSelf;
-			
-			dispatch_sync(_timersObservationQueue, ^{
-				_WXJSTimingObservationWrapper* _observationWrapper = [strongSelf->_observations objectForKey:_self];
-				
-				if(_observationWrapper == nil)
-				{
-					_observationWrapper = [[_WXJSTimingObservationWrapper alloc] initWithTimers:[_self valueForKey:@"_timers"]];
-					[_self setValue:_observationWrapper forKey:@"_timers"];
-					[strongSelf->_observations setObject:_observationWrapper forKey:_self];
-				}
-				
-				
-				if(duration > 0 && duration <= _durationThreshold && repeats == NO)
-				{
-					dtx_log_info(@"Observing timer: %@ d: %@ r: %@", timerID, @(duration), @(repeats));
-					
-					[_observationWrapper addObservedTimer:timerID];
-				}
-				else
-				{
-					dtx_log_info(@"Ignoring timer: %@ failure reason: \"%@\"", timerID, [strongSelf failuireReasonForDuration:duration repeats:repeats]);
-				}
-			});
-			
-			orig_createTimer(_self, createTimerSel, timerID, duration, jsDate, repeats);
-		}));
+
+		// Check if the createTimer interface is using doubles or NSObjects.
+		// Earlier versions of react native use NSObjects for the timer and
+		// date params, while later versions use doubles for these.
+		char timerArgType[10];
+		method_getArgumentType(m, 2, timerArgType, 10);
+		if (strcmp(timerArgType, "d") == 0) {
+			void (*orig_createTimer)(id, SEL, double, NSTimeInterval, double, BOOL) = (void(*)(id, SEL, double, NSTimeInterval, double, BOOL))method_getImplementation(m);
+			method_setImplementation(m, imp_implementationWithBlock(^(id _self, double timerID, NSTimeInterval duration, double jsDate, BOOL repeats) {
+				__strong __typeof(weakSelf) strongSelf = weakSelf;
+				[strongSelf attachObservation:_self timerID:[NSNumber numberWithDouble:timerID] duration:duration repeats:repeats];
+				orig_createTimer(_self, createTimerSel, timerID, duration, jsDate, repeats);
+			}));
+		} else {
+			void (*orig_createTimer)(id, SEL, NSNumber*, NSTimeInterval, NSDate*, BOOL) = (void(*)(id, SEL, NSNumber*, NSTimeInterval, NSDate*, BOOL))method_getImplementation(m);
+			method_setImplementation(m, imp_implementationWithBlock(^(id _self, NSNumber* timerID, NSTimeInterval duration, NSDate* jsDate, BOOL repeats) {
+				__strong __typeof(weakSelf) strongSelf = weakSelf;
+				[strongSelf attachObservation:_self timerID:timerID duration:duration repeats:repeats];
+				orig_createTimer(_self, createTimerSel, timerID, duration, jsDate, repeats);
+			}));
+		}
 	}
 	return self;
+}
+
+- (void)attachObservation:(id)_self
+                  timerID:(NSNumber *)timerID
+                 duration:(NSTimeInterval)duration
+                  repeats:(BOOL)repeats
+{
+	dispatch_sync(_timersObservationQueue, ^{
+		_WXJSTimingObservationWrapper* _observationWrapper = [self->_observations objectForKey:_self];
+
+		if(_observationWrapper == nil)
+		{
+			_observationWrapper = [[_WXJSTimingObservationWrapper alloc] initWithTimers:[_self valueForKey:@"_timers"]];
+			[_self setValue:_observationWrapper forKey:@"_timers"];
+			[self->_observations setObject:_observationWrapper forKey:_self];
+		}
+
+		if(duration > 0 && duration <= _durationThreshold && repeats == NO)
+		{
+			dtx_log_info(@"Observing timer: %@ d: %@ r: %@", timerID, @(duration), @(repeats));
+			[_observationWrapper addObservedTimer:timerID];
+		}
+		else
+		{
+			dtx_log_info(@"Ignoring timer: %@ failure reason: \"%@\"", timerID, [self failuireReasonForDuration:duration repeats:repeats]);
+		}
+	});
 }
 
 - (BOOL)isIdleNow


### PR DESCRIPTION
**Description:**

The API for createTimer has changed in react native master branch. 

See relevant change: https://github.com/facebook/react-native/commit/2b5f4de7eb4e5453e91d4956bcb0f58fe37b6562

Due to this change, Detox seems to crash.

The stack trace appears like this:

```
Signal 11 was raised
(
		0   Detox                               0x000000010cf38b36 _ZL16__DTXHandleCrashP11NSExceptionP8NSNumberP8NSString + 497
	1   Detox                               0x000000010cf388bb _ZL17__DTXHandleSignali + 61
	2   libsystem_platform.dylib            0x0000000116f52b5d _sigtramp + 29
	3   ???                                 0x0000000000000000 0x0 + 0
	4   CoreFoundation                      0x0000000110b544cc __invoking___ + 140
	5   CoreFoundation                      0x0000000110b51a45 -[NSInvocation invoke] + 325
	6   CoreFoundation                      0x0000000110b51e96 -[NSInvocation invokeWithTarget:] + 54
	7   Twilight                            0x0000000109ba3cbc RCTParseMethodSignature + 31388
	8   Twilight                            0x0000000109b01397 _ZN8facebook5react15RCTNativeModule26callSerializableNativeHookEjON5folly7dynamicE + 967
	9   Twilight                            0x0000000109b00ea6 _ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi + 1302
	10  Twilight                            0x0000000109b00df9 _ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi + 1129
	11  Twilight                            0x0000000109b00b71 _ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi + 481
	12  Twilight                            0x000000010b0de900 _ZN8facebook5react14ModuleRegistry16callNativeMethodEjjON5folly7dynamicEi + 336
	13  Twilight                            0x000000010b0eb735 
```

The API change in the link above shows that it has been changed from:

```
             createTimer:(nonnull NSNumber *)callbackID
                   duration:(NSTimeInterval)jsDuration
   jsSchedulingTime:(NSDate *)jsSchedulingTime
                   repeats:(BOOL)repeats)
```

to

```
            createTimer:(double)callbackID
                  duration:(NSTimeInterval)jsDuration
  jsSchedulingTime:(double)jsSchedulingTime
                  repeats:(BOOL)repeats)
```

In this PR I use method_getArgumentType to determine if the API is now using a double for the argument and use that correct function type in that case.

For some context on why I'm interested in sending a PR in regards to a react native api change in master. At Facebook most apps run against react native master (so code can be battle-tested before it gets officially released as OSS). One downside here is that when we run a Detox test, we can run into an incompatibility like this one before anyone else does. I recognize that I am running against an unsupported version of react native, but I would like to contribute this fix into Detox now so we can avoid having to fork+patch detox before the next react native release (and before official support from detox exists).

Feedback welcome :) Thanks!