### PR TITLE
code(artifacts): remove onBeforeAll, rename onAfterAll -> onBeforeCleanup

### DIFF
--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -81,13 +81,11 @@ class Detox {
       Object.assign(global, globalsToExport);
     }
 
-    await this._artifactsManager.onBeforeAll();
-
     return this;
   }
 
   async cleanup() {
-    await this._artifactsManager.onAfterAll();
+    await this._artifactsManager.onBeforeCleanup();
 
     if (this._client) {
       this._client.dumpPendingRequests();

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -198,10 +198,6 @@ describe('Detox', () => {
       artifactsManager = detox._artifactsManager; // TODO: rewrite to avoid accessing private fields
     });
 
-    it(`Calling detox.init() should trigger artifactsManager.beforeAll()`, async () => {
-      expect(artifactsManager.onBeforeAll).toHaveBeenCalledTimes(1);
-    });
-
     it(`Calling detox.beforeEach() will trigger artifacts manager .onBeforeEach`, async () => {
       const testSummary = { title: 'test', fullName: 'suite - test', status: 'running' };
       await detox.beforeEach(testSummary);
@@ -236,9 +232,9 @@ describe('Detox', () => {
       expect(artifactsManager.onTestDone).toHaveBeenCalledWith(testSummary);
     });
 
-    it(`Calling detox.cleanup() should trigger artifactsManager.afterAll()`, async () => {
+    it(`Calling detox.cleanup() should trigger artifactsManager.onBeforeCleanup()`, async () => {
       await detox.cleanup();
-      expect(artifactsManager.onAfterAll).toHaveBeenCalledTimes(1);
+      expect(artifactsManager.onBeforeCleanup).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/detox/src/artifacts/ArtifactsManager.js
+++ b/detox/src/artifacts/ArtifactsManager.js
@@ -139,10 +139,6 @@ class ArtifactsManager {
     });
   }
 
-  async onBeforeAll() {
-    await this._callPlugins('ascending', 'onBeforeAll');
-  }
-
   async onTestStart(testSummary) {
     await this._callPlugins('ascending', 'onTestStart', testSummary);
   }
@@ -151,8 +147,8 @@ class ArtifactsManager {
     await this._callPlugins('descending', 'onTestDone', testSummary);
   }
 
-  async onAfterAll() {
-    await this._callPlugins('descending', 'onAfterAll');
+  async onBeforeCleanup() {
+    await this._callPlugins('descending', 'onBeforeCleanup');
     await this._idlePromise;
   }
 

--- a/detox/src/artifacts/ArtifactsManager.test.js
+++ b/detox/src/artifacts/ArtifactsManager.test.js
@@ -121,10 +121,9 @@ describe('ArtifactsManager', () => {
           onBeforeLaunchApp: jest.fn(),
           onLaunchApp: jest.fn(),
           onCreateExternalArtifact: jest.fn(),
-          onBeforeAll: jest.fn(),
           onTestStart: jest.fn(),
           onTestDone: jest.fn(),
-          onAfterAll: jest.fn(),
+          onBeforeCleanup: jest.fn(),
           onTerminate: jest.fn(),
         });
       };
@@ -282,13 +281,11 @@ describe('ArtifactsManager', () => {
           });
         }
 
-        itShouldCatchErrorsOnPhase('onBeforeAll', () => undefined);
-
         itShouldCatchErrorsOnPhase('onTestStart', () => testSummaries.running());
 
         itShouldCatchErrorsOnPhase('onTestDone', () => testSummaries.passed());
 
-        itShouldCatchErrorsOnPhase('onAfterAll', () => undefined);
+        itShouldCatchErrorsOnPhase('onBeforeCleanup', () => undefined);
 
         itShouldCatchErrorsOnPhase('onTerminate', () => undefined);
 
@@ -338,14 +335,6 @@ describe('ArtifactsManager', () => {
         }));
       });
 
-      describe('onBeforeAll', () => {
-        it('should call onBeforeAll in plugins', async () => {
-          expect(testPlugin.onBeforeAll).not.toHaveBeenCalled();
-          await artifactsManager.onBeforeAll();
-          expect(testPlugin.onBeforeAll).toHaveBeenCalled();
-        });
-      });
-
       describe('onTestStart', () => {
         it('should call onTestStart in plugins with the passed argument', async () => {
           const testSummary = testSummaries.running();
@@ -366,11 +355,11 @@ describe('ArtifactsManager', () => {
         });
       });
 
-      describe('onAfterAll', () => {
-        it('should call onAfterAll in plugins', async () => {
-          expect(testPlugin.onAfterAll).not.toHaveBeenCalled();
-          await artifactsManager.onAfterAll();
-          expect(testPlugin.onAfterAll).toHaveBeenCalled();
+      describe('onBeforeCleanup', () => {
+        it('should call onBeforeCleanup in plugins', async () => {
+          expect(testPlugin.onBeforeCleanup).not.toHaveBeenCalled();
+          await artifactsManager.onBeforeCleanup();
+          expect(testPlugin.onBeforeCleanup).toHaveBeenCalled();
         });
       });
 

--- a/detox/src/artifacts/log/LogArtifactPlugin.js
+++ b/detox/src/artifacts/log/LogArtifactPlugin.js
@@ -11,8 +11,8 @@ class LogArtifactPlugin extends StartupAndTestRecorderPlugin {
     super({ api });
   }
 
-  async onAfterAll() {
-    await super.onAfterAll();
+  async onBeforeCleanup() {
+    await super.onBeforeCleanup();
 
     if (this.shouldKeepArtifactOfSession()) {
       this.api.requestIdleCallback(async () => {

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
@@ -11,7 +11,7 @@ const log = require('../../../utils/logger').child({ __filename });
 class ArtifactPlugin {
   constructor({ api }) {
     this.api = api;
-    this.context = {};
+    this.context = { testSummary: null };
     this.enabled = api.userConfig.enabled;
     this.keepOnlyFailedTestsArtifacts = api.userConfig.keepOnlyFailedTestsArtifacts;
     this.priority = 16;
@@ -171,19 +171,6 @@ class ArtifactPlugin {
   async onCreateExternalArtifact(event) {}
 
   /**
-   * Hook that is called before any test begins
-   *
-   * @protected
-   * @async
-   * @return {Promise<void>} - when done
-   */
-  async onBeforeAll() {
-    this.context.testSummary = null;
-    this._hasFailingTests = false;
-    this._finishedTests = false;
-  }
-
-  /**
    * Hook that is called before a test begins
    *
    * @protected
@@ -210,13 +197,13 @@ class ArtifactPlugin {
   }
 
   /**
-   * Hook that is called after all tests run
+   * Hook that is called when detox.cleanup() just begins
    *
    * @protected
    * @async
    * @return {Promise<void>} - when done
    */
-  async onAfterAll() {
+  async onBeforeCleanup() {
     this.context.testSummary = null;
     this._finishedTests = true;
     this._logDisableWarning();
@@ -241,10 +228,9 @@ class ArtifactPlugin {
     this.onBeforeLaunchApp = _.noop;
     this.onLaunchApp = _.noop;
     this.onUserAction = _.noop;
-    this.onBeforeAll = _.noop;
     this.onTestStart = _.noop;
     this.onTestDone = _.noop;
-    this.onAfterAll = _.noop;
+    this.onBeforeCleanup = _.noop;
   }
 
   _logDisableWarning() {

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.test.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.test.js
@@ -199,12 +199,6 @@ describe('ArtifactPlugin', () => {
       })).resolves.toBe(void 0);
     });
 
-    it('should have .onBeforeAll, which resets context.testSummary if called', async () => {
-      plugin.context.testSummary = {};
-      await plugin.onBeforeAll();
-      expect(plugin.context.testSummary).toBe(null);
-    });
-
     it('should have .onTestStart, which updates context.testSummary if called', async () => {
       const testSummary = testSummaries.running();
       await plugin.onTestStart(testSummary);
@@ -217,9 +211,9 @@ describe('ArtifactPlugin', () => {
       expect(plugin.context.testSummary).toBe(testSummary);
     });
 
-    it('should have .onAfterAll, which resets context.testSummary if called', async () => {
+    it('should have .onBeforeCleanup, which resets context.testSummary if called', async () => {
       plugin.context.testSummary = {};
-      await plugin.onAfterAll();
+      await plugin.onBeforeCleanup();
       expect(plugin.context.testSummary).toBe(null);
     });
 
@@ -240,10 +234,9 @@ describe('ArtifactPlugin', () => {
         expect(plugin.onLaunchApp).toBe(plugin.onTerminate);
         expect(plugin.onBeforeTerminateApp).toBe(plugin.onTerminate);
         expect(plugin.onTerminateApp).toBe(plugin.onTerminate);
-        expect(plugin.onBeforeAll).toBe(plugin.onTerminate);
         expect(plugin.onTestStart).toBe(plugin.onTerminate);
         expect(plugin.onTestDone).toBe(plugin.onTerminate);
-        expect(plugin.onAfterAll).toBe(plugin.onTerminate);
+        expect(plugin.onBeforeCleanup).toBe(plugin.onTerminate);
         expect(plugin.onUserAction).toBe(plugin.onTerminate);
       });
 

--- a/detox/src/artifacts/templates/plugin/StartupAndTestRecorderPlugin.js
+++ b/detox/src/artifacts/templates/plugin/StartupAndTestRecorderPlugin.js
@@ -53,14 +53,14 @@ class StartupAndTestRecorderPlugin extends WholeTestRecorderPlugin {
     }
   }
 
-  async onAfterAll() {
-    await super.onAfterAll();
+  async onBeforeCleanup() {
+    await super.onBeforeCleanup();
 
     if (this.startupRecording) {
       this._tryToFinalizeStartupRecording();
     }
 
-    await super.onAfterAll();
+    await super.onBeforeCleanup();
   }
 
   /***

--- a/detox/src/artifacts/templates/plugin/StartupAndTestRecorderPlugin.test.js
+++ b/detox/src/artifacts/templates/plugin/StartupAndTestRecorderPlugin.test.js
@@ -48,11 +48,11 @@ describe('StartupAndTestRecorderPlugin', () => {
       it('should end correctly, but do nothing', expectThatNothingActuallyHappens);
     });
 
-    describe('onAfterAll', () => {
+    describe('onBeforeCleanup', () => {
       beforeEach(async () => {
         await plugin.onTestStart(testSummaries.running());
         await plugin.onTestDone(testSummaries.failed());
-        await plugin.onAfterAll();
+        await plugin.onBeforeCleanup();
       });
 
       it('should end correctly, but do nothing', expectThatNothingActuallyHappens);
@@ -184,7 +184,7 @@ describe('StartupAndTestRecorderPlugin', () => {
     });
   });
 
-  describe('onAfterAll', () => {
+  describe('onBeforeCleanup', () => {
     describe('when the plugin is configured to keep all artifacts', () => {
       beforeEach(() => {
         plugin.keepOnlyFailedTestsArtifacts = false;
@@ -193,7 +193,7 @@ describe('StartupAndTestRecorderPlugin', () => {
       describe('when there were no calls to .onTestStart and .onTestDone', () => {
         beforeEach(async () => {
           await plugin.onReadyToRecord();
-          await plugin.onAfterAll();
+          await plugin.onBeforeCleanup();
         });
 
         it('should schedule saving of the start-up recording', () => {
@@ -252,7 +252,7 @@ describe('StartupAndTestRecorderPlugin', () => {
           await plugin.onReadyToRecord();
 
           api.requestIdleCallback.mockClear();
-          await plugin.onAfterAll();
+          await plugin.onBeforeCleanup();
         });
 
         itShouldScheduleDiscardingAndUntrackingOfStartupArtifact();
@@ -265,7 +265,7 @@ describe('StartupAndTestRecorderPlugin', () => {
           await plugin.onTestDone(testSummaries.passed());
 
           api.requestIdleCallback.mockClear();
-          await plugin.onAfterAll();
+          await plugin.onBeforeCleanup();
         });
 
         itShouldScheduleDiscardingAndUntrackingOfStartupArtifact();

--- a/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.js
+++ b/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.js
@@ -37,8 +37,8 @@ class TwoSnapshotsPerTestPlugin extends ArtifactPlugin {
     this._flushSessionSnapshots();
   }
 
-  async onAfterAll() {
-    await super.onAfterAll();
+  async onBeforeCleanup() {
+    await super.onBeforeCleanup();
     this._flushSessionSnapshots();
   }
 

--- a/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.test.js
+++ b/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.test.js
@@ -193,7 +193,7 @@ describe('TwoSnapshotsPerTestPlugin', () => {
       });
     });
 
-    describe('when an external snapshot is created before afterAll', function() {
+    describe('when an external snapshot is created before Detox cleanup', function() {
       let artifact;
 
       beforeEach(async () => {
@@ -205,7 +205,7 @@ describe('TwoSnapshotsPerTestPlugin', () => {
           artifact,
           name: 'final_name',
         });
-        await plugin.onAfterAll();
+        await plugin.onBeforeCleanup();
       });
 
       it('should be saved using the suggested name and untracked', async () => {


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

This is the second step to implement: https://github.com/wix/Detox/issues/1661 .

This pull request returns the original meaning to `before all` and `after all` events from Detox terminology, which is `onAfterInit` and `onBeforeCleanup`, if we are honest.

However, after looking at the code, I have found out that the former `onBeforeAll` is no longer in use, apparently, after the SimulatorLogPlugin refactoring in the past year. That's why I just remove the unused code.

The new naming reflects much more closely the actual workflow in Detox artifacts manager.

The full solution of #1661 will be too voluminous for one pull request and involve way too many files for a human reviewer's eye, hence I'll be splitting it into micro-PRs like #1845 and this one.
