### PR TITLE
Introduce safety time-margins between launches of multiple android emu's

### DIFF
--- a/detox/src/devices/DeviceRegistry.js
+++ b/detox/src/devices/DeviceRegistry.js
@@ -15,13 +15,16 @@ class DeviceRegistry {
 
   /***
    * @param {string|Function} getDeviceId
-   * @returns {Promise<string>}
+   * @returns {Promise<Object>}
    */
   async allocateDevice(getDeviceId) {
     return this._lockfile.exclusively(async () => {
       const deviceId = await safeAsync(getDeviceId);
-      this._toggleDeviceStatus(deviceId, true);
-      return deviceId;
+      const newState = this._toggleDeviceStatus(deviceId, true);
+      return {
+        deviceId,
+        deviceIndex: newState.length - 1,
+      };
     });
   }
 
@@ -49,6 +52,7 @@ class DeviceRegistry {
 
   /***
    * @private
+   * @returns {Array}
    */
   _toggleDeviceStatus(deviceId, busy) {
     const state = this._lockfile.read();
@@ -58,6 +62,8 @@ class DeviceRegistry {
       : _.without(state, deviceId);
 
     this._lockfile.write(newState);
+
+    return newState;
   }
 }
 

--- a/detox/src/devices/DeviceRegistry.test.js
+++ b/detox/src/devices/DeviceRegistry.test.js
@@ -15,6 +15,26 @@ describe('DeviceRegistry', () => {
     await fs.remove(lockfilePath);
   });
 
+  it('should allocate the first device', async () => {
+    const deviceId = 'mock-device';
+    const getDeviceIdFn = jest.fn().mockResolvedValue(deviceId);
+    await registry.allocateDevice(getDeviceIdFn);
+
+    const fileContent = await fs.readFile(lockfilePath);
+    expect(JSON.parse(fileContent)).toEqual([deviceId]);
+  });
+
+  it('should return device and \'index\' upon allocation', async () => {
+    const deviceId1 = 'mock-device';
+    const deviceId2 = 'mock-device2';
+
+    const result1 = await registry.allocateDevice(jest.fn().mockResolvedValue(deviceId1));
+    expect(result1).toEqual({ deviceId: deviceId1, deviceIndex: 0 });
+
+    const result2 = await registry.allocateDevice(jest.fn().mockResolvedValue(deviceId2));
+    expect(result2).toEqual({ deviceId: deviceId2, deviceIndex: 1 });
+  });
+
   it('should throw on attempt to checking if device is busy outside of allocation/disposal context', async () => {
     const deviceId = 'emulator-5554';
 
@@ -27,7 +47,7 @@ describe('DeviceRegistry', () => {
       return deviceId;
     });
 
-    expect(result).toBe(deviceId);
+    expect(result.deviceId).toBe(deviceId);
 
     assertForbiddenOutOfContext();
     await registry.disposeDevice(() => {

--- a/detox/src/devices/drivers/ios/SimulatorDriver.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.js
@@ -42,7 +42,7 @@ class SimulatorDriver extends IosDriver {
   }
 
   async acquireFreeDevice(deviceQuery) {
-    const udid = await this.deviceRegistry.allocateDevice(async () => {
+    const {deviceId: udid} = await this.deviceRegistry.allocateDevice(async () => {
       return await this._findOrCreateDevice(deviceQuery);
     });
 


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Add `sleep()`s in between Android emulator launches so as to heuristically prevent absolute simultaneous launches of emulators of the same AVD.

This aims at improving 2 things:
1. The Android emulator binary doesn't seem to handle many launches taking place at the same time very well. In particular, seems launches touch some of the configuration, and - if race conditions are met, that evidently causes some emulators either boot from scratch (overlook snapshots) due to an alleged config change or possibly boot with the wrong specs.
2. The well-known `adb jam` problem (see #1857): making tests run timeline vary can help avoid launching multiple `adb install` commands simultaneously, which seems to be the soft spot of `adb` with respect to that specific bug.