### PR TITLE
(Android) Friendly-fail test runner if app crashes on launch

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -6,14 +6,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Handler;
 import android.os.Looper;
-import androidx.annotation.NonNull;
 import android.util.Base64;
+import android.util.Log;
 
 import java.util.Arrays;
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 
@@ -118,7 +118,7 @@ public final class Detox {
         sActivityTestRule = activityTestRule;
 
         Intent intent = extractInitialIntent();
-        activityTestRule.launchActivity(intent);
+        sActivityTestRule.launchActivity(intent);
 
         // Kicks off another thread and attaches a Looper to that.
         // The goal is to keep the test thread intact,
@@ -127,14 +127,7 @@ public final class Detox {
             @Override
             public void run() {
                 Looper.prepare();
-                Handler handler = new Handler();
-                handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        DetoxManager detoxManager = new DetoxManager(context);
-                        detoxManager.start();
-                    }
-                });
+                new DetoxManager(context).start();
                 Looper.loop();
             }
         }, "com.wix.detox.manager");
@@ -144,7 +137,7 @@ public final class Detox {
             t.join();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new RuntimeException("Got interrupted", e);
+            throw new RuntimeException("Detox got interrupted prematurely", e);
         }
     }
 

--- a/detox/android/detox/src/main/java/com/wix/detox/DetoxManager.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/DetoxManager.java
@@ -74,10 +74,15 @@ class DetoxManager implements WebSocketClient.ActionHandler {
 
     void start() {
         if (detoxServerUrl != null && detoxSessionId != null) {
-            initReactNativeIfNeeded();
-            initWSClient();
-            initCrashHandler();
-            initActionHandlers();
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    initReactNativeIfNeeded();
+                    initWSClient();
+                    initCrashHandler();
+                    initActionHandlers();
+                }
+            });
         }
     }
 

--- a/detox/src/devices/drivers/AndroidDriver.js
+++ b/detox/src/devices/drivers/AndroidDriver.js
@@ -19,6 +19,7 @@ const ADBScreencapPlugin = require('../../artifacts/screenshot/ADBScreencapPlugi
 const ADBScreenrecorderPlugin = require('../../artifacts/video/ADBScreenrecorderPlugin');
 const AndroidDevicePathBuilder = require('../../artifacts/utils/AndroidDevicePathBuilder');
 const temporaryPath = require('../../artifacts/utils/temporaryPath');
+const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
 const sleep = require('../../utils/sleep');
 const retry = require('../../utils/retry');
 const { interruptProcess, spawnAndLog } = require('../../utils/exec');
@@ -32,9 +33,10 @@ class AndroidDriver extends DeviceDriverBase {
   constructor(config) {
     super(config);
 
-    this.instrumentationLogsParser = new InstrumentationLogsParser();
+    this.instrumentationLogsParser = null;
     this.instrumentationProcess = null;
     this.instrumentationStackTrace = '';
+    this.instrumentationCloseListener = _.noop;
 
     this.invocationManager = new InvocationManager(this.client);
     this.matchers = new AndroidExpect(this.invocationManager);
@@ -97,7 +99,7 @@ class AndroidDriver extends DeviceDriverBase {
   async launchApp(deviceId, bundleId, launchArgs, languageAndLocale) {
     await this.emitter.emit('beforeLaunchApp', { deviceId, bundleId, launchArgs });
 
-    if (!this.instrumentationProcess) {
+    if (!this._isInstrumentationRunning()) {
       await this._launchInstrumentationProcess(deviceId, bundleId, launchArgs);
       await sleep(500);
     } else {
@@ -131,21 +133,17 @@ class AndroidDriver extends DeviceDriverBase {
   }
 
   async waitUntilReady() {
-    let intervalId;
-    try {
+      try {
         await Promise.race([
           super.waitUntilReady(),
           new Promise((resolve, reject) => {
-            intervalId = setInterval(() => {
-              if (!this.instrumentationProcess) {
-                reject(new Error('Failed to run application on the device; Stack-trace dump:\n' + this.instrumentationStackTrace));
-              }
-            }, 100);
+            this.instrumentationCloseListener = () => reject(this._getInstrumentationCrashError());
+            !this._isInstrumentationRunning() && this.instrumentationCloseListener();
           }),
         ]);
-    } finally {
-      !_.isUndefined(intervalId) && clearInterval(intervalId);
-    }
+      } finally {
+        this.instrumentationCloseListener = _.noop;
+      }
   }
 
   async sendToHome(deviceId, params) {
@@ -160,10 +158,23 @@ class AndroidDriver extends DeviceDriverBase {
   }
 
   async _terminateInstrumentation() {
-    if (this.instrumentationProcess) {
+    if (this._isInstrumentationRunning()) {
       await interruptProcess(this.instrumentationProcess);
       this.instrumentationProcess = null;
+      this.instrumentationCloseListener();
     }
+  }
+
+  _isInstrumentationRunning() {
+    return !!this.instrumentationProcess;
+  }
+
+  _getInstrumentationCrashError() {
+    return new DetoxRuntimeError({
+      message: 'Failed to run application on the device',
+      hint: 'Most likely, your main activity has crashed prematurely',
+      debugInfo: 'Native stacktrace dump: ' + this.instrumentationStackTrace,
+    });
   }
 
   async cleanup(deviceId, bundleId) {
@@ -239,8 +250,10 @@ class AndroidDriver extends DeviceDriverBase {
     const testRunner = await this.adb.getInstrumentationRunner(deviceId, bundleId);
     const spawnFlags = [`-s`, `${deviceId}`, `shell`, `am`, `instrument`, `-w`, `-r`, ...launchArgs, ...additionalLaunchArgs, testRunner];
 
+    this.instrumentationLogsParser = new InstrumentationLogsParser();
     this.instrumentationProcess = spawnAndLog(this.adb.adbBin, spawnFlags, { detached: false });
-    this.instrumentationProcess.childProcess.stdout.on('data', (raw) => this._extractStackTraceFromInstrumLogs(raw.toString()));
+    this.instrumentationProcess.childProcess.stdout.setEncoding('utf8');
+    this.instrumentationProcess.childProcess.stdout.on('data', this._extractStackTraceFromInstrumLogs.bind(this));
     this.instrumentationProcess.childProcess.on('close', async () => {
       await this._terminateInstrumentation();
       await this.adb.reverseRemove(deviceId, serverPort);
@@ -248,7 +261,9 @@ class AndroidDriver extends DeviceDriverBase {
   }
 
   _extractStackTraceFromInstrumLogs(logsDump) {
-    if (this.instrumentationLogsParser.hasStackTraceLog(logsDump)) {
+    this.instrumentationLogsParser.parse(logsDump);
+
+    if (this.instrumentationLogsParser.containsStackTraceLog(logsDump)) {
       this.instrumentationStackTrace = this.instrumentationLogsParser.getStackTrace(logsDump);
     }
   }

--- a/detox/src/devices/drivers/AndroidDriver.test.js
+++ b/detox/src/devices/drivers/AndroidDriver.test.js
@@ -5,7 +5,6 @@ describe('Android driver', () => {
 
   let logger;
   let client;
-  let mockInstrumLogsParser;
   let exec;
   beforeEach(() => {
     jest.mock('../../utils/encoding', () => ({
@@ -35,6 +34,7 @@ describe('Android driver', () => {
         childProcess: {
           on: jest.fn(),
           stdout: {
+            setEncoding: jest.fn(),
             on: jest.fn(),
           }
         }
@@ -91,7 +91,8 @@ describe('Android driver', () => {
         await promise;
         fail('Expected an error and none was thrown');
       } catch (e) {
-        expect(e.message).toEqual('Failed to run application on the device; Stack-trace dump:\nStacktrace mock');
+        expect(e.message).toContain('DetoxRuntimeError: Failed to run application on the device');
+        expect(e.message).toContain(`Native stacktrace dump: ${mockInstrumentationLogsParserClass.INSTRUMENTATION_STACKTRACE_MOCK}`);
       } finally {
         clientWaitResolve();
       }
@@ -246,7 +247,9 @@ class mockAsyncEmitter {
 
 class mockInstrumentationLogsParserClass {
   constructor() {
-    this.hasStackTraceLog = () => true;
-    this.getStackTrace = () => 'Stacktrace mock';
+    this.parse = () => {};
+    this.containsStackTraceLog = () => true;
+    this.getStackTrace = () => mockInstrumentationLogsParserClass.INSTRUMENTATION_STACKTRACE_MOCK;
   }
 }
+mockInstrumentationLogsParserClass.INSTRUMENTATION_STACKTRACE_MOCK = 'Stacktrace mock';

--- a/detox/src/devices/drivers/InstrumentationLogsParser.js
+++ b/detox/src/devices/drivers/InstrumentationLogsParser.js
@@ -1,0 +1,42 @@
+const INSTRUMENTATION_LOGS_PREFIX = 'INSTRUMENTATION_STATUS';
+const STACKTRACE_PREFIX_TEXT = INSTRUMENTATION_LOGS_PREFIX + ': stack=';
+
+class InstrumentationLogsParser {
+  hasStackTraceLog(logsDump) {
+    return logsDump.includes(STACKTRACE_PREFIX_TEXT);
+  }
+
+  getStackTrace(logsDump) {
+    const logLines = logsDump.split('\n');
+
+    const index = this._findStackTraceLog(logLines);
+    const stackTrace = this._extractStackTrace(logLines, index);
+    return stackTrace;
+  }
+
+  _findStackTraceLog(logLines) {
+    let i;
+    for (i = 0; i < logLines.length && !logLines[i].includes(STACKTRACE_PREFIX_TEXT); i++) {}
+    return i;
+  }
+
+  _extractStackTrace(logLines, i) {
+    if (i < logLines.length) {
+      logLines[i] = logLines[i].replace(STACKTRACE_PREFIX_TEXT, '');
+    }
+
+    let stackTrace = '';
+    for (
+      ; i < logLines.length
+        && logLines[i].trim()
+        && !logLines[i].includes(INSTRUMENTATION_LOGS_PREFIX)
+      ; i++) {
+      stackTrace = stackTrace.concat(logLines[i], '\n');
+    }
+    return stackTrace;
+  }
+}
+
+module.exports = {
+  InstrumentationLogsParser
+};

--- a/detox/src/devices/drivers/InstrumentationLogsParser.test.js
+++ b/detox/src/devices/drivers/InstrumentationLogsParser.test.js
@@ -1,0 +1,48 @@
+describe('Instrumentation logs parser', () => {
+  describe('stack trace parser', () => {
+    let uut;
+    beforeEach(() => {
+      const { InstrumentationLogsParser } = require('./InstrumentationLogsParser');
+      uut = new InstrumentationLogsParser();
+    });
+
+    it('should query stacktrace for false for a no-string', () => {
+      const logsDump = '';
+      expect(uut.hasStackTraceLog(logsDump)).toEqual(false);
+    });
+
+    it('should query stacktrace for true for a log matching the stacktrace prefix', () => {
+      const logsDump = 'INSTRUMENTATION_STATUS: stack=';
+      expect(uut.hasStackTraceLog(logsDump)).toEqual(true);
+    });
+
+    it('should query stacktrack for true for a log that holds the stacktrace prefix alongside other stuff', () => {
+      const logsDump = [
+        'INSTRUMENTATION_STATUS: stream=\ncom.example.DetoxTest',
+        'INSTRUMENTATION_STATUS: stack=stackFrame1\n    stackFrame2',
+        'INSTRUMENTATION_STATUS: id=AndroidJUnitRunner',
+      ].join('\n');
+      expect(uut.hasStackTraceLog(logsDump)).toEqual(true);
+    });
+
+    it('should return empty stacktrace for a no-string', () => {
+      const logsDump = '';
+      expect(uut.getStackTrace(logsDump)).toEqual('');
+    });
+
+    it('should return stacktrace for a stack-trace logs dump', () => {
+      const logsDump = 'INSTRUMENTATION_STATUS: stack=stackFrame1\n    stackFrame2\n';
+      expect(uut.getStackTrace(logsDump)).toEqual('stackFrame1\n    stackFrame2\n');
+    });
+
+    it('should return stacktrace for a multi-content logs dump', () => {
+      const logsDump = [
+        'INSTRUMENTATION_STATUS: stream=\ncom.example.DetoxTest',
+        'INSTRUMENTATION_STATUS: stack=stackFrame1\n    stackFrame2',
+        'INSTRUMENTATION_STATUS_CODE: 1',
+        'INSTRUMENTATION_STATUS: id=AndroidJUnitRunner',
+      ].join('\n');
+      expect(uut.getStackTrace(logsDump)).toEqual('stackFrame1\n    stackFrame2\n');
+    });
+  });
+});

--- a/detox/src/devices/drivers/InstrumentationLogsParser.test.js
+++ b/detox/src/devices/drivers/InstrumentationLogsParser.test.js
@@ -8,41 +8,78 @@ describe('Instrumentation logs parser', () => {
 
     it('should query stacktrace for false for a no-string', () => {
       const logsDump = '';
-      expect(uut.hasStackTraceLog(logsDump)).toEqual(false);
+      uut.parse(logsDump);
+      expect(uut.containsStackTraceLog()).toEqual(false);
     });
 
     it('should query stacktrace for true for a log matching the stacktrace prefix', () => {
-      const logsDump = 'INSTRUMENTATION_STATUS: stack=';
-      expect(uut.hasStackTraceLog(logsDump)).toEqual(true);
+      const logsDump = 'INSTRUMENTATION_STATUS: stack=\n\n';
+      uut.parse(logsDump);
+      expect(uut.containsStackTraceLog()).toEqual(true);
     });
 
-    it('should query stacktrack for true for a log that holds the stacktrace prefix alongside other stuff', () => {
+    it('should query stacktrace for true for a log that holds the stacktrace prefix alongside other stuff', () => {
       const logsDump = [
-        'INSTRUMENTATION_STATUS: stream=\ncom.example.DetoxTest',
-        'INSTRUMENTATION_STATUS: stack=stackFrame1\n    stackFrame2',
-        'INSTRUMENTATION_STATUS: id=AndroidJUnitRunner',
-      ].join('\n');
-      expect(uut.hasStackTraceLog(logsDump)).toEqual(true);
+        'INSTRUMENTATION_STATUS: stream=\ncom.example.DetoxTest\n',
+        'INSTRUMENTATION_STATUS: stack=stackFrame1\n\tstackFrame2\n\n',
+        'INSTRUMENTATION_STATUS: id=AndroidJUnitRunner\n',
+      ].join('');
+      uut.parse(logsDump);
+      expect(uut.containsStackTraceLog()).toEqual(true);
     });
 
     it('should return empty stacktrace for a no-string', () => {
       const logsDump = '';
+      uut.parse(logsDump);
       expect(uut.getStackTrace(logsDump)).toEqual('');
     });
 
     it('should return stacktrace for a stack-trace logs dump', () => {
-      const logsDump = 'INSTRUMENTATION_STATUS: stack=stackFrame1\n    stackFrame2\n';
-      expect(uut.getStackTrace(logsDump)).toEqual('stackFrame1\n    stackFrame2\n');
+      const logsDump = 'INSTRUMENTATION_STATUS: stack=stackFrame1\n\tstackFrame2\n\n';
+      uut.parse(logsDump);
+      expect(uut.getStackTrace(logsDump)).toEqual('stackFrame1\n\tstackFrame2\n');
     });
 
     it('should return stacktrace for a multi-content logs dump', () => {
       const logsDump = [
-        'INSTRUMENTATION_STATUS: stream=\ncom.example.DetoxTest',
-        'INSTRUMENTATION_STATUS: stack=stackFrame1\n    stackFrame2',
-        'INSTRUMENTATION_STATUS_CODE: 1',
-        'INSTRUMENTATION_STATUS: id=AndroidJUnitRunner',
-      ].join('\n');
-      expect(uut.getStackTrace(logsDump)).toEqual('stackFrame1\n    stackFrame2\n');
+        'INSTRUMENTATION_STATUS: stream=\ncom.example.DetoxTest\n',
+        'INSTRUMENTATION_STATUS: stack=stackFrame1\n\tstackFrame2\n\n',
+        'INSTRUMENTATION_STATUS_CODE: 1\n',
+        'INSTRUMENTATION_STATUS: id=AndroidJUnitRunner\n',
+      ].join('');
+
+      uut.parse(logsDump);
+      expect(uut.getStackTrace()).toEqual('stackFrame1\n\tstackFrame2\n');
+    });
+
+    it('should return stacktrace for a stack split across 2 log dumps', () => {
+      const logsDump1 = [
+        'INSTRUMENTATION_STATUS: stream=\ncom.example.DetoxTest\n',
+        'INSTRUMENTATION_STATUS: stack=stackFrame1\n',
+      ].join('');
+      const logsDump2 = [
+        '\tstackFrame2\n\n',
+        'INSTRUMENTATION_STATUS_CODE: 1\n',
+      ].join('');
+
+      uut.parse(logsDump1);
+      uut.parse(logsDump2);
+      expect(uut.getStackTrace()).toEqual('stackFrame1\n\tstackFrame2\n');
+    });
+
+    it('should return stacktrace for a split-stack cut in prefix', () => {
+      const logsDump1 = [
+        'INSTRUMENTATION_STATUS: stream=\ncom.example.DetoxTest\n',
+        'INSTRUM',
+      ].join('');
+      const logsDump2 = [
+        'ENTATION_STATUS: stack=stackFrame1\n\tstackFrame2\n\n',
+        'INSTRUMENTATION_STATUS_CODE: 1\n',
+      ].join('');
+
+      uut.parse(logsDump1);
+      uut.parse(logsDump2);
+      expect(uut.getStackTrace()).toEqual('stackFrame1\n\tstackFrame2\n');
     });
   });
 });

--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -2,20 +2,16 @@ package com.example;
 
 import android.os.Bundle;
 
-import androidx.test.filters.LargeTest;
-import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.ActivityTestRule;
-
 import com.wix.detox.Detox;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/**
- * Created by simonracz on 28/05/2017.
- */
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
@@ -26,7 +22,10 @@ public class DetoxTest {
      * Important so as to allow for some testing of Detox in this particular mode, which has been proven to introduce caveats.
      * </br>Here for internal usage; Not external-API related.
      */
-    private static final String SINGLE_INSTANCE_ACTIVITY_ARG = "androidSingleInstanceActivity";
+    private static final String USE_SINGLE_INSTANCE_ACTIVITY_ARG = "detoxAndroidSingleInstanceActivity";
+
+    /** Similar concept to that of {@link #USE_SINGLE_INSTANCE_ACTIVITY_ARG}. */
+    private static final String USE_CRASHING_ACTIVITY_ARG = "detoxAndroidCrashingActivity";
 
     @Rule
     public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
@@ -34,11 +33,20 @@ public class DetoxTest {
     @Rule
     public ActivityTestRule<SingleInstanceActivity> mSingleInstanceActivityRule = new ActivityTestRule<>(SingleInstanceActivity.class, false, false);
 
+    @Rule
+    public ActivityTestRule<CrashingActivity> mCrashingActivityTestRule = new ActivityTestRule<>(CrashingActivity.class, false, false);
+
     @Test
     public void runDetoxTests() {
         final Bundle arguments = InstrumentationRegistry.getArguments();
-        final boolean forceSingleTaskActivity = Boolean.parseBoolean(arguments.getString(SINGLE_INSTANCE_ACTIVITY_ARG, "false"));
-        final ActivityTestRule<?> rule = forceSingleTaskActivity ? mSingleInstanceActivityRule : mActivityRule;
+        final boolean useSingleTaskActivity = Boolean.parseBoolean(arguments.getString(USE_SINGLE_INSTANCE_ACTIVITY_ARG, "false"));
+        final boolean useCrashingActivity = Boolean.parseBoolean(arguments.getString(USE_CRASHING_ACTIVITY_ARG, "false"));
+        final ActivityTestRule<?> rule =
+                useSingleTaskActivity
+                        ? mSingleInstanceActivityRule
+                        : useCrashingActivity
+                            ? mCrashingActivityTestRule
+                            : mActivityRule;
         Detox.runTests(rule);
     }
 }

--- a/detox/test/android/app/src/main/AndroidManifest.xml
+++ b/detox/test/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     package="com.example"
     android:versionCode="1"
     android:versionName="1.0"
@@ -56,10 +55,17 @@
             <category android:name="android.intent.category.DEFAULT" />
             <data android:scheme="detoxtesturlscheme.singleinstance"/>
         </intent-filter>
-       </activity>
+      </activity>
 
+      <!--
+       MainActivity flavor that crashes on onResume(), thus keeping Detox from starting.
+       Used by specific Detox E2E tests, inspecting this behavior.
+       -->
+      <activity
+        android:name=".CrashingActivity"
+        android:label="@string/app_name_single_instance"
+        />
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 
     </application>
-
 </manifest>

--- a/detox/test/android/app/src/main/java/com/example/CrashingActivity.java
+++ b/detox/test/android/app/src/main/java/com/example/CrashingActivity.java
@@ -1,0 +1,9 @@
+package com.example;
+
+public class CrashingActivity extends MainActivity {
+    @Override
+    protected void onResume() {
+        super.onResume();
+        throw new IllegalStateException("This is an intentional crash!");
+    }
+}

--- a/detox/test/android/app/src/main/java/com/example/MainActivity.java
+++ b/detox/test/android/app/src/main/java/com/example/MainActivity.java
@@ -12,5 +12,4 @@ public class MainActivity extends ReactActivity {
     protected String getMainComponentName() {
         return "example";
     }
-
 }

--- a/detox/test/android/app/src/main/res/values/strings.xml
+++ b/detox/test/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Detox Test</string>
     <string name="app_name_single_instance">Detox Test (SingleInstance)</string>
+    <string name="app_name_crashing">Detox Test (Crashing)</string>
 </resources>

--- a/detox/test/e2e/15.urls.test.js
+++ b/detox/test/e2e/15.urls.test.js
@@ -14,7 +14,7 @@ describe('Open URLs', () => {
 
   const withSingleInstanceActivityArgs = () => ({
     url: 'detoxtesturlscheme.singleinstance://such-string',
-    launchArgs: { androidSingleInstanceActivity: true },
+    launchArgs: { detoxAndroidSingleInstanceActivity: true },
   });
 
   [

--- a/detox/test/e2e/19.crash-handling.test.js
+++ b/detox/test/e2e/19.crash-handling.test.js
@@ -1,5 +1,12 @@
 describe('Crash Handling', () => {
-  it('Should throw error upon app crash', async () => {
+  afterAll(async () => {
+    await device.launchApp({
+      newInstance: true,
+      launchArgs: undefined,
+    });
+  });
+
+  it('Should throw error upon internal app crash', async () => {
     await device.reloadReactNative();
     let failed = false;
 
@@ -17,4 +24,18 @@ describe('Crash Handling', () => {
     await device.launchApp({newInstance: false});
     await expect(element(by.text('Sanity'))).toBeVisible();
   });
+
+  it(':android: Should throw error upon app bootstrap crash', async () => {
+    let failed = false;
+    try {
+      await device.launchApp({ newInstance: true, launchArgs: { detoxAndroidCrashingActivity: true }});
+    } catch (e) {
+      console.error(e);
+      failed = true;
+    }
+
+    // This is not effectively needed, as if crash handling doesn't go right launchApp would typically
+    // just hang forever (and thus a timeout will fail the test - not this assertion).
+    if (!failed) throw new Error('Test should have thrown an error, but did not');
+  }, 60000);
 });


### PR DESCRIPTION
- [ ] This is a small change 
- [x] This change has been discussed in issue #1880 and the solution has been agreed upon with maintainers.

---

**Description:**

Fixes #1880 by monitoring instrumentation status immediately after instrumentation launch (i.e. by running the `adb shell am instrument ...` command), alongside waiting for the traditional 'device ready' response from the device. Upon failure, also dumps stacktrace parsed from background-reported instrumentation logs.