### PR TITLE
Update getDirectories to include symbolic links to directories

### DIFF
--- a/detox/src/utils/fsext.js
+++ b/detox/src/utils/fsext.js
@@ -6,7 +6,7 @@ async function getDirectories (rootPath) {
   let dirs = [];
   for (let file of files) {
     let pathString = path.resolve(rootPath, file);
-    if ((await fs.lstat(pathString)).isDirectory()) {
+    if ((await fs.stat(pathString)).isDirectory()) {
       dirs.push(file);
     }
   }


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #1798  and the solution has been agreed upon with maintainers.

---

**Description:**

Update `getDirectories` to follow symbolic links and return those ones whose destinations are folders.