### PR TITLE
feat(artifacts): codec option for simulator video recording

### DIFF
--- a/detox/src/artifacts/video/SimulatorRecordVideoPlugin.js
+++ b/detox/src/artifacts/video/SimulatorRecordVideoPlugin.js
@@ -14,14 +14,14 @@ class SimulatorRecordVideoPlugin extends VideoArtifactPlugin {
   }
 
   createTestRecording() {
-    const { context, appleSimUtils } = this;
+    const { api, context, appleSimUtils } = this;
     const temporaryFilePath = temporaryPath.for.mp4();
     let processPromise = null;
 
     return new Artifact({
       name: 'SimulatorVideoRecording',
       start: async () => {
-        processPromise = appleSimUtils.recordVideo(context.deviceId, temporaryFilePath);
+        processPromise = appleSimUtils.recordVideo(context.deviceId, temporaryFilePath, api.userConfig.simulator);
       },
       stop: async () => {
         if (processPromise) {

--- a/detox/src/devices/ios/AppleSimUtils.js
+++ b/detox/src/devices/ios/AppleSimUtils.js
@@ -232,8 +232,13 @@ class AppleSimUtils {
     });
   }
 
-  recordVideo(udid, destination) {
-    return exec.spawnAndLog('/usr/bin/xcrun', ['simctl', 'io', udid, 'recordVideo', destination]);
+  recordVideo(udid, destination, options = {}) {
+    const args = ['simctl', 'io', udid, 'recordVideo', destination];
+    if (options.codec) {
+      args.push('--codec');
+      args.push(options.codec);
+    }
+    return exec.spawnAndLog('/usr/bin/xcrun', args);
   }
 
   async _execAppleSimUtils(options, statusLogs, retries, interval) {

--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -75,7 +75,9 @@ Detox can control artifacts collection via settings from `package.json`:
           "android": {
             "bitRate": 4000000
           },
-          "simulator": {}
+          "simulator": {
+            "codec": "hevc"
+          }
         }
       }
     },


### PR DESCRIPTION
- [x] This change has been discussed in issue #1912  and the solution has been agreed upon with maintainers.

---

**Description:**

Adds `codec` option to artifacts JSON config (in package.json), e.g.:

```json
{
  "detox": {
    "artifacts": {
      "plugins": {
        "video": {
          "simulator": {
            "codec": "h264"
          }
        }
      }
    }
  }
}
```
