### PR TITLE
Make Android's adb-reverse a public device API

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -140,7 +140,7 @@ class Device {
   }
 
   async setBiometricEnrollment(toggle) {
-    let yesOrNo = toggle ? 'YES' : 'NO'
+    const yesOrNo = toggle ? 'YES' : 'NO';
     await this.deviceDriver.setBiometricEnrollment(this._deviceId, yesOrNo);
   }
 
@@ -208,6 +208,14 @@ class Device {
     lat = String(lat);
     lon = String(lon);
     await this.deviceDriver.setLocation(this._deviceId, lat, lon);
+  }
+
+  async reverseTcpPort(port) {
+    await this.deviceDriver.reverseTcpPort(this._deviceId, port);
+  }
+
+  async unreverseTcpPort(port) {
+    await this.deviceDriver.unreverseTcpPort(this._deviceId, port);
   }
 
   async clearKeychain() {

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -71,6 +71,14 @@ describe('Device', () => {
     expectTerminateNotCalled() {
       expect(this.driver.terminate).not.toHaveBeenCalled();
     }
+
+    expectReverseTcpPortCalled(deviceId, port) {
+      expect(this.driver.reverseTcpPort).toHaveBeenCalledWith(deviceId, port);
+    }
+
+    expectUnreverseTcpPortCalled(deviceId, port) {
+      expect(this.driver.unreverseTcpPort).toHaveBeenCalledWith(deviceId, port);
+    }
   }
 
   function schemeDevice(scheme, configuration) {
@@ -533,7 +541,7 @@ describe('Device', () => {
 
     expect(driverMock.driver.setStatusBar).toHaveBeenCalledWith(device._deviceId, params);
   });
-  
+
   it(`resetStatusBar() should pass to device driver`, async () => {
     const device = validDevice();
     await device.resetStatusBar();
@@ -614,6 +622,20 @@ describe('Device', () => {
     await device.setLocation(30.1, 30.2);
 
     expect(driverMock.driver.setLocation).toHaveBeenCalledWith(device._deviceId, '30.1', '30.2');
+  });
+
+  it(`reverseTcpPort should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.reverseTcpPort(666);
+
+    await driverMock.expectReverseTcpPortCalled(device._deviceId, 666);
+  });
+
+  it(`unreverseTcpPort should pass to device driver`, async () => {
+    const device = validDevice();
+    await device.unreverseTcpPort(777);
+
+    await driverMock.expectUnreverseTcpPortCalled(device._deviceId, 777);
   });
 
   it(`setURLBlacklist() should pass to device driver`, async () => {

--- a/detox/src/devices/drivers/AndroidDriver.js
+++ b/detox/src/devices/drivers/AndroidDriver.js
@@ -149,6 +149,14 @@ class AndroidDriver extends DeviceDriverBase {
     return this.uiDevice;
   }
 
+  async reverseTcpPort(deviceId, port) {
+    await this.adb.reverse(deviceId, port);
+  }
+
+  async unreverseTcpPort(deviceId, port) {
+    await this.adb.reverseRemove(deviceId, port);
+  }
+
   async setURLBlacklist(urlList) {
     const call = EspressoDetoxApi.setURLBlacklist(urlList);
     await this.invocationManager.execute(call);

--- a/detox/src/devices/drivers/AndroidDriver.test.js
+++ b/detox/src/devices/drivers/AndroidDriver.test.js
@@ -8,6 +8,7 @@ describe('Android driver', () => {
     jest.mock('../../utils/encoding', () => ({
       encodeBase64: (x) => `base64(${x})`,
     }));
+
     jest.mock('../android/ADB', () => mockADBClass);
     jest.mock('../../utils/AsyncEmitter', () => mockAsyncEmitter);
     jest.mock('../../utils/sleep', () => jest.fn().mockResolvedValue(''));
@@ -69,6 +70,21 @@ describe('Android driver', () => {
         key: 'string-arg',
         value: 'base64(text, with commas-and-dashes,)'
       });
+    });
+  });
+
+  describe('net-port reversing', () => {
+    const deviceId = 1010;
+    const port = 1337;
+
+    it(`should invoke ADB's reverse`, async () => {
+      await uut.reverseTcpPort(deviceId, port);
+      expect(uut.adb.reverse).toHaveBeenCalledWith(deviceId, port);
+    });
+
+    it(`should invoke ADB's reverse-remove`, async () => {
+      await uut.unreverseTcpPort(deviceId, port);
+      expect(uut.adb.reverseRemove).toHaveBeenCalledWith(deviceId, port);
     });
   });
 });

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -100,6 +100,14 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
+  async reverseTcpPort() {
+    return await Promise.resolve('');
+  }
+
+  async unreverseTcpPort() {
+    return await Promise.resolve('');
+  }
+
   async clearKeychain(_udid) {
     return await Promise.resolve('')
   }

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -31,6 +31,8 @@
 - [`device.clearKeychain()` **iOS Only**](#deviceclearkeychain-ios-only)
 - [`device.setStatusBar()` **iOS Only**](#devicesetstatusbar-ios-only)
 - [`device.resetStatusBar()` **iOS Only**](#deviceresetstatusbar-ios-only)
+- [`device.reverseTcpPort()` **Android Only**](#devicereversetcpport-android-only)
+- [`device.unreverseTcpPort()` **Android Only**](#deviceunreversetcpport-android-only)
 - [`device.pressBack()` **Android Only**](#devicepressback-android-only)
 - [`device.getUIDevice()` **Android Only**](#devicegetuidevice-android-only)
 
@@ -410,6 +412,14 @@ Override simulator's status bar. Available options:
 
 ### `device.resetStatusBar()` **iOS Only**
 Resets any override in simulator's status bar.
+
+### `device.reverseTcpPort()` **Android Only**
+
+Reverse a TCP port from the device (guest) back to the host-computer, as typically done with the `adb reverse` command. The end result would be that all network requests going from the device to the specified port will be forwarded to the computer.
+
+### `device.unreverseTcpPort()` **Android Only**
+
+Clear a _reversed_ TCP-port (e.g. previously set using `device.reverseTcpPort()`).
 
 ### `device.pressBack()` **Android Only**
 Simulate press back button.


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #0 and the solution has been agreed upon with maintainers.

---

**Description:**

Introduce the common `adb reverse` command in Detox' `device` API.

@viktorijasujetaite 