### PR TITLE
iOS: Move boot + bootstatus from critical section. 

### DIFF
--- a/detox/src/devices/drivers/SimulatorDriver.js
+++ b/detox/src/devices/drivers/SimulatorDriver.js
@@ -40,18 +40,18 @@ class SimulatorDriver extends IosDriver {
   }
 
   async acquireFreeDevice(deviceQuery) {
-    return this.deviceRegistry.allocateDevice(async () => {
-      const udid = await this._findOrCreateDevice(deviceQuery);
-      const deviceComment = this._commentDevice(deviceQuery);
-
-      if (!udid) {
-        throw new Error(`Failed to find device matching ${deviceComment}`);
-      }
-
-      await this._boot(udid);
-      this._name = `${udid} ${deviceComment}`;
-      return udid;
+    const udid = await this.deviceRegistry.allocateDevice(async () => {
+      return await this._findOrCreateDevice(deviceQuery);
     });
+
+    const deviceComment = this._commentDevice(deviceQuery);
+    if (!udid) {
+      throw new Error(`Failed to find device matching ${deviceComment}`);
+    }
+
+    await this._boot(udid);
+    this._name = `${udid} ${deviceComment}`;
+    return udid;
   }
 
   async getBundleIdFromBinary(appPath) {


### PR DESCRIPTION
**Description:**
Fixed non-optimal performance on multiple simulator boot, while every worker performed the boot inside the critical section, causing all the others to wait for it.
This fix moves everything besides the acquiring of devide udid outside the critical section.