### PR TITLE
Resolve "Mismatch between dex2oat instruction set features" warning by android emu's on CI

### DIFF
--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -26,7 +26,7 @@ android {
         versionCode 1
         versionName '1.0'
         ndk {
-            abiFilters 'armeabi-v7a', 'x86'
+            abiFilters 'armeabi-v7a', 'x86', 'x86_64'
         }
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -38,7 +38,14 @@ android {
         ]
         */
     }
-
+    splits {
+        abi {
+            reset()
+            enable false
+            universalApk false  // If true, also generate a universal APK
+            include 'armeabi-v7a', 'x86', 'x86_64'
+        }
+    }
     signingConfigs {
         release {
             storeFile file("keystore.jks")
@@ -47,7 +54,6 @@ android {
             keyPassword "12345678"
         }
     }
-
     buildTypes {
         release {
             minifyEnabled true
@@ -56,7 +62,6 @@ android {
             signingConfig signingConfigs.release
         }
     }
-
     productFlavors {
         flavorDimensions 'compileRNFromSource'
         fromSource {
@@ -66,7 +71,6 @@ android {
             dimension 'compileRNFromSource'
         }
     }
-
     packagingOptions {
         pickFirst '**/libc++_shared.so'
 

--- a/examples/demo-react-native/android/app/build.gradle
+++ b/examples/demo-react-native/android/app/build.gradle
@@ -23,7 +23,7 @@ android {
         versionCode 1
         versionName '1.0'
         ndk {
-            abiFilters "armeabi-v7a", "x86"
+            abiFilters 'armeabi-v7a', 'x86', 'x86_64'
         }
 
         testBuildType System.getProperty('testBuildType', 'debug')
@@ -34,7 +34,7 @@ android {
             reset()
             enable false
             universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "x86"
+            include 'armeabi-v7a', 'x86', 'x86_64'
         }
     }
     signingConfigs {
@@ -52,19 +52,6 @@ android {
             proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
 
             signingConfig signingConfigs.release
-        }
-    }
-    // applicationVariants are e.g. debug, release
-    applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            // For each separate APK per architecture, set a unique version code as described here:
-            // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
-            def versionCodes = ["armeabi-v7a": 1, "x86": 2]
-            def abi = output.getFilter(OutputFile.ABI)
-            if (abi != null) {  // null for the universal-debug, universal-release variants
-                output.versionCodeOverride =
-                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
-            }
         }
     }
 


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

All of our emulators on Detox CI agents are `x86_64` and since we don't include `x86_64` as an abi the emulators produce this unnecessary warning:

```
12-23 05:34:30.046  2849  2849 W dex2oat : Mismatch between dex2oat instruction set features (ISA: X86 Feature string: -ssse3,-sse4.1,-sse4.2,-avx,-avx2,-popcnt) and those of dex2oat executable (ISA: X86 Feature string: ssse3,sse4.1,sse4.2,-avx,-avx2,popcnt) for the command line:
12-23 05:34:30.046  2849  2849 W dex2oat : /system/bin/dex2oat --zip-fd=8 --zip-location=base.apk --input-vdex-fd=-1 --output-vdex-fd=10 --oat-fd=9 --oat-location=/data/app/com.wix.detox.test-prlD12c1NzR2c6C8rI4Kcg==/oat/x86/base.odex --instruction-set=x86 --instruction-set-variant=x86_64 --instruction-set-features=default --runtime-arg -Xms64m --runtime-arg -Xmx512m --compiler-filter=speed-profile --swap-fd=11 --app-image-fd=12 --image-format=lz4 --classpath-dir=/data/app/com.wix.detox.test-prlD12c1NzR2c6C8rI4Kcg== --class-loader-context=PCL[] --generate-mini-debug-info --compact-dex-level=none --runtime-arg -Xtarget-sdk-version:29 --runtime-arg -Xhidden-api-checks --compilation-reason=install
```

This simple PR basically removes it.
