### PR TITLE
Relax androidx.annotation version constraint

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     api 'androidx.test:runner:1.2.0'
     api 'androidx.test:rules:1.2.0'
     api 'androidx.test.ext:junit:1.1.1'
-    api 'androidx.annotation:annotation:1.1.0'
+    api 'androidx.annotation:annotation:1.0.0'
 
     // Version is the latest; Cannot sync with the Github repo (e.g. android/android-test) because the androidx
     // packaging version of associated classes is simply not there...


### PR DESCRIPTION
Relaxes the `androidx.annotation:annotation` version constraint. [Looking at the release notes](https://developer.android.com/jetpack/androidx/releases/annotation#version_110_3), Detox doesn’t seem to use any of the new features exclusive to v1.1.0.

Resolves #1898.