### PR TITLE
fix(windows): unescaped regexp issue, unit tests

### DIFF
--- a/detox/src/utils/callsites.js
+++ b/detox/src/utils/callsites.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const {escapeRegExp} = require('lodash');
 const cwd = process.cwd() + path.sep;
 
 // Taken from https://github.com/sindresorhus/callsites
@@ -15,6 +16,5 @@ module.exports.stackdump = (endFrame = 0) => {
     .split('\n')
     .slice(2 + endFrame) // 2 = 1 for 'Error:' prefix and 1 for this function's frame
     .join('\n')
-    .split(cwd)
-    .join('');
+    .replace(new RegExp(escapeRegExp(cwd), 'g'), '');
 };

--- a/detox/src/utils/callsites.js
+++ b/detox/src/utils/callsites.js
@@ -15,5 +15,6 @@ module.exports.stackdump = (endFrame = 0) => {
     .split('\n')
     .slice(2 + endFrame) // 2 = 1 for 'Error:' prefix and 1 for this function's frame
     .join('\n')
-    .replace(new RegExp(cwd, 'g'), '');
+    .split(cwd)
+    .join('');
 };

--- a/detox/src/utils/callsites.test.js
+++ b/detox/src/utils/callsites.test.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 describe('callsites', () => {
 
   let callsites;
@@ -8,10 +10,12 @@ describe('callsites', () => {
   describe('call-sites query', () => {
     const callFromWrapperFn = () => callsites();
 
-    it('should return a query-able callsites array', () => {
+    it('should return a query-able callsites array', function it() {
       const [callsite0, callsite1] = callFromWrapperFn();
 
-      expect(callsite0.getFileName()).toEqual(expect.stringContaining('src/utils/callsites.test.js'));
+      const expectedFileName = path.normalize('src/utils/callsites.test.js');
+
+      expect(callsite0.getFileName()).toEqual(expect.stringContaining(expectedFileName));
       expect(callsite0.getFunctionName()).toEqual('callFromWrapperFn');
       expect(callsite0.isToplevel()).toEqual(true);
       expect(callsite1.getFunctionName()).toEqual('it');
@@ -23,8 +27,8 @@ describe('callsites', () => {
     const callStackDumpFromWrapperFn = (endFrame) => callsites.stackdump(endFrame);
     const callStackDumpFromTwoWrapperFn = (endFrame) => callStackDumpFromWrapperFn(endFrame);
 
-    const expectedTopFrameRegExp = /^ {4}at callStackDumpFromWrapperFn \(src\/utils\/callsites\.test\.js:[0-9][0-9]?:[0-9][0-9]?\)/;
-    const expected2ndLineRegExp = /^ {4}at callStackDumpFromTwoWrapperFn \(src\/utils\/callsites\.test\.js:[0-9][0-9]?:[0-9][0-9]?\)/;
+    const expectedTopFrameRegExp = /^ {4}at callStackDumpFromWrapperFn \(src[\\/]utils[\\/]callsites\.test\.js:[0-9][0-9]?:[0-9][0-9]?\)/;
+    const expected2ndLineRegExp = /^ {4}at callStackDumpFromTwoWrapperFn \(src[\\/]utils[\\/]callsites\.test\.js:[0-9][0-9]?:[0-9][0-9]?\)/;
 
     it('should return a valid, multi-line, stack-dump string', () => {
       const stackdump = callStackDumpFromTwoWrapperFn();

--- a/detox/src/utils/customConsoleLogger.test.js
+++ b/detox/src/utils/customConsoleLogger.test.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const ignored = expect.anything;
 
 describe('customConsoleLogger', () => {
@@ -52,7 +53,7 @@ describe('customConsoleLogger', () => {
   });
 
   it('should use relative file-name rather than absolute in origin', () => {
-    const expectedOrigin = 'at src/utils/customConsoleLogger.test.js:';
+    const expectedOrigin = `at ${path.normalize('src/utils/customConsoleLogger.test.js')}:`;
 
     const logger = require('./customConsoleLogger');
     logger.override('__log', bunyanLogger.mock);


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

1. Fixed implementation of `callsites.stackdump` - added RegExp escaping. Otherwise, I see issue on Windows 10:

```
  ● callsites › stack-dump › should slice according to end-frame arg

    SyntaxError: Invalid regular expression: /C:\Users\noomo\Projects\wix\Detox\detox\/: \ at end of pattern
        at new RegExp (<anonymous>)

      16 |     .slice(2 + endFrame) // 2 = 1 for 'Error:' prefix and 1 for this function's frame
      17 |     .join('\n')
    > 18 |     .replace(new RegExp(cwd, 'g'), '');
         |              ^
      19 | };
      20 |

      at Function.stackdump (src/utils/callsites.js:18:14)
      at callStackDumpFromWrapperFn (src/utils/callsites.test.js:23:64)
      at callStackDumpFromTwoWrapperFn (src/utils/callsites.test.js:24:57)
      at Object.<anonymous> (src/utils/callsites.test.js:38:25)
```

Most likely, it is apt to occur in a real situation as well, not unit tests only.

For the solution to replace all, I use the suggestion option: https://stackoverflow.com/a/1145525
I think it is not a performance-critical code, because it is not invoked hundreds of times, right? Detox calls this function only to facilitate debugging when something goes wrong, I assume.

2. Fixed unit tests so they pass both on POSIX and Win32 platforms.
