### PR TITLE
fix(artifacts): by default take appNotReady screenshot

### DIFF
--- a/detox/src/artifacts/screenshot/ScreenshotArtifactPlugin.js
+++ b/detox/src/artifacts/screenshot/ScreenshotArtifactPlugin.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const TwoSnapshotsPerTestPlugin = require('../templates/plugin/TwoSnapshotsPerTestPlugin');
 
 /***
@@ -6,6 +7,10 @@ const TwoSnapshotsPerTestPlugin = require('../templates/plugin/TwoSnapshotsPerTe
 class ScreenshotArtifactPlugin extends TwoSnapshotsPerTestPlugin {
   constructor({ api }) {
     super({ api });
+
+    _.defaults(this.takeAutomaticSnapshots, {
+      appNotReady: true,
+    })
   }
 
   async preparePathForSnapshot(testSummary, name) {

--- a/detox/src/artifacts/screenshot/ScreenshotArtifactPlugin.test.js
+++ b/detox/src/artifacts/screenshot/ScreenshotArtifactPlugin.test.js
@@ -1,6 +1,34 @@
 const ScreenshotArtifactPlugin = require('./ScreenshotArtifactPlugin');
 
 describe('ScreenshotArtifactPlugin', () => {
+  describe('default options', () => {
+    it('should have takeAutomaticSnapshots.appReady = true', () => {
+      const plugin = new ScreenshotArtifactPlugin({
+        api: {
+          userConfig: {
+            takeWhen: {},
+          },
+        }
+      });
+
+      expect(plugin.takeAutomaticSnapshots.appNotReady).toBe(true);
+    });
+
+    it('should allow to set takeAutomaticSnapshots.appReady to false', () => {
+      const plugin = new ScreenshotArtifactPlugin({
+        api: {
+          userConfig: {
+            takeWhen: {
+              appNotReady: false,
+            },
+          },
+        }
+      });
+
+      expect(plugin.takeAutomaticSnapshots.appNotReady).toBe(false);
+    });
+  });
+
   describe('static parseConfig(config)', () => {
     const parseConfig = ScreenshotArtifactPlugin.parseConfig;
 


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

This fixes the thing I forgot when merging both #1971 and #1980.
I think that the right thing to do even if the user supplies this as a configuration:

```js
{
  "takeWhen": {
    "testStart": true,
    // "appNotReady": undefined,
  }
}
```

is still set `appNotReady = true` by default, unless it is explicitly forbidden, which is doubtful, to be honest.
