### PR TITLE
feat(artifacts): take appNotReady.png screenshot if needed

### DIFF
--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -236,6 +236,21 @@ describe('Detox', () => {
     }
   });
 
+  it(`should log EMIT_ERROR if the internal emitter throws an error`, async () => {
+    Detox = require('./Detox');
+    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
+
+    const emitter = detox._eventEmitter;
+    emitter.on('launchApp', () => { throw new Error('TestError'); });
+    await emitter.emit('launchApp');
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      { event: 'EMIT_ERROR', fn: 'launchApp' },
+      expect.stringMatching(/Caught an exception in.*emit.*launchApp.*undefined/),
+      expect.any(Error),
+    )
+  });
+
   describe('.artifactsManager', () => {
     let artifactsManager;
 

--- a/detox/src/artifacts/ArtifactsManager.js
+++ b/detox/src/artifacts/ArtifactsManager.js
@@ -73,6 +73,7 @@ class ArtifactsManager {
     deviceEmitter.on('shutdownDevice', this.onShutdownDevice.bind(this));
     deviceEmitter.on('beforeLaunchApp', this.onBeforeLaunchApp.bind(this));
     deviceEmitter.on('launchApp', this.onLaunchApp.bind(this));
+    deviceEmitter.on('appReady', this.onAppReady.bind(this));
     deviceEmitter.on('beforeUninstallApp', this.onBeforeUninstallApp.bind(this));
     deviceEmitter.on('beforeTerminateApp', this.onBeforeTerminateApp.bind(this));
     deviceEmitter.on('terminateApp', this.onTerminateApp.bind(this));
@@ -109,6 +110,10 @@ class ArtifactsManager {
 
   async onLaunchApp(appLaunchInfo) {
     await this._callPlugins('plain', 'onLaunchApp', appLaunchInfo);
+  }
+
+  async onAppReady(appInfo) {
+    await this._callPlugins('plain', 'onAppReady', appInfo);
   }
 
   async onCreateExternalArtifact({ pluginId, artifactName, artifactPath }) {

--- a/detox/src/artifacts/ArtifactsManager.test.js
+++ b/detox/src/artifacts/ArtifactsManager.test.js
@@ -86,6 +86,7 @@ describe('ArtifactsManager', () => {
           onTerminateApp: jest.fn(),
           onBeforeLaunchApp: jest.fn(),
           onLaunchApp: jest.fn(),
+          onAppReady: jest.fn(),
           onCreateExternalArtifact: jest.fn(),
           onTestStart: jest.fn(),
           onTestDone: jest.fn(),
@@ -253,6 +254,12 @@ describe('ArtifactsManager', () => {
         }));
 
         itShouldCatchErrorsOnPhase('onLaunchApp', () => ({
+          bundleId: 'testBundleId',
+          deviceId: 'testDeviceId',
+          pid: 2018,
+        }));
+
+        itShouldCatchErrorsOnPhase('onAppReady', () => ({
           bundleId: 'testBundleId',
           deviceId: 'testDeviceId',
           pid: 2018,
@@ -440,6 +447,20 @@ describe('ArtifactsManager', () => {
         expect(testPlugin.onLaunchApp).not.toHaveBeenCalled();
         await artifactsManager.onLaunchApp(launchInfo);
         expect(testPlugin.onLaunchApp).toHaveBeenCalledWith(launchInfo);
+      });
+    });
+
+    describe('onAppReady', () => {
+      it('should call onAppReady in plugins', async () => {
+        const appInfo = {
+          deviceId: 'testDeviceId',
+          bundleId: 'testBundleId',
+          pid: 2020,
+        };
+
+        expect(testPlugin.onAppReady).not.toHaveBeenCalled();
+        await artifactsManager.onAppReady(appInfo);
+        expect(testPlugin.onAppReady).toHaveBeenCalledWith(appInfo);
       });
     });
   });

--- a/detox/src/artifacts/screenshot/ScreenshotArtifactPlugin.js
+++ b/detox/src/artifacts/screenshot/ScreenshotArtifactPlugin.js
@@ -12,6 +12,15 @@ class ScreenshotArtifactPlugin extends TwoSnapshotsPerTestPlugin {
     return this.api.preparePathForArtifact(`${name}.png`, testSummary);
   }
 
+  async onBeforeCleanup(e) {
+    if (this.context.isAppReady === false) {
+      this._hasFailingTests = true;
+      await this._takeAutomaticSnapshot('appNotReady');
+    }
+
+    await super.onBeforeCleanup(e);
+  }
+
   /** @param {string} config */
   static parseConfig(config) {
     switch (config) {

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
@@ -46,7 +46,11 @@ class ArtifactPlugin {
    * @param {Object} event.launchArgs - Mutable key-value pairs of args before the launch
    * @return {Promise<void>} - when done
    */
-  async onBeforeLaunchApp(event) {}
+  async onBeforeLaunchApp(event) {
+    Object.assign(this.context, {
+      isAppReady: false,
+    });
+  }
 
   /**
    * Hook that is called inside device.launchApp() and
@@ -68,6 +72,24 @@ class ArtifactPlugin {
       launchArgs: event.launchArgs,
       pid: event.pid,
    });
+  }
+
+  /**
+   * Hook that is called after app sends ready signal
+   * over the web socket.
+   *
+   * @protected
+   * @async
+   * @param {Object} event - App ready event object
+   * @param {string} event.deviceId - Current deviceId
+   * @param {string} event.bundleId - Current bundleId
+   * @param {number} event.pid - Process id of the running app
+   * @return {Promise<void>} - when done
+   */
+  async onAppReady(event) {
+    Object.assign(this.context, {
+      isAppReady: true,
+    });
   }
 
   /**
@@ -113,6 +135,7 @@ class ArtifactPlugin {
       bundleId: '',
       launchArgs: null,
       pid: NaN,
+      isAppReady: undefined,
     });
   }
 
@@ -154,6 +177,7 @@ class ArtifactPlugin {
       bundleId: '',
       launchArgs: null,
       pid: NaN,
+      isAppReady: undefined,
     });
   }
 

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.test.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.test.js
@@ -79,7 +79,7 @@ describe('ArtifactPlugin', () => {
       };
     });
 
-    it('should not update context on .onBeforeLaunchApp', async () => {
+    it('should set isAppReady = false on .onBeforeLaunchApp', async () => {
       await expect(plugin.onBeforeLaunchApp({
         deviceId: 'testDeviceId',
         bundleId: 'testBundleId',
@@ -90,7 +90,8 @@ describe('ArtifactPlugin', () => {
 
       expect(plugin.context).toEqual({
         deviceId: 'someOriginalDeviceId',
-        shouldNotBeDeletedFromContext: 'extraProperty'
+        shouldNotBeDeletedFromContext: 'extraProperty',
+        isAppReady: false,
       });
     });
 
@@ -112,6 +113,20 @@ describe('ArtifactPlugin', () => {
         },
         pid: 2018,
         shouldNotBeDeletedFromContext: 'extraProperty',
+      });
+    });
+
+    it('should set isAppReady = true on .onAppReady', async () => {
+      await expect(plugin.onAppReady({
+        deviceId: 'testDeviceId',
+        bundleId: 'testBundleId',
+        pid: 2020
+      }));
+
+      expect(plugin.context).toEqual({
+        deviceId: 'someOriginalDeviceId',
+        shouldNotBeDeletedFromContext: 'extraProperty',
+        isAppReady: true,
       });
     });
 
@@ -149,6 +164,7 @@ describe('ArtifactPlugin', () => {
         bundleId: '',
         launchArgs: null,
         pid: NaN,
+        isAppReady: undefined,
         deviceId: 'someOriginalDeviceId',
         shouldNotBeDeletedFromContext: 'extraProperty',
       });
@@ -187,6 +203,7 @@ describe('ArtifactPlugin', () => {
         bundleId: '',
         launchArgs: null,
         pid: NaN,
+        isAppReady: undefined,
         shouldNotBeDeletedFromContext: 'extraProperty',
       });
     });

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -86,6 +86,11 @@ class Device {
 
     await this.deviceDriver.waitUntilReady();
     await this.deviceDriver.waitForActive();
+    await this.deviceDriver.emitter.emit('appReady', {
+      deviceId: this._deviceId,
+      bundleId: _bundleId,
+      pid: processId,
+    });
 
     if(params.detoxUserNotificationDataURL) {
       await this.deviceDriver.cleanupRandomDirectory(params.detoxUserNotificationDataURL);

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -5,9 +5,10 @@ const argparse = require('../utils/argparse');
 const debug = require('../utils/debug'); //debug utils, leave here even if unused
 
 class Device {
-  constructor({ deviceConfig, deviceDriver, sessionConfig }) {
+  constructor({ deviceConfig, deviceDriver, emitter, sessionConfig }) {
     this._deviceConfig = deviceConfig;
     this._sessionConfig = sessionConfig;
+    this._emitter = emitter;
     this._processes = {};
     this.deviceDriver = deviceDriver;
     this.deviceDriver.validateDeviceConfig(deviceConfig);
@@ -86,7 +87,7 @@ class Device {
 
     await this.deviceDriver.waitUntilReady();
     await this.deviceDriver.waitForActive();
-    await this.deviceDriver.emitter.emit('appReady', {
+    await this._emitter.emit('appReady', {
       deviceId: this._deviceId,
       bundleId: _bundleId,
       pid: processId,

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -89,6 +89,7 @@ describe('Device', () => {
     const device = new Device({
       deviceConfig: scheme.configurations[configuration],
       deviceDriver: driverMock.driver,
+      emitter: new AsyncEmitter(),
       sessionConfig: scheme.session,
     });
 
@@ -700,6 +701,7 @@ describe('Device', () => {
     expect(() => new Device({
       deviceConfig: invalidDeviceNoBinary.configurations['ios.sim.release'],
       deviceDriver: new SimulatorDriver(client),
+      emitter: new AsyncEmitter(),
       sessionConfig: validScheme.session,
     })).toThrowError(/binaryPath.* is missing/);
   });

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -10,6 +10,7 @@ describe('Device', () => {
   let fs;
   let DeviceDriverBase;
   let SimulatorDriver;
+  let AsyncEmitter;
   let Device;
   let argparse;
   let Client;
@@ -33,6 +34,8 @@ describe('Device', () => {
     jest.mock('../client/Client');
     Client = require('../client/Client');
 
+    jest.mock('../utils/AsyncEmitter');
+    AsyncEmitter = require('../utils/AsyncEmitter');
     Device = require('./Device');
   });
 
@@ -48,6 +51,7 @@ describe('Device', () => {
   class DeviceDriverMock {
     constructor() {
       this.driver = new DeviceDriverBase(client);
+      this.driver.emitter = new AsyncEmitter();
     }
 
     expectLaunchCalled(device, expectedArgs, languageAndLocale) {

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -19,6 +19,7 @@ class DeviceDriverBase {
         'beforeUninstallApp',
         'beforeLaunchApp',
         'launchApp',
+        'appReady',
         'createExternalArtifact',
       ],
       onError: this._onEmitError.bind(this),

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -2,40 +2,17 @@ const _ = require('lodash');
 const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
-const AsyncEmitter = require('../../utils/AsyncEmitter');
 const log = require('../../utils/logger').child({ __filename });
 
 class DeviceDriverBase {
-  constructor({ client }) {
+  constructor({ client, emitter }) {
     this.client = client;
+    this.emitter = emitter;
     this.matchers = null;
-    this.emitter = new AsyncEmitter({
-      events: [
-        'bootDevice',
-        'beforeShutdownDevice',
-        'shutdownDevice',
-        'beforeTerminateApp',
-        'terminateApp',
-        'beforeUninstallApp',
-        'beforeLaunchApp',
-        'launchApp',
-        'appReady',
-        'createExternalArtifact',
-      ],
-      onError: this._onEmitError.bind(this),
-    });
   }
 
   get name() {
     return 'UNSPECIFIED_DEVICE';
-  }
-
-  off(event, listener) {
-    this.emitter.off(event, listener);
-  }
-
-  on(event, listener) {
-    this.emitter.on(event, listener);
   }
 
   declareArtifactPlugins() {
@@ -209,14 +186,6 @@ class DeviceDriverBase {
   async pressBack() {
     log.warn('pressBack() is an android specific function, make sure you create an android specific test for this scenario');
     return await Promise.resolve('');
-  }
-
-  _onEmitError({ error, eventName, eventObj }) {
-    log.error(
-      { event: 'EMIT_ERROR', className: this.constructor.name, eventName },
-      `Caught an exception in: emitter.emit("${eventName}", ${JSON.stringify(eventObj)})\n\n`,
-      error
-    );
   }
 
   async setStatusBar(deviceId, flags) {

--- a/detox/src/devices/drivers/android/AndroidDriver.test.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.test.js
@@ -12,7 +12,6 @@ describe('Android driver', () => {
     }));
 
     jest.mock('./tools/ADB', () => mockADBClass);
-    jest.mock('../../../utils/AsyncEmitter', () => mockAsyncEmitter);
     jest.mock('../../../utils/sleep', () => jest.fn().mockResolvedValue(''));
     jest.mock('../../../utils/retry', () => jest.fn().mockResolvedValue(''));
 
@@ -56,6 +55,7 @@ describe('Android driver', () => {
     const AndroidDriver = require('./AndroidDriver');
     uut = new AndroidDriver({
       client,
+      emitter: new mockAsyncEmitter(),
     });
   });
 
@@ -252,4 +252,5 @@ class mockInstrumentationLogsParserClass {
     this.getStackTrace = () => mockInstrumentationLogsParserClass.INSTRUMENTATION_STACKTRACE_MOCK;
   }
 }
+
 mockInstrumentationLogsParserClass.INSTRUMENTATION_STACKTRACE_MOCK = 'Stacktrace mock';

--- a/detox/src/devices/drivers/ios/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.test.js
@@ -12,7 +12,7 @@ describe('IOS simulator driver', () => {
     emitter = new AsyncEmitter({
       events: ['beforeLaunchApp'],
       onError: (e) => { throw e },
-    })
+    });
   });
 
   describe('launch args', () => {

--- a/detox/src/devices/drivers/ios/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.test.js
@@ -1,11 +1,18 @@
+const AsyncEmitter = require('../../../utils/AsyncEmitter');
+
 describe('IOS simulator driver', () => {
-  let uut, sim;
+  let uut, sim, emitter;
 
   const deviceId = 'device-id-mock';
   const bundleId = 'bundle-id-mock';
 
   beforeEach(() => {
     jest.mock('./tools/AppleSimUtils', () => mockAppleSimUtils);
+
+    emitter = new AsyncEmitter({
+      events: ['beforeLaunchApp'],
+      onError: (e) => { throw e },
+    })
   });
 
   describe('launch args', () => {
@@ -20,7 +27,7 @@ describe('IOS simulator driver', () => {
       languageAndLocale = '';
 
       const SimulatorDriver = require('./SimulatorDriver');
-      uut = new SimulatorDriver({ client: {} });
+      uut = new SimulatorDriver({ client: {}, emitter });
     });
 
     it('should be passed to AppleSimUtils', async () => {
@@ -29,7 +36,7 @@ describe('IOS simulator driver', () => {
     });
 
     it('should be passed to AppleSimUtils even if some of them were received from `beforeLaunchApp` phase', async () => {
-      uut.emitter.on('beforeLaunchApp', ({ launchArgs }) => {
+      emitter.on('beforeLaunchApp', ({ launchArgs }) => {
         launchArgs.dog3 = 'Chika, from plugin';
       });
 
@@ -46,7 +53,7 @@ describe('IOS simulator driver', () => {
       languageAndLocale = '';
 
       const SimulatorDriver = require('./SimulatorDriver');
-      sim = new SimulatorDriver({ client: {} });
+      sim = new SimulatorDriver({ client: {}, emitter });
     });
 
     it('enrolls in biometrics by passing to AppleSimUtils', async () => {
@@ -85,7 +92,7 @@ describe('IOS simulator driver', () => {
 
     beforeEach(() => {
       const SimulatorDriver = require('./SimulatorDriver');
-      uut = new SimulatorDriver({ client: {} });
+      uut = new SimulatorDriver({ client: {}, emitter });
       jest.spyOn(uut.deviceRegistry, 'isDeviceBusy').mockReturnValue(false);
       applesimutils = uut.applesimutils;
       applesimutils.list.mockImplementation(async () => require('./tools/applesimutils.mock')['--list']);


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Supplements #1914 . Will be taking an automatic screenshot `appNotReady.png`, when there was an issue with launching the app, when it never signalled back that it is ready and active.

@d4vidi, here the question is mostly whether `device.driver.emitter` makes you smell _Feature envy_, one of the code smells, or it is fine?
