### PR TITLE
Fix wix-app crash introduced due to recent Detox RN-code refactoring

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/reactnative/ReactNativeInfo.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/reactnative/ReactNativeInfo.kt
@@ -1,6 +1,7 @@
 package com.wix.detox.reactnative
 
 import org.joor.Reflect
+import java.util.Map
 
 data class RNVersion(val major: Int, val minor: Int, val patch: Int)
 
@@ -9,7 +10,7 @@ object ReactNativeInfo {
             try {
                 val versionClass = Class.forName("com.facebook.react.modules.systeminfo.ReactNativeVersion")
                 val versionMap: Map<String, Int> = Reflect.on(versionClass).field("VERSION").get()
-                RNVersion(versionMap.getValue("major"), versionMap.getValue("minor"), versionMap.getValue("patch"))
+                RNVersion(versionMap.get("major")!!, versionMap.get("minor")!!, versionMap.get("patch")!!)
             } catch (e: ClassNotFoundException) {
                 // ReactNativeVersion was introduced in RN50, default to latest previous version.
                 RNVersion(0, 49, 0)


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #0 and the solution has been agreed upon with maintainers.

---

**Description:**

Hopefully fix a crash seen in the Wix app:

```
1-18 17:32:05.510 32451 32527 E AndroidRuntime: java.lang.NoSuchMethodError: No static method getValue(Ljava/util/Map;Ljava/lang/Object;)Ljava/lang/Object; in class Lkotlin/collections/MapsKt; or its super classes (declaration of 'kotlin.collections.MapsKt' appears in /data/app/com.wix.android.dev-V3p587DH9Rh1U3XZZqydAg==/base.apk:classes2.dex)
11-18 17:32:05.510 32451 32527 E AndroidRuntime:     at com.wix.detox.reactnative.ReactNativeInfo.<clinit>(ReactNativeInfo.kt:12)
11-18 17:32:05.510 32451 32527 E AndroidRuntime:     at com.wix.detox.reactnative.ReactNativeExtension.waitForRNBootstrap(ReactNativeExtension.kt:53)
11-18 17:32:05.510 32451 32527 E AndroidRuntime:     at com.wix.detox.DetoxManager.initReactNativeIfNeeded(DetoxManager.java:122)
11-18 17:32:05.510 32451 32527 E AndroidRuntime:     at com.wix.detox.DetoxManager.start(DetoxManager.java:67)
11-18 17:32:05.510 32451 32527 E AndroidRuntime:     at com.wix.detox.Detox$1$1.run(Detox.java:131)
11-18 17:32:05.510 32451 32527 E AndroidRuntime:     at android.os.Handler.handleCallback(Handler.java:789)
11-18 17:32:05.510 32451 32527 E AndroidRuntime:     at android.os.Handler.dispatchMessage(Handler.java:98)
11-18 17:32:05.510 32451 32527 E AndroidRuntime:     at android.os.Looper.loop(Looper.java:164)
11-18 17:32:05.510 32451 32527 E AndroidRuntime:     at com.wix.detox.Detox$1.run(Detox.java:134)
11-18 17:32:05.510 32451 32527 E AndroidRuntime:     at java.lang.Thread.run(Thread.java:764)
```