### PR TITLE
(Android) Introduce ANR monitor to produce warn-logs

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     api 'androidx.test:rules:1.2.0'
     api 'androidx.test.ext:junit:1.1.1'
     api 'androidx.annotation:annotation:1.1.0'
+    api 'com.github.anrwatchdog:anrwatchdog:1.4.0'
 
     // Version is the latest; Cannot sync with the Github repo (e.g. android/android-test) because the androidx
     // packaging version of associated classes is simply not there...

--- a/detox/android/detox/src/main/java/com/wix/detox/DetoxANRHandler.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/DetoxANRHandler.kt
@@ -1,0 +1,24 @@
+package com.wix.detox
+
+import android.util.Log
+import com.github.anrwatchdog.ANRWatchDog
+
+class DetoxANRHandler(private val wsClient: WebSocketClient) {
+    fun attach() {
+        ANRWatchDog().setReportMainThreadOnly().setANRListener {
+            val info = mapOf("threadDump" to Log.getStackTraceString(it))
+            wsClient.sendAction(ACTION_NAME, info, MESSAGE_ID)
+        }.start()
+
+        ANRWatchDog().setANRListener {
+            Log.e(LOG_TAG, "App nonresnponsive detection!", it)
+        }.start()
+    }
+
+    companion object {
+        val LOG_TAG: String = DetoxANRHandler::class.java.simpleName
+
+        private const val ACTION_NAME = "AppNonresponsiveDetected"
+        private const val MESSAGE_ID = -10001L
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/DetoxCrashHandler.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/DetoxCrashHandler.kt
@@ -1,22 +1,21 @@
 package com.wix.detox
 
 import android.util.Log
-import org.apache.commons.lang3.exception.ExceptionUtils
 
 class DetoxCrashHandler(private val wsClient: WebSocketClient) {
     fun attach() {
         Thread.setDefaultUncaughtExceptionHandler { thread, exception ->
             Log.e(LOG_TAG, "Crash detected!!! thread=${thread.name} (${thread.id})")
 
-            val crashInfo = mapOf("errorDetails" to "@Thread ${thread.name}(${thread.id}):\n${ExceptionUtils.getStackTrace(exception)}")
-            wsClient.sendAction(APP_CRASH_ACTION_NAME, crashInfo, APP_CRASH_MESSAGE_ID)
+            val crashInfo = mapOf("errorDetails" to "@Thread ${thread.name}(${thread.id}):\n${Log.getStackTraceString(exception)}")
+            wsClient.sendAction(ACTION_NAME, crashInfo, MESSAGE_ID)
         }
     }
 
     companion object {
         val LOG_TAG: String = DetoxCrashHandler::class.java.simpleName
 
-        const val APP_CRASH_ACTION_NAME = "AppWillTerminateWithError"
-        const val APP_CRASH_MESSAGE_ID = -10000L
+        private const val ACTION_NAME = "AppWillTerminateWithError"
+        private const val MESSAGE_ID = -10000L
     }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/DetoxManager.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/DetoxManager.java
@@ -7,6 +7,8 @@ import android.os.Looper;
 import androidx.annotation.NonNull;
 import android.util.Log;
 
+import com.github.anrwatchdog.ANRError;
+import com.github.anrwatchdog.ANRWatchDog;
 import com.wix.detox.instruments.DetoxInstrumentsManager;
 import com.wix.detox.reactnative.ReactNativeExtension;
 import com.wix.detox.systeminfo.Environment;
@@ -72,6 +74,7 @@ class DetoxManager implements WebSocketClient.ActionHandler {
                     initReactNativeIfNeeded();
                     initWSClient();
                     initCrashHandler();
+                    initANRListener();
                     initActionHandlers();
                 }
             });
@@ -136,6 +139,10 @@ class DetoxManager implements WebSocketClient.ActionHandler {
 
     private void initCrashHandler() {
         new DetoxCrashHandler(wsClient).attach();
+    }
+
+    private void initANRListener() {
+        new DetoxANRHandler(wsClient).attach();
     }
 
     private void initActionHandlers() {

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -110,6 +110,10 @@ class Client {
     return crash;
   }
 
+  setNonresponsivenessListener(clientCallback) {
+    this.setActionListener(new actions.AppNonresponsive(), (event) => clientCallback(event.params));
+  }
+
   setActionListener(action, clientCallback) {
     this.ws.setEventCallback(action.messageId, (response) => {
       const parsedResponse = JSON.parse(response);

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -161,6 +161,17 @@ class AppWillTerminateWithError extends Action {
   }
 }
 
+class AppNonresponsive extends Action {
+  constructor(params) {
+    super(params);
+    this.messageId = -10001;
+  }
+
+  handle(response) {
+    this.expectResponseOfType(response, 'AppNonresponsiveDetected');
+  }
+}
+
 module.exports = {
   Login,
   WaitForBackground,
@@ -173,5 +184,6 @@ module.exports = {
   CurrentStatus,
   Shake,
   SetInstrumentsRecordingState,
-  AppWillTerminateWithError
+  AppWillTerminateWithError,
+  AppNonresponsive,
 };

--- a/detox/test/android/app/src/main/java/com/example/NativeModule.java
+++ b/detox/test/android/app/src/main/java/com/example/NativeModule.java
@@ -26,10 +26,11 @@ import java.util.Set;
 
 public class NativeModule extends ReactContextBaseJavaModule {
 
-    public static final String NAME = "NativeModule";
-    ReactApplicationContext reactContext;
+    private static final String NAME = "NativeModule";
 
-    public NativeModule(ReactApplicationContext reactContext) {
+    private ReactApplicationContext reactContext;
+
+    NativeModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
     }
@@ -53,45 +54,31 @@ public class NativeModule extends ReactContextBaseJavaModule {
     public void nativeSetTimeout(int delay, final Callback callback) {
 //        HashMap paramsMap = ((ReadableNativeMap) params).toHashMap();
         Handler handler = new Handler(Looper.getMainLooper());
-
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                callback.invoke();
-            }
-        }, delay);
+        handler.postDelayed(callback::invoke, delay);
     }
 
     @ReactMethod
     public void switchToNativeRoot() {
-        reactContext.getCurrentActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                Activity currentActivity = getCurrentActivity();
+        reactContext.getCurrentActivity().runOnUiThread(() -> {
+            Activity currentActivity = getCurrentActivity();
 
-                LinearLayout layout = new LinearLayout(currentActivity);
-                layout.setGravity(Gravity.CENTER);
-                LinearLayout.LayoutParams llp = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
+            LinearLayout layout = new LinearLayout(currentActivity);
+            layout.setGravity(Gravity.CENTER);
+            LayoutParams llp = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
 
-                TextView tv = new TextView(currentActivity);
-                tv.setText("this is a new native root");
-                LinearLayout.LayoutParams lp = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
-                tv.setLayoutParams(lp);
+            TextView tv = new TextView(currentActivity);
+            tv.setText("this is a new native root");
+            LayoutParams lp = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+            tv.setLayoutParams(lp);
 
-                layout.addView(tv);
-                currentActivity.setContentView(layout, llp);
-            }
+            layout.addView(tv);
+            currentActivity.setContentView(layout, llp);
         });
     }
 
     @ReactMethod
     public void switchToMultipleReactRoots() {
-        reactContext.getCurrentActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-
-            }
-        });
+        reactContext.getCurrentActivity().runOnUiThread(() -> {}); // TODO?
     }
 
     @ReactMethod
@@ -111,6 +98,18 @@ public class NativeModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void spyLongTaps(final String testID) {
         new LongTapCrasher(testID).attach();
+    }
+
+    @ReactMethod
+    public void chokeMainThread() {
+        reactContext.getCurrentActivity().runOnUiThread(() -> {
+            try {
+                Thread.sleep(10500);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     /**

--- a/detox/test/e2e/19.app-responsiveness.test.js
+++ b/detox/test/e2e/19.app-responsiveness.test.js
@@ -1,0 +1,19 @@
+const LogInterceptor = require('./utils/log-interceptor');
+
+describe(':android: App responsiveness', () => {
+  it('should log ANR warning when app nonresponsive', async () => {
+    const logInterceptor = new LogInterceptor();
+
+    try {
+      logInterceptor.startStderr();
+      await element(by.text('ANR')).tap();
+    } finally {
+      logInterceptor.stopAll();
+    }
+
+    if (!logInterceptor.strerrData.includes('APP_NONRESPONSIVE')) {
+      console.error('APP_NONRESPONSIVE warning-log was expected, but got:\n'+logInterceptor.strerrData);
+      fail('APP_NONRESPONSIVE not found in intercepted log');
+    }
+  });
+});

--- a/detox/test/e2e/utils/log-interceptor.js
+++ b/detox/test/e2e/utils/log-interceptor.js
@@ -1,0 +1,29 @@
+class LogInterceptor {
+  constructor() {
+    this._stderrWrite = null;
+    this._stderrData = [];
+  }
+
+  startStderr() {
+    this._stderrWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (...args) => {
+      const [data] = args;
+      this._stderrData.push(data);
+
+      this._stderrWrite(...args);
+    };
+  }
+
+  get strerrData() {
+    return this._stderrData.join('');
+  }
+
+  stopAll() {
+    if (this._stderrWrite) {
+      process.stderr.write = this._stderrWrite;
+      this._stderrWrite = null;
+    }
+  }
+}
+
+module.exports = LogInterceptor;

--- a/detox/test/src/app.js
+++ b/detox/test/src/app.js
@@ -5,11 +5,14 @@ import {
   TouchableOpacity,
   Linking,
   Platform,
+  NativeModules,
 } from 'react-native';
 
 import * as Screens from './Screens';
 
 const isAndroid = Platform.OS === 'android';
+
+const { NativeModule } = NativeModules;
 
 class example extends Component {
 
@@ -107,9 +110,17 @@ class example extends Component {
           {this.renderScreenButton('Location', Screens.LocationScreen)}
           {!isAndroid && this.renderScreenButton('DatePicker', Screens.DatePickerScreen)}
           {!isAndroid && this.renderScreenButton('Picker', Screens.PickerViewScreen)}
-          {this.renderButton('Crash', () => {
-            throw new Error('Simulated Crash')
-          })}
+
+          <View style={{flexDirection: 'row', justifyContent: 'center'}}>
+            {this.renderButton('Crash', () => {
+              throw new Error('Simulated Crash')
+            })}
+            {isAndroid && <Text style={{width: 10}}> | </Text>}
+            {isAndroid && this.renderButton('ANR', () => {
+              NativeModule.chokeMainThread();
+            })}
+          </View>
+
           {this.renderScreenButton('Shake', Screens.ShakeScreen)}
           {isAndroid && this.renderScreenButton('Launch Args', Screens.LaunchArgsScreen)}
         </View>


### PR DESCRIPTION
- [ ] This is a small change 
- [x] This change has been discussed in issue #1925 and the solution has been agreed upon with maintainers.

---

**Description:**

Resolves #1925. Introduces usage of the very interesting [ANR-WatchDog project](https://github.com/SalomonBrys/ANR-WatchDog) for the sake of ANR-state proximation. The ends result is a warning on the Detox (tester) side with a main-thread stacktrace, when main-thread blockage is detected, alongside a complete thread-dump on the device logs.

Integration of it all was pretty straightforward, but testing this (e2e) was a bit of a pain since logs are not easy to intercept.