### PR TITLE
Refactor bloated emulator driver according to sub-concerns, part 2

### DIFF
--- a/detox/src/devices/drivers/android/EmulatorVersion.js
+++ b/detox/src/devices/drivers/android/EmulatorVersion.js
@@ -1,0 +1,40 @@
+const log = require('../../../utils/logger').child({ __filename });
+
+const EMU_BIN_VERSION_DETECT_EV = 'EMU_BIN_VERSION_DETECT';
+
+class EmulatorVersion {
+  constructor(emulator) {
+    this.emulator = emulator;
+    this.version = undefined;
+  }
+
+  async resolve() {
+    if (!this.version) {
+      this.version = await this._resolve();
+    }
+    return this.version;
+  }
+
+  async _resolve() {
+    const rawOutput = await this.emulator.exec('-version') || '';
+    const matches = rawOutput.match(/Android emulator version ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]*)/);
+    if (!matches) {
+      log.warn({ event: EMU_BIN_VERSION_DETECT_EV, success: false }, 'Could not detect emulator binary version, got:', rawOutput);
+      return null;
+    }
+
+    const version = this._parseVersionString(matches[1]);
+    log.debug({ event: EMU_BIN_VERSION_DETECT_EV, success: true }, 'Detected emulator binary version', version);
+    return version;
+  }
+
+  _parseVersionString(versionRaw) {
+    const [major, minor, patch] = versionRaw.split('\.');
+    return {
+      major: Number(major),
+      minor: Number(minor),
+      patch: Number(patch),
+    };
+  }
+}
+module.exports = EmulatorVersion;

--- a/detox/src/devices/drivers/android/EmulatorVersion.test.js
+++ b/detox/src/devices/drivers/android/EmulatorVersion.test.js
@@ -1,0 +1,80 @@
+describe('Emulator binary version', () => {
+  const versionResult = [
+    'Android emulator version 30.1.2.3 (build_id 6306047) (CL:N/A)',
+    "Copyright (C) 2006-2017 The Android Open Source Project and many others.",
+    "This program is a derivative of the QEMU CPU emulator (www.qemu.org).",
+    "  This software is licensed under the terms of the GNU General Public",
+    "  License version 2, as published by the Free Software Foundation, and",
+    "  may be copied, distributed, and modified under those terms.",
+    "  This program is distributed in the hope that it will be useful,",
+    "  but WITHOUT ANY WARRANTY; without even the implied warranty of",
+    "  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the",
+    "  GNU General Public License for more details.",
+  ].join('\n');
+  const expectedVersion = {
+    major: 30,
+    minor: 1,
+    patch: 2,
+  };
+
+  let emulator;
+  let log;
+  let emulatorVersion;
+  beforeEach(() => {
+    emulator = {
+      exec: jest.fn().mockResolvedValue(versionResult),
+    };
+
+    jest.mock('../../../utils/logger', () => ({
+      child: jest.fn().mockReturnValue({
+        debug: jest.fn(),
+        warn: jest.fn(),
+      }),
+    }));
+    log = require('../../../utils/logger').child();
+
+    const EmulatorVersion = require('./EmulatorVersion');
+    emulatorVersion = new EmulatorVersion(emulator);
+  });
+
+  it('should query the emulator', async () => {
+    await emulatorVersion.resolve();
+    expect(emulator.exec).toHaveBeenCalledWith('-version');
+  });
+
+  it('should extract version from common log', async () => {
+    const version = await emulatorVersion.resolve();
+    expect(version).toEqual(expectedVersion);
+  });
+
+  it('should return null for an empty query result', async () => {
+    emulator.exec.mockResolvedValue(undefined);
+    const version = await emulatorVersion.resolve();
+    expect(version).toEqual(null);
+  });
+
+  it('should return null for a query result that has an invalid syntax', async () => {
+    emulator.exec.mockResolvedValue('Android emulator version \<invalid\> (build_id 6306047) (CL:N/A)');
+    const version = await emulatorVersion.resolve();
+    expect(version).toEqual(null);
+  });
+
+  it('should cache the version', async () => {
+    await emulatorVersion.resolve();
+    const version = await emulatorVersion.resolve();
+
+    expect(emulator.exec).toHaveBeenCalledTimes(1);
+    expect(version).toEqual(expectedVersion);
+  });
+
+  it('should log the version', async () => {
+    await emulatorVersion.resolve();
+    expect(log.debug).toHaveBeenCalledWith({event: 'EMU_BIN_VERSION_DETECT', success: true}, expect.any(String), expectedVersion);
+  });
+
+  it('should log in case of an error', async () => {
+    emulator.exec.mockResolvedValue('mock result');
+    await emulatorVersion.resolve();
+    expect(log.warn).toHaveBeenCalledWith({event: 'EMU_BIN_VERSION_DETECT', success: false}, expect.any(String), 'mock result');
+  });
+});


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

Part 2 of #1984. This time, extracting away emulator-version querying logic. To be continued...