### PR TITLE
Swap order of mocha vs. jest demo-prj run to stabilize CI

### DIFF
--- a/scripts/demo-projects.android.sh
+++ b/scripts/demo-projects.android.sh
@@ -11,11 +11,16 @@ popd
 
 pushd examples/demo-react-native
 run_f "npm run build:android-release"
-run_f "npm run test:android-release-ci -- --device-launch-args=\"-read-only\""
-run_f "npm run test:android-explicit-require-ci"
 popd
 
+# this needs to go first because it preloads all the emulators we need,
+# as it runs tests in parallel.
 pushd examples/demo-react-native-jest
 run_f "npm run test:android-release-ci"
 run_f "npm run test:jest-circus:android-release-ci"
+popd
+
+pushd examples/demo-react-native
+run_f "npm run test:android-release-ci"
+run_f "npm run test:android-explicit-require-ci"
 popd


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

Lately we've been facing major instabilities with the demo-project build job on CI on Android.
In a nutshell - though things used to be a bit different (but still unstable), the script runs a total of 4 test projects/configurations such that the first 2 (in the context of`demo-react-native`) are run on a single emulator (no parallelization) and then those of the 2nd group (context of `demo-react-native-jest`) are run on 2 emulators (parallel-execution).

It appears that the *emulator binary* (/ `qemu`) does not cope very well the loading of an additional emulator, while a different emulator is already fully up and running (as resulted by the script's run). More specifically, in about 40-50% of the cases the newly dispatched emulator (or actually it's `adb` at fault...) just seems to hang. Typically, things get stuck during the installation of the demo app, but sometimes later, for example - right after instrumentation is issued.

> The term "hang" is a bit falsely used here since sometimes one can still `adb shell` into the nonresponsive emulator. Nevertheless, the running command (e.g. `adb install`) never exits. Eventually, the test simply times out.

Some concrete examples:
- https://jenkins-oss.wixpress.com/job/detox-demo-projects-android-61-4-master/313/console
- https://jenkins-oss.wixpress.com/job/detox-demo-projects-android-61-4-master/317/console
- https://jenkins-oss.wixpress.com/job/detox-demo-projects-android-61-4-master/318/console
- https://jenkins-oss.wixpress.com/job/detox-demo-projects-android-61-4-master/321/console
- https://jenkins-oss.wixpress.com/job/detox-demo-projects-android-61-4-master/322/console

Whatever the reason for this is, it is not a detox issue directly. We should consider reporting this to the emulator team at Google, but for now swapping the order of the two suite groups seems to stabilize things (I've manually ran a couple of consecutive builds). This is a bit of a surprise, since the resulting conclusion is that launching of emulators simultaneously is more stable than sequentially, under some conditions. Need to further investigate that.