### PR TITLE
code(artifacts): remove not used event onInit

### DIFF
--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -90,8 +90,6 @@ class Detox {
       Object.assign(global, globalsToExport);
     }
 
-    await this._artifactsManager.onInit();
-
     return this;
   }
 

--- a/detox/src/artifacts/ArtifactsManager.js
+++ b/detox/src/artifacts/ArtifactsManager.js
@@ -134,10 +134,6 @@ class ArtifactsManager {
     await this._callPlugins('descending', 'onSuiteEnd', suite);
   }
 
-  async onInit() {
-    await this._callPlugins('descending', 'onInit');
-  }
-
   async onBeforeCleanup() {
     await this._callPlugins('descending', 'onBeforeCleanup');
     await this._idlePromise;

--- a/detox/src/artifacts/ArtifactsManager.test.js
+++ b/detox/src/artifacts/ArtifactsManager.test.js
@@ -91,7 +91,6 @@ describe('ArtifactsManager', () => {
           onTestDone: jest.fn(),
           onSuiteStart: jest.fn(),
           onSuiteEnd: jest.fn(),
-          onInit: jest.fn(),
           onBeforeCleanup: jest.fn(),
         });
       };
@@ -227,8 +226,6 @@ describe('ArtifactsManager', () => {
 
         itShouldCatchErrorsOnPhase('onSuiteEnd', () => (testSuite.mock()));
 
-        itShouldCatchErrorsOnPhase('onInit', () => undefined);
-
         itShouldCatchErrorsOnPhase('onBeforeCleanup', () => undefined);
 
         itShouldCatchErrorsOnPhase('onBootDevice', () => ({
@@ -314,14 +311,6 @@ describe('ArtifactsManager', () => {
           expect(testPlugin.onSuiteEnd).not.toHaveBeenCalled();
           await artifactsManager.onSuiteEnd(suite);
           expect(testPlugin.onSuiteEnd).toHaveBeenCalledWith(suite);
-        });
-      });
-
-      describe('onInit', () => {
-        it('should call onInit in plugins', async () => {
-          expect(testPlugin.onInit).not.toHaveBeenCalled();
-          await artifactsManager.onInit();
-          expect(testPlugin.onInit).toHaveBeenCalled();
         });
       });
 

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
@@ -221,15 +221,6 @@ class ArtifactPlugin {
   }
 
   /**
-   * Hook that is called when detox.init() finishes
-   *
-   * @protected
-   * @async
-   * @return {Promise<void>} - when done
-   */
-  async onInit() {}
-
-  /**
    * Hook that is called when detox.cleanup() just begins
    *
    * @protected
@@ -265,7 +256,6 @@ class ArtifactPlugin {
     this.onTestDone = _.noop;
     this.onSuiteStart = _.noop;
     this.onSuiteEnd = _.noop;
-    this.onInit = _.noop;
     this.onBeforeCleanup = _.noop;
   }
 

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.test.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.test.js
@@ -224,12 +224,6 @@ describe('ArtifactPlugin', () => {
       expect(plugin.context.suite).toBe(null);
     });
 
-    it('should have .onInit, which is doing nothing', async () => {
-      const prevContext = {...plugin.context};
-      await plugin.onInit();
-      expect(plugin.context).toEqual(prevContext);
-    });
-
     it('should have .onBeforeCleanup, which resets context.testSummary if called', async () => {
       plugin.context.testSummary = {};
       await plugin.onBeforeCleanup();
@@ -257,7 +251,6 @@ describe('ArtifactPlugin', () => {
         expect(plugin.onTestDone).toBe(plugin.onTerminate);
         expect(plugin.onSuiteStart).toBe(plugin.onTerminate);
         expect(plugin.onSuiteEnd).toBe(plugin.onTerminate);
-        expect(plugin.onInit).toBe(plugin.onTerminate);
         expect(plugin.onBeforeCleanup).toBe(plugin.onTerminate);
         expect(plugin.onUserAction).toBe(plugin.onTerminate);
       });


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

During another code review, I have noticed that `onInit` is technically useless and not in use at all, so why not remove it?
