### PR TITLE
fix(configuration): pathBuilder resolution should be Node.js-ish

### DIFF
--- a/detox/src/configuration.js
+++ b/detox/src/configuration.js
@@ -82,9 +82,7 @@ function getArtifactsCliConfig() {
 }
 
 function resolveModuleFromPath(modulePath) {
-  return path.isAbsolute(modulePath)
-    ? require(modulePath)
-    : require(path.join(process.cwd(), modulePath));
+  return require.resolve(modulePath, { paths: [process.cwd()]});
 }
 
 function composeArtifactsConfig({

--- a/detox/src/configuration.js
+++ b/detox/src/configuration.js
@@ -82,7 +82,8 @@ function getArtifactsCliConfig() {
 }
 
 function resolveModuleFromPath(modulePath) {
-  return require.resolve(modulePath, { paths: [process.cwd()]});
+  const resolvedModulePath = require.resolve(modulePath, { paths: [process.cwd()]});
+  return require(resolvedModulePath);
 }
 
 function composeArtifactsConfig({

--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -63,7 +63,7 @@ Detox can control artifacts collection via settings from `package.json`:
   "detox": {
     "artifacts": {
       "rootDir": ".artifacts",
-      "pathBuilder": "config/pathbuilder.js",
+      "pathBuilder": "./config/pathbuilder.js",
       "plugins": {
         "instruments": "none",
         "log": "all",

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -23,7 +23,7 @@
     "configurations": {
       "ios.sim.release": {
         "artifacts": {
-          "pathBuilder": "e2e/detox.pathbuilder.ios.js"
+          "pathBuilder": "./e2e/detox.pathbuilder.ios.js"
         },
         "binaryPath": "../demo-react-native/ios/build/Build/Products/Release-iphonesimulator/example.app",
         "type": "ios.simulator",
@@ -33,7 +33,7 @@
       },
       "android.emu.release": {
         "artifacts": {
-          "pathBuilder": "e2e/detox.pathbuilder.android.js"
+          "pathBuilder": "./e2e/detox.pathbuilder.android.js"
         },
         "binaryPath": "../demo-react-native/android/app/build/outputs/apk/release/app-release.apk",
         "type": "android.emulator",


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Fixes the following bug in #1729 :

The custom `pathBuilder` string in the configuration originally was intended to be a regular `Node.js`-ish path to a module, but by mistake, I made it something like a relative path.

Before:
```
"pathBuilder": "config/pathbuilder.js",
```

After:
```
"pathBuilder": "./config/pathbuilder.js",
```