### PR TITLE
code: fix Error inheritance

### DIFF
--- a/detox/src/devices/drivers/AndroidDriver.test.js
+++ b/detox/src/devices/drivers/AndroidDriver.test.js
@@ -91,8 +91,8 @@ describe('Android driver', () => {
         await promise;
         fail('Expected an error and none was thrown');
       } catch (e) {
-        expect(e.message).toContain('DetoxRuntimeError: Failed to run application on the device');
-        expect(e.message).toContain(`Native stacktrace dump: ${mockInstrumentationLogsParserClass.INSTRUMENTATION_STACKTRACE_MOCK}`);
+        expect(e.toString()).toContain('DetoxRuntimeError: Failed to run application on the device');
+        expect(e.toString()).toContain(`Native stacktrace dump: ${mockInstrumentationLogsParserClass.INSTRUMENTATION_STACKTRACE_MOCK}`);
       } finally {
         clientWaitResolve();
       }

--- a/detox/src/errors/DetoxRuntimeError.js
+++ b/detox/src/errors/DetoxRuntimeError.js
@@ -1,14 +1,15 @@
+const _ = require('lodash');
+
 class DetoxRuntimeError extends Error {
   constructor({ message = '', hint = '', debugInfo = '' } = {}) {
-    super(`DetoxRuntimeError: ${message}` +
-      (!hint ? '' : '\n\nHINT: ' + hint) +
-      (!debugInfo ? '' : '\n\n' + debugInfo));
+    const formattedMessage = _.compact([
+      message,
+      hint && `HINT: ${hint}`,
+      debugInfo
+    ]).join('\n\n');
 
-    Error.captureStackTrace(this, DetoxRuntimeError);
-  }
-
-  toString() {
-    return super.toString().replace(/^Error: /, '\n');
+    super(formattedMessage);
+    this.name = 'DetoxRuntimeError';
   }
 }
 


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

The way I was adding `DetoxRuntimeError: ` prefix for this custom error code is not idiomatically correct. When you call `err.toString()`, you can see something like `Error: DetoxRuntimeError: …`.

It appears that nowadays all you need when [extending Error](https://javascript.info/custom-errors#extending-error), is just to call `super(message)` and write down `this.name = 'MyCustomError'` and voila.