### PR TITLE
Tone down tap gesture on Android

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxSingleTap.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxSingleTap.kt
@@ -47,6 +47,19 @@ class DetoxSingleTap(
     }
 
     companion object {
-        private const val EVENTS_TIME_GAP_MS = 10
+        /**
+         * ### IMPORTANT NOTE ON THIS:
+         *
+         * Given the implementation of [UiControllerImpl.injectMotionEventSequence](androidx.test.espresso.base.UiControllerImpl.injectMotionEventSequence) - which
+         * eventually handles the events injection, ideally we would just use 10ms. Actually, in the original implementation, that's what we did.
+         *
+         * However, recently, annoying RN related bugs we can't control suddenly came to be ([this one](https://github.com/software-mansion/react-native-reanimated/issues/596)
+         * in particular), and so in order to comply, we need to try to meet it half-way and use a time gap that's more likely to be applied by a real user,
+         * even though for all we know 10ms is enough for any Android native / pure-RN View. The trade-off here, however, being that the more we wait, the
+         * higher the chance is for a simple tap to accidentally be registered as a _long_ tap (i.e. on slow devices/emulators).
+         * Lastly, With the case of _that_ specific bug, we implicitly indirectly work around it with this approach, because we highly increase
+         * the chance of allowing a frame to be drawn in between the _down_ and _up_ events.
+         */
+        private const val EVENTS_TIME_GAP_MS = 30
     }
 }

--- a/detox/android/detox/src/test/java/com/wix/detox/espresso/action/DetoxSingleTapSpec.kt
+++ b/detox/android/detox/src/test/java/com/wix/detox/espresso/action/DetoxSingleTapSpec.kt
@@ -66,9 +66,8 @@ object DetoxSingleTapSpec: Spek({
             verify(motionEvents).obtainUpEvent(eq(downEvent), any(), eq(coordinates[0]), eq(coordinates[1]))
         }
 
-        // See UIControllerImpl.injectMotionEventSequence()
-        it("should create up event with max time-gap (10ms) to avoid espresso sleep") {
-            val expectedUpEventTime = DEFAULT_EVENT_TIME + 10
+        it("should create up event with a reasonable time-gap (30ms)") {
+            val expectedUpEventTime = DEFAULT_EVENT_TIME + 30
             val coordinates = dontCareCoordinates()
             val precision = dontCarePrecision()
 


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #0 and the solution has been agreed upon with maintainers.

---

**Description:**
In the context of issues such as https://github.com/software-mansion/react-native-reanimated/issues/596, we find that the current implementation of Detox' single-tap - though optimal, can be a bit too rough. We therefore need to unwillingly tone it down a bit, in the very least, until that bug is fixed.