### PR TITLE
Fixed output of build_framework.ios.sh on failures

### DIFF
--- a/detox/scripts/build_framework.ios.sh
+++ b/detox/scripts/build_framework.ios.sh
@@ -33,14 +33,12 @@ function buildFramework () {
   mkdir -p "${detoxFrameworkDirPath}"
 	logPath="${detoxFrameworkDirPath}"/detox_ios.log
 	echo -n "" > "${logPath}"
-  "${detoxRootPath}"/scripts/build_universal_framework.sh "${detoxSourcePath}"/Detox.xcodeproj "${detoxFrameworkDirPath}" &> "${logPath}"
-	errno=$?
-	if [ $errno -ne 0 ]; then
+  "${detoxRootPath}"/scripts/build_universal_framework.sh "${detoxSourcePath}"/Detox.xcodeproj "${detoxFrameworkDirPath}" &> "${logPath}" || {
 		echo -e "#################################\nError building Detox.framework:\n----------------------------------\n"
 		cat "${logPath}"
 		echo "#################################"
-	fi
-	exit $errno
+	  exit 1
+  }
 }
 
 function main () {


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [X] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
This is a fix for missing logs on `build_universal_framework.sh` failures. (`build_framework.ios.sh` runs with `bash -e` which means it fails right away on `build_universal_framework.sh` failure, so no log is printed)