### PR TITLE
Resort to soft-failing errors in emulator version detection for skin-cfg patching

### DIFF
--- a/detox/src/devices/drivers/android/EmulatorDriver.js
+++ b/detox/src/devices/drivers/android/EmulatorDriver.js
@@ -105,7 +105,16 @@ class EmulatorDriver extends AndroidDriver {
   }
 
   async _fixEmulatorConfigIniSkinNameIfNeeded(avdName) {
-    const binaryVersion = _.get(await this.binaryVersion(), 'major', EMU_BIN_STABLE_SKIN_VER - 1);
+    const binaryVersion = _.get(await this.binaryVersion(), 'major');
+    if (!binaryVersion) {
+      log.warn({ event: 'EMU_SKIN_CFG_PATCH' }, [
+        'Failed to detect emulator version! (see previous logs)',
+        'This leaves Detox unable to tell if it should automatically apply this patch-fix: https://stackoverflow.com/a/47265664/453052, which seems to be needed in emulator versions < 28.',
+        'If you feel this is not needed, you can either ignore this message, or otherwise apply the patch manually.',
+      ].join('\n'));
+      return;
+    }
+
     if (binaryVersion >= EMU_BIN_STABLE_SKIN_VER) {
       return;
     }

--- a/detox/src/devices/drivers/android/emulator/EmulatorVersionResolver.js
+++ b/detox/src/devices/drivers/android/emulator/EmulatorVersionResolver.js
@@ -17,7 +17,14 @@ class EmulatorVersionResolver {
   }
 
   async _resolve() {
-    const rawOutput = await this._emulatorExec.exec(new QueryVersionCommand()) || '';
+    let rawOutput;
+    try {
+      rawOutput = await this._emulatorExec.exec(new QueryVersionCommand()) || '';
+    } catch (error) {
+      log.error({ event: EMU_BIN_VERSION_DETECT_EV, success: false, error }, 'Could not detect emulator binary version', error);
+      return null;
+    }
+
     const matches = rawOutput.match(/Android emulator version ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]*)/);
     if (!matches) {
       log.warn({ event: EMU_BIN_VERSION_DETECT_EV, success: false }, 'Could not detect emulator binary version, got:', rawOutput);


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
With respect to #1995 - which has been closed nonetheless, this applies less extreme failing measures in case of emulator version detection.
Also, will evidently resolve #1157.