### PR TITLE
(Android) Switch to Pixel_API_28 w/o google-api's

### DIFF
--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -79,7 +79,7 @@
         "build": "cd android && ./gradlew assembleFromBinDebug assembleFromBinDebugAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
         "device": {
-          "avdName": "Nexus_5X_API_26"
+          "avdName": "Pixel_API_28"
         }
       },
       "android.emu.release": {
@@ -87,7 +87,7 @@
         "build": "cd android && ./gradlew assembleFromBinRelease assembleFromBinReleaseAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
         "device": {
-          "avdName": "Nexus_5X_API_26"
+          "avdName": "Pixel_API_28"
         }
       },
       "android.emu.debug.fromSource": {
@@ -95,7 +95,7 @@
         "build": "cd android && ./gradlew assembleFromSourceDebug assembleFromSourceDebugAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
         "device": {
-          "avdName": "Nexus_5X_API_26"
+          "avdName": "Pixel_API_28"
         }
       }
     }

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -38,7 +38,7 @@
         "binaryPath": "../demo-react-native/android/app/build/outputs/apk/release/app-release.apk",
         "type": "android.emulator",
         "device": {
-          "avdName": "Nexus_5X_API_26"
+          "avdName": "Pixel_API_28"
         }
       }
     }

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -61,7 +61,7 @@
         "build": "cd android ; ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug ; cd -",
         "type": "android.emulator",
         "device": {
-          "avdName": "Nexus_5X_API_26"
+          "avdName": "Pixel_API_28"
         }
       },
       "android.emu.release": {
@@ -69,7 +69,7 @@
         "build": "cd android ; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release ; cd -",
         "type": "android.emulator",
         "device": {
-          "avdName": "Nexus_5X_API_26"
+          "avdName": "Pixel_API_28"
         }
       }
     }


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #0 and the solution has been agreed upon with maintainers.

---

**Description:**

Move CI to an SDK-28 AOSP Emulator