### PR TITLE
Clean up and document Android deps

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -57,38 +57,52 @@ android {
     }
 }
 
+// In a nutshell:
+// "The api configuration should be used to declare dependencies which are exported by the library API, whereas the
+//  implementation configuration should be used to declare dependencies which are internal to the component."
+// --> https://docs.gradle.org/5.5/userguide/java_library_plugin.html
+
+// Fundamental deps.
 dependencies {
     implementation "org.jetbrains.kotlin:$_kotlinStdlib:$_kotlinVersion"
 
     // noinspection GradleDynamicVersion
     compileOnly 'com.facebook.react:react-native:+'
+}
 
-    implementation 'org.apache.commons:commons-lang3:3.7'
+// androidx.test deps.
+// All are aligned with this release: https://developer.android.com/jetpack/androidx/releases/test#1.2.0
+dependencies {
 
-    // Versions are in-sync with the 'androidx-test-1.1.0' release/tag of the android-test github repo,
-    // used by the Detox generator. See https://github.com/android/android-test/releases/tag/androidx-test-1.1.0
+    // Versions are in-sync with the 'androidx-test-1.2.0' release/tag of the android-test github repo,
+    // used by the Detox generator. See https://github.com/android/android-test/releases/tag/androidx-test-1.2.0
     // Important: Should remain so when generator tag is replaced!
-    api('androidx.test.espresso:espresso-core:3.2.0') {
+    api('androidx.test.espresso:espresso-core:3.2.0') { // Needed all across Detox but also makes Espresso seamlessly provided to Detox users with hybrid apps/E2E-tests.
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
-    api 'androidx.test:runner:1.2.0'
-    api 'androidx.test:rules:1.2.0'
-    api 'androidx.test.ext:junit:1.1.1'
-    api 'androidx.annotation:annotation:1.1.0'
-    api 'com.github.anrwatchdog:anrwatchdog:1.4.0'
+    api 'androidx.test:rules:1.2.0' // Needed because of ActivityTestRule. Needed by users *and* internally used by Detox.
+    api 'androidx.test.ext:junit:1.1.1' // Needed so as to seamlessly provide AndroidJUnit4 to Detox users. Depends on junit core.
 
     // Version is the latest; Cannot sync with the Github repo (e.g. android/android-test) because the androidx
     // packaging version of associated classes is simply not there...
-    api 'androidx.test.uiautomator:uiautomator:2.2.0'
+    api 'androidx.test.uiautomator:uiautomator:2.2.0' // Needed by Detox but also makes UIAutomator seamlessly provided to Detox users with hybrid apps/E2E-tests.
+}
 
+// Third-party deps.
+dependencies {
+    implementation 'org.apache.commons:commons-lang3:3.7' // Needed by invoke.
+    implementation 'com.github.anrwatchdog:anrwatchdog:1.4.0'
+}
+
+// Unit-testing deps.
+dependencies {
+    // noinspection GradleDynamicVersion
+    testImplementation 'com.facebook.react:react-native:+'
     testImplementation 'org.json:json:20140107'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:3.8.0'
     testImplementation 'org.apache.commons:commons-io:1.3.2'
-    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
-
-    // noinspection GradleDynamicVersion
-    testImplementation 'com.facebook.react:react-native:+'
+    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
 }
 
 // Spek (https://spekframework.org/setup-android)

--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -95,7 +95,6 @@ dependencies {
     fromBinImplementation 'com.facebook.react:react-native:+'
 
     androidTestImplementation(project(path: ':detox'))
-    androidTestImplementation 'junit:junit:4.12'
 }
 
 if (isRN60OrHigher) {

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -56,8 +56,7 @@ In your app's buildscript (i.e. `app/build.gradle`) add this in `dependencies` s
 ```groovy
 dependencies {
 	  // ...
-    androidTestImplementation('com.wix:detox:+') { transitive = true } 
-    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation('com.wix:detox:+')
 }
 ```
 
@@ -242,7 +241,6 @@ In your app's buildscript (i.e. `app/build.gradle`) add this in `dependencies` s
 dependencies {
   	// ...
     androidTestImplementation(project(path: ":detox"))
-    androidTestImplementation 'junit:junit:4.12'
 }
 ```
 
@@ -297,9 +295,8 @@ Of all [Kotlin implementation flavours](https://kotlinlang.org/docs/reference/us
 
 ```diff
 dependencies {
--    androidTestImplementation('com.wix:detox:+') { transitive = true } 
+-    androidTestImplementation('com.wix:detox:+')
 +    androidTestImplementation('com.wix:detox:+') { 
-+        transitive = true
 +        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
 +    }
 }

--- a/examples/demo-react-native/android/app/build.gradle
+++ b/examples/demo-react-native/android/app/build.gradle
@@ -75,8 +75,7 @@ dependencies {
     // noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 
-    androidTestImplementation('com.wix:detox:+') { transitive = true }
-    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation('com.wix:detox:+')
 }
 
 if (isRN60OrHigher) {


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

- Removes unneeded transitive deps currently defined for the Detox lib, improves docs and adds notes as to explain why deps are needed.
- Resolves #1898.