### PR TITLE
code(artifacts): beforeEach -> testStart, afterEach -> testDone

### DIFF
--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -114,13 +114,13 @@ class Detox {
       pendingRequests: false,
       testName: testSummary.fullName,
     });
-    await this._artifactsManager.onBeforeEach(testSummary);
+    await this._artifactsManager.onTestStart(testSummary);
   }
 
   async afterEach(testSummary) {
     this._validateTestSummary(testSummary);
     this._logTestRunCheckpoint('DETOX_AFTER_EACH', testSummary);
-    await this._artifactsManager.onAfterEach(testSummary);
+    await this._artifactsManager.onTestDone(testSummary);
     await this._dumpUnhandledErrorsIfAny({
       pendingRequests: testSummary.timedOut,
       testName: testSummary.fullName,

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -206,34 +206,34 @@ describe('Detox', () => {
       const testSummary = { title: 'test', fullName: 'suite - test', status: 'running' };
       await detox.beforeEach(testSummary);
 
-      expect(artifactsManager.onBeforeEach).toHaveBeenCalledWith(testSummary);
+      expect(artifactsManager.onTestStart).toHaveBeenCalledWith(testSummary);
     });
 
     it(`Calling detox.beforeEach() and detox.afterEach() with a deprecated signature will throw an exception`, async () => {
       const testSummary = { title: 'test', fullName: 'suite - test', status: 'running' };
 
       await expect(detox.beforeEach(testSummary.title, testSummary.fullName, testSummary.status)).rejects.toThrowError();
-      expect(artifactsManager.onBeforeEach).not.toHaveBeenCalled();
+      expect(artifactsManager.onTestStart).not.toHaveBeenCalled();
 
       await expect(detox.afterEach(testSummary.title, testSummary.fullName, testSummary.status)).rejects.toThrowError();
-      expect(artifactsManager.onAfterEach).not.toHaveBeenCalled();
+      expect(artifactsManager.onTestDone).not.toHaveBeenCalled();
     });
 
     it(`Calling detox.beforeEach() and detox.afterEach() with incorrect test status will throw an exception`, async () => {
       const testSummary = { title: 'test', fullName: 'suite - test', status: 'incorrect status' };
 
       await expect(detox.beforeEach(testSummary)).rejects.toThrowError();
-      expect(artifactsManager.onBeforeEach).not.toHaveBeenCalled();
+      expect(artifactsManager.onTestStart).not.toHaveBeenCalled();
 
       await expect(detox.afterEach(testSummary)).rejects.toThrowError();
-      expect(artifactsManager.onAfterEach).not.toHaveBeenCalled();
+      expect(artifactsManager.onTestDone).not.toHaveBeenCalled();
     });
 
     it(`Calling detox.afterEach() should trigger artifactsManager.onAfterEach`, async () => {
       const testSummary = { title: 'test', fullName: 'suite - test', status: 'passed' };
       await detox.afterEach(testSummary);
 
-      expect(artifactsManager.onAfterEach).toHaveBeenCalledWith(testSummary);
+      expect(artifactsManager.onTestDone).toHaveBeenCalledWith(testSummary);
     });
 
     it(`Calling detox.cleanup() should trigger artifactsManager.afterAll()`, async () => {

--- a/detox/src/artifacts/ArtifactsManager.js
+++ b/detox/src/artifacts/ArtifactsManager.js
@@ -143,12 +143,12 @@ class ArtifactsManager {
     await this._callPlugins('ascending', 'onBeforeAll');
   }
 
-  async onBeforeEach(testSummary) {
-    await this._callPlugins('ascending', 'onBeforeEach', testSummary);
+  async onTestStart(testSummary) {
+    await this._callPlugins('ascending', 'onTestStart', testSummary);
   }
 
-  async onAfterEach(testSummary) {
-    await this._callPlugins('descending', 'onAfterEach', testSummary);
+  async onTestDone(testSummary) {
+    await this._callPlugins('descending', 'onTestDone', testSummary);
   }
 
   async onAfterAll() {

--- a/detox/src/artifacts/ArtifactsManager.test.js
+++ b/detox/src/artifacts/ArtifactsManager.test.js
@@ -122,8 +122,8 @@ describe('ArtifactsManager', () => {
           onLaunchApp: jest.fn(),
           onCreateExternalArtifact: jest.fn(),
           onBeforeAll: jest.fn(),
-          onBeforeEach: jest.fn(),
-          onAfterEach: jest.fn(),
+          onTestStart: jest.fn(),
+          onTestDone: jest.fn(),
           onAfterAll: jest.fn(),
           onTerminate: jest.fn(),
         });
@@ -350,9 +350,9 @@ describe('ArtifactsManager', () => {
         it('should call onTestStart in plugins with the passed argument', async () => {
           const testSummary = testSummaries.running();
 
-          expect(testPlugin.onBeforeEach).not.toHaveBeenCalled();
+          expect(testPlugin.onTestStart).not.toHaveBeenCalled();
           await artifactsManager.onTestStart(testSummary);
-          expect(testPlugin.onBeforeEach).toHaveBeenCalledWith(testSummary);
+          expect(testPlugin.onTestStart).toHaveBeenCalledWith(testSummary);
         });
       });
 
@@ -360,9 +360,9 @@ describe('ArtifactsManager', () => {
         it('should call onTestDone in plugins with the passed argument', async () => {
           const testSummary = testSummaries.passed();
 
-          expect(testPlugin.onAfterEach).not.toHaveBeenCalled();
+          expect(testPlugin.onTestDone).not.toHaveBeenCalled();
           await artifactsManager.onTestDone(testSummary);
-          expect(testPlugin.onAfterEach).toHaveBeenCalledWith(testSummary);
+          expect(testPlugin.onTestDone).toHaveBeenCalledWith(testSummary);
         });
       });
 

--- a/detox/src/artifacts/ArtifactsManager.test.js
+++ b/detox/src/artifacts/ArtifactsManager.test.js
@@ -284,9 +284,9 @@ describe('ArtifactsManager', () => {
 
         itShouldCatchErrorsOnPhase('onBeforeAll', () => undefined);
 
-        itShouldCatchErrorsOnPhase('onBeforeEach', () => testSummaries.running());
+        itShouldCatchErrorsOnPhase('onTestStart', () => testSummaries.running());
 
-        itShouldCatchErrorsOnPhase('onAfterEach', () => testSummaries.passed());
+        itShouldCatchErrorsOnPhase('onTestDone', () => testSummaries.passed());
 
         itShouldCatchErrorsOnPhase('onAfterAll', () => undefined);
 
@@ -346,22 +346,22 @@ describe('ArtifactsManager', () => {
         });
       });
 
-      describe('onBeforeEach', () => {
-        it('should call onBeforeEach in plugins with the passed argument', async () => {
+      describe('onTestStart', () => {
+        it('should call onTestStart in plugins with the passed argument', async () => {
           const testSummary = testSummaries.running();
 
           expect(testPlugin.onBeforeEach).not.toHaveBeenCalled();
-          await artifactsManager.onBeforeEach(testSummary);
+          await artifactsManager.onTestStart(testSummary);
           expect(testPlugin.onBeforeEach).toHaveBeenCalledWith(testSummary);
         });
       });
 
-      describe('onAfterEach', () => {
-        it('should call onAfterEach in plugins with the passed argument', async () => {
+      describe('onTestDone', () => {
+        it('should call onTestDone in plugins with the passed argument', async () => {
           const testSummary = testSummaries.passed();
 
           expect(testPlugin.onAfterEach).not.toHaveBeenCalled();
-          await artifactsManager.onAfterEach(testSummary);
+          await artifactsManager.onTestDone(testSummary);
           expect(testPlugin.onAfterEach).toHaveBeenCalledWith(testSummary);
         });
       });

--- a/detox/src/artifacts/log/ios/SimulatorLogPlugin.test.js
+++ b/detox/src/artifacts/log/ios/SimulatorLogPlugin.test.js
@@ -91,7 +91,7 @@ describe('SimulatorLogPlugin', () => {
     await artifactsManager.onBeforeAll();
     await logToDeviceLogs('take - inside before all');
 
-    await artifactsManager.onBeforeEach({ title: 'test', fullName: 'some test', status: 'running'});
+    await artifactsManager.onTestStart({ title: 'test', fullName: 'some test', status: 'running'});
     await logToDeviceLogs('take - inside before each');
 
     await logToDeviceLogs('take - before relaunch inside test');
@@ -100,7 +100,7 @@ describe('SimulatorLogPlugin', () => {
     await artifactsManager.onLaunchApp({ device: 'booted', bundleId: 'com.test', pid: 8001 });
     await logToDeviceLogs('take - after relaunch inside test');
 
-    await artifactsManager.onAfterEach({ title: 'test', fullName: 'some test', status: 'passed'});
+    await artifactsManager.onTestDone({ title: 'test', fullName: 'some test', status: 'passed'});
     await logToDeviceLogs('omit - after afterEach');
     await artifactsManager.onAfterAll();
     await logToDeviceLogs('omit - after afterAll');

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
@@ -191,7 +191,7 @@ class ArtifactPlugin {
    * @param {TestSummary} testSummary - has name of currently running test
    * @return {Promise<void>} - when done
    */
-  async onBeforeEach(testSummary) {
+  async onTestStart(testSummary) {
     this.context.testSummary = testSummary;
   }
 
@@ -201,7 +201,7 @@ class ArtifactPlugin {
    * @param {TestSummary} testSummary - has name and status of test that ran
    * @return {Promise<void>} - when done
    */
-  async onAfterEach(testSummary) {
+  async onTestDone(testSummary) {
     this.context.testSummary = testSummary;
 
     if (testSummary.status === 'failed') {
@@ -242,8 +242,8 @@ class ArtifactPlugin {
     this.onLaunchApp = _.noop;
     this.onUserAction = _.noop;
     this.onBeforeAll = _.noop;
-    this.onBeforeEach = _.noop;
-    this.onAfterEach = _.noop;
+    this.onTestStart = _.noop;
+    this.onTestDone = _.noop;
     this.onAfterAll = _.noop;
   }
 

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.test.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.test.js
@@ -205,15 +205,15 @@ describe('ArtifactPlugin', () => {
       expect(plugin.context.testSummary).toBe(null);
     });
 
-    it('should have .onBeforeEach, which updates context.testSummary if called', async () => {
+    it('should have .onTestStart, which updates context.testSummary if called', async () => {
       const testSummary = testSummaries.running();
-      await plugin.onBeforeEach(testSummary);
+      await plugin.onTestStart(testSummary);
       expect(plugin.context.testSummary).toBe(testSummary);
     });
 
-    it('should have .onAfterEach, which updates context.testSummary if called', async () => {
+    it('should have .onTestDone, which updates context.testSummary if called', async () => {
       const testSummary = testSummaries.failed();
-      await plugin.onAfterEach(testSummary);
+      await plugin.onTestDone(testSummary);
       expect(plugin.context.testSummary).toBe(testSummary);
     });
 
@@ -241,8 +241,8 @@ describe('ArtifactPlugin', () => {
         expect(plugin.onBeforeTerminateApp).toBe(plugin.onTerminate);
         expect(plugin.onTerminateApp).toBe(plugin.onTerminate);
         expect(plugin.onBeforeAll).toBe(plugin.onTerminate);
-        expect(plugin.onBeforeEach).toBe(plugin.onTerminate);
-        expect(plugin.onAfterEach).toBe(plugin.onTerminate);
+        expect(plugin.onTestStart).toBe(plugin.onTerminate);
+        expect(plugin.onTestDone).toBe(plugin.onTerminate);
         expect(plugin.onAfterAll).toBe(plugin.onTerminate);
         expect(plugin.onUserAction).toBe(plugin.onTerminate);
       });

--- a/detox/src/artifacts/templates/plugin/StartupAndTestRecorderPlugin.js
+++ b/detox/src/artifacts/templates/plugin/StartupAndTestRecorderPlugin.js
@@ -34,7 +34,7 @@ class StartupAndTestRecorderPlugin extends WholeTestRecorderPlugin {
     }
   }
 
-  async onBeforeEach(testSummary) {
+  async onTestStart(testSummary) {
     this._isInStartupPhase = false;
 
     if (this._isRecordingStartup) {
@@ -42,11 +42,11 @@ class StartupAndTestRecorderPlugin extends WholeTestRecorderPlugin {
       this._isRecordingStartup = false;
     }
 
-    await super.onBeforeEach(testSummary);
+    await super.onTestStart(testSummary);
   }
 
-  async onAfterEach(testSummary) {
-    await super.onAfterEach(testSummary);
+  async onTestDone(testSummary) {
+    await super.onTestDone(testSummary);
 
     if (this.startupRecording) {
       this._tryToFinalizeStartupRecording();

--- a/detox/src/artifacts/templates/plugin/StartupAndTestRecorderPlugin.test.js
+++ b/detox/src/artifacts/templates/plugin/StartupAndTestRecorderPlugin.test.js
@@ -31,18 +31,18 @@ describe('StartupAndTestRecorderPlugin', () => {
       it('should end correctly, but do nothing', expectThatNothingActuallyHappens);
     });
 
-    describe('onBeforeEach', () => {
+    describe('onTestStart', () => {
       beforeEach(async () => {
-        await plugin.onBeforeEach(testSummaries.running());
+        await plugin.onTestStart(testSummaries.running());
       });
 
       it('should end correctly, but do nothing', expectThatNothingActuallyHappens);
     });
 
-    describe('onAfterEach', () => {
+    describe('onTestDone', () => {
       beforeEach(async () => {
-        await plugin.onBeforeEach(testSummaries.running());
-        await plugin.onAfterEach(testSummaries.failed());
+        await plugin.onTestStart(testSummaries.running());
+        await plugin.onTestDone(testSummaries.failed());
       });
 
       it('should end correctly, but do nothing', expectThatNothingActuallyHappens);
@@ -50,8 +50,8 @@ describe('StartupAndTestRecorderPlugin', () => {
 
     describe('onAfterAll', () => {
       beforeEach(async () => {
-        await plugin.onBeforeEach(testSummaries.running());
-        await plugin.onAfterEach(testSummaries.failed());
+        await plugin.onTestStart(testSummaries.running());
+        await plugin.onTestDone(testSummaries.failed());
         await plugin.onAfterAll();
       });
 
@@ -89,11 +89,11 @@ describe('StartupAndTestRecorderPlugin', () => {
     });
   });
 
-  describe('onBeforeEach', () => {
+  describe('onTestStart', () => {
     describe('if app was launched before', () => {
       beforeEach(async () => {
         await plugin.onReadyToRecord();
-        await plugin.onBeforeEach(testSummaries.running());
+        await plugin.onTestStart(testSummaries.running());
       });
 
       it('should stop start-up recording', () => {
@@ -107,7 +107,7 @@ describe('StartupAndTestRecorderPlugin', () => {
 
     describe('', () => {
       beforeEach(async () => {
-        await plugin.onBeforeEach(testSummaries.running());
+        await plugin.onTestStart(testSummaries.running());
       });
 
       it('should create test recording', () => {
@@ -132,7 +132,7 @@ describe('StartupAndTestRecorderPlugin', () => {
     });
   });
 
-  describe('onAfterEach', () => {
+  describe('onTestDone', () => {
     describe('when plugin is keeping only artifacts from failed tests', () => {
       beforeEach(() => {
         plugin.keepOnlyFailedTestsArtifacts = true;
@@ -141,8 +141,8 @@ describe('StartupAndTestRecorderPlugin', () => {
       describe('and current test passed well', () => {
         beforeEach(async () => {
           await plugin.onReadyToRecord();
-          await plugin.onBeforeEach(testSummaries.running());
-          await plugin.onAfterEach(testSummaries.passed());
+          await plugin.onTestStart(testSummaries.running());
+          await plugin.onTestDone(testSummaries.passed());
           await api.emulateRunningAllIdleCallbacks();
         });
 
@@ -159,8 +159,8 @@ describe('StartupAndTestRecorderPlugin', () => {
       describe('and current test failed', () => {
         beforeEach(async () => {
           await plugin.onReadyToRecord();
-          await plugin.onBeforeEach(testSummaries.running());
-          await plugin.onAfterEach(testSummaries.failed());
+          await plugin.onTestStart(testSummaries.running());
+          await plugin.onTestDone(testSummaries.failed());
         });
 
         itShouldScheduleSavingAndUntrackingOfBothArtifacts();
@@ -175,8 +175,8 @@ describe('StartupAndTestRecorderPlugin', () => {
       describe('and test finished anyhow', () => {
         beforeEach(async () => {
           await plugin.onReadyToRecord();
-          await plugin.onBeforeEach(testSummaries.running());
-          await plugin.onAfterEach(testSummaries.passed());
+          await plugin.onTestStart(testSummaries.running());
+          await plugin.onTestDone(testSummaries.passed());
         });
 
         itShouldScheduleSavingAndUntrackingOfBothArtifacts();
@@ -190,7 +190,7 @@ describe('StartupAndTestRecorderPlugin', () => {
         plugin.keepOnlyFailedTestsArtifacts = false;
       });
 
-      describe('when there were no calls to .onBeforeEach and .onAfterEach', () => {
+      describe('when there were no calls to .onTestStart and .onTestDone', () => {
         beforeEach(async () => {
           await plugin.onReadyToRecord();
           await plugin.onAfterAll();
@@ -224,11 +224,11 @@ describe('StartupAndTestRecorderPlugin', () => {
         });
       });
 
-      describe('when there were already calls to .onAfterEach', () => {
+      describe('when there were already calls to .onTestDone', () => {
         beforeEach(async () => {
           await plugin.onReadyToRecord();
-          await plugin.onBeforeEach(testSummaries.running());
-          await plugin.onAfterEach(testSummaries.passed());
+          await plugin.onTestStart(testSummaries.running());
+          await plugin.onTestDone(testSummaries.passed());
           api.requestIdleCallback.mockClear();
         });
 
@@ -247,7 +247,7 @@ describe('StartupAndTestRecorderPlugin', () => {
         plugin.keepOnlyFailedTestsArtifacts = true;
       });
 
-      describe('when there were no calls to .onBeforeEach and .onAfterEach', () => {
+      describe('when there were no calls to .onTestStart and .onTestDone', () => {
         beforeEach(async () => {
           await plugin.onReadyToRecord();
 
@@ -261,8 +261,8 @@ describe('StartupAndTestRecorderPlugin', () => {
       describe('when all tests were successful', () => {
         beforeEach(async () => {
           await plugin.onReadyToRecord();
-          await plugin.onBeforeEach(testSummaries.running());
-          await plugin.onAfterEach(testSummaries.passed());
+          await plugin.onTestStart(testSummaries.running());
+          await plugin.onTestDone(testSummaries.passed());
 
           api.requestIdleCallback.mockClear();
           await plugin.onAfterAll();

--- a/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.js
+++ b/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.js
@@ -15,19 +15,19 @@ class TwoSnapshotsPerTestPlugin extends ArtifactPlugin {
     };
   }
 
-  async onBeforeEach(testSummary) {
+  async onTestStart(testSummary) {
     this.context.testSummary = null;
     this._flushSessionSnapshots();
 
-    await super.onBeforeEach(testSummary);
-    await this._takeAutomaticSnapshot('beforeEach');
+    await super.onTestStart(testSummary);
+    await this._takeAutomaticSnapshot('testStart');
   }
 
-  async onAfterEach(testSummary) {
-    await super.onAfterEach(testSummary);
+  async onTestDone(testSummary) {
+    await super.onTestDone(testSummary);
 
     if (this.shouldKeepArtifactOfTest(testSummary)) {
-      await this._takeAutomaticSnapshot('afterEach');
+      await this._takeAutomaticSnapshot('testDone');
       this._startSavingSnapshots('fromTest');
     } else {
       this._startDiscardingSnapshots('fromTest');

--- a/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.test.js
+++ b/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.test.js
@@ -22,18 +22,18 @@ describe('TwoSnapshotsPerTestPlugin', () => {
   describe('when disabled', () => {
     beforeEach(() => plugin.disable());
 
-    describe('onBeforeEach', () => {
-      beforeEach(async () => plugin.onBeforeEach(testSummaries.running()));
+    describe('onTestStart', () => {
+      beforeEach(async () => plugin.onTestStart(testSummaries.running()));
 
-      it('should not create artifact onBeforeEach', async () =>
+      it('should not create artifact onTestStart', async () =>
         expect(plugin.createTestArtifact).not.toHaveBeenCalled());
     });
 
     describe('when configured to keep artifacts', function() {
       beforeEach(() => plugin.configureToKeepArtifacts(true));
 
-      describe('onAfterEach', () => {
-        beforeEach(async () => plugin.onAfterEach(testSummaries.passed()));
+      describe('onTestDone', () => {
+        beforeEach(async () => plugin.onTestDone(testSummaries.passed()));
 
         it('should not do create artifacts', async () =>
           expect(plugin.createTestArtifact).not.toHaveBeenCalled());
@@ -46,8 +46,8 @@ describe('TwoSnapshotsPerTestPlugin', () => {
     describe('when configured to keep artifacts', function() {
       beforeEach(() => plugin.configureToKeepArtifacts(false));
 
-      describe('onAfterEach', () => {
-        beforeEach(async () => plugin.onAfterEach(testSummaries.passed()));
+      describe('onTestDone', () => {
+        beforeEach(async () => plugin.onTestDone(testSummaries.passed()));
 
         it('should not do create artifacts', async () =>
           expect(plugin.createTestArtifact).not.toHaveBeenCalled());
@@ -58,9 +58,9 @@ describe('TwoSnapshotsPerTestPlugin', () => {
     });
   });
 
-  describe('when onBeforeEach called', function() {
+  describe('when onTestStart called', function() {
     beforeEach(async () => {
-      await plugin.onBeforeEach(testSummaries.running());
+      await plugin.onTestStart(testSummaries.running());
     });
 
     it('should create test artifact', () => {
@@ -94,10 +94,10 @@ describe('TwoSnapshotsPerTestPlugin', () => {
   describe('when the plugin should keep a test artifact', () => {
     beforeEach(() => plugin.configureToKeepArtifacts(true));
 
-    describe('when onBeforeEach and onAfterEach are called', () => {
+    describe('when onTestStart and onTestDone are called', () => {
       beforeEach(async () => {
-        await plugin.onBeforeEach(testSummaries.running());
-        await plugin.onAfterEach(testSummaries.passed());
+        await plugin.onTestStart(testSummaries.running());
+        await plugin.onTestDone(testSummaries.passed());
       });
 
       it('should create the second test artifact', () => {
@@ -150,12 +150,12 @@ describe('TwoSnapshotsPerTestPlugin', () => {
       beforeEach(async () => {
         artifact = new ArtifactMock('screenshot');
 
-        await plugin.onBeforeEach(testSummaries.running());
+        await plugin.onTestStart(testSummaries.running());
         await plugin.onCreateExternalArtifact({
           artifact,
           name: 'final_name',
         });
-        await plugin.onAfterEach(testSummaries.passed());
+        await plugin.onTestDone(testSummaries.passed());
       });
 
       it('should be saved using the suggested name and untracked', async () => {
@@ -179,7 +179,7 @@ describe('TwoSnapshotsPerTestPlugin', () => {
           artifact,
           name: 'final_name',
         });
-        await plugin.onBeforeEach(testSummaries.running());
+        await plugin.onTestStart(testSummaries.running());
       });
 
       it('should be saved using the suggested name and untracked', async () => {
@@ -199,8 +199,8 @@ describe('TwoSnapshotsPerTestPlugin', () => {
       beforeEach(async () => {
         artifact = new ArtifactMock('screenshot');
 
-        await plugin.onBeforeEach(testSummaries.running());
-        await plugin.onAfterEach(testSummaries.passed());
+        await plugin.onTestStart(testSummaries.running());
+        await plugin.onTestDone(testSummaries.passed());
         await plugin.onCreateExternalArtifact({
           artifact,
           name: 'final_name',
@@ -223,10 +223,10 @@ describe('TwoSnapshotsPerTestPlugin', () => {
   describe('when the plugin should not keep a test artifact', () => {
     beforeEach(() => plugin.configureToKeepArtifacts(false));
 
-    describe('when onBeforeEach and onAfterEach are called', () => {
+    describe('when onTestStart and onTestDone are called', () => {
       beforeEach(async () => {
-        await plugin.onBeforeEach(testSummaries.running());
-        await plugin.onAfterEach(testSummaries.passed());
+        await plugin.onTestStart(testSummaries.running());
+        await plugin.onTestDone(testSummaries.passed());
       });
 
       it('should not create the second test artifact', () => {
@@ -257,12 +257,12 @@ describe('TwoSnapshotsPerTestPlugin', () => {
       beforeEach(async () => {
         artifact = new ArtifactMock('screenshot');
 
-        await plugin.onBeforeEach(testSummaries.running());
+        await plugin.onTestStart(testSummaries.running());
         await plugin.onCreateExternalArtifact({
           artifact,
           name: 'final_name',
         });
-        await plugin.onAfterEach(testSummaries.passed());
+        await plugin.onTestDone(testSummaries.passed());
       });
 
       it('should be discarded and untracked', async () => {

--- a/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.test.js
+++ b/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.test.js
@@ -68,12 +68,12 @@ describe('TwoSnapshotsPerTestPlugin', () => {
     });
 
     it('should start and stop recording in the artifact', () => {
-      expect(plugin.snapshots.fromTest['beforeEach'].start).toHaveBeenCalledTimes(1);
-      expect(plugin.snapshots.fromTest['beforeEach'].stop).toHaveBeenCalledTimes(1);
+      expect(plugin.snapshots.fromTest['testStart'].start).toHaveBeenCalledTimes(1);
+      expect(plugin.snapshots.fromTest['testStart'].stop).toHaveBeenCalledTimes(1);
     });
 
     it('should put the artifact under tracking', () => {
-      expect(api.trackArtifact).toHaveBeenCalledWith(plugin.snapshots.fromTest['beforeEach']);
+      expect(api.trackArtifact).toHaveBeenCalledWith(plugin.snapshots.fromTest['testStart']);
     });
   });
 
@@ -105,12 +105,12 @@ describe('TwoSnapshotsPerTestPlugin', () => {
       });
 
       it('should start and stop the second test artifact', () => {
-        expect(plugin.snapshots.fromTest['afterEach'].start).toHaveBeenCalledTimes(1);
-        expect(plugin.snapshots.fromTest['afterEach'].stop).toHaveBeenCalledTimes(1);
+        expect(plugin.snapshots.fromTest['testDone'].start).toHaveBeenCalledTimes(1);
+        expect(plugin.snapshots.fromTest['testDone'].stop).toHaveBeenCalledTimes(1);
       });
 
       it('should put the second test artifact under tracking', () => {
-        expect(api.trackArtifact).toHaveBeenCalledWith(plugin.snapshots.fromTest['afterEach']);
+        expect(api.trackArtifact).toHaveBeenCalledWith(plugin.snapshots.fromTest['testDone']);
       });
 
       it('should schedule two saving operations and specify itself as an initiator', () => {
@@ -122,25 +122,25 @@ describe('TwoSnapshotsPerTestPlugin', () => {
       it('should schedule to save and untrack the first artifact', async () => {
         const [saveRequest] = api.requestIdleCallback.mock.calls[0];
 
-        expect(plugin.snapshots.fromTest['beforeEach'].save).not.toHaveBeenCalled();
+        expect(plugin.snapshots.fromTest['testStart'].save).not.toHaveBeenCalled();
         expect(api.untrackArtifact).not.toHaveBeenCalled();
 
         await saveRequest();
 
-        expect(plugin.snapshots.fromTest['beforeEach'].save).toBeCalledWith('test/beforeEach.png');
-        expect(api.untrackArtifact).toBeCalledWith(plugin.snapshots.fromTest['beforeEach']);
+        expect(plugin.snapshots.fromTest['testStart'].save).toBeCalledWith('test/testStart.png');
+        expect(api.untrackArtifact).toBeCalledWith(plugin.snapshots.fromTest['testStart']);
       });
 
       it('should ultimately save and untrack the second artifact', async () => {
         const [saveRequest] = api.requestIdleCallback.mock.calls[1];
 
-        expect(plugin.snapshots.fromTest['afterEach'].save).not.toHaveBeenCalled();
+        expect(plugin.snapshots.fromTest['testDone'].save).not.toHaveBeenCalled();
         expect(api.untrackArtifact).not.toHaveBeenCalled();
 
         await saveRequest();
 
-        expect(plugin.snapshots.fromTest['afterEach'].save).toBeCalledWith('test/afterEach.png');
-        expect(api.untrackArtifact).toBeCalledWith(plugin.snapshots.fromTest['afterEach']);
+        expect(plugin.snapshots.fromTest['testDone'].save).toBeCalledWith('test/testDone.png');
+        expect(api.untrackArtifact).toBeCalledWith(plugin.snapshots.fromTest['testDone']);
       });
     });
 
@@ -241,13 +241,13 @@ describe('TwoSnapshotsPerTestPlugin', () => {
       it('should ultimately discard and untrack the first artifact', async () => {
         const [discardRequest] = api.requestIdleCallback.mock.calls[0];
 
-        expect(plugin.snapshots.fromTest['beforeEach'].discard).not.toHaveBeenCalled();
+        expect(plugin.snapshots.fromTest['testStart'].discard).not.toHaveBeenCalled();
         expect(api.untrackArtifact).not.toHaveBeenCalled();
 
         await discardRequest();
 
-        expect(plugin.snapshots.fromTest['beforeEach'].discard).toHaveBeenCalledTimes(1);
-        expect(api.untrackArtifact).toBeCalledWith(plugin.snapshots.fromTest['beforeEach']);
+        expect(plugin.snapshots.fromTest['testStart'].discard).toHaveBeenCalledTimes(1);
+        expect(api.untrackArtifact).toBeCalledWith(plugin.snapshots.fromTest['testStart']);
       });
     });
 

--- a/detox/src/artifacts/templates/plugin/WholeTestRecorderPlugin.js
+++ b/detox/src/artifacts/templates/plugin/WholeTestRecorderPlugin.js
@@ -10,8 +10,8 @@ class WholeTestRecorderPlugin extends ArtifactPlugin {
     this.testRecording = null;
   }
 
-  async onBeforeEach(testSummary) {
-    await super.onBeforeEach(testSummary);
+  async onTestStart(testSummary) {
+    await super.onTestStart(testSummary);
 
     if (this.enabled) {
       this.testRecording = this.createTrackedTestRecording();
@@ -19,8 +19,8 @@ class WholeTestRecorderPlugin extends ArtifactPlugin {
     }
   }
 
-  async onAfterEach(testSummary) {
-    await super.onAfterEach(testSummary);
+  async onTestDone(testSummary) {
+    await super.onTestDone(testSummary);
 
     if (this.testRecording) {
       await this.testRecording.stop();

--- a/detox/src/artifacts/templates/plugin/WholeTestRecorderPlugin.test.js
+++ b/detox/src/artifacts/templates/plugin/WholeTestRecorderPlugin.test.js
@@ -20,15 +20,15 @@ describe('WholeTestRecorderPlugin', () => {
   describe('when disabled', () => {
     beforeEach(() => plugin.disable());
 
-    describe('onBeforeEach', () => {
-      beforeEach(async () => plugin.onBeforeEach(testSummaries.running()));
+    describe('onTestStart', () => {
+      beforeEach(async () => plugin.onTestStart(testSummaries.running()));
 
-      it('should not create recording onBeforeEach', async () =>
+      it('should not create recording onTestStart', async () =>
         expect(plugin.createTestRecording).not.toHaveBeenCalled());
     });
 
-    describe('onAfterEach', () => {
-      beforeEach(async () => plugin.onAfterEach(testSummaries.passed()));
+    describe('onTestDone', () => {
+      beforeEach(async () => plugin.onTestDone(testSummaries.passed()));
 
       it('should not create recording', async () =>
         expect(plugin.createTestRecording).not.toHaveBeenCalled());
@@ -38,8 +38,8 @@ describe('WholeTestRecorderPlugin', () => {
     });
   });
 
-  describe('onBeforeEach', () => {
-    beforeEach(async () => plugin.onBeforeEach(testSummaries.running()));
+  describe('onTestStart', () => {
+    beforeEach(async () => plugin.onTestStart(testSummaries.running()));
 
     it('should create artifact', async () => {
       expect(plugin.createTestRecording).toHaveBeenCalled();
@@ -61,10 +61,10 @@ describe('WholeTestRecorderPlugin', () => {
   describe('when the plugin should keep a test artifact', () => {
     beforeEach(() => plugin.configureToKeepArtifacts(true));
 
-    describe('onAfterEach', () => {
+    describe('onTestDone', () => {
       beforeEach(async () => {
-        await plugin.onBeforeEach(testSummaries.running());
-        await plugin.onAfterEach(testSummaries.failed());
+        await plugin.onTestStart(testSummaries.running());
+        await plugin.onTestDone(testSummaries.failed());
       });
 
       it('should stop artifact recording', async () => {
@@ -93,10 +93,10 @@ describe('WholeTestRecorderPlugin', () => {
   describe('when the plugin should discard a test artifact', () => {
     beforeEach(() => plugin.configureToKeepArtifacts(false));
 
-    describe('onAfterEach', () => {
+    describe('onTestDone', () => {
       beforeEach(async () => {
-        await plugin.onBeforeEach(testSummaries.running());
-        await plugin.onAfterEach(testSummaries.failed());
+        await plugin.onTestStart(testSummaries.running());
+        await plugin.onTestDone(testSummaries.failed());
       });
 
       it('should stop artifact recording', async () => {


### PR DESCRIPTION
- [x] This is a small change 

**Description:**

This is the first step to implement: https://github.com/wix/Detox/issues/1661 .

This pull request aligns `before each` and `after each` events from Detox terminology to the `test start` and `test done` from Jest Circus terminology. This naming reflects much more closely the actual workflow in Detox artifacts manager.

The full solution of #1661 will be too voluminous for one pull request and involve way too many files for a human reviewer's eye, hence I'll be splitting it into micro-PRs.