### PR TITLE
Handle logging in async function

### DIFF
--- a/detox/src/utils/customConsoleLogger.js
+++ b/detox/src/utils/customConsoleLogger.js
@@ -11,7 +11,7 @@ function getStackDump() {
 
 function getOrigin() {
   const userCallsite = callsites()[USER_STACK_FRAME_INDEX];
-  const filename = path.relative(process.cwd(), userCallsite.getFileName());
+  const filename = userCallsite && userCallsite.getFileName() ? path.relative(process.cwd(), userCallsite.getFileName()) : '?';
   return `at ${filename}:${userCallsite.getLineNumber() || '?'}:${userCallsite.getColumnNumber() || '?'}`;
 }
 

--- a/detox/src/utils/customConsoleLogger.js
+++ b/detox/src/utils/customConsoleLogger.js
@@ -12,8 +12,10 @@ function getStackDump() {
 function getOrigin() {
   const userCallsite = callsites()[USER_STACK_FRAME_INDEX];
   const callsiteFilename = userCallsite && userCallsite.getFileName();
+  const callsiteLine = userCallsite && userCallsite.getLineNumber();
+  const callsiteCol = userCallsite && userCallsite.getColumnNumber();
   const filename = callsiteFilename ? path.relative(process.cwd(), callsiteFilename) : '<unknown>';
-  return `at ${filename}:${userCallsite.getLineNumber() || '?'}:${userCallsite.getColumnNumber() || '?'}`;
+  return `at ${filename}:${callsiteLine || '?'}:${callsiteCol || '?'}`;
 }
 
 function override(consoleLevel, bunyanFn) {

--- a/detox/src/utils/customConsoleLogger.js
+++ b/detox/src/utils/customConsoleLogger.js
@@ -11,7 +11,8 @@ function getStackDump() {
 
 function getOrigin() {
   const userCallsite = callsites()[USER_STACK_FRAME_INDEX];
-  const filename = userCallsite && userCallsite.getFileName() ? path.relative(process.cwd(), userCallsite.getFileName()) : '?';
+  const callsiteFilename = userCallsite && userCallsite.getFileName();
+  const filename = callsiteFilename ? path.relative(process.cwd(), callsiteFilename) : '<unknown>';
   return `at ${filename}:${userCallsite.getLineNumber() || '?'}:${userCallsite.getColumnNumber() || '?'}`;
 }
 

--- a/detox/src/utils/customConsoleLogger.test.js
+++ b/detox/src/utils/customConsoleLogger.test.js
@@ -62,6 +62,16 @@ describe('customConsoleLogger', () => {
     expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining(expectedOrigin), ignored(), ignored());
   });
 
+  it('should handle unknown file in origin', () => {
+    mockCallsites({file: undefined, line: undefined, col: undefined});
+
+    const logger = require('./customConsoleLogger');
+    logger.override('__log', bunyanLogger.mock);
+    console.__log('');
+
+    expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining('<undefined>:?:?'), ignored(), ignored());
+  });  
+  
   it('should handle missing file line/column in origin', () => {
     mockCallsites({file: 'mockfilename', line: undefined, col: undefined});
 

--- a/detox/src/utils/customConsoleLogger.test.js
+++ b/detox/src/utils/customConsoleLogger.test.js
@@ -69,7 +69,7 @@ describe('customConsoleLogger', () => {
     logger.override('__log', bunyanLogger.mock);
     console.__log('');
 
-    expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining('<undefined>:?:?'), ignored(), ignored());
+    expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining('<unknown>:?:?'), ignored(), ignored());
   });  
   
   it('should handle missing file line/column in origin', () => {


### PR DESCRIPTION
- [x] This is a small change 
---

**Description:**

Sorry I didn't file an issue cuz this was such a small change. 

When using mocha, and trying to log within a hook/test `detox/src/utils/customConsoleLogger.js:: getOrigin()` blows up because `userCallsite.getFileName()` is `undefined` and therefore `path.relative()` explodes.

Simple reproduce:
```
  before: async () => {
    console.log('**********BLAH');
```

PR is not the most elegant solution, but not sure there is much that can be done when using https://github.com/sindresorhus/callsites

Without this fix, I can not use Detox (and I want to, cuz really like it :)