### PR TITLE
Allow expecting visibility with specified percentage

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxMatcher.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxMatcher.java
@@ -2,6 +2,8 @@ package com.wix.detox.espresso;
 
 import android.view.View;
 
+import java.lang.Math;
+
 import org.hamcrest.Matcher;
 
 import androidx.test.espresso.matcher.ViewMatchers.Visibility;
@@ -73,6 +75,10 @@ public class DetoxMatcher {
 
     public static Matcher<View> matcherForSufficientlyVisible() {
         return isDisplayingAtLeast(75);
+    }
+
+    public static Matcher<View> matcherForMinimumVisiblePercent(double percentage) {
+        return isDisplayingAtLeast((int)percentage * 100);
     }
 
     public static Matcher<View> matcherForNotVisible() {

--- a/detox/src/android/espressoapi/DetoxMatcher.js
+++ b/detox/src/android/espressoapi/DetoxMatcher.js
@@ -155,6 +155,21 @@ class DetoxMatcher {
     };
   }
 
+  static matcherForMinimumVisiblePercent(percentage) {
+    if (typeof percentage !== "number") throw new Error("percentage should be a number, but got " + (percentage + (" (" + (typeof percentage + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.espresso.DetoxMatcher"
+      },
+      method: "matcherForMinimumVisiblePercent",
+      args: [{
+        type: "Double",
+        value: percentage
+      }]
+    };
+  }
+
   static matcherForNotVisible() {
     return {
       target: {

--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -271,8 +271,8 @@ class ExpectElement extends Expect {
     super(invocationManager);
     this._element = element;
   }
-  async toBeVisible() {
-    return await new MatcherAssertionInteraction(this._invocationManager, this._element, new VisibleMatcher()).execute();
+  async toBeVisible(percentage) {
+    return await new MatcherAssertionInteraction(this._invocationManager, this._element, new VisibleMatcher(percentage)).execute();
   }
   async toBeNotVisible() {
     return await this._invocationManager.execute(DetoxAssertionApi.assertNotVisible(call(this._element._call)));
@@ -309,8 +309,8 @@ class WaitForElement extends WaitFor {
     //if ((!element instanceof Element)) throw new Error(`WaitForElement ctor argument must be a valid Element, got ${typeof element}`);
     this._element = element;
   }
-  toBeVisible() {
-    return new WaitForInteraction(this._invocationManager, this._element, new VisibleMatcher());
+  toBeVisible(percentage) {
+    return new WaitForInteraction(this._invocationManager, this._element, new VisibleMatcher(percentage));
   }
   toBeNotVisible() {
     return new WaitForInteraction(this._invocationManager, this._element, new NotVisibleMatcher());

--- a/detox/src/android/expect.test.js
+++ b/detox/src/android/expect.test.js
@@ -7,6 +7,7 @@ describe('expect', () => {
   });
 
   it(`element by accessibilityLabel`, async () => {
+    await e.expect(e.element(e.by.accessibilityLabel('test'))).toBeVisible(0.3);
     await e.expect(e.element(e.by.accessibilityLabel('test'))).toBeVisible();
     await e.expect(e.element(e.by.accessibilityLabel('test'))).toBeNotVisible();
     await e.expect(e.element(e.by.accessibilityLabel('test'))).toExist();
@@ -18,6 +19,7 @@ describe('expect', () => {
   });
 
   it(`element by label (for backwards compat)`, async () => {
+    await e.expect(e.element(e.by.label('test'))).toBeVisible(0.3);
     await e.expect(e.element(e.by.label('test'))).toBeVisible();
     await e.expect(e.element(e.by.label('test'))).toBeNotVisible();
     await e.expect(e.element(e.by.label('test'))).toExist();
@@ -73,6 +75,7 @@ describe('expect', () => {
 
   it(`waitFor (element)`, async () => {
     await e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout(0);
+    await e.waitFor(e.element(e.by.id('id'))).toBeVisible(0.3);
     await e.waitFor(e.element(e.by.id('id'))).toBeVisible();
     await e.waitFor(e.element(e.by.id('id'))).toBeNotVisible();
     await e.waitFor(e.element(e.by.id('id'))).toExist();

--- a/detox/src/android/matcher.js
+++ b/detox/src/android/matcher.js
@@ -65,9 +65,9 @@ class TypeMatcher extends Matcher {
 }
 
 class VisibleMatcher extends Matcher {
-  constructor() {
+  constructor(percentage = 0.75) {
     super();
-    this._call = invoke.callDirectly(DetoxMatcherApi.matcherForSufficientlyVisible());
+    this._call = invoke.callDirectly(DetoxMatcherApi.matcherForMinimumVisiblePercent(percentage));
   }
 }
 

--- a/detox/src/ios/expect.js
+++ b/detox/src/ios/expect.js
@@ -359,8 +359,8 @@ class ExpectElement extends Expect {
     super(invocationManager);
     this._element = element;
   }
-  async toBeVisible() {
-    return await new MatcherAssertionInteraction(this._invocationManager, this._element, new VisibleMatcher()).execute();
+  async toBeVisible(percentage) {
+    return await new MatcherAssertionInteraction(this._invocationManager, this._element, new VisibleMatcher(percentage)).execute();
   }
   async toBeNotVisible() {
     return await new MatcherAssertionInteraction(this._invocationManager, this._element, new NotVisibleMatcher()).execute();
@@ -397,8 +397,8 @@ class WaitForElement extends WaitFor {
     //if ((!element instanceof Element)) throw new Error(`WaitForElement ctor argument must be a valid Element, got ${typeof element}`);
     this._element = element;
   }
-  toBeVisible() {
-    return new WaitForInteraction(this._invocationManager, this._element, new VisibleMatcher());
+  toBeVisible(percentage) {
+    return new WaitForInteraction(this._invocationManager, this._element, new VisibleMatcher(percentage));
   }
   toBeNotVisible() {
     return new WaitForInteraction(this._invocationManager, this._element, new VisibleMatcher())._not();

--- a/detox/src/ios/matchers.js
+++ b/detox/src/ios/matchers.js
@@ -74,9 +74,9 @@ class TraitsMatcher extends Matcher {
 }
 
 class VisibleMatcher extends Matcher {
-  constructor() {
+  constructor(percentage = 0.75) {
     super();
-    this._call = invoke.callDirectly(GreyMatchers.matcherForSufficientlyVisible());
+    this._call = invoke.callDirectly(GreyMatchers.matcherForMinimumVisiblePercent(percentage));
   }
 }
 

--- a/detox/test/e2e/02.matchers.test.js
+++ b/detox/test/e2e/02.matchers.test.js
@@ -4,6 +4,13 @@ describe('Matchers', () => {
     await element(by.text('Matchers')).tap();
   });
 
+  it('should assert visibility', async () => {
+    await expect(element(by.id('visible30%'))).toBeVisible(0.3);
+    await expect(element(by.id('visible1%'))).toBeVisible(0.01);
+    await expect(element(by.id('visible75%'))).toBeVisible(0.75);
+    await expect(element(by.id('visible75%'))).toBeVisible();
+  });
+
   it('should match elements by (accessibility) label', async () => {
     await element(by.label('Label')).tap();
     await expect(element(by.text('Label Working!!!'))).toBeVisible();

--- a/detox/test/src/Screens/MatchersScreen.js
+++ b/detox/test/src/Screens/MatchersScreen.js
@@ -63,6 +63,20 @@ export default class MatchersScreen extends Component {
           <Text style={{color: 'brown', marginBottom: 20}}>Index</Text>
         </TouchableOpacity>        
 
+        <View style={{ width: 100, height: 100, backgroundColor: 'yellow', overflow: 'hidden' }}>
+          <View
+            testID="visible30%"
+            style={{ position: 'absolute', width: 100, height: 25, backgroundColor: 'magenta', left: -70 }}
+          />
+          <View
+            testID="visible1%"
+            style={{ position: 'absolute', width: 100, height: 25, backgroundColor: 'red', left: -99, top: 25 }}
+          />
+          <View
+            testID="visible75%"
+            style={{ position: 'absolute', width: 100, height: 25, backgroundColor: 'green', left: -25, top: 50 }}
+          />
+        </View>
       </View>
     );
   }

--- a/docs/APIRef.Expect.md
+++ b/docs/APIRef.Expect.md
@@ -16,11 +16,18 @@ Expect verifies if a certain value is as expected to be.
 - [`.toHaveValue()`](#tohavevaluevalue)
 
 
-### `toBeVisible()`
-Expect the view to be at least 75% visible.
+
+### `toBeVisible(percentage=0.75)`
+Expect the view to be at least 75% visible by default. Any arbitrary visibility
+percentage in a range of [0, 1] (inclusive) can be specified.
 
 ```js
 await expect(element(by.id('UniqueId204'))).toBeVisible();
+```
+
+
+```js
+await expect(element(by.id('visible30%'))).toBeVisible(0.3);
 ```
 
 ### `toBeNotVisible()`


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [x] This change has been discussed in issue #1524 and the solution has been agreed upon with maintainers.

---

**Description:**

This PR changes signature of `toBeVisible` allowing to match visibility by any arbitrary %