### PR TITLE
Update getting started iOS

### DIFF
--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -12,7 +12,7 @@ Running Detox (on iOS) requires the following:
 
 * Mac with macOS (at least macOS High Sierra 10.13.6)
 
-* Xcode 10.1+ with Xcode command line tools
+* Xcode 10.2+ with Xcode command line tools
 > TIP: Verify Xcode command line tools is installed by typing `gcc -v` in terminal (shows a popup if not installed)
 
 * A working [React Native](https://facebook.github.io/react-native/docs/getting-started.html) app you want to test


### PR DESCRIPTION
Version 16.x now requires Xcode 10.2 or greater

- [X] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
I see the latest release notes that 10.2 is now required, updating corresponding doc. Searched the project and seems like you already got all the other ones updated!