### PR TITLE
Fix crash related to FLAG_ACTIVITY_NEW_TASK intent flag in url launches (#1728)

### DIFF
--- a/detox/src/android/espressoapi/Detox.js
+++ b/detox/src/android/espressoapi/Detox.js
@@ -23,6 +23,17 @@ class Detox {
     };
   }
 
+  static launchMainActivity() {
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.Detox"
+      },
+      method: "launchMainActivity",
+      args: []
+    };
+  }
+
   static startActivityFromUrl(url) {
     if (typeof url !== "string") throw new Error("url should be a string, but got " + (url + (" (" + (typeof url + ")"))));
     return {
@@ -35,24 +46,13 @@ class Detox {
     };
   }
 
-  static launchMainActivity() {
+  static extractInitialIntent() {
     return {
       target: {
         type: "Class",
         value: "com.wix.detox.Detox"
       },
-      method: "launchMainActivity",
-      args: []
-    };
-  }
-
-  static extractLaunchIntent() {
-    return {
-      target: {
-        type: "Class",
-        value: "com.wix.detox.Detox"
-      },
-      method: "extractLaunchIntent",
+      method: "extractInitialIntent",
       args: []
     };
   }
@@ -68,15 +68,19 @@ class Detox {
     };
   }
 
-  static intentWithUrl(url) {
+  static intentWithUrl(url, initialLaunch) {
     if (typeof url !== "string") throw new Error("url should be a string, but got " + (url + (" (" + (typeof url + ")"))));
+    if (typeof initialLaunch !== "boolean") throw new Error("initialLaunch should be a boolean, but got " + (initialLaunch + (" (" + (typeof initialLaunch + ")"))));
     return {
       target: {
         type: "Class",
         value: "com.wix.detox.Detox"
       },
       method: "intentWithUrl",
-      args: [url]
+      args: [url, {
+        type: "boolean",
+        value: initialLaunch
+      }]
     };
   }
 


### PR DESCRIPTION
- [x] This is a small change 
- [x] This change has been discussed in issue #1728 and the solution has been agreed upon with maintainers.

---

**Description:**

Fixes #1728. Core issue was that app activity launches made while the app is running (e.g. in background) were performed using `appContext.startActivity()` rather than `activity.startActivity()`, which seems to have been protected-from in newer sdk's (>= 28 I presume).

The diff is however larger than that because just by changing that one line didn't resolve having multiple activities of the test app running in the same task (which we're really trying to avoid). Usage of additional pin-point flags fixes that.

---

+Note on this: on CI, we're currently only running on an SDK 26 emu. Nevertheless I've deep-inspected this solution (often running `adb shell dumpsys activity activites`) locally and it works. With upcoming plans to upgrade the emu to a clean (google-api's-less) 28 one, we should be good nevertheless.