### PR TITLE
fixing #1728

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -193,6 +193,7 @@ public final class Detox {
      */
     private static Intent intentWithUrl(String url) {
         final Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         intent.setData(Uri.parse(url));
         return intent;
     }


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #1728  and the solution has been agreed upon with maintainers.

---

This is a small change.

Debug trace of the error:

11-18 17:59:07.916  6755  6964 E DetoxManager: Exception
11-18 17:59:07.916  6755  6964 E DetoxManager: java.lang.reflect.InvocationTargetException
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at java.lang.reflect.Method.invoke(Native Method)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at org.apache.commons.lang3.reflect.MethodUtils.invokeStaticMethod(MethodUtils.java:443)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at org.apache.commons.lang3.reflect.MethodUtils.invokeStaticMethod(MethodUtils.java:405)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at com.wix.invoke.types.ClassTarget.execute(ClassTarget.java:23)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at com.wix.invoke.types.Target.invoke(Target.java:59)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at com.wix.invoke.MethodInvocation.invoke(MethodInvocation.java:35)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at com.wix.invoke.MethodInvocation.invoke(MethodInvocation.java:26)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at com.wix.invoke.MethodInvocation.invoke(MethodInvocation.java:20)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at com.wix.detox.InvokeActionHandler.handle(DetoxActionHandlers.kt:49)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at com.wix.detox.DetoxManager$2.run(DetoxManager.java:105)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at android.os.Handler.handleCallback(Handler.java:873)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at android.os.Handler.dispatchMessage(Handler.java:99)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at android.os.Looper.loop(Looper.java:193)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at com.wix.detox.Detox$1.run(Detox.java:134)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at java.lang.Thread.run(Thread.java:764)
11-18 17:59:07.916  6755  6964 E DetoxManager: Caused by: android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at android.app.ContextImpl.startActivity(ContextImpl.java:912)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at android.app.ContextImpl.startActivity(ContextImpl.java:888)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at android.content.ContextWrapper.startActivity(ContextWrapper.java:379)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at com.wix.detox.Detox.launchActivitySync(Detox.java:219)
11-18 17:59:07.916  6755  6964 E DetoxManager: 	at com.wix.detox.Detox.startActivityFromUrl(Detox.java:148)

Do you have a test for this maybe where I could see it working?
