### PR TITLE
Apply Jest timeout setup optimization into init (cli) template

### DIFF
--- a/detox/local-cli/templates/jest.js
+++ b/detox/local-cli/templates/jest.js
@@ -14,6 +14,7 @@ const specReporter = require('detox/runners/jest/specReporter');
 
 // Set the default timeout
 jest.setTimeout(120000);
+
 jasmine.getEnv().addReporter(adapter);
 
 // This takes care of generating status logs on a per-spec basis. By default, jest only reports at file-level.
@@ -22,7 +23,7 @@ jasmine.getEnv().addReporter(specReporter);
 
 beforeAll(async () => {
   await detox.init(config);
-});
+}, 300000);
 
 beforeEach(async () => {
   await adapter.beforeEach();


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

Compliments #1821 by applying fix in Jest init template.
Related to #1194 (i.e. the root that's sparked all of this).