### PR TITLE
wip

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -92,6 +92,7 @@
       "EmulatorTelnet.js",
       "EmulatorExec.js",
       "EmulatorLauncher.js",
+      "EmulatorAllocator.js",
       "DeviceDriverBase.js",
       "GREYConfiguration.js",
       "src/utils/environment.js",

--- a/detox/src/devices/drivers/android/EmulatorDriver.js
+++ b/detox/src/devices/drivers/android/EmulatorDriver.js
@@ -120,6 +120,12 @@ class EmulatorDriver extends AndroidDriver {
     const emulatorAllocator = new EmulatorAllocator(avdName, this.adb, this.deviceRegistry, this._emulatorExec);
 
     const adbName = await this.deviceRegistry.allocateDevice(() => emulatorAllocator.allocate());
+    // TODO temp, just for testing - must not be merged
+    if (emulatorAllocator.coldBooted) {
+      const sleep = require('../../../utils/sleep');
+      await sleep(15000);
+    }
+
     await this._waitForDevice(adbName);
     await this.emitter.emit('bootDevice', { coldBoot: emulatorAllocator.coldBooted, deviceId: adbName, type: adbName });
     return adbName;

--- a/detox/src/devices/drivers/android/emulator/EmulatorAllocator.js
+++ b/detox/src/devices/drivers/android/emulator/EmulatorAllocator.js
@@ -1,0 +1,57 @@
+const EmulatorLauncher = require('./EmulatorLauncher');
+const FreeEmulatorFinder = require('./FreeEmulatorFinder');
+const log = require('../../../../utils/logger').child({ __filename });
+
+const ALLOCATE_DEVICE_EV = 'ALLOCATE_DEVICE';
+const DetoxEmulatorsPortRange = {
+  min: 10000,
+  max: 20000
+};
+
+class EmulatorAllocator {
+  constructor(avdName, adb, deviceRegistry, emulatorExec) {
+    this._avdName = avdName;
+    this._freeEmuFinder = new FreeEmulatorFinder(adb, deviceRegistry, avdName);
+    this._emuLauncher = new EmulatorLauncher(emulatorExec);
+
+    this.coldBooted = undefined;
+  }
+
+  async allocate() {
+    log.debug({ event: ALLOCATE_DEVICE_EV }, `Looking up a device based on ${this._avdName}`);
+
+    let adbName = await this._freeEmuFinder.findFreeDevice();
+
+    let launchPort;
+    if (!adbName) {
+      launchPort = this._allocateAdbPort();
+      adbName = this._nameNewDevice(launchPort);
+    }
+
+    log.debug({ event: ALLOCATE_DEVICE_EV }, `Settled on ${adbName}`);
+
+    if (launchPort) {
+      await this._bootDevice(this._avdName, adbName, launchPort);
+    }
+    this.coldBooted = !!launchPort;
+
+    return adbName;
+  }
+
+  _allocateAdbPort() {
+    const {min, max} = DetoxEmulatorsPortRange;
+    let port = Math.random() * (max - min) + min;
+    port = port & 0xFFFFFFFE; // Should always be even
+    return port;
+  }
+
+  _nameNewDevice(port) {
+    return `emulator-${port}`;
+  }
+
+  async _bootDevice(avdName, adbName, port) {
+    await this._emuLauncher.launch(avdName, { port });
+  }
+}
+
+module.exports = EmulatorAllocator;

--- a/detox/src/devices/drivers/android/emulator/EmulatorAllocator.js
+++ b/detox/src/devices/drivers/android/emulator/EmulatorAllocator.js
@@ -31,7 +31,7 @@ class EmulatorAllocator {
     log.debug({ event: ALLOCATE_DEVICE_EV }, `Settled on ${adbName}`);
 
     if (launchPort) {
-      await this._bootDevice(this._avdName, adbName, launchPort);
+      await this._emuLauncher.launch(this._avdName, { port: launchPort });
     }
     this.coldBooted = !!launchPort;
 
@@ -47,10 +47,6 @@ class EmulatorAllocator {
 
   _nameNewDevice(port) {
     return `emulator-${port}`;
-  }
-
-  async _bootDevice(avdName, adbName, port) {
-    await this._emuLauncher.launch(avdName, { port });
   }
 }
 

--- a/detox/src/devices/drivers/android/emulator/FreeEmulatorFinder.js
+++ b/detox/src/devices/drivers/android/emulator/FreeEmulatorFinder.js
@@ -1,33 +1,31 @@
 const AdbDevicesHelper = require('../tools/AdbDevicesHelper');
 const log = require('../../../../utils/logger').child({ __filename });
 
-const ACQUIRE_DEVICE_EV = 'ACQUIRE_DEVICE';
+const DEVICE_LOOKUP_EV = 'DEVICE_LOOKUP';
 
 class FreeEmulatorFinder {
   constructor(adb, deviceRegistry, avdName) {
-    this.adbDevicesHelper = new AdbDevicesHelper(adb);
-    this.deviceRegistry = deviceRegistry;
     this.avdName = avdName;
+    this._adbDevicesHelper = new AdbDevicesHelper(adb);
+    this._deviceRegistry = deviceRegistry;
 
     this._matcherFn = this._matcherFn.bind(this);
   }
 
   async findFreeDevice() {
-    return await this.adbDevicesHelper.lookupDevice(this._matcherFn);
+    return await this._adbDevicesHelper.lookupDevice(this._matcherFn);
   }
 
   async _matcherFn(candidate) {
     const isEmulator = candidate.type === 'emulator';
-    const isBusy = this.deviceRegistry.isDeviceBusy(candidate.adbName);
+    const isBusy = this._deviceRegistry.isDeviceBusy(candidate.adbName);
 
     if (isEmulator && !isBusy) {
       if (await candidate.queryName() === this.avdName) {
-        log.debug({ event: ACQUIRE_DEVICE_EV }, `Found ${candidate.adbName}!`);
+        log.debug({ event: DEVICE_LOOKUP_EV }, `Found ${candidate.adbName}!`);
         return true;
       }
-      log.debug({ event: ACQUIRE_DEVICE_EV }, `${candidate.adbName} is available but AVD is different`);
-    } else {
-      log.debug({ event: ACQUIRE_DEVICE_EV }, `${candidate.adbName} is not a free emulator`, isEmulator, !isBusy);
+      log.debug({ event: DEVICE_LOOKUP_EV }, `${candidate.adbName} is available but AVD is different`);
     }
     return false;
   }

--- a/detox/test/e2e/utils/timeoutUtils.js
+++ b/detox/test/e2e/utils/timeoutUtils.js
@@ -2,5 +2,5 @@ const isInTimeoutTest = process.env.TIMEOUT_E2E_TEST === '1';
 
 module.exports = {
   initTimeout: isInTimeoutTest ? 30000 : 300000,
-  testTimeout: 120000,
+  testTimeout: 180000,
 };


### PR DESCRIPTION
- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

# Description:

A rephrase of the work in #2011: more deterministic and thorough. Introduces 2 fundamental changes:

#### Forced sequential launch of emulators (i.e. await launch if a launch is in session).

Implemented by including the emulator spawn in the lock-file scoped handler function (i.e. don't unlock until emu starts loading).
This aims at solving the following problem: The Android emulator binary doesn't seem to handle many launches taking place at the same time very well. In particular, seems launches touch some of the configuration, and - if race conditions are met, that evidently causes some emulators either boot from scratch (overlook snapshots) due to an alleged config change or possibly boot with the wrong specs.

#### Post-launch delay (todo)
 
Avoid moving forward to ADB commands until all emulators have completed spawning.
This addresses the now well-know adb-jam problem (see #1857), which following #2011, I now believe that reproduces when an emulator launches while an adb command is in-flight.
