### PR TITLE
Upgrade demo apps to android 10 (sdk 29), upgrade espresso and gradle

### DIFF
--- a/detox/android/build.gradle
+++ b/detox/android/build.gradle
@@ -1,21 +1,26 @@
 buildscript {
-    ext.isOfficialDetoxLib = true
-    ext.kotlinVersion = '1.3.41'
+    ext {
+        isOfficialDetoxLib = true
+        kotlinVersion = '1.3.41'
+        dokkaVersion = '0.9.18'
+        buildToolsVersion = '29.0.0'
+        compileSdkVersion = 29
+        targetSdkVersion = 29
+        minSdkVersion = 18
+    }
     ext.detoxKotlinVerion = ext.kotlinVersion
-    ext.dokkaVersion = '0.9.18'
-    ext.buildToolsVersion = '28.0.3'
 
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
 
         // Needed by Spek (https://spekframework.org/setup-android)
-        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.4.2.1"
+        classpath 'de.mannodermaus.gradle.plugins:android-junit5:1.4.2.1'
     }
 }
 

--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 def _ext = rootProject.ext
-
 def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 28
 def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '28.0.3'
 def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 18
@@ -18,7 +17,7 @@ android {
         minSdkVersion _minSdkVersion
         targetSdkVersion _targetSdkVersion
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
 
         consumerProguardFiles 'proguard-rules.pro'
     }
@@ -69,12 +68,12 @@ dependencies {
     // Versions are in-sync with the 'androidx-test-1.1.0' release/tag of the android-test github repo,
     // used by the Detox generator. See https://github.com/android/android-test/releases/tag/androidx-test-1.1.0
     // Important: Should remain so when generator tag is replaced!
-    api('androidx.test.espresso:espresso-core:3.1.1') {
+    api('androidx.test.espresso:espresso-core:3.2.0') {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
-    api 'androidx.test:runner:1.1.1'
-    api 'androidx.test:rules:1.1.1'
-    api 'androidx.test.ext:junit:1.1.0'
+    api 'androidx.test:runner:1.2.0'
+    api 'androidx.test:rules:1.2.0'
+    api 'androidx.test.ext:junit:1.1.1'
     api 'androidx.annotation:annotation:1.1.0'
 
     // Version is the latest; Cannot sync with the Github repo (e.g. android/android-test) because the androidx

--- a/detox/android/gradle/wrapper/gradle-wrapper.properties
+++ b/detox/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -6,13 +6,13 @@ apply plugin: 'com.android.application'
 project.ext.react = [
     enableHermes: false
 ]
-apply from: "../../node_modules/react-native/react.gradle"
+apply from: '../../node_modules/react-native/react.gradle'
 
 Boolean isRN60OrHigher = getRNVersion() >= 60
 Boolean isRN61OrHigher = getRNVersion() >= 61
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -20,16 +20,16 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.wix.detox.test"
-        minSdkVersion 18
-        targetSdkVersion 28
+        applicationId 'com.wix.detox.test'
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
         ndk {
-            abiFilters "armeabi-v7a", "x86"
+            abiFilters 'armeabi-v7a', 'x86'
         }
         testBuildType System.getProperty('testBuildType', 'debug')
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
         /*
         testInstrumentationRunnerArguments = [
@@ -58,12 +58,12 @@ android {
     }
 
     productFlavors {
-        flavorDimensions "compileRNFromSource"
+        flavorDimensions 'compileRNFromSource'
         fromSource {
-            dimension "compileRNFromSource"
+            dimension 'compileRNFromSource'
         }
         fromBin {
-            dimension "compileRNFromSource"
+            dimension 'compileRNFromSource'
         }
     }
 
@@ -86,11 +86,11 @@ dependencies {
         implementation 'com.android.support:appcompat-v7:28.0.0'
     }
 
-    fromSourceImplementation(project(path: ":ReactAndroid"))
+    fromSourceImplementation(project(path: ':ReactAndroid'))
     // noinspection GradleDynamicVersion
-    fromBinImplementation "com.facebook.react:react-native:+"
+    fromBinImplementation 'com.facebook.react:react-native:+'
 
-    androidTestImplementation(project(path: ":detox"))
+    androidTestImplementation(project(path: ':detox'))
     androidTestImplementation 'junit:junit:4.12'
 }
 
@@ -98,12 +98,12 @@ if (isRN60OrHigher) {
     // refs: https://react-native-community.github.io/upgrade-helper/?from=0.59.9&to=0.60.6
     //       https://react-native-community.github.io/upgrade-helper/?from=0.60.6&to=0.61.4
     dependencies {
-        def enableHermes = project.ext.react.get("enableHermes", false)
-
+        def enableHermes = project.ext.react.get('enableHermes', false)
         if (enableHermes) {
-            def hermesPath = (isRN61OrHigher ? "../../node_modules/hermes-engine/android/" : "../../node_modules/hermesvm/android/")
-            debugImplementation files(hermesPath + "hermes-debug.aar")
-            releaseImplementation files(hermesPath + "hermes-release.aar")
+            def hermesModuleName = isRN61OrHigher ? 'hermes-engine' : 'hermesvm'
+            def hermesPath = "../../node_modules/$hermesModuleName/android/"
+            debugImplementation files(hermesPath + 'hermes-debug.aar')
+            releaseImplementation files(hermesPath + 'hermes-release.aar')
         } else {
             implementation 'org.webkit:android-jsc:+'
         }

--- a/detox/test/android/build.gradle
+++ b/detox/test/android/build.gradle
@@ -1,8 +1,13 @@
 buildscript {
-    ext.isOfficialDetoxApp = true
-    ext.kotlinVersion = '1.3.41'
+    ext {
+        isOfficialDetoxApp = true
+        kotlinVersion = '1.3.41'
+        buildToolsVersion = '29.0.0'
+        compileSdkVersion = 29
+        targetSdkVersion = 29
+        minSdkVersion = 18
+    }
     ext.detoxKotlinVerion = ext.kotlinVersion
-    ext.buildToolsVersion = '28.0.3'
 
     repositories {
         google()
@@ -17,7 +22,7 @@ buildscript {
 
         // Needed by Spek (https://spekframework.org/setup-android)
         // Here in order to enable unit-tests run from Android Studio when working on the test app.
-        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.4.2.1"
+        classpath 'de.mannodermaus.gradle.plugins:android-junit5:1.4.2.1'
     }
 }
 

--- a/detox/test/android/gradle/wrapper/gradle-wrapper.properties
+++ b/detox/test/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/examples/demo-react-native/android/app/build.gradle
+++ b/examples/demo-react-native/android/app/build.gradle
@@ -1,32 +1,33 @@
 import groovy.json.JsonSlurper
 import com.android.build.OutputFile
 
-apply plugin: "com.android.application"
+apply plugin: 'com.android.application'
 
 //project.ext.react = [:]
 project.ext.react = [
     enableHermes: false
 ]
-apply from: "../../node_modules/react-native/react.gradle"
+apply from: '../../node_modules/react-native/react.gradle'
 
 Boolean isRN60OrHigher = getRNVersion() >= 60
+Boolean isRN61OrHigher = getRNVersion() >= 61
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
+    buildToolsVersion '29.0.0'
 
     defaultConfig {
-        applicationId "com.detox.rn.example"
+        applicationId 'com.detox.rn.example'
         minSdkVersion 18
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
 
         testBuildType System.getProperty('testBuildType', 'debug')
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     splits {
         abi {
@@ -92,14 +93,15 @@ dependencies {
 }
 
 if (isRN60OrHigher) {
-    // ref: https://react-native-community.github.io/upgrade-helper/?from=0.59.9&to=0.60.6
+    // refs: https://react-native-community.github.io/upgrade-helper/?from=0.59.9&to=0.60.6
+    //       https://react-native-community.github.io/upgrade-helper/?from=0.60.6&to=0.61.4
     dependencies {
-        def enableHermes = project.ext.react.get("enableHermes", false)
-
+        def enableHermes = project.ext.react.get('enableHermes', false)
         if (enableHermes) {
-            def hermesPath = "../../node_modules/hermesvm/android/"
-            debugImplementation files(hermesPath + "hermes-debug.aar")
-            releaseImplementation files(hermesPath + "hermes-release.aar")
+            def hermesModuleName = isRN61OrHigher ? 'hermes-engine' : 'hermesvm'
+            def hermesPath = "../../node_modules/$hermesModuleName/android/"
+            debugImplementation files(hermesPath + 'hermes-debug.aar')
+            releaseImplementation files(hermesPath + 'hermes-release.aar')
         } else {
             implementation 'org.webkit:android-jsc:+'
         }

--- a/examples/demo-react-native/android/build.gradle
+++ b/examples/demo-react-native/android/build.gradle
@@ -1,5 +1,11 @@
 buildscript {
-    ext.kotlinVersion = '1.3.41'
+    ext {
+        kotlinVersion = '1.3.41'
+        buildToolsVersion = '29.0.0'
+        compileSdkVersion = 29
+        targetSdkVersion = 29
+        minSdkVersion = 18
+    }
     ext.detoxKotlinVersion = ext.kotlinVersion
 
     repositories {
@@ -7,7 +13,8 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'de.undercouch:gradle-download-task:3.4.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/examples/demo-react-native/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/demo-react-native/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Upgrade example/test-apps' target SDK to 29 (i.e. android 10) and various dep's versions to the latest available (e.g. android's test runner, Gradle and even Espresso).

---

*Note: avoided an upgrade of the Android Gradle plugin to 3.5+ (3.5.2 currently) as it has been found to break the build on CI (and not locally) due to problems in evaluating RN's ReactAndroid build script. More specifically:*

```
12:02:24 * What went wrong:
12:02:24 A problem occurred evaluating project ':ReactAndroid'.
12:02:24 > extensionSupplier.get()!!.compileSdkVersion must not be null
```
> Example: https://jenkins-oss.wixpress.com/view/Tree/job/detox-android-61-4-master/560/console