### PR TITLE
deprecation: CLI (-f, --file, -s, --specs), package.json (detox.file)

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -7,7 +7,6 @@ const DetoxConfigError = require('../src/errors/DetoxConfigError');
 
 const log = require('../src/utils/logger').child({ __filename });
 const {getDetoxSection, getDefaultConfiguration, getConfigurationByKey} = require('./utils/configurationUtils');
-const {coerceDeprecation, printFileDeprecationWarning} = require('./utils/deprecation');
 const shellQuote = require('./utils/shellQuote');
 
 module.exports.command = 'test';
@@ -24,20 +23,6 @@ module.exports.builder = {
     alias: 'runner-config',
     group: 'Configuration:',
     describe: 'Test runner config file, defaults to e2e/mocha.opts for mocha and e2e/config.json for jest',
-  },
-  f: {
-    alias: 'file',
-    group: 'Configuration:',
-    describe: 'Specify test file to run',
-    coerce: coerceDeprecation('-f, --file'),
-    hidden: true,
-  },
-  s: {
-    alias: 'specs',
-    group: 'Configuration:',
-    describe: 'Root of tests look-up folder. Overrides the equivalent configuration in `package.json`, if set.',
-    coerce: coerceDeprecation('-s, --specs'),
-    hidden: true,
   },
   l: {
     alias: 'loglevel',
@@ -145,11 +130,6 @@ const collectExtraArgs = require('./utils/collectExtraArgs')(module.exports.buil
 
 module.exports.handler = async function test(program) {
   const config = getDetoxSection();
-
-  if (!program.file && config.file) {
-    printFileDeprecationWarning(config.file);
-  }
-
   const runner = getConfigFor('test-runner') || 'mocha';
   const runnerConfig = getConfigFor('runner-config') || getDefaultRunnerConfig();
 
@@ -201,7 +181,7 @@ module.exports.handler = async function test(program) {
       return args;
     }
 
-    const fallbackTestFolder = `"${getConfigFor('file', 'specs') || 'e2e'}"`;
+    const fallbackTestFolder = `"${config.specs || 'e2e'}"`;
     return args.concat(fallbackTestFolder);
   }
 

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -55,12 +55,6 @@ describe('test', () => {
       );
     });
 
-    it('should warn about deprecated options', async () => {
-      mockAndroidMochaConfiguration();
-      await callCli('./test', 'test --specs e2e');
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('migration guide'));
-    });
-
     it('should pass in device-launch-args as an environment variable', async () => {
       mockAndroidMochaConfiguration();
 

--- a/detox/local-cli/utils/deprecation.js
+++ b/detox/local-cli/utils/deprecation.js
@@ -1,26 +1,14 @@
 const chalk = require('chalk');
 const log = require('../../src/utils/logger').child({ __filename });
-const migrationGuideUrl = 'https://github.com/wix/Detox/blob/master/docs/Guide.Migration.md#migrating-from-detox-120x-to-121x';
 
 function coerceDeprecation(option) {
   return function coerceDeprecationFn(value) {
     log.warn(`Beware: ${option} will be removed in the next version of Detox.`);
-    log.warn(`See the migration guide:\n${migrationGuideUrl} `);
 
     return value;
   };
 }
 
-function printFileDeprecationWarning(file) {
-  log.warn('Deprecated: "file" option in "detox" section of package.json won\'t be supported in the next Detox version.\n');
-  console.log(`   "detox": {`);
-  console.log(chalk.red(`-    "file": ${JSON.stringify(file)},`));
-  console.log(chalk.green(`+    "specs": ${JSON.stringify(file)},\n`));
-  log.warn(`Please rename it to "specs", as demonstrated above.`);
-}
-
 module.exports = {
   coerceDeprecation,
-  migrationGuideUrl,
-  printFileDeprecationWarning,
 };


### PR DESCRIPTION
**Description:**

I am going to release a major version of Detox due to a small yet breaking :man_shrugging: change in https://github.com/wix/Detox/pull/1827.

It's time to fulfill the deprecation warnings for `file` and `specs`.