### PR TITLE
fix: use bugfixed telnet-client version

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -53,7 +53,7 @@
     "sanitize-filename": "^1.6.1",
     "shell-utils": "^1.0.9",
     "tail": "^2.0.0",
-    "telnet-client": "0.15.3",
+    "telnet-client": "1.2.8",
     "tempfile": "^2.0.0",
     "which": "^1.3.1",
     "ws": "^3.3.1",


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

I see CI build stuck with telnet connecting for 1 hour in TeamCity.

Checked source code of the former telnet-client version and it appears...

...they don't throw any error on timeout.

<img src="https://user-images.githubusercontent.com/1962469/80618454-14d6f200-8a4c-11ea-80bb-f96329c90561.png" width=64 >

P. S. Cannot bump to the latest, because they have changed licensing to LGPLv3, and I am not legally sure if we can use it.