### PR TITLE
Fix the 'Verion' typo that caused kotlin version usage mixup

### DIFF
--- a/detox/android/build.gradle
+++ b/detox/android/build.gradle
@@ -1,14 +1,14 @@
 buildscript {
     ext {
         isOfficialDetoxLib = true
-        kotlinVersion = '1.3.41'
+        kotlinVersion = '1.2.0'
         dokkaVersion = '0.9.18'
         buildToolsVersion = '29.0.0'
         compileSdkVersion = 29
         targetSdkVersion = 29
         minSdkVersion = 18
     }
-    ext.detoxKotlinVerion = ext.kotlinVersion
+    ext.detoxKotlinVersion = ext.kotlinVersion
 
     repositories {
         jcenter()
@@ -37,7 +37,7 @@ allprojects {
 
 subprojects {
     afterEvaluate { p ->
-        if (p.hasProperty('android')){
+        if (p.hasProperty('android')) {
             android {
                 buildToolsVersion rootProject.ext.buildToolsVersion
             }

--- a/detox/test/android/build.gradle
+++ b/detox/test/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         targetSdkVersion = 29
         minSdkVersion = 18
     }
-    ext.detoxKotlinVerion = ext.kotlinVersion
+    ext.detoxKotlinVersion = ext.kotlinVersion
 
     repositories {
         google()

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -338,7 +338,7 @@ Could not determine the dependencies of task ':detox:compileDebugAidl'.
 
 Detox requires the Kotlin standard-library as it's own dependency. Due to the [many flavours](https://kotlinlang.org/docs/reference/using-gradle.html#configuring-dependencies) by which Kotlin has been released, multiple dependencies often create a conflict.
 
-For that, Detox allows for the exact specification of the standard library to use using two Gradle globals: `detoxKotlinVerion` and `detoxKotlinStdlib`. You can define both in your  root build-script file (i.e.`android/build.gradle`):
+For that, Detox allows for the exact specification of the standard library to use using two Gradle globals: `detoxKotlinVersion` and `detoxKotlinStdlib`. You can define both in your  root build-script file (i.e.`android/build.gradle`):
 
 ```groovy
 buildscript {

--- a/examples/demo-react-native/android/build.gradle
+++ b/examples/demo-react-native/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
         targetSdkVersion = 29
         minSdkVersion = 18
     }
-    ext.detoxKotlinVersion = ext.kotlinVersion
 
     repositories {
         jcenter()


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

This was previously proposed in #1836, #1835 and #1833 but never made it to a fulfilling PR level (see https://github.com/wix/Detox/pull/1836#issuecomment-572244062). This is a one-PR-to-rule-them-all.