### PR TITLE
Upgrade demo-app's SDK and deps versions

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -4,10 +4,10 @@ apply plugin: 'kotlin-android-extensions'
 
 def _ext = rootProject.ext
 
-def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 28
-def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '28.0.3'
-def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 18
-def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 28
+def _compileSdkVersion = _ext.has('detoxCompileSdkVersion') ? _ext.detoxCompileSdkVersion : 28
+def _targetSdkVersion = _ext.has('detoxTargetSdkVersion') ? _ext.detoxTargetSdkVersion : 28
+def _minSdkVersion = _ext.has('detoxMinSdkVersion') ? _ext.detoxMinSdkVersion : 18
+def _buildToolsVersion = _ext.has('detoxBuildToolsVersion') ? _ext.detoxBuildToolsVersion : '28.0.3'
 def _kotlinVersion = _ext.has('detoxKotlinVersion') ? _ext.detoxKotlinVersion : '1.2.0'
 def _kotlinStdlib = _ext.has('detoxKotlinStdlib') ? _ext.detoxKotlinStdlib : 'kotlin-stdlib-jdk8'
 
@@ -72,9 +72,9 @@ dependencies {
     api('androidx.test.espresso:espresso-core:3.1.1') {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
-    api 'androidx.test:runner:1.1.1'
-    api 'androidx.test:rules:1.1.1'
-    api 'androidx.test.ext:junit:1.1.0'
+    api 'androidx.test:runner:1.2.0'
+    api 'androidx.test:rules:1.2.0'
+    api 'androidx.test.ext:junit:1.1.1'
     api 'androidx.annotation:annotation:1.1.0'
 
     // Version is the latest; Cannot sync with the Github repo (e.g. android/android-test) because the androidx

--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -1,18 +1,20 @@
 import groovy.json.JsonSlurper
 
+def _ext = rootProject.ext
+
 apply plugin: 'com.android.application'
 
 //project.ext.react = [:]
 project.ext.react = [
     enableHermes: false
 ]
-apply from: "../../node_modules/react-native/react.gradle"
+apply from: '../../node_modules/react-native/react.gradle'
 
 Boolean isRN60OrHigher = getRNVersion() >= 60
 Boolean isRN61OrHigher = getRNVersion() >= 61
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion _ext.detoxCompileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -20,16 +22,16 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.wix.detox.test"
+        applicationId 'com.wix.detox.test'
         minSdkVersion 18
-        targetSdkVersion 28
+        targetSdkVersion _ext.detoxTargetSdkVersion
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
         testBuildType System.getProperty('testBuildType', 'debug')
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
         /*
         testInstrumentationRunnerArguments = [
@@ -58,12 +60,12 @@ android {
     }
 
     productFlavors {
-        flavorDimensions "compileRNFromSource"
+        flavorDimensions 'compileRNFromSource'
         fromSource {
-            dimension "compileRNFromSource"
+            dimension 'compileRNFromSource'
         }
         fromBin {
-            dimension "compileRNFromSource"
+            dimension 'compileRNFromSource'
         }
     }
 
@@ -83,14 +85,15 @@ dependencies {
         implementation 'androidx.appcompat:appcompat:1.1.0'
         implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
     } else {
-        implementation 'com.android.support:appcompat-v7:28.0.0'
+        implementation 'com.android.support:appcompat-v7:29.0.0'
     }
 
-    fromSourceImplementation(project(path: ":ReactAndroid"))
-    // noinspection GradleDynamicVersion
-    fromBinImplementation "com.facebook.react:react-native:+"
+    fromSourceImplementation(project(path: ':ReactAndroid'))
 
-    androidTestImplementation(project(path: ":detox"))
+    // noinspection GradleDynamicVersion
+    fromBinImplementation 'com.facebook.react:react-native:+'
+
+    androidTestImplementation(project(path: ':detox'))
     androidTestImplementation 'junit:junit:4.12'
 }
 
@@ -98,12 +101,13 @@ if (isRN60OrHigher) {
     // refs: https://react-native-community.github.io/upgrade-helper/?from=0.59.9&to=0.60.6
     //       https://react-native-community.github.io/upgrade-helper/?from=0.60.6&to=0.61.4
     dependencies {
-        def enableHermes = project.ext.react.get("enableHermes", false)
+        def enableHermes = project.ext.react.get('enableHermes', false)
 
         if (enableHermes) {
-            def hermesPath = (isRN61OrHigher ? "../../node_modules/hermes-engine/android/" : "../../node_modules/hermesvm/android/")
-            debugImplementation files(hermesPath + "hermes-debug.aar")
-            releaseImplementation files(hermesPath + "hermes-release.aar")
+            def hermesModuleName = isRN61OrHigher ? 'hermes-engine' : 'hermesvm'
+            def hermesPath = "../../node_modules/$hermesModuleName/android/"
+            debugImplementation files(hermesPath + 'hermes-debug.aar')
+            releaseImplementation files(hermesPath + 'hermes-release.aar')
         } else {
             implementation 'org.webkit:android-jsc:+'
         }

--- a/detox/test/android/app/src/main/AndroidManifest.xml
+++ b/detox/test/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     package="com.example"
     android:versionCode="1"
     android:versionName="1.0"

--- a/detox/test/android/build.gradle
+++ b/detox/test/android/build.gradle
@@ -2,7 +2,10 @@ buildscript {
     ext.isOfficialDetoxApp = true
     ext.kotlinVersion = '1.3.41'
     ext.detoxKotlinVerion = ext.kotlinVersion
-    ext.buildToolsVersion = '28.0.3'
+    ext.buildToolsVersion = '29.0.0'
+    ext.detoxBuildToolsVersion = ext.buildToolsVersion
+    ext.detoxCompileSdkVersion = 29
+    ext.detoxTargetSdkVersion = 29
 
     repositories {
         google()
@@ -11,13 +14,13 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath 'de.undercouch:gradle-download-task:3.4.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // Needed by Spek (https://spekframework.org/setup-android)
         // Here in order to enable unit-tests run from Android Studio when working on the test app.
-        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.4.2.1"
+        classpath 'de.mannodermaus.gradle.plugins:android-junit5:1.4.2.1'
     }
 }
 

--- a/detox/test/android/gradle/wrapper/gradle-wrapper.properties
+++ b/detox/test/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Sep 15 22:36:02 IDT 2019
+#Wed Nov 13 16:05:29 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip


### PR DESCRIPTION
Upgrade demo-app's target SDK to 29 (i.e. android 10) and various dep's versions to the latest available (e.g. android's test runner, gradle)