### PR TITLE
(Android) Apply existing tap improvements and adjustments to tapAtPoint()

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxAction.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxAction.java
@@ -1,11 +1,10 @@
 package com.wix.detox.espresso;
 
-import android.view.InputDevice;
-import android.view.MotionEvent;
 import android.view.View;
 
 import com.wix.detox.espresso.DetoxErrors.DetoxRuntimeException;
 import com.wix.detox.espresso.DetoxErrors.StaleActionException;
+import com.wix.detox.espresso.action.RNClickAction;
 import com.wix.detox.espresso.common.annot.MotionDir;
 import com.wix.detox.espresso.scroll.ScrollEdgeException;
 import com.wix.detox.espresso.scroll.ScrollHelper;
@@ -20,7 +19,6 @@ import androidx.test.espresso.action.GeneralLocation;
 import androidx.test.espresso.action.GeneralSwipeAction;
 import androidx.test.espresso.action.Press;
 import androidx.test.espresso.action.Swipe;
-import androidx.test.espresso.action.Tap;
 
 import static androidx.test.espresso.action.ViewActions.actionWithAssertions;
 import static androidx.test.espresso.action.ViewActions.swipeDown;
@@ -61,12 +59,10 @@ public class DetoxAction {
                 view.getLocationOnScreen(xy);
                 final float fx = xy[0] + px;
                 final float fy = xy[1] + py;
-                float[] coordinates = {fx, fy};
-                return coordinates;
+                return new float[] {fx, fy};
             }
         };
-        return actionWithAssertions(new GeneralClickAction(
-                Tap.SINGLE, c, Press.FINGER, InputDevice.SOURCE_UNKNOWN, MotionEvent.BUTTON_PRIMARY));
+        return actionWithAssertions(new RNClickAction(c));
     }
 
     /**

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/RNClickAction.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/RNClickAction.java
@@ -10,6 +10,7 @@ import org.hamcrest.Matcher;
 
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.action.CoordinatesProvider;
 import androidx.test.espresso.action.GeneralClickAction;
 import androidx.test.espresso.action.GeneralLocation;
 import androidx.test.espresso.action.Press;
@@ -17,13 +18,25 @@ import androidx.test.espresso.action.Press;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
 
 public class RNClickAction implements ViewAction {
-    private final GeneralClickAction clickAction =
-            new GeneralClickAction(
-                new DetoxSingleTap(),
-                GeneralLocation.VISIBLE_CENTER,
-                Press.FINGER,
-                InputDevice.SOURCE_UNKNOWN,
-                MotionEvent.BUTTON_PRIMARY);
+    private final GeneralClickAction clickAction;
+
+    public RNClickAction() {
+        clickAction = new GeneralClickAction(
+                        new DetoxSingleTap(),
+                        GeneralLocation.VISIBLE_CENTER,
+                        Press.FINGER,
+                        InputDevice.SOURCE_UNKNOWN,
+                        MotionEvent.BUTTON_PRIMARY);
+    }
+
+    public RNClickAction(CoordinatesProvider coordinatesProvider) {
+        clickAction = new GeneralClickAction(
+                        new DetoxSingleTap(),
+                        coordinatesProvider,
+                        Press.FINGER,
+                        InputDevice.SOURCE_UNKNOWN,
+                        MotionEvent.BUTTON_PRIMARY);
+    }
 
     @Override
     public Matcher<View> getConstraints() {


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue # and the solution has been agreed upon with maintainers.

---

**Description:**

Except for offsets calculation, reimplement `tapAtPoint()` so as to apply existing fixes and adjustment implemented in `tap()`.