### PR TITLE
Configure lerna to avoid adhering to dangling package-lock files

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -26,6 +26,9 @@
         "generation",
         "."
       ]
+    },
+    "bootstrap": {
+      "npmClientArgs": ["--no-package-lock"]
     }
   }
 }


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

Just stumbled upon an error resulted by this matter. We don't commit nor rely on dep management via `package-lock.json` files so it's better to remove them altogether.