### PR TITLE
give hint for setDatePickerDate date conversion

### DIFF
--- a/docs/APIRef.ActionsOnElement.md
+++ b/docs/APIRef.ActionsOnElement.md
@@ -149,7 +149,9 @@ await element(by.id('pickerView')).setColumnToValue(2,"34");
 Sets the date of a date picker to a date generated from the provided string and date format.  
 
 dateString - string representing a date in the supplied dateFormat  
-dateFormat - format for the dateString supplied  
+dateFormat - format for the dateString supplied
+
+The `dateString` is converted to `NSDate` using `NSDateFormatter`. If you use JavaScript's [Date.toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString), the corresponding `dateFormat` is `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`.
 
 ```js
 await expect(element(by.id('datePicker'))).toBeVisible();


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

I used JS Date object to call `setDatePickerDate` and it took me a while to figure out the correct format. I thought this might help someone else.