### PR TITLE
Add clearer logging when detox init fails

### DIFF
--- a/detox/src/index.js
+++ b/detox/src/index.js
@@ -4,7 +4,12 @@ let detox;
 
 async function init(config, params) {
   detox = new Detox(config);
-  await detox.init(params);
+  try {
+    await detox.init(params);
+  } catch (e) {
+    console.error(`Error during detox initialization: ${e.message}`);
+    throw e;
+  }
 }
 
 async function cleanup() {

--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -1,11 +1,14 @@
 const schemes = require('./configurations.mock');
 describe('index', () => {
-  let detox;
+  let detox, mockDetox;
   beforeEach(() => {
     jest.mock('detox-server');
     jest.mock('./devices/Device');
     jest.mock('./client/Client');
+    jest.mock('./Detox');
+    mockDetox = require('./Detox');
     detox = require('./index');
+    global.console.error = jest.fn();
   });
 
   it(`Basic usage`, async() => {
@@ -15,6 +18,18 @@ describe('index', () => {
 
   it(`Basic usage, if detox is undefined, do not throw an error`, async() => {
     await detox.cleanup();
+  });
+
+  it('Basic usage, if init throws, log a clear explanation', async () => {
+    mockDetox.mockImplementation(() => ({
+      init: () => Promise.reject(new Error('Some tragic event occurred'))
+    }));
+    try {
+      await detox.init(schemes.validOneDeviceNoSession);
+    } catch (e) {
+      expect(e).toBeDefined();
+      expect(global.console.error).toHaveBeenCalledWith('Error during detox initialization: Some tragic event occurred');
+    }
   });
 
   it(`beforeEach() should be covered - with detox initialized`, async() => {


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
When detox init fails for any reason, the only indication is that the global injection does not happen and so globals like device and element are undefined.

This PR adds an explicit log that in it failed, without changing any other behaviour.