### PR TITLE
Update docs

### DIFF
--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -39,7 +39,10 @@ Node is the JavaScript runtime Detox will run on. **Install Node 8.3.0 or above*
 
 A collection of utils for Apple simulators, Detox uses it to communicate with the simulator.
 
+If you are using `MacOS Mojave` run `xcode-select install` first
+
 ```sh
+xcode-select install
 brew tap wix/brew
 brew install applesimutils
 ```

--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -23,6 +23,12 @@ Running Detox (on iOS) requires the following:
 
 Homebrew is a package manager for macOS, we'll need it to install other command line tools.
 
+To ensure everything needed for Homebrew tool installation is installed, run
+
+```sh
+xcode-select install
+```
+
 > TIP: Verify it works by typing in terminal `brew -h` to output list of available commands
 
 #### 2. Install [Node.js](https://nodejs.org/en/)
@@ -39,10 +45,7 @@ Node is the JavaScript runtime Detox will run on. **Install Node 8.3.0 or above*
 
 A collection of utils for Apple simulators, Detox uses it to communicate with the simulator.
 
-If you are using `MacOS Mojave` run `xcode-select install` first
-
 ```sh
-xcode-select install
 brew tap wix/brew
 brew install applesimutils
 ```


### PR DESCRIPTION
For MacOS Mojave 10.14.6 you need to install first

`xcode-select install` before Step number 1.3

```sh
brew tap wix/brew
brew install applesimutils
```

<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
