### PR TITLE
Properly handle instrumentation args passed in as launch-args

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -11,6 +11,9 @@ import android.os.Looper;
 import androidx.annotation.NonNull;
 import android.util.Base64;
 
+import java.util.Arrays;
+import java.util.List;
+
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 
@@ -71,6 +74,7 @@ public final class Detox {
     private static final String LAUNCH_ARGS_KEY = "launchArgs";
     private static final String DETOX_URL_OVERRIDE_ARG = "detoxURLOverride";
     private static final long ACTIVITY_LAUNCH_TIMEOUT = 10000L;
+    private static final List<String> RESERVED_INSTRUMENTATION_ARGS = Arrays.asList("class", "package", "func", "unit", "size", "perf", "debug", "log", "emma", "coverageFile");
 
     private static ActivityTestRule sActivityTestRule;
 
@@ -234,11 +238,13 @@ public final class Detox {
     }
 
     private static Bundle readLaunchArgs() {
-        final Bundle instrumArgs = InstrumentationRegistry.getArguments();
+        final Bundle instrumentationArgs = InstrumentationRegistry.getArguments();
         final Bundle launchArgs = new Bundle();
 
-        for (String arg : instrumArgs.keySet()) {
-            launchArgs.putString(arg, decodeLaunchArgValue(arg, instrumArgs));
+        for (String arg : instrumentationArgs.keySet()) {
+            if (!RESERVED_INSTRUMENTATION_ARGS.contains(arg)) {
+                launchArgs.putString(arg, decodeLaunchArgValue(arg, instrumentationArgs));
+            }
         }
         return launchArgs;
     }

--- a/detox/src/devices/drivers/AndroidDriver.test.js
+++ b/detox/src/devices/drivers/AndroidDriver.test.js
@@ -3,6 +3,7 @@ describe('Android driver', () => {
   const deviceId = 'device-id-mock';
   const bundleId = 'bundle-id-mock';
 
+  let logger;
   let exec;
   beforeEach(() => {
     jest.mock('../../utils/encoding', () => ({
@@ -13,6 +14,15 @@ describe('Android driver', () => {
     jest.mock('../../utils/AsyncEmitter', () => mockAsyncEmitter);
     jest.mock('../../utils/sleep', () => jest.fn().mockResolvedValue(''));
     jest.mock('../../utils/retry', () => jest.fn().mockResolvedValue(''));
+
+    const mockLogger = {
+      warn: jest.fn(),
+    };
+    jest.mock('../../utils/logger', () => ({
+      child: () => mockLogger,
+      ...mockLogger,
+    }));
+    logger = require('../../utils/logger');
 
     jest.mock('../../utils/exec', () => ({
       spawnAndLog: jest.fn().mockReturnValue({
@@ -43,6 +53,7 @@ describe('Android driver', () => {
           expect(spawnedFlags[index]).toEqual('-e');
           expect(spawnedFlags[index + 1]).toEqual(key);
           expect(spawnedFlags[index + 2]).toEqual(value);
+          return index + 3;
         }
       }),
     });
@@ -62,14 +73,72 @@ describe('Android driver', () => {
       const spawnArgs = exec.spawnAndLog.mock.calls[0];
       const spawnedFlags = spawnArgs[1];
 
-      expectSpawnedFlag(spawnedFlags).startingIndex(7).toBe({
+      let index = 7;
+      index = expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({
         key: 'object-arg',
         value: 'base64({"such":"wow","much":"amaze","very":111})'
       });
-      expectSpawnedFlag(spawnedFlags).startingIndex(10).toBe({
+      expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({
         key: 'string-arg',
         value: 'base64(text, with commas-and-dashes,)'
       });
+    });
+
+    // Ref: https://developer.android.com/studio/test/command-line#AMOptionsSyntax
+    it('should whitelist reserved instrumentation args with respect to base64 encoding', async () => {
+      const launchArgs = {
+        // Free arg
+        'user-arg': 'merry christ-nukah',
+
+        // Reserved instrumentation args
+        'class': 'class-value',
+        'package': 'package-value',
+        'func': 'func-value',
+        'unit': 'unit-value',
+        'size': 'size-value',
+        'perf': 'perf-value',
+        'debug': 'debug-value',
+        'log': 'log-value',
+        'emma': 'emma-value',
+        'coverageFile': 'coverageFile-value',
+      };
+
+      await uut.launchApp(deviceId, bundleId, launchArgs, '');
+
+      const spawnArgs = exec.spawnAndLog.mock.calls[0];
+      const spawnedFlags = spawnArgs[1];
+
+      let index = 10;
+      index = expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({ key: 'class', value: 'class-value' });
+      index = expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({ key: 'package', value: 'package-value' });
+      index = expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({ key: 'func', value: 'func-value' });
+      index = expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({ key: 'unit', value: 'unit-value' });
+      index = expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({ key: 'size', value: 'size-value' });
+      index = expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({ key: 'perf', value: 'perf-value' });
+      index = expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({ key: 'debug', value: 'debug-value' });
+      index = expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({ key: 'log', value: 'log-value' });
+      index = expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({ key: 'emma', value: 'emma-value' });
+      expectSpawnedFlag(spawnedFlags).startingIndex(index).toBe({ key: 'coverageFile', value: 'coverageFile-value' });
+    });
+
+    it('should log reserved instrumentation args usage warning, if such have been used', async () => {
+      const launchArgs = {
+        'class': 'class-value',
+      };
+
+      await uut.launchApp(deviceId, bundleId, launchArgs, '');
+
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('should NOT log instrumentation args usage warning, if none used', async () => {
+      const launchArgs = {
+        'user-arg': 'merry christ-nukah',
+      };
+
+      await uut.launchApp(deviceId, bundleId, launchArgs, '');
+
+      expect(logger.warn).not.toHaveBeenCalled();
     });
   });
 

--- a/detox/test/e2e/22.launch-args.test.js
+++ b/detox/test/e2e/22.launch-args.test.js
@@ -7,6 +7,10 @@ describe(':android: Launch arguments', () => {
     await expect(element(by.id(`launchArg-${key}.value`))).toHaveText(expectedValue);
   }
 
+  async function assertNoLaunchArg(launchArgKey) {
+    await expect(element(by.id(`launchArg-${launchArgKey}.name`))).toBeNotVisible();
+  }
+
   it('should handle primitive args', async () => {
     const launchArgs = {
       hello: 'world',
@@ -39,5 +43,23 @@ describe(':android: Launch arguments', () => {
 
     await assertLaunchArg(launchArgs, 'complex', JSON.stringify(launchArgs.complex));
     await assertLaunchArg(launchArgs, 'complexlist', JSON.stringify(launchArgs.complexlist));
+  });
+
+  // Ref: https://developer.android.com/studio/test/command-line#AMOptionsSyntax
+  it('should not pass android instrumentation args through', async () => {
+    const launchArgs = {
+      hello: 'world',
+      debug: false,
+      log: false,
+      size: 'large',
+    };
+
+    await device.launchApp({newInstance: true, launchArgs});
+
+    await element(by.text('Launch Args')).tap();
+    await assertLaunchArg(launchArgs, 'hello', 'world');
+    await assertNoLaunchArg('debug');
+    await assertNoLaunchArg('log');
+    await assertNoLaunchArg('size');
   });
 });


### PR DESCRIPTION
- [x] This is a small change 
- [x] This change has been discussed in issue #1804 and the solution has been agreed upon with maintainers.

---

**Description:**

Fixes #1804 by introducing these two changes:
1. On the tester (JS) side, allow reserved instrumentation args to pass-through unencoded.
2. On the Android-native side, refrain from passing such instrumentation args into the activity through the intent's extras.