### PR TITLE
Update kotlin version in Android intro

### DIFF
--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -87,7 +87,7 @@ If your project does not already support Kotlin, add the Kotlin Gradle-plugin to
 ```groovy
 buildscript {
     // ...
-    ext.kotlinVersion = '1.3.0'
+    ext.kotlinVersion = '1.3.50'
 
     dependencies: {
         // ...


### PR DESCRIPTION
Builds won't work with Kotlin version 1.3.0.
Works fine with 1.3.50

Fixes #1686 

