### PR TITLE
ci: save coverage from different e2e tests

### DIFF
--- a/scripts/ci.android.sh
+++ b/scripts/ci.android.sh
@@ -9,16 +9,25 @@ pushd detox/android
 run_f "./gradlew test"
 popd
 
+mkdir -p coverage
+
 pushd detox/test
+
 # Workaround until react android issue will be fixed - react-native: 0.55
 mv node_modules/react-native/ReactAndroid/release.gradle node_modules/react-native/ReactAndroid/release.gradle.bak
 cp extras/release.gradle node_modules/react-native/ReactAndroid/
 
 run_f "npm run build:android"
-run_f "npm run e2e:android-ci"
-run_f "npm run e2e:android-timeout-ci"
-run_f "npm run e2e:jest-circus-timeout:android"
+cp ../coverage/lcov.info ../../coverage/unit.lcov
 
-cp coverage/lcov.info coverage/e2e.lcov
+run_f "npm run e2e:android-ci"
+cp coverage/lcov.info ../../coverage/e2e-android-ci.lcov
+
+run_f "npm run e2e:android-timeout-ci"
+cp coverage/lcov.info ../../coverage/e2e-android-timeout-ci.lcov
+
+run_f "npm run e2e:jest-circus-timeout:android"
+cp coverage/lcov.info ../../coverage/e2e-jest-circus-timeout-android.lcov
+
 # run_f "npm run verify-artifacts:android"
 popd

--- a/scripts/ci.ios.sh
+++ b/scripts/ci.ios.sh
@@ -4,12 +4,21 @@ source $(dirname "$0")/ci.sh
 
 run_f "$(dirname "$0")/unit.ios.sh"
 
-pushd detox/test
-run_f "npm run build:ios"
-run_f "npm run e2e:ios-ci"
-run_f "npm run e2e:ios-timeout-ci"
-run_f "npm run e2e:jest-circus-timeout:ios"
+mkdir -p coverage
 
-cp coverage/lcov.info coverage/e2e.lcov
+pushd detox/test
+
+run_f "npm run build:ios"
+cp ../coverage/lcov.info ../../coverage/unit.lcov
+
+run_f "npm run e2e:ios-ci"
+cp coverage/lcov.info ../../coverage/e2e-ios-ci.lcov
+
+run_f "npm run e2e:ios-timeout-ci"
+cp coverage/lcov.info ../../coverage/e2e-ios-timeout-ci.lcov
+
+run_f "npm run e2e:jest-circus-timeout:ios"
+cp coverage/lcov.info ../../coverage/e2e-jest-circus-timeout-ios.lcov
+
 # run_f "npm run verify-artifacts:ios"
 popd


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

The latest extra e2e tests overwrite the coverage of the main suite, so I am giving now the coverage files different names to save it all.
