### PR TITLE
feat(local-cli): using cosmiconfig to remove requirement on package.j…

### DIFF
--- a/detox/__tests__/setupJest.js
+++ b/detox/__tests__/setupJest.js
@@ -20,12 +20,17 @@ function callCli(modulePath, cmd) {
   });
 }
 
-function mockPackageJson(mockContent) {
-  jest.mock(path.join(process.cwd(), 'package.json'), () => ({
-    detox: mockContent
+function mockDetoxConfig(mockContent) {
+  jest.mock('cosmiconfig', () => ({
+    cosmiconfigSync: (key) => ({
+      search: () => ({ config: {
+          detox: mockContent
+        }[key]
+      })
+    })
   }));
 }
 
-global.mockPackageJson = mockPackageJson;
+global.mockDetoxConfig = mockDetoxConfig;
 global.callCli = callCli;
 global.IS_RUNNING_DETOX_UNIT_TESTS = true;

--- a/detox/local-cli/build.test.js
+++ b/detox/local-cli/build.test.js
@@ -10,7 +10,7 @@ describe('build', () => {
   });
 
   it('runs the build script if there is only one config', async () => {
-    mockPackageJson({
+    mockDetoxConfig({
       configurations: {
         only: {
           build: 'echo "only"'
@@ -23,7 +23,7 @@ describe('build', () => {
   });
 
   it('runs the build script of selected config', async () => {
-    mockPackageJson({
+    mockDetoxConfig({
       configurations: {
         only: {
           build: 'echo "only"'
@@ -39,7 +39,7 @@ describe('build', () => {
   });
 
   it('fails with multiple configs if none is selected', async () => {
-    mockPackageJson({
+    mockDetoxConfig({
       configurations: {
         only: {
           build: 'echo "only"'
@@ -55,14 +55,14 @@ describe('build', () => {
   });
 
   it('fails without configurations', async () => {
-    mockPackageJson({});
+    mockDetoxConfig({});
 
     await expect(callCli('./build', 'build')).rejects.toThrowErrorMatchingSnapshot();
     expect(mockExec).not.toHaveBeenCalled();
   });
 
   it('fails without build script', async () => {
-    mockPackageJson({
+    mockDetoxConfig({
       configurations: {
         only: {}
       }
@@ -73,7 +73,7 @@ describe('build', () => {
   });
 
   it('fails without build script and configuration', async () => {
-    mockPackageJson({
+    mockDetoxConfig({
       configurations: {
         only: {}
       }

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -6,7 +6,7 @@ const environment = require('../src/utils/environment');
 const DetoxConfigError = require('../src/errors/DetoxConfigError');
 
 const log = require('../src/utils/logger').child({ __filename });
-const {getDetoxSection, getDefaultConfiguration, getConfigurationByKey} = require('./utils/configurationUtils');
+const {getDetoxConfig, getDefaultConfiguration, getConfigurationByKey} = require('./utils/configurationUtils');
 const shellQuote = require('./utils/shellQuote');
 
 module.exports.command = 'test';
@@ -131,7 +131,7 @@ module.exports.builder = {
 const collectExtraArgs = require('./utils/collectExtraArgs')(module.exports.builder);
 
 module.exports.handler = async function test(program) {
-  const config = getDetoxSection();
+  const config = getDetoxConfig();
   const runner = getConfigFor('test-runner') || 'mocha';
   const runnerConfig = getConfigFor('runner-config') || getDefaultRunnerConfig();
 

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -29,7 +29,7 @@ describe('test', () => {
   const mockIOSJestConfiguration = () => mockConfiguration('ios.sim', 'jest');
   const mockAndroidMochaConfiguration = () => mockConfiguration('android.emulator');
   const mockIOSMochaConfiguration = () => mockConfiguration('ios.sim');
-  const mockConfiguration = (deviceType, runner) => mockPackageJson({
+  const mockConfiguration = (deviceType, runner) => mockDetoxConfig({
     'test-runner': runner,
     configurations: {
       only: {

--- a/detox/local-cli/utils/configurationUtils.js
+++ b/detox/local-cli/utils/configurationUtils.js
@@ -1,26 +1,24 @@
 const _ = require('lodash');
-const path = require('path');
+const { cosmiconfigSync } = require('cosmiconfig');
+
+const explorer = cosmiconfigSync("detox")
 
 function hintConfigurations(configurations) {
   return Object.keys(configurations).map(c => `* ${c}`).join('\n')
 }
 
-function getDefaultPathToPackageJson() {
-  return path.join(process.cwd(), 'package.json');
-}
-
-function getDetoxSection(pathToPackageJson = getDefaultPathToPackageJson()) {
-  const { detox } = require(pathToPackageJson);
-  if (!detox) {
-    throw new Error('Cannot find "detox" section in package.json');
+function getDetoxConfig(pathToConfig = process.cwd()) {
+  const result = explorer.search(pathToConfig);
+  if (!result || !result.config) {
+    throw new Error('Cannot find detox configuration');
   }
 
-  return detox;
+  return result.config;
 }
 
-function getDefaultConfiguration(pathToPackageJson = getDefaultPathToPackageJson()) {
+function getDefaultConfiguration(pathToConfig) {
   try {
-    const configurations = require(pathToPackageJson).detox.configurations;
+    const { configurations } = getDetoxConfig(pathToConfig);
     const keys = Object.keys(configurations);
     if (keys.length === 1) {
       return keys[0];
@@ -31,7 +29,7 @@ function getDefaultConfiguration(pathToPackageJson = getDefaultPathToPackageJson
 }
 
 function getConfigurationByKey(key) {
-  const { configurations } = getDetoxSection();
+  const { configurations } = getDetoxConfig();
 
   if (_.isEmpty(configurations)) {
     throw new Error('There are no "configurations" in "detox" section of package.json');
@@ -56,7 +54,7 @@ function getConfigurationByKey(key) {
 }
 
 module.exports = {
-  getDetoxSection,
+  getDetoxConfig,
   getDefaultConfiguration,
   getConfigurationByKey,
 };

--- a/detox/package.json
+++ b/detox/package.json
@@ -43,6 +43,7 @@
     "bunyan-debug-stream": "^1.1.0",
     "chalk": "^2.4.2",
     "child-process-promise": "^2.2.0",
+    "cosmiconfig": "^6.0.0",
     "fs-extra": "^4.0.2",
     "funpermaproxy": "^1.0.1",
     "get-port": "^2.1.0",

--- a/examples/demo-react-native/detox.config.js
+++ b/examples/demo-react-native/detox.config.js
@@ -1,0 +1,50 @@
+module.exports = {
+  'test-runner': 'mocha',
+  'runner-config': 'e2e/mocha.opts',
+  configurations: {
+      'ios.sim.release': {
+          binaryPath: 'ios/build/Build/Products/Release-iphonesimulator/example.app',
+          build: 'export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet',
+          type: 'ios.simulator',
+          device: {
+              type: 'iPhone 11 Pro'
+          }
+      },
+      'ios.sim.debug': {
+          binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/example.app',
+          build: 'xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build',
+          type: 'ios.simulator',
+          device: {
+              type: 'iPhone 11 Pro'
+          }
+      },
+      'ios.none': {
+          binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/example.app',
+          build: 'xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build',
+          type: 'ios.none',
+          device: {
+              type: 'iPhone 11 Pro'
+          },
+          session: {
+              server: 'ws://localhost:8099',
+              sessionId: 'com.wix.demo.react.native'
+          }
+      },
+      'android.emu.debug': {
+          binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
+          build: 'cd android ; ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug ; cd -',
+          type: 'android.emulator',
+          device: {
+              avdName: 'Pixel_API_28'
+          }
+      },
+      'android.emu.release': {
+          binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
+          build: 'cd android ; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release ; cd -',
+          type: 'android.emulator',
+          device: {
+              avdName: 'Pixel_API_28'
+          }
+      }
+  }
+}

--- a/examples/demo-react-native/e2e/init.js
+++ b/examples/demo-react-native/e2e/init.js
@@ -1,5 +1,5 @@
 const detox = require('detox');
-const config = require('../package.json').detox;
+const config = require('../detox.config');
 const adapter = require('detox/runners/mocha/adapter');
 
 before(async () => {

--- a/examples/demo-react-native/e2eExplicitRequire/init.js
+++ b/examples/demo-react-native/e2eExplicitRequire/init.js
@@ -1,5 +1,5 @@
 const detox = require('detox');
-const config = require('../package.json').detox;
+const config = require('../detox.config');
 
 /*
 Example showing how to use Detox with required objects rather than globally exported.

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -25,55 +25,5 @@
   "devDependencies": {
     "detox": "^15.2.2",
     "mocha": "^6.1.3"
-  },
-  "detox": {
-    "test-runner": "mocha",
-    "runner-config": "e2e/mocha.opts",
-    "configurations": {
-      "ios.sim.release": {
-        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-        "build": "export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet",
-        "type": "ios.simulator",
-        "device": {
-          "type": "iPhone 11 Pro"
-        }
-      },
-      "ios.sim.debug": {
-        "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
-        "build": "xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
-        "type": "ios.simulator",
-        "device": {
-          "type": "iPhone 11 Pro"
-        }
-      },
-      "ios.none": {
-        "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
-        "build": "xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
-        "type": "ios.none",
-        "device": {
-          "type": "iPhone 11 Pro"
-        },
-        "session": {
-          "server": "ws://localhost:8099",
-          "sessionId": "com.wix.demo.react.native"
-        }
-      },
-      "android.emu.debug": {
-        "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
-        "build": "cd android ; ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug ; cd -",
-        "type": "android.emulator",
-        "device": {
-          "avdName": "Pixel_API_28"
-        }
-      },
-      "android.emu.release": {
-        "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
-        "build": "cd android ; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release ; cd -",
-        "type": "android.emulator",
-        "device": {
-          "avdName": "Pixel_API_28"
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
…son key

- [x ] This is a small change 

---

**Description:**

It has been long pointed out that the package.json holds much responsibility in the node world, this is from Ryan Dahl himself. The larger a projects gets, the more clutter it can accumulate. 

From this a lot of libraries are now choosing to enable developers to split from the package.json and resolve config from individual files. This single config responsibility can aid in code reviewing, separation of concerns and enabling develops to write config in a language of their choice, from json, to js, to yaml. 

[cosmiconfig](https://www.npmjs.com/package/cosmiconfig) is widely popular util library to enable such a thing without being invasive. This change is backwards compatible and as such would not require any immediate change to the docs.
