### PR TITLE
Add product flavor docs to Android

### DIFF
--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -147,22 +147,22 @@ Use this type to connect to Genymotion emulator.
 
 #### 5a. Using product flavors
 
-Instead of using `debug` and `release` configurations to Detox you may want to use your own [productFlavors](https://developer.android.com/studio/build/build-variants#product-flavors):
+If you are using custom [productFlavors](https://developer.android.com/studio/build/build-variants#product-flavors) the config needs to be applied a bit differently. This example shows how a `beta` product flavor would look for both debug and release build types:
 
 ```json
 "detox" : {
     "configurations": {
-        "android.emu.myProductFlavor.debug": {
-        "binaryPath": "android/app/build/outputs/apk/myProductFlavor/debug/app-myProductFlavor-debug.apk",
-        "build": "cd android && ./gradlew assembleMyProductFlavorDebug assembleMyProductFlavorDebugAndroidTest -DtestBuildType=debug && cd ..",
+        "android.emu.beta.debug": {
+        "binaryPath": "android/app/build/outputs/apk/beta/debug/app-beta-debug.apk",
+        "build": "cd android && ./gradlew assembleBetaDebug assembleBetaDebugAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
         "device": {
           "avdName": "Galaxy_Nexus_API_29"
         }
       },
-      "android.emu.myProductFlavor.release": {
-        "binaryPath": "android/app/build/outputs/apk/myProductFlavor/release/app-myProductFlavor-release.apk",
-        "build": "cd android && ./gradlew assembleMyProductFlavorRelease assembleMyProductFlavorReleaseAndroidTest -DtestBuildType=release && cd ..",
+      "android.emu.beta.release": {
+        "binaryPath": "android/app/build/outputs/apk/beta/release/app-beta-release.apk",
+        "build": "cd android && ./gradlew assembleBetaRelease assembleBetaReleaseAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
         "device": {
           "avdName": "Galaxy_Nexus_API_29"
@@ -171,8 +171,6 @@ Instead of using `debug` and `release` configurations to Detox you may want to u
     }
 }
 ```
-
-Simply add your `productFlavor` name to the configuration, here we have used `myProductFlavor` as an example.
 
 ### 6. Run the tests
 

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -145,6 +145,35 @@ Following device types could be used to control Android devices:
 `android.attached`. Connect to already-attached android device. The device should be listed in the output of `adb devices` command under provided `name`.
 Use this type to connect to Genymotion emulator.
 
+#### 5a. Using product flavors
+
+Instead of using `debug` and `release` configurations to Detox you may want to use your own [productFlavors](https://developer.android.com/studio/build/build-variants#product-flavors):
+
+```json
+"detox" : {
+    "configurations": {
+        "android.emu.myProductFlavor.debug": {
+        "binaryPath": "android/app/build/outputs/apk/myProductFlavor/debug/app-myProductFlavor-debug.apk",
+        "build": "cd android && ./gradlew assembleMyProductFlavorDebug assembleMyProductFlavorDebugAndroidTest -DtestBuildType=debug && cd ..",
+        "type": "android.emulator",
+        "device": {
+          "avdName": "Galaxy_Nexus_API_29"
+        }
+      },
+      "android.emu.myProductFlavor.release": {
+        "binaryPath": "android/app/build/outputs/apk/myProductFlavor/release/app-myProductFlavor-release.apk",
+        "build": "cd android && ./gradlew assembleMyProductFlavorRelease assembleMyProductFlavorReleaseAndroidTest -DtestBuildType=release && cd ..",
+        "type": "android.emulator",
+        "device": {
+          "avdName": "Galaxy_Nexus_API_29"
+        }
+      }
+    }
+}
+```
+
+Simply add your `productFlavor` name to the configuration, here we have used `myProductFlavor` as an example.
+
 ### 6. Run the tests
 
 Using the `android.emu.debug` configuration from above, you can invoke it in the standard way.

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -157,7 +157,7 @@ If you are using custom [productFlavors](https://developer.android.com/studio/bu
         "build": "cd android && ./gradlew assembleBetaDebug assembleBetaDebugAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
         "device": {
-          "avdName": "Galaxy_Nexus_API_29"
+          "avdName": "Pixel_API_29"
         }
       },
       "android.emu.beta.release": {
@@ -165,7 +165,7 @@ If you are using custom [productFlavors](https://developer.android.com/studio/bu
         "build": "cd android && ./gradlew assembleBetaRelease assembleBetaReleaseAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
         "device": {
-          "avdName": "Galaxy_Nexus_API_29"
+          "avdName": "Pixel_API_29"
         }
       }
     }


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 

---

**Description:**

I spent a good few hours trying to work out how to get product flavors working before stumbling across 
 issue https://github.com/wix/Detox/issues/1810.

To help other developers who may want to use [productFlavors](https://developer.android.com/studio/build/build-variants#product-flavors) i've added an example to the Android getting started docs.

