### PR TITLE
config(docs): rm outdated parallelization note

### DIFF
--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -174,8 +174,6 @@ Session can also be set per configuration:
 
 `config.json` refers to `--config` in https://facebook.github.io/jest/docs/en/configuration.html
 
->NOTE: jest tests will run in band, as Detox does not currently supports parallelization.
-
 ## detox-cli
 
 ### Build Configuration


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
detox supports `--workers` flag to enable parallelization with jest as noted in CLI docs: https://github.com/wix/Detox/blob/master/docs/APIRef.DetoxCLI.md