### PR TITLE
Changed log stream predicate from processImagePath to process==

### DIFF
--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const path = require('path');
 const {joinArgs} = require('../../utils/argparse');
 const exec = require('../../utils/exec');
 const log = require('../../utils/logger').child({ __filename });
@@ -299,7 +300,8 @@ class AppleSimUtils {
 
   async _printLoggingHint(udid, bundleId) {
     const appContainer = await this.getAppContainer(udid, bundleId);
-    const predicate = `processImagePath beginsWith "${appContainer}"`;
+    const CFBundleExecutable = await exec.execAsync(`/usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "${path.join(appContainer, 'Info.plist')}"`);
+    const predicate = `process == ${CFBundleExecutable}`;
     const command = `/usr/bin/xcrun simctl spawn ${udid} log stream --level debug --style compact --predicate '${predicate}'`;
 
     log.info(`${bundleId} launched. To watch simulator logs, run:\n        ${command}`);

--- a/detox/src/utils/exec.js
+++ b/detox/src/utils/exec.js
@@ -158,9 +158,13 @@ async function interruptProcess(childProcessPromise, signal = 'SIGINT') {
   });
 }
 
+async function execAsync(command) {
+  const result = await exec(command);
+  return _.trim(result.stdout);
+}
 module.exports = {
   execWithRetriesAndLogs,
   spawnAndLog,
   interruptProcess,
+  execAsync
 };
-

--- a/detox/src/utils/exec.test.js
+++ b/detox/src/utils/exec.test.js
@@ -277,6 +277,12 @@ describe('spawn', () => {
     expect(log.error).toBeCalledWith(expect.objectContaining({ event: 'SPAWN_ERROR' }), 'command failed with code = -2');
     expect(log.error).toBeCalledWith(expect.objectContaining({ event: 'SPAWN_STDERR', stderr: true }), 'Command `command` not found.');
   });
+
+  it(`execAsync command with no arguments successfully`, async () => {
+    mockCppSuccessful(cpp);
+    await exec.execAsync('bin');
+    expect(cpp.exec).toHaveBeenCalledWith(`bin`);
+  });
 });
 
 function nextCycle() {

--- a/detox/wallaby.js
+++ b/detox/wallaby.js
@@ -15,6 +15,7 @@ module.exports = function(wallaby) {
       'src/**/*.js',
       'src/**/*.mock.*',
       '!src/**/*.test.js',
+      '__tests__/setupJest.js'
     ],
 
     tests: [


### PR DESCRIPTION
**Description:**
Changed `log stream` predicate from processImagePath to process==. This predicate suites detox much more since it is constant between installs, unlike processImagePath which changes on every reinstallation.
