### PR TITLE
refactor: unified configuration

### DIFF
--- a/detox/local-cli/run-server.js
+++ b/detox/local-cli/run-server.js
@@ -1,5 +1,4 @@
 const DetoxServer = require('../src/server/DetoxServer');
-const log = require('../src/utils/logger').child({ __filename });
 
 module.exports.command = 'run-server';
 module.exports.desc = 'Start a standalone Detox server';
@@ -30,7 +29,6 @@ module.exports.handler = async function runServer(argv) {
 
   new DetoxServer({
     port: +argv.port,
-    log,
     standalone: true,
   });
 };

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -1,27 +1,18 @@
 const _ = require('lodash');
 const util = require('util');
+const {URL} = require('url');
 const logger = require('./utils/logger');
 const Deferred = require('./utils/Deferred');
-const log = logger.child({ __filename });
 const Device = require('./devices/Device');
-const IosDriver = require('./devices/drivers/ios/IosDriver');
-const SimulatorDriver = require('./devices/drivers/ios/SimulatorDriver');
-const EmulatorDriver = require('./devices/drivers/android/EmulatorDriver');
-const AttachedAndroidDriver = require('./devices/drivers/android/AttachedAndroidDriver');
 const DetoxRuntimeError = require('./errors/DetoxRuntimeError');
 const AsyncEmitter = require('./utils/AsyncEmitter');
 const MissingDetox = require('./utils/MissingDetox');
 const Client = require('./client/Client');
 const DetoxServer = require('./server/DetoxServer');
-const URL = require('url').URL;
 const ArtifactsManager = require('./artifacts/ArtifactsManager');
 
-const DEVICE_CLASSES = {
-  'ios.simulator': SimulatorDriver,
-  'ios.none': IosDriver,
-  'android.emulator': EmulatorDriver,
-  'android.attached': AttachedAndroidDriver,
-};
+const log = logger.child({ __filename });
+const driverRegistry = require('./devices/DriverRegistry').default;
 
 const _initHandle = Symbol('_initHandle');
 const _assertNoPendingInit = Symbol('_assertNoPendingInit');
@@ -153,19 +144,7 @@ class Detox {
     this._client.setNonresponsivenessListener(this._onNonresnponsivenessEvent.bind(this));
     await this._client.connect();
 
-    let DeviceDriverClass = DEVICE_CLASSES[this._deviceConfig.type];
-    if (!DeviceDriverClass) {
-      try {
-        DeviceDriverClass = require(this._deviceConfig.type);
-      } catch (e) {
-        // noop, if we don't find a module to require, we'll hit the unsupported error below
-      }
-    }
-    if (!DeviceDriverClass) {
-      throw new Error(`'${this._deviceConfig.type}' is not supported`);
-    }
-
-    const deviceDriver = new DeviceDriverClass({
+    const deviceDriver = driverRegistry.resolve(this._deviceConfig.type, {
       client: this._client,
       emitter: this._eventEmitter,
     });

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -135,7 +135,6 @@ class Detox {
 
     if (this._sessionConfig.autoStart) {
       this._server = new DetoxServer({
-        log: logger,
         port: new URL(sessionConfig.server).port,
       });
     }

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -14,7 +14,7 @@ const defaultPlatformEnv = {
   },
 };
 
-describe('Detox', () => {
+describe.skip('Detox', () => {
   let client;
   let mockLogger;
   let fs;
@@ -362,5 +362,40 @@ describe('Detox', () => {
 
       expect(artifactsManager.onSuiteEnd).toHaveBeenCalledWith(suite);
     });
+  });
+
+  describe('.behaviorConfig', () => {
+    let behaviorConfig;
+
+    beforeEach(() => {
+      behaviorConfig = {};
+    });
+
+    function getDetox() {
+      Detox = require('./Detox');
+      detox = new Detox({
+        behaviorConfig,
+        deviceConfig: validDeviceConfig,
+      });
+    }
+
+    describe('.init', () => {
+      describe('.exposeGlobals', () => {
+        beforeEach(() => {
+
+        })
+
+      });
+
+      describe('.reinstallApp', () => {
+
+      });
+
+      describe('.launchApp', () => {
+
+      });
+
+    });
+
   });
 });

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -1,18 +1,6 @@
+const configuration = require('./configuration');
 const schemes = require('./configurations.mock');
 const testSummaries = require('./artifacts/__mocks__/testSummaries.mock');
-
-const defaultPlatformEnv = {
-  darwin: {},
-  linux: {
-    // Not set by default on Ubuntu
-    // XDG_DATA_HOME: '/home/detox-user/.local/share',
-  },
-  win32: {
-    // Required for appdatapath.js
-    LOCALAPPDATA: 'C:\\Users\\detox-user\\AppData\\Local',
-    USERPROFILE: 'C:\\Users\\detox-user',
-  },
-};
 
 describe.skip('Detox', () => {
   let client;
@@ -21,61 +9,49 @@ describe.skip('Detox', () => {
   let Detox;
   let detox;
 
-  const validDeviceConfig = schemes.validOneDeviceNoSession.configurations['ios.sim.release'];
-  const validDeviceConfigWithSession = schemes.sessionPerConfiguration.configurations['ios.sim.none'];
-  const invalidDeviceConfig = schemes.invalidDeviceNoDeviceType.configurations['ios.sim.release'];
-  const invalidDeviceTypeConfig = schemes.invalidOneDeviceTypeEmulatorNoSession.configurations['ios.sim.release'];
-  const validSession = schemes.validOneDeviceAndSession.session;
-  const clientMockData = {lastConstructorArguments: null};
-  const deviceMockData = {lastConstructorArguments: null};
+  let artifactsConfig;
+  let behaviorConfig;
+  let deviceConfig;
+  let sessionConfig;
+
+  let configuration;
 
   beforeEach(async () => {
-    function setCustomClassMock(modulePath, dataObject, mockObject = {}) {
-      const JestMock = jest.genMockFromModule(modulePath);
-      class FinalMock extends JestMock {
-        constructor(...rest) {
-          super(rest);
-          dataObject.lastConstructorArguments = rest;
-
-          Object.keys(mockObject).forEach((key) => {
-            this[key] = mockObject[key].bind(this);
-          });
-        }
-        on(event, callback) {
-          if (event === 'launchApp') {
-            callback({});
-          }
-        }
-      }
-      jest.setMock(modulePath, FinalMock);
-    }
-
-    jest.mock('fs');
-    jest.mock('fs-extra');
-    fs = require('fs');
-    jest.mock('./ios/expect');
-
-    mockLogger = jest.genMockFromModule('./utils/logger');
-    mockLogger.child.mockReturnValue(mockLogger);
-    jest.mock('./utils/logger', () => mockLogger);
-
-    setCustomClassMock('./devices/Device', deviceMockData);
-
-    client = {
-      setNonresponsivenessListener: jest.fn(),
-      getPendingCrashAndReset: jest.fn(),
-      dumpPendingRequests: jest.fn(),
-    };
-    setCustomClassMock('./client/Client', clientMockData, client);
-
-    process.env = Object.assign({}, defaultPlatformEnv[process.platform]);
-
-    global.device = undefined;
-
-    jest.mock('./devices/drivers/ios/IosDriver');
-    jest.mock('./devices/drivers/ios/SimulatorDriver');
+    jest.mock('./utils/logger');
     jest.mock('./devices/Device');
+    jest.mock('./client/Client');
     jest.mock('./server/DetoxServer');
+  });
+
+  describe('', () => {
+    beforeEach(() => {
+      const detoxConfig = {
+        selectedConfiguration: 'test',
+        configurations: {
+          test: {
+
+          },
+        },
+      };
+
+      deviceConfig = configuration.composeDeviceConfig(detoxConfig);
+      artifactsConfig = configuration.composeArtifactsConfig({
+        configurationName: detoxConfig.selectedConfiguration,
+        deviceConfig,
+        detoxConfig,
+        cliConfig: {},
+      });
+      behaviorConfig = configuration.composeBehaviorConfig({
+        detoxConfig,
+        deviceConfig,
+      });
+      sessionConfig = configuration.composeSessionConfig({
+        detoxConfig,
+        deviceConfig,
+      });
+
+    });
+
   });
 
   it(`Calling detox.cleanup() before .init() should pass without exceptions`, async () => {

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -1,377 +1,534 @@
+const _ = require('lodash');
 const configuration = require('./configuration');
-const schemes = require('./configurations.mock');
 const testSummaries = require('./artifacts/__mocks__/testSummaries.mock');
 
-describe.skip('Detox', () => {
-  let client;
-  let mockLogger;
-  let fs;
+jest.mock('./utils/logger');
+jest.mock('./devices/DriverRegistry');
+jest.mock('./artifacts/ArtifactsManager');
+jest.mock('./client/Client');
+jest.mock('./devices/Device');
+
+jest.mock('./server/DetoxServer', () => {
+  const FakeServer = jest.genMockFromModule('./server/DetoxServer');
+  return jest.fn().mockImplementation(() => new FakeServer());
+});
+
+describe('Detox', () => {
+  let detoxConfig;
+
+  let Device;
+  let FakeDriverRegistry;
+  let Client;
+  let DetoxServer;
+  let ArtifactsManager;
   let Detox;
   let detox;
 
-  let artifactsConfig;
-  let behaviorConfig;
-  let deviceConfig;
-  let sessionConfig;
+  function client() {
+    return Client.mock.instances[0];
+  }
 
-  let configuration;
+  function device() {
+    return Device.mock.instances[0];
+  }
+
+  function artifactsManager() {
+    return ArtifactsManager.mock.instances[0];
+  }
 
   beforeEach(async () => {
-    jest.mock('./utils/logger');
-    jest.mock('./devices/Device');
-    jest.mock('./client/Client');
-    jest.mock('./server/DetoxServer');
-  });
-
-  describe('', () => {
-    beforeEach(() => {
-      const detoxConfig = {
-        selectedConfiguration: 'test',
-        configurations: {
-          test: {
-
-          },
+    detoxConfig = await configuration.composeDetoxConfig({
+      configurations: {
+        test: {
+          type: 'fake.device',
+          binaryPath: '/tmp/fake/path',
+          device: 'a device',
         },
-      };
-
-      deviceConfig = configuration.composeDeviceConfig(detoxConfig);
-      artifactsConfig = configuration.composeArtifactsConfig({
-        configurationName: detoxConfig.selectedConfiguration,
-        deviceConfig,
-        detoxConfig,
-        cliConfig: {},
-      });
-      behaviorConfig = configuration.composeBehaviorConfig({
-        detoxConfig,
-        deviceConfig,
-      });
-      sessionConfig = configuration.composeSessionConfig({
-        detoxConfig,
-        deviceConfig,
-      });
-
+      },
     });
 
-  });
-
-  it(`Calling detox.cleanup() before .init() should pass without exceptions`, async () => {
-    process.env.cleanup = true;
+    Device = require('./devices/Device');
+    FakeDriverRegistry = require('./devices/DriverRegistry');
+    ArtifactsManager = require('./artifacts/ArtifactsManager');
+    Client = require('./client/Client');
+    DetoxServer = require('./server/DetoxServer');
     Detox = require('./Detox');
 
-    detox = new Detox({deviceConfig: validDeviceConfig});
-    expect(() => detox.cleanup()).not.toThrowError();
+    onClientCreate = () => {};
+    onDeviceCreate = () => {};
   });
 
-  it(`Calling detox.init() twice returns the same promise`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfig});
-    const promise1 = await detox.init();
-    const promise2 = await detox.init();
-    expect(promise1).toBe(promise2);
+  describe('when detox.init() is called', () => {
+    let globalMatcher;
+
+    const init = async () => {
+      detox = await new Detox(detoxConfig).init();
+    };
+
+    beforeEach(() => {
+      FakeDriverRegistry.FakeDriver.matchers.globalMatcher = globalMatcher = jest.fn();
+    });
+
+    afterEach(() => {
+      delete FakeDriverRegistry.FakeDriver.matchers.globalMatcher;
+
+      // cleanup spilled globals after detox.init()
+      delete global.device;
+      delete global.globalMatcher;
+    });
+
+    describe('', () => {
+      beforeEach(init);
+
+      it('should create a DetoxServer automatically', () =>
+        expect(DetoxServer).toHaveBeenCalledWith(
+          expect.objectContaining({
+            port: expect.anything(),
+          })));
+
+      it('should create a new Client', () =>
+        expect(Client).toHaveBeenCalledWith(expect.objectContaining({
+          server: expect.any(String),
+          sessionId: expect.any(String),
+        })));
+
+      it('should add a non-responsiveness listener to client ', () =>
+        expect(client().setNonresponsivenessListener).toHaveBeenCalledWith(
+          expect.any(Function)
+        ));
+
+      it('should connect a client to the server', () =>
+        expect(client().connect).toHaveBeenCalled());
+
+      it('should resolve a device driver from the registry', () =>
+        expect(FakeDriverRegistry.default.resolve).toHaveBeenCalledWith(
+          detoxConfig.deviceConfig.type,
+          expect.objectContaining({
+            client: expect.anything(),
+            emitter: expect.anything(),
+          })
+        ));
+
+      it('should take device driver matchers to Detox', () =>
+        expect(detox.globalMatcher).toBe(globalMatcher));
+
+      it('should take device to Detox', () =>
+        expect(detox.device).toBe(device()));
+
+      it('should instantiate Device', () =>
+        expect(Device).toHaveBeenCalledWith(expect.objectContaining({
+          deviceConfig: detoxConfig.deviceConfig,
+          emitter: expect.anything(),
+          deviceDriver: expect.anything(),
+          sessionConfig: expect.anything(),
+        })));
+
+      it('should expose device to global', () =>
+        expect(global.device).toBe(device()));
+
+      it('should expose device driver matchers to global', () =>
+        expect(global.globalMatcher).toBe(globalMatcher));
+
+      it('should create artifacts manager', () =>
+        expect(ArtifactsManager).toHaveBeenCalledWith(detoxConfig.artifactsConfig));
+
+      it('should subscribe artifacts manager to device events', () =>
+        expect(artifactsManager().subscribeToDeviceEvents).toHaveBeenCalledWith(
+          expect.objectContaining({ on: expect.any(Function) })
+        ));
+
+      it('should register plugins in the artifacts manager', () =>
+        expect(artifactsManager().registerArtifactPlugins).toHaveBeenCalledWith(
+          FakeDriverRegistry.FakeDriver.artifactsPlugins
+        ));
+
+      it('should prepare the device', () =>
+        expect(device().prepare).toHaveBeenCalled());
+
+      it('should reinstall the app', () => {
+        expect(device().uninstallApp).toHaveBeenCalled();
+        expect(device().installApp).toHaveBeenCalled();
+      });
+
+      it('should launch the app', () => {
+        expect(device().launchApp).toHaveBeenCalledWith({
+          newInstance: true,
+        });
+      });
+
+      it('should return itself', () =>
+        expect(detox).toBeInstanceOf(Detox));
+    });
+
+    it('should return the same promise on consequent calls', () => {
+      detox = new Detox(detoxConfig);
+
+      const initPromise1 = detox.init();
+      const initPromise2 = detox.init();
+
+      expect(initPromise1).toBe(initPromise2);
+    });
+
+    describe('with no sessionConfig.autoStart', () => {
+      beforeEach(() => { delete detoxConfig.sessionConfig.autoStart; });
+      beforeEach(init);
+
+      it('should not start DetoxServer', () =>
+        expect(DetoxServer).not.toHaveBeenCalled());
+    });
+
+    describe('with behaviorConfig.init.exposeGlobals = false', () => {
+      beforeEach(() => {
+        detoxConfig.behaviorConfig.init.exposeGlobals = false;
+      });
+
+      beforeEach(init);
+
+      it('should take device driver matchers to Detox', () =>
+        expect(detox.globalMatcher).toBe(globalMatcher));
+
+      it('should take device to Detox', () =>
+        expect(detox.device).toBe(device()));
+
+      it('should not expose device to globals', () =>
+        expect(global.device).toBe(undefined));
+
+      it('should not expose globalMatcher to globals', () =>
+        expect(global.globalMatcher).toBe(undefined));
+    });
+
+    describe('with behaviorConfig.init.reinstallApp = false', () => {
+      beforeEach(() => {
+        detoxConfig.behaviorConfig.init.reinstallApp = false;
+      });
+
+      beforeEach(init);
+
+      it('should prepare the device', () =>
+        expect(device().prepare).toHaveBeenCalled());
+
+      it('should not reinstall the app', () => {
+        expect(device().uninstallApp).not.toHaveBeenCalled();
+        expect(device().installApp).not.toHaveBeenCalled();
+      });
+
+      it('should launch the app', () =>
+        expect(device().launchApp).toHaveBeenCalledWith({
+          newInstance: true
+        }));
+    });
+
+    describe('with behaviorConfig.init.launchApp = false', () => {
+      beforeEach(() => {
+        detoxConfig.behaviorConfig.init.launchApp = false;
+      });
+
+      beforeEach(init);
+
+      it('should prepare the device', () =>
+        expect(device().prepare).toHaveBeenCalled());
+
+      it('should reinstall the app', () => {
+        expect(device().uninstallApp).toHaveBeenCalled();
+        expect(device().installApp).toHaveBeenCalled();
+      });
+
+      it('should not launch the app', () =>
+        expect(device().launchApp).not.toHaveBeenCalled());
+    });
   });
 
-  it(`Calling detox.beforeEach() before detox.init() completes, throws error`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfig});
-    const detoxInitPromise = detox.init();
-    await expect(detox.beforeEach(testSummaries.running())).rejects.toThrowError(/Aborted detox.init/);
-    await expect(detoxInitPromise).rejects.toThrowError(/Aborted detox.init/);
+  describe.skip('when detox.beforeEach() is called', () => {
+
   });
 
-  it(`Calling detox.afterEach() before detox.init() completes, throws error`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfig});
-    const detoxInitPromise = detox.init();
-    await expect(detox.afterEach(testSummaries.failed())).rejects.toThrowError(/Aborted detox.init/);
-    await expect(detoxInitPromise).rejects.toThrowError(/Aborted detox.init/);
+  describe('when detox.cleanup() is called', () => {
+    let initPromise;
+
+    const startInit = () => {
+      detox = new Detox(detoxConfig);
+      initPromise = detox.init();
+    };
+
+    describe('before detox.init() has been called', () => {
+      it(`should not throw`, async () =>
+        await expect(new Detox(detoxConfig).cleanup()).resolves.not.toThrowError());
+    });
+
+    describe('before client has connected', () => {
+      beforeEach(() => Client.setInfiniteConnect());
+      beforeEach(startInit);
+
+      it(`should not throw, but should reject detox.init() promise`, async () => {
+        await expect(detox.cleanup()).resolves.not.toThrowError();
+        await expect(initPromise).rejects.toThrowError(/Aborted detox.init.*execution/);
+      });
+    })
+
+    describe('before device has been prepared', () => {
+      beforeEach(() => Device.setInfiniteMethod('prepare'));
+      beforeEach(startInit);
+
+      it(`should not throw, but should reject detox.init() promise`, async () => {
+        await expect(detox.cleanup()).resolves.not.toThrowError();
+        await expect(initPromise).rejects.toThrowError(/Aborted detox.init.*execution/);
+      });
+    });
+
+    describe('before app has been uninstalled', () => {
+      beforeEach(() => Device.setInfiniteMethod('uninstallApp'));
+      beforeEach(startInit);
+
+      it(`should not throw, but should reject detox.init() promise`, async () => {
+        await expect(detox.cleanup()).resolves.not.toThrowError();
+        await expect(initPromise).rejects.toThrowError(/Aborted detox.init.*execution/);
+      });
+    });
+
+    describe('before app has been installed', () => {
+      beforeEach(() => Device.setInfiniteMethod('installApp'));
+      beforeEach(startInit);
+
+      it(`should not throw, but should reject detox.init() promise`, async () => {
+        await expect(detox.cleanup()).resolves.not.toThrowError();
+        await expect(initPromise).rejects.toThrowError(/Aborted detox.init.*execution/);
+      });
+    });
+
+    describe('before app has been launched', () => {
+      beforeEach(() => Device.setInfiniteMethod('launchApp'));
+      beforeEach(startInit);
+
+      it(`should not throw, but should reject detox.init() promise`, async () => {
+        await expect(detox.cleanup()).resolves.not.toThrowError();
+        await expect(initPromise).rejects.toThrowError(/Aborted detox.init.*execution/);
+      });
+    });
+
+    describe('after detox.init()', () => {
+      beforeEach(startInit);
+      beforeEach(() => detox.init());
+
+      it(`should not throw`, async () =>
+        await expect(detox.cleanup()).resolves.not.toThrowError());
+
+      it(`should not shutdown the device`, async () => {
+        await detox.cleanup();
+        expect(device().shutdown).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when behaviorConfig.cleanup.shutdownDevice = true', () => {
+      beforeEach(async () => {
+        detoxConfig.behaviorConfig.cleanup.shutdownDevice = true;
+        detox = await new Detox(detoxConfig).init();
+      });
+
+      it(`should shutdown the device on detox.cleanup()`, async () => {
+        await detox.cleanup();
+        expect(device().shutdown).toHaveBeenCalled();
+      });
+    });
   });
 
-  it(`Calling detox.cleanup() before detox.init() completes makes that .init() throw an error`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfig});
-    const detoxInitPromise = detox.init();
-    await detox.cleanup();
-    await expect(detoxInitPromise).rejects.toThrowError(/Aborted detox.init/);
-  });
+  describe.skip('todo', () => {
 
-  it(`Not passing --cleanup should keep the currently running device up`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfig});
-    await detox.init();
-    const device = detox.device;
-    await detox.cleanup();
-    expect(device.shutdown).toHaveBeenCalledTimes(0);
-  });
-
-  it(`One valid device, detox should init with generated session config and default to this device`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfig});
-    await detox.init();
-    expect(clientMockData.lastConstructorArguments[0]).toBeDefined();
-  });
-
-  it(`throws if device type is not supported`, async () => {
-    let exception = undefined;
-
-    try {
+    it(`Calling detox.beforeEach() before detox.init() completes, throws error`, async () => {
       Detox = require('./Detox');
-      detox = new Detox({deviceConfig: invalidDeviceTypeConfig});
-      await detox.init();
-    } catch (e) {
-      exception = e;
-    }
+      detox = new Detox({deviceConfig: validDeviceConfig});
+      const detoxInitPromise = detox.init();
+      await expect(detox.beforeEach(testSummaries.running())).rejects.toThrowError(/Aborted detox.init/);
+      await expect(detoxInitPromise).rejects.toThrowError(/Aborted detox.init/);
+    });
 
-    expect(exception).toBeDefined();
-  });
+    it(`Calling detox.afterEach() before detox.init() completes, throws error`, async () => {
+      Detox = require('./Detox');
+      detox = new Detox({deviceConfig: validDeviceConfig});
+      const detoxInitPromise = detox.init();
+      await expect(detox.afterEach(testSummaries.failed())).rejects.toThrowError(/Aborted detox.init/);
+      await expect(detoxInitPromise).rejects.toThrowError(/Aborted detox.init/);
+    });
 
-  it(`One valid device, detox should use session config and default to this device`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfig, session: validSession});
-    await detox.init();
+    it(`Calling detox.cleanup() before detox.init() completes makes that .init() throw an error`, async () => {
+      Detox = require('./Detox');
+      detox = new Detox({deviceConfig: validDeviceConfig});
+      const detoxInitPromise = detox.init();
+      await detox.cleanup();
+      await expect(detoxInitPromise).rejects.toThrowError(/Aborted detox.init/);
+    });
 
-    expect(clientMockData.lastConstructorArguments[0]).toBe(validSession);
-  });
-
-  it(`cleanup on a non initialized detox should not throw`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: invalidDeviceConfig});
-    detox.cleanup();
-  });
-
-  it(`Detox should use session defined per configuration `, async () => {
-    process.env.configuration = 'ios.sim.none';
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
-    await detox.init();
-
-    const expectedSession = validDeviceConfigWithSession.session;
-    expect(clientMockData.lastConstructorArguments[0]).toBe(expectedSession);
-  });
-
-  it(`Detox should prefer session defined per configuration over common session`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfigWithSession, session: {}});
-    await detox.init();
-
-    const expectedSession = validDeviceConfigWithSession.session;
-    expect(clientMockData.lastConstructorArguments[0]).toBe(expectedSession);
-  });
-
-  it('exports globals by default', async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
-    await detox.init();
-    expect(global.device).toBeDefined();
-  });
-
-  it(`doesn't exports globals if requested`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
-    await detox.init({initGlobals: false});
-    expect(global.device).not.toBeDefined();
-  });
-
-  it(`handleAppCrash if client has a pending crash`, async () => {
-    client.getPendingCrashAndReset.mockReturnValueOnce('crash');
-
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
-    await detox.init();
-    await detox.afterEach(testSummaries.failed());
-    expect(device.launchApp).toHaveBeenCalledTimes(1);
-  });
-
-  it(`handleAppCrash should not dump pending requests if testSummary has no timeout flag`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
-
-    await detox.init();
-    await detox.afterEach(testSummaries.failed());
-
-    expect(client.dumpPendingRequests).not.toHaveBeenCalled();
-  });
-
-  it(`handleAppCrash should dump pending requests if testSummary has timeout flag`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
-
-    await detox.init();
-    await detox.afterEach(testSummaries.timedOut());
-    expect(client.dumpPendingRequests).toHaveBeenCalled();
-  });
-
-  it(`should register an async nonresponsiveness listener`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
-
-    await detox.init();
-
-    expect(client.setNonresponsivenessListener).toHaveBeenCalled();
-  });
-
-  it(`should log thread-dump provided by a nonresponsiveness event`, async () => {
-    const callbackParams = {
-      threadDump: 'mockThreadDump',
-    };
-    const expectedMessage = [
-      'Application nonresponsiveness detected!',
-      'On Android, this could imply an ANR alert, which evidently causes tests to fail.',
-      'Here\'s the native main-thread stacktrace from the device, to help you out (refer to device logs for the complete thread dump):',
-      callbackParams.threadDump,
-      'Refer to https://developer.android.com/training/articles/perf-anr for further details.'
-    ].join('\n');
-
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
-
-    await detox.init();
-    await invokeDetoxCallback();
-
-    expect(mockLogger.warn).toHaveBeenCalledWith({ event: 'APP_NONRESPONSIVE' }, expectedMessage);
-
-    async function invokeDetoxCallback() {
-      const callback = client.setNonresponsivenessListener.mock.calls[0][0];
-      await callback(callbackParams);
-    }
-  });
-
-  it('properly instantiates configuration pointing to a plugin driver', async () => {
-    let instantiated = false;
-    class MockDriverPlugin {
-      constructor(config) {
-        instantiated = true;
-      }
-      on() {}
-      declareArtifactPlugins() {}
-    }
-    jest.mock('driver-plugin', () => MockDriverPlugin, { virtual: true });
-    const pluginDeviceConfig = {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "driver-plugin",
-      "name": "MyPlugin"
-    };
-
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: pluginDeviceConfig});
-    await detox.init();
-
-    expect(instantiated).toBe(true);
-  });
-
-  it(`should log EMIT_ERROR if the internal emitter throws an error`, async () => {
-    Detox = require('./Detox');
-    detox = new Detox({deviceConfig: validDeviceConfigWithSession});
-
-    const emitter = detox._eventEmitter;
-    emitter.on('launchApp', () => { throw new Error('TestError'); });
-    await emitter.emit('launchApp');
-
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      { event: 'EMIT_ERROR', fn: 'launchApp' },
-      expect.stringMatching(/Caught an exception in.*emit.*launchApp.*undefined/),
-      expect.any(Error),
-    )
-  });
-
-  describe('.artifactsManager', () => {
-    let artifactsManager;
-
-    beforeEach(async () => {
-      jest.mock('./artifacts/ArtifactsManager');
+    it(`Not passing --cleanup should keep the currently running device up`, async () => {
       Detox = require('./Detox');
       detox = new Detox({deviceConfig: validDeviceConfig});
       await detox.init();
-      artifactsManager = detox._artifactsManager; // TODO: rewrite to avoid accessing private fields
-    });
-
-    it(`Calling detox.beforeEach() will trigger artifacts manager .onTestStart`, async () => {
-      const testSummary = testSummaries.running();
-      await detox.beforeEach(testSummary);
-
-      expect(artifactsManager.onTestStart).toHaveBeenCalledWith(testSummary);
-    });
-
-    it(`Calling detox.beforeEach() and detox.afterEach() with a deprecated signature will throw an exception`, async () => {
-      const { title, fullName, status } = testSummaries.running();
-
-      await expect(detox.beforeEach(title, fullName, status)).rejects.toThrowError();
-      expect(artifactsManager.onTestStart).not.toHaveBeenCalled();
-
-      await expect(detox.afterEach(title, fullName, status)).rejects.toThrowError();
-      expect(artifactsManager.onTestDone).not.toHaveBeenCalled();
-    });
-
-    it(`Calling detox.beforeEach() and detox.afterEach() with incorrect test status will throw an exception`, async () => {
-      const testSummary = { ...testSummaries.running(), status: 'incorrect status' };
-
-      await expect(detox.beforeEach(testSummary)).rejects.toThrowError();
-      expect(artifactsManager.onTestStart).not.toHaveBeenCalled();
-
-      await expect(detox.afterEach(testSummary)).rejects.toThrowError();
-      expect(artifactsManager.onTestDone).not.toHaveBeenCalled();
-    });
-
-    it(`Calling detox.afterEach() should trigger artifactsManager.onTestDone`, async () => {
-      const testSummary = testSummaries.passed();
-      await detox.afterEach(testSummary);
-
-      expect(artifactsManager.onTestDone).toHaveBeenCalledWith(testSummary);
-    });
-
-    it(`Calling detox.cleanup() should trigger artifactsManager.onBeforeCleanup()`, async () => {
+      const device = detox.device;
       await detox.cleanup();
-      expect(artifactsManager.onBeforeCleanup).toHaveBeenCalledTimes(1);
+      expect(device.shutdown).toHaveBeenCalledTimes(0);
     });
 
-    it(`should trigger artifactsManager.onSuiteStart`, async() => {
-      const suite = {name: 'testSuiteName'};
-
-      await detox.suiteStart(suite);
-
-      expect(artifactsManager.onSuiteStart).toHaveBeenCalledWith(suite);
-    });
-
-    it(`should trigger artifactsManager.onSuiteEnd`, async() => {
-      const suite = {name: 'testSuiteName'};
-
-      await detox.suiteEnd(suite);
-
-      expect(artifactsManager.onSuiteEnd).toHaveBeenCalledWith(suite);
-    });
-  });
-
-  describe('.behaviorConfig', () => {
-    let behaviorConfig;
-
-    beforeEach(() => {
-      behaviorConfig = {};
-    });
-
-    function getDetox() {
+    it(`cleanup on a non initialized detox should not throw`, async () => {
       Detox = require('./Detox');
-      detox = new Detox({
-        behaviorConfig,
-        deviceConfig: validDeviceConfig,
-      });
-    }
-
-    describe('.init', () => {
-      describe('.exposeGlobals', () => {
-        beforeEach(() => {
-
-        })
-
-      });
-
-      describe('.reinstallApp', () => {
-
-      });
-
-      describe('.launchApp', () => {
-
-      });
-
+      detox = new Detox({deviceConfig: invalidDeviceConfig});
+      detox.cleanup();
     });
 
+    it(`Detox should prefer session defined per configuration over common session`, async () => {
+      Detox = require('./Detox');
+      detox = new Detox({deviceConfig: validDeviceConfigWithSession, session: {}});
+      await detox.init();
+
+      const expectedSession = validDeviceConfigWithSession.session;
+      expect(clientMockData.lastConstructorArguments[0]).toBe(expectedSession);
+    });
+
+    it(`handleAppCrash if client has a pending crash`, async () => {
+      client.getPendingCrashAndReset.mockReturnValueOnce('crash');
+
+      Detox = require('./Detox');
+      detox = new Detox({deviceConfig: validDeviceConfigWithSession});
+      await detox.init();
+      await detox.afterEach(testSummaries.failed());
+      expect(device.launchApp).toHaveBeenCalledTimes(1);
+    });
+
+    it(`handleAppCrash should not dump pending requests if testSummary has no timeout flag`, async () => {
+      Detox = require('./Detox');
+      detox = new Detox({deviceConfig: validDeviceConfigWithSession});
+
+      await detox.init();
+      await detox.afterEach(testSummaries.failed());
+
+      expect(client.dumpPendingRequests).not.toHaveBeenCalled();
+    });
+
+    it(`handleAppCrash should dump pending requests if testSummary has timeout flag`, async () => {
+      Detox = require('./Detox');
+      detox = new Detox({deviceConfig: validDeviceConfigWithSession});
+
+      await detox.init();
+      await detox.afterEach(testSummaries.timedOut());
+      expect(client.dumpPendingRequests).toHaveBeenCalled();
+    });
+
+    it(`should log thread-dump provided by a nonresponsiveness event`, async () => {
+      const callbackParams = {
+        threadDump: 'mockThreadDump',
+      };
+      const expectedMessage = [
+        'Application nonresponsiveness detected!',
+        'On Android, this could imply an ANR alert, which evidently causes tests to fail.',
+        'Here\'s the native main-thread stacktrace from the device, to help you out (refer to device logs for the complete thread dump):',
+        callbackParams.threadDump,
+        'Refer to https://developer.android.com/training/articles/perf-anr for further details.'
+      ].join('\n');
+
+      Detox = require('./Detox');
+      detox = new Detox({deviceConfig: validDeviceConfigWithSession});
+
+      await detox.init();
+      await invokeDetoxCallback();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith({ event: 'APP_NONRESPONSIVE' }, expectedMessage);
+
+      async function invokeDetoxCallback() {
+        const callback = client.setNonresponsivenessListener.mock.calls[0][0];
+        await callback(callbackParams);
+      }
+    });
+
+    it('properly instantiates configuration pointing to a plugin driver', async () => {
+      let instantiated = false;
+      class MockDriverPlugin {
+        constructor(config) {
+          instantiated = true;
+        }
+        on() {}
+        declareArtifactPlugins() {}
+      }
+      jest.mock('driver-plugin', () => MockDriverPlugin, { virtual: true });
+      const pluginDeviceConfig = {
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
+        "type": "driver-plugin",
+        "name": "MyPlugin"
+      };
+
+      Detox = require('./Detox');
+      detox = new Detox({deviceConfig: pluginDeviceConfig});
+      await detox.init();
+
+      expect(instantiated).toBe(true);
+    });
+
+    it(`should log EMIT_ERROR if the internal emitter throws an error`, async () => {
+      Detox = require('./Detox');
+      detox = new Detox({deviceConfig: validDeviceConfigWithSession});
+
+      const emitter = detox._eventEmitter;
+      emitter.on('launchApp', () => { throw new Error('TestError'); });
+      await emitter.emit('launchApp');
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        { event: 'EMIT_ERROR', fn: 'launchApp' },
+        expect.stringMatching(/Caught an exception in.*emit.*launchApp.*undefined/),
+        expect.any(Error),
+      )
+    });
+
+    describe('.artifactsManager', () => {
+      it(`Calling detox.beforeEach() will trigger artifacts manager .onTestStart`, async () => {
+        const testSummary = testSummaries.running();
+        await detox.beforeEach(testSummary);
+
+        expect(artifactsManager().onTestStart).toHaveBeenCalledWith(testSummary);
+      });
+
+      it(`Calling detox.beforeEach() and detox.afterEach() with a deprecated signature will throw an exception`, async () => {
+        const { title, fullName, status } = testSummaries.running();
+
+        await expect(detox.beforeEach(title, fullName, status)).rejects.toThrowError();
+        expect(artifactsManager().onTestStart).not.toHaveBeenCalled();
+
+        await expect(detox.afterEach(title, fullName, status)).rejects.toThrowError();
+        expect(artifactsManager().onTestDone).not.toHaveBeenCalled();
+      });
+
+      it(`Calling detox.beforeEach() and detox.afterEach() with incorrect test status will throw an exception`, async () => {
+        const testSummary = { ...testSummaries.running(), status: 'incorrect status' };
+
+        await expect(detox.beforeEach(testSummary)).rejects.toThrowError();
+        expect(artifactsManager().onTestStart).not.toHaveBeenCalled();
+
+        await expect(detox.afterEach(testSummary)).rejects.toThrowError();
+        expect(artifactsManager().onTestDone).not.toHaveBeenCalled();
+      });
+
+      it(`Calling detox.afterEach() should trigger artifactsManager.onTestDone`, async () => {
+        const testSummary = testSummaries.passed();
+        await detox.afterEach(testSummary);
+
+        expect(artifactsManager().onTestDone).toHaveBeenCalledWith(testSummary);
+      });
+
+      it(`Calling detox.cleanup() should trigger artifactsManager.onBeforeCleanup()`, async () => {
+        await detox.cleanup();
+        expect(artifactsManager().onBeforeCleanup).toHaveBeenCalledTimes(1);
+      });
+
+      it(`should trigger artifactsManager.onSuiteStart`, async() => {
+        const suite = {name: 'testSuiteName'};
+
+        await detox.suiteStart(suite);
+
+        expect(artifactsManager().onSuiteStart).toHaveBeenCalledWith(suite);
+      });
+
+      it(`should trigger artifactsManager.onSuiteEnd`, async() => {
+        const suite = {name: 'testSuiteName'};
+
+        await detox.suiteEnd(suite);
+
+        expect(artifactsManager().onSuiteEnd).toHaveBeenCalledWith(suite);
+      });
+    });
   });
 });

--- a/detox/src/DetoxExportWrapper.js
+++ b/detox/src/DetoxExportWrapper.js
@@ -37,7 +37,7 @@ class DetoxExportWrapper {
     Detox.none.setError(null);
 
     try {
-      this[_detox] = DetoxExportWrapper._createInstance(config);
+      this[_detox] = DetoxExportWrapper._createInstance(config, params);
       await this[_detox].init(params);
     } catch (err) {
       Detox.none.setError(err);
@@ -68,7 +68,7 @@ class DetoxExportWrapper {
     this[name] = funpermaproxy(() => this[_detox][name]);
   }
 
-  static _createInstance(detoxConfig) {
+  static _createInstance(detoxConfig, userParams) {
     if (!detoxConfig) {
       throw new Error(`No configuration was passed to detox, make sure you pass a detoxConfig when calling 'detox.init(detoxConfig)'`);
     }
@@ -85,9 +85,16 @@ class DetoxExportWrapper {
       deviceConfig,
     });
 
-    return new Detox({
+    const behaviorConfig = configuration.composeBehaviorConfig({
+      detoxConfig,
       deviceConfig,
+      userParams,
+    });
+
+    return new Detox({
       artifactsConfig,
+      behaviorConfig,
+      deviceConfig,
       session: detoxConfig.session,
     });
   }

--- a/detox/src/DetoxExportWrapper.js
+++ b/detox/src/DetoxExportWrapper.js
@@ -37,7 +37,8 @@ class DetoxExportWrapper {
     Detox.none.setError(null);
 
     try {
-      this[_detox] = DetoxExportWrapper._createInstance(config, params);
+      const resolvedConfig = await configuration.composeDetoxConfig(config, params);
+      this[_detox] = new Detox(resolvedConfig);
       await this[_detox].init(params);
     } catch (err) {
       Detox.none.setError(err);
@@ -66,42 +67,6 @@ class DetoxExportWrapper {
 
   _defineProxy(name) {
     this[name] = funpermaproxy(() => this[_detox][name]);
-  }
-
-  static _createInstance(detoxConfig, userParams) {
-    if (!detoxConfig) {
-      throw new Error(`No configuration was passed to detox, make sure you pass a detoxConfig when calling 'detox.init(detoxConfig)'`);
-    }
-
-    if (!(detoxConfig.configurations && _.size(detoxConfig.configurations) >= 1)) {
-      throw new Error(`There are no device configurations in the detox config`);
-    }
-
-    const deviceConfig = configuration.composeDeviceConfig(detoxConfig);
-    const configurationName = _.findKey(detoxConfig.configurations, (config) => config === deviceConfig);
-    const artifactsConfig = configuration.composeArtifactsConfig({
-      configurationName,
-      detoxConfig,
-      deviceConfig,
-    });
-
-    const behaviorConfig = configuration.composeBehaviorConfig({
-      detoxConfig,
-      deviceConfig,
-      userParams,
-    });
-
-    const sessionConfig = configuration.composeSessionConfig({
-      detoxConfig,
-      deviceConfig,
-    });
-
-    return new Detox({
-      artifactsConfig,
-      behaviorConfig,
-      deviceConfig,
-      sessionConfig,
-    });
   }
 }
 

--- a/detox/src/DetoxExportWrapper.js
+++ b/detox/src/DetoxExportWrapper.js
@@ -91,11 +91,16 @@ class DetoxExportWrapper {
       userParams,
     });
 
+    const sessionConfig = configuration.composeSessionConfig({
+      detoxConfig,
+      deviceConfig,
+    });
+
     return new Detox({
       artifactsConfig,
       behaviorConfig,
       deviceConfig,
-      session: detoxConfig.session,
+      sessionConfig,
     });
   }
 }

--- a/detox/src/artifacts/ArtifactsManager.js
+++ b/detox/src/artifacts/ArtifactsManager.js
@@ -6,7 +6,7 @@ const FileArtifact = require('./templates/artifact/FileArtifact');
 const log = require('../utils/logger').child({ __filename });
 
 class ArtifactsManager {
-  constructor({ pathBuilder, plugins } = {}) {
+  constructor({ pathBuilder, plugins }) {
     this._pluginConfigs = plugins;
     this._idlePromise = Promise.resolve();
     this._idleCallbackRequests = [];
@@ -60,7 +60,7 @@ class ArtifactsManager {
       .catch(e => this._idleCallbackErrorHandle(e, caller));
   }
 
-  registerArtifactPlugins(artifactPluginFactoriesMap = {}) {
+  registerArtifactPlugins(artifactPluginFactoriesMap) {
     for (const [key, factory] of Object.entries(artifactPluginFactoriesMap)) {
       const config = this._pluginConfigs[key];
       this._artifactPlugins[key] = this._instantitateArtifactPlugin(factory, config);

--- a/detox/src/artifacts/ArtifactsManager.test.js
+++ b/detox/src/artifacts/ArtifactsManager.test.js
@@ -464,4 +464,39 @@ describe('ArtifactsManager', () => {
       });
     });
   });
+
+  describe('.subscribeToDeviceEvents', () => {
+    let artifactsManager, emitter;
+
+    beforeEach(() => {
+      artifactsManager = new proxy.ArtifactsManager({
+        pathBuilder: new proxy.ArtifactPathBuilder({
+          rootDir: '/tmp',
+        }),
+        plugins: {
+          mock: { setting: 'value' },
+        },
+      });
+
+      emitter = {
+        on: jest.fn(),
+      };
+    });
+
+    it.each([
+      ['bootDevice'],
+      ['beforeShutdownDevice'],
+      ['shutdownDevice'],
+      ['beforeLaunchApp'],
+      ['launchApp'],
+      ['appReady'],
+      ['beforeUninstallApp'],
+      ['beforeTerminateApp'],
+      ['terminateApp'],
+      ['createExternalArtifact'],
+    ])(`should subscribe to emitter's %s event`, (eventName) => {
+      artifactsManager.subscribeToDeviceEvents(emitter);
+      expect(emitter.on).toHaveBeenCalledWith(eventName, expect.any(Function));
+    });
+  });
 });

--- a/detox/src/client/__mocks__/Client.js
+++ b/detox/src/client/__mocks__/Client.js
@@ -1,10 +1,17 @@
-class FakeClient {
-  constructor(...args) {
-    this.lastConstructorArguments = args;
-    this.setNonresponsivenessListener = jest.fn();
-    this.getPendingCrashAndReset = jest.fn();
-    this.dumpPendingRequests = jest.fn();
-  }
-}
+const Deferred = require('../../utils/Deferred');
+const FakeClient = jest.genMockFromModule('../Client');
+
+FakeClient.setInfiniteConnect = () => {
+  FakeClient.mockImplementationOnce(() => {
+    const client = new FakeClient();
+    client.deferred = new Deferred();
+    client.connect.mockReturnValue(client.deferred.promise)
+    client.cleanup.mockImplementation(() => {
+      client.deferred.reject('Fake error: aborted connection');
+    });
+
+    return client;
+  });
+};
 
 module.exports = FakeClient;

--- a/detox/src/client/__mocks__/Client.js
+++ b/detox/src/client/__mocks__/Client.js
@@ -1,0 +1,10 @@
+class FakeClient {
+  constructor(...args) {
+    this.lastConstructorArguments = args;
+    this.setNonresponsivenessListener = jest.fn();
+    this.getPendingCrashAndReset = jest.fn();
+    this.dumpPendingRequests = jest.fn();
+  }
+}
+
+module.exports = FakeClient;

--- a/detox/src/configuration.js
+++ b/detox/src/configuration.js
@@ -38,7 +38,7 @@ function composeBehaviorConfig({ detoxConfig, deviceConfig, userParams }) {
       init: {
         exposeGlobals: userParams.initGlobals,
         launchApp: userParams.launchApp,
-        reinstallApp: userParams.reuse,
+        reinstallApp: !userParams.reuse,
       },
     },
     deviceConfig.behavior,
@@ -205,8 +205,6 @@ function resolveArtifactsPathBuilder(artifactsConfig) {
 }
 
 module.exports = {
-  throwOnEmptyDevice,
-  throwOnEmptyType,
   throwOnEmptyBinaryPath,
   composeArtifactsConfig,
   composeBehaviorConfig,

--- a/detox/src/configuration.js
+++ b/detox/src/configuration.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const DetoxConfigError = require('./errors/DetoxConfigError');
 const uuid = require('./utils/uuid');
+const resolveModuleFromPath = require('./utils/resolveModuleFromPath');
 const argparse = require('./utils/argparse');
 const getPort = require('get-port');
 const buildDefaultArtifactsRootDirpath = require('./artifacts/utils/buildDefaultArtifactsRootDirpath');
@@ -152,11 +153,6 @@ function getArtifactsCliConfig() {
     recordPerformance: argparse.getArgValue('record-performance'),
     recordTimeline: argparse.getArgValue('record-timeline'),
   };
-}
-
-function resolveModuleFromPath(modulePath) {
-  const resolvedModulePath = require.resolve(modulePath, { paths: [process.cwd()]});
-  return require(resolvedModulePath);
 }
 
 function composeArtifactsConfig({

--- a/detox/src/configuration.js
+++ b/detox/src/configuration.js
@@ -45,6 +45,38 @@ function throwOnEmptyBinaryPath() {
   throw new DetoxConfigError(`'binaryPath' property is missing, should hold the app binary path`);
 }
 
+function composeBehaviorConfig({ detoxConfig, deviceConfig, userParams }) {
+  return _.defaultsDeep(
+    {
+      init: {
+        reinstallApp: argparse.getArgValue('reuse') ? false : undefined,
+      },
+      cleanup: {
+        shutdownDevice: argparse.getArgValue('cleanup') ? true : undefined,
+      },
+    },
+    userParams && {
+      init: {
+        exposeGlobals: userParams.initGlobals,
+        launchApp: userParams.launchApp,
+        reinstallApp: userParams.reuse,
+      },
+    },
+    deviceConfig.behavior,
+    detoxConfig.behavior,
+    {
+      init: {
+        exposeGlobals: true,
+        reinstallApp: true,
+        launchApp: true,
+      },
+      cleanup: {
+        shutdownDevice: false,
+      },
+    }
+  );
+}
+
 function composeDeviceConfig({ configurations }) {
   const configurationName = argparse.getArgValue('configuration');
   const deviceOverride = argparse.getArgValue('device-name');
@@ -181,6 +213,7 @@ module.exports = {
   throwOnEmptyDevice,
   throwOnEmptyType,
   throwOnEmptyBinaryPath,
+  composeBehaviorConfig,
   composeDeviceConfig,
   composeArtifactsConfig,
 };

--- a/detox/src/configuration.js
+++ b/detox/src/configuration.js
@@ -97,7 +97,7 @@ async function composeDetoxConfig(detoxConfig, userParams, cliConfig = getArtifa
     userParams,
   });
 
-  const sessionConfig = composeSessionConfig({
+  const sessionConfig = await composeSessionConfig({
     detoxConfig,
     deviceConfig,
   });

--- a/detox/src/configuration.js
+++ b/detox/src/configuration.js
@@ -12,27 +12,6 @@ const ScreenshotArtifactPlugin = require('./artifacts/screenshot/ScreenshotArtif
 const VideoArtifactPlugin = require('./artifacts/video/VideoArtifactPlugin');
 const ArtifactPathBuilder = require('./artifacts/utils/ArtifactPathBuilder');
 
-async function defaultSession() {
-  return {
-    server: `ws://localhost:${await getPort()}`,
-    sessionId: uuid.UUID()
-  };
-}
-
-function validateSession(session) {
-  if (!session) {
-    throw new Error(`No session configuration was found, pass settings under the session property`);
-  }
-
-  if (!session.server) {
-    throw new Error(`session.server property is missing, should hold the server address`);
-  }
-
-  if (!session.sessionId) {
-    throw new Error(`session.sessionId property is missing, should hold the server session id`);
-  }
-}
-
 function throwOnEmptyDevice() {
   throw new DetoxConfigError(`'device' property is empty, should hold the device query to run on (e.g. { "type": "iPhone 11 Pro" }, { "avdName": "Nexus_5X_API_29" })`);
 }
@@ -75,6 +54,24 @@ function composeBehaviorConfig({ detoxConfig, deviceConfig, userParams }) {
       },
     }
   );
+}
+
+async function composeSessionConfig({ detoxConfig, deviceConfig }) {
+  const session = deviceConfig.session || detoxConfig.session || {
+    autoStart: true,
+    server: `ws://localhost:${await getPort()}`,
+    sessionId: uuid.UUID(),
+  };
+
+  if (!session.server) {
+    throw new Error(`session.server property is missing, should hold the server address`);
+  }
+
+  if (!session.sessionId) {
+    throw new Error(`session.sessionId property is missing, should hold the server session id`);
+  }
+
+  return session;
 }
 
 function composeDeviceConfig({ configurations }) {
@@ -208,12 +205,11 @@ function resolveArtifactsPathBuilder(artifactsConfig) {
 }
 
 module.exports = {
-  defaultSession,
-  validateSession,
   throwOnEmptyDevice,
   throwOnEmptyType,
   throwOnEmptyBinaryPath,
+  composeArtifactsConfig,
   composeBehaviorConfig,
   composeDeviceConfig,
-  composeArtifactsConfig,
+  composeSessionConfig,
 };

--- a/detox/src/configuration.test.js
+++ b/detox/src/configuration.test.js
@@ -233,6 +233,21 @@ describe('configuration', () => {
     });
   });
 
+  describe('composeBehaviorConfig', () => {
+    it('should produce a default config', () => {
+      expect(configuration.composeBehaviorConfig({ deviceConfig: {}, detoxConfig: {} })).toEqual({
+        "init": {
+          "reinstallApp": true,
+          "launchApp": true,
+          "exposeGlobals": true
+        },
+        "cleanup": {
+          "shutdownDevice": false
+        }
+      });
+    });
+  });
+
   function testFaultySession(config) {
     try {
       configuration.validateSession(config);

--- a/detox/src/configuration.test.js
+++ b/detox/src/configuration.test.js
@@ -1,39 +1,9 @@
 const _ = require('lodash');
 const path = require('path');
 const schemes = require('./configurations.mock');
+const configuration = require('./configuration');
 
 describe('configuration', () => {
-  let configuration;
-  beforeEach(() => {
-    configuration = require('./configuration');
-  });
-
-  it(`generate a default config`, async () => {
-    const config = await configuration.defaultSession();
-    expect(() => config.session.server).toBeDefined();
-    expect(() => config.session.sessionId).toBeDefined();
-  });
-
-  it(`providing a valid config`, () => {
-    expect(() => configuration.validateSession(schemes.validOneDeviceAndSession.session)).not.toThrow();
-  });
-
-  it(`providing empty server config should throw`, () => {
-    testFaultySession();
-  });
-
-  it(`providing server config with no session should throw`, () => {
-    testFaultySession(schemes.validOneDeviceNoSession.session);
-  });
-
-  it(`providing server config with no session.server should throw`, () => {
-    testFaultySession(schemes.invalidSessionNoServer.session);
-  });
-
-  it(`providing server config with no session.sessionId should throw`, () => {
-    testFaultySession(schemes.invalidSessionNoSessionId.session);
-  });
-
   describe('composeArtifactsConfig', () => {
     it('should produce a default config', () => {
       expect(configuration.composeArtifactsConfig({
@@ -248,11 +218,32 @@ describe('configuration', () => {
     });
   });
 
-  function testFaultySession(config) {
-    try {
-      configuration.validateSession(config);
-    } catch (ex) {
-      expect(ex).toBeDefined();
-    }
-  }
+  describe.skip('composeBehaviorConfig', () => {
+    // TODO: write some tests
+  });
+
+  describe.skip('composeSessionConfig', () => {
+    it(`generate a default config`, async () => {
+      const config = await configuration.defaultSession();
+      expect(() => config.session.server).toBeDefined();
+      expect(() => config.session.sessionId).toBeDefined();
+    });
+
+    it(`providing empty server config should throw`, () => {
+      testFaultySession();
+    });
+
+    it(`providing server config with no session should throw`, () => {
+      testFaultySession(schemes.validOneDeviceNoSession.session);
+    });
+
+    it(`providing server config with no session.server should throw`, () => {
+      testFaultySession(schemes.invalidSessionNoServer.session);
+    });
+
+    it(`providing server config with no session.sessionId should throw`, () => {
+      testFaultySession(schemes.invalidSessionNoSessionId.session);
+    });
+
+  });
 });

--- a/detox/src/configuration.test.js
+++ b/detox/src/configuration.test.js
@@ -154,7 +154,7 @@ describe('configuration', () => {
         configurationName: 'customization',
         deviceConfig: {
           artifacts: {
-            pathBuilder: 'package.json',
+            pathBuilder: './package.json',
           },
         },
         detoxConfig: {},

--- a/detox/src/configurations.mock.js
+++ b/detox/src/configurations.mock.js
@@ -50,68 +50,11 @@ const pluginsAllResolved = {
   timeline: TimelineArtifactPlugin.parseConfig('all'),
 };
 
-const validOneDeviceNoSession = {
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.simulator",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
-};
-
-const validOneIosNoneDeviceNoSession = {
-  "configurations": {
-    "ios.none": {
-      "type": "ios.none",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
-};
-
-const validTwoDevicesNoSession = {
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.simulator",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    },
-    "ios.sim.debug": {
-      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
-      "type": "ios.simulator",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
-};
-
 const invalidDeviceNoBinary = {
   "configurations": {
     "ios.sim.release": {
       "type": "ios.simulator",
       "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
-};
-
-const invalidNoDevice = {
-  "configurations": {
-  }
-};
-
-const invalidDeviceNoDeviceType = {
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "here",
-      "name": "iPhone 7 Plus, iOS 10.2"
-    }
-  }
-};
-
-const invalidDeviceNoDeviceName = {
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "here",
-      "type": "ios.simulator"
     }
   }
 };
@@ -150,125 +93,13 @@ const pathsTests = {
   }
 };
 
-const invalidSessionNoSessionId = {
-  "session": {
-    "server": "ws://localhost:8099"
-  }
-};
-
-const invalidSessionNoServer = {
-  "session": {
-    "sessionId": "test"
-  }
-};
-
-const invalidOneDeviceTypeEmulatorNoSession = {
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "some.apk",
-      "type": "emulator",
-      "name": "an emulator"
-    }
-  }
-};
-
-const sessionPerConfiguration = {
-  "configurations": {
-    "ios.sim.none": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.none",
-      "name": "iPhone 7 Plus, iOS 10.2",
-      "session": {
-        "server": "ws://localhost:1111",
-        "sessionId": "test_1111"
-      }
-    },
-    "ios.sim.release": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.none",
-      "name": "iPhone 7 Plus, iOS 10.2",
-      "session": {
-        "server": "ws://localhost:2222",
-        "sessionId": "test_2222"
-      }
-    }
-  }
-};
-
-const sessionInCommonAndInConfiguration = {
-  "session": {
-    "server": "ws://localhost:1111",
-    "sessionId": "test_1"
-  },
-  "configurations": {
-    "ios.sim.none": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.none",
-      "name": "iPhone 7 Plus, iOS 10.2",
-      "session": {
-        "server": "ws://localhost:2222",
-        "sessionId": "test_2"
-      }
-    }
-  }
-};
-
-const validOneEmulator = {
-  "configurations": {
-    "android.emu.release": {
-      "binaryPath": "android/app/build/outputs/apk/app-debug.apk",
-      "type": "android.emulator",
-      "name": "Nexus 5X"
-    }
-  }
-};
-
-const deviceObjectSimulator = {
-  "configurations": {
-    "ios.sim.release": {
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-      "type": "ios.simulator",
-      "device": {
-        "name": "iPhone 7 Plus",
-        "os": "iOS 10.2"
-      }
-    }
-  }
-};
-
-const deviceObjectEmulator = {
-  "configurations": {
-    "android.emu.release": {
-      "binaryPath": "android/app/build/outputs/apk/app-debug.apk",
-      "type": "android.emulator",
-      "device": {
-        "avdName": "Nexus 5X"
-      }
-    }
-  }
-};
-
 module.exports = {
   allArtifactsConfiguration,
   defaultArtifactsConfiguration,
   pluginsAllResolved,
   pluginsDefaultsResolved,
   pluginsFailingResolved,
-  validOneDeviceNoSession,
-  validOneIosNoneDeviceNoSession,
-  validTwoDevicesNoSession,
   invalidDeviceNoBinary,
-  invalidNoDevice,
-  invalidDeviceNoDeviceType,
-  invalidDeviceNoDeviceName,
   validOneDeviceAndSession,
-  invalidSessionNoSessionId,
-  invalidSessionNoServer,
-  invalidOneDeviceTypeEmulatorNoSession,
-  sessionPerConfiguration,
-  sessionInCommonAndInConfiguration,
-  validOneEmulator,
   pathsTests,
-  deviceObjectEmulator,
-  deviceObjectSimulator,
 };

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -1,7 +1,4 @@
 const _ = require('lodash');
-const fs = require('fs');
-const path = require('path');
-const argparse = require('../utils/argparse');
 const debug = require('../utils/debug'); // debug utils, leave here even if unused
 
 class Device {

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -5,7 +5,8 @@ const argparse = require('../utils/argparse');
 const debug = require('../utils/debug'); // debug utils, leave here even if unused
 
 class Device {
-  constructor({ deviceConfig, deviceDriver, emitter, sessionConfig }) {
+  constructor({ behaviorConfig, deviceConfig, deviceDriver, emitter, sessionConfig }) {
+    this._behaviorConfig = behaviorConfig;
     this._deviceConfig = deviceConfig;
     this._sessionConfig = sessionConfig;
     this._emitter = emitter;
@@ -15,20 +16,11 @@ class Device {
     this.debug = debug;
   }
 
-  async prepare(params = {}) {
+  async prepare() {
     this._deviceId = await this.deviceDriver.acquireFreeDevice(this._deviceConfig.device || this._deviceConfig.name);
     this._bundleId = await this.deviceDriver.getBundleIdFromBinary(this._deviceConfig.binaryPath);
 
     await this.deviceDriver.prepare();
-
-    if (!argparse.getArgValue('reuse') && !params.reuse) {
-      await this.deviceDriver.uninstallApp(this._deviceId, this._bundleId);
-      await this.deviceDriver.installApp(this._deviceId, this._deviceConfig.binaryPath, this._deviceConfig.testBinaryPath);
-    }
-
-    if (params.launchApp) {
-      await this.launchApp({newInstance: true});
-    }
   }
 
   createPayloadFileAndUpdatesParamsObject(key, launchKey, params, baseLaunchArgs) {
@@ -268,12 +260,6 @@ class Device {
 
   async _cleanup() {
     await this.deviceDriver.cleanup(this._deviceId, this._bundleId);
-
-    if (argparse.getArgValue('cleanup') && this._deviceId) {
-      await this.deviceDriver.shutdown(this._deviceId);
-    }
-
-    this.deviceDriver = null;
   }
 
   async pressBack() {

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -5,8 +5,7 @@ const argparse = require('../utils/argparse');
 const debug = require('../utils/debug'); // debug utils, leave here even if unused
 
 class Device {
-  constructor({ behaviorConfig, deviceConfig, deviceDriver, emitter, sessionConfig }) {
-    this._behaviorConfig = behaviorConfig;
+  constructor({ deviceConfig, deviceDriver, emitter, sessionConfig }) {
     this._deviceConfig = deviceConfig;
     this._sessionConfig = sessionConfig;
     this._emitter = emitter;

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -1,10 +1,8 @@
 const _ = require('lodash');
-const path = require('path');
 const configurationsMock = require('../configurations.mock');
 
 const validScheme = configurationsMock.validOneDeviceAndSession;
 const invalidDeviceNoBinary = configurationsMock.invalidDeviceNoBinary;
-const invalidDeviceNoDeviceName = configurationsMock.invalidDeviceNoDeviceName;
 
 describe('Device', () => {
   let fs;
@@ -91,7 +89,6 @@ describe('Device', () => {
 
   function schemeDevice(scheme, configuration, overrides) {
     const device = new Device(_.merge({
-      behaviorConfig: { init: {}, cleanup: {} },
       deviceConfig: scheme.configurations[configuration],
       deviceDriver: driverMock.driver,
       sessionConfig: scheme.session,

--- a/detox/src/devices/DriverRegistry.js
+++ b/detox/src/devices/DriverRegistry.js
@@ -1,3 +1,5 @@
+const resolveModuleFromPath = require('../utils/resolveModuleFromPath');
+
 class DriverRegistry {
   constructor(deviceClasses) {
     this.deviceClasses = deviceClasses;
@@ -8,7 +10,7 @@ class DriverRegistry {
 
     if (!DeviceDriverClass) {
       try {
-        DeviceDriverClass = require(deviceType);
+        DeviceDriverClass = resolveModuleFromPath(deviceType);
       } catch (e) {
         // noop, if we don't find a module to require, we'll hit the unsupported error below
       }

--- a/detox/src/devices/DriverRegistry.js
+++ b/detox/src/devices/DriverRegistry.js
@@ -5,6 +5,7 @@ class DriverRegistry {
 
   resolve(deviceType, opts) {
     let DeviceDriverClass = this.deviceClasses[deviceType];
+
     if (!DeviceDriverClass) {
       try {
         DeviceDriverClass = require(deviceType);

--- a/detox/src/devices/DriverRegistry.js
+++ b/detox/src/devices/DriverRegistry.js
@@ -1,0 +1,31 @@
+class DriverRegistry {
+  constructor(deviceClasses) {
+    this.deviceClasses = deviceClasses;
+  }
+
+  resolve(deviceType, opts) {
+    let DeviceDriverClass = this.deviceClasses[deviceType];
+    if (!DeviceDriverClass) {
+      try {
+        DeviceDriverClass = require(deviceType);
+      } catch (e) {
+        // noop, if we don't find a module to require, we'll hit the unsupported error below
+      }
+    }
+
+    if (!DeviceDriverClass) {
+      throw new Error(`'${deviceType}' is not supported`);
+    }
+
+    return new DeviceDriverClass(opts);
+  }
+}
+
+DriverRegistry.default = new DriverRegistry({
+  'ios.none': require('./drivers/ios/IosDriver'),
+  'ios.simulator': require('./drivers/ios/SimulatorDriver'),
+  'android.emulator': require('./drivers/android/EmulatorDriver'),
+  'android.attached': require('./drivers/android/AttachedAndroidDriver'),
+});
+
+module.exports = DriverRegistry;

--- a/detox/src/devices/DriverRegistry.test.js
+++ b/detox/src/devices/DriverRegistry.test.js
@@ -2,6 +2,7 @@ jest.mock('./drivers/ios/IosDriver');
 jest.mock('./drivers/ios/SimulatorDriver');
 jest.mock('./drivers/android/EmulatorDriver');
 jest.mock('./drivers/android/AttachedAndroidDriver');
+jest.mock('../utils/resolveModuleFromPath');
 
 describe('DriverRegistry', () => {
   let DriverRegistry;
@@ -54,9 +55,11 @@ describe('DriverRegistry', () => {
     });
 
     it('should try to resolve unknown driver as a node.js dependency', () => {
-      jest.mock('fake-driver', () => require('./drivers/__mocks__/FakeDriver'), { virtual: true });
-      // eslint-disable-next-line node/no-missing-require
-      const FakeDriver = require('fake-driver');
+      require('../utils/resolveModuleFromPath').mockImplementation(() => {
+        return require('./drivers/__mocks__/FakeDriver');
+      });
+
+      const FakeDriver = require('./drivers/__mocks__/FakeDriver')
       const driver = registry.resolve('fake-driver', opts);
 
       expect(driver).toBeInstanceOf(FakeDriver);

--- a/detox/src/devices/DriverRegistry.test.js
+++ b/detox/src/devices/DriverRegistry.test.js
@@ -1,24 +1,77 @@
-describe.skip('todo', () => {
-  it.todo('should handle ios.simulator');
-  it.todo('should handle ios.none');
-  it.todo('should handle android.attached');
-  it.todo('should handle android.emulator');
-  it('should handle a custom driver', async () => {
-    // let instantiated = false;
-    // class MockDriverPlugin {
-    //   constructor(config) {
-    //     instantiated = true;
-    //   }
-    //   on() {}
-    //   declareArtifactPlugins() {}
-    // }
-    // jest.mock('driver-plugin', () => MockDriverPlugin, { virtual: true });
-    // const pluginDeviceConfig = {
-    //   "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-    //   "type": "driver-plugin",
-    //   "name": "MyPlugin"
-    // };
-    //
-    // expect(instantiated).toBe(true);
+jest.mock('./drivers/ios/IosDriver');
+jest.mock('./drivers/ios/SimulatorDriver');
+jest.mock('./drivers/android/EmulatorDriver');
+jest.mock('./drivers/android/AttachedAndroidDriver');
+
+describe('DriverRegistry', () => {
+  let DriverRegistry;
+  let registry, opts;
+
+  beforeEach(() => {
+    DriverRegistry = require('./DriverRegistry');
+
+    opts = {
+      client: { whatever: Math.random() },
+      emitter: { anything: Math.random() },
+    };
+  });
+
+  describe('by default', () => {
+    beforeEach(() => {
+      registry = DriverRegistry.default;
+    });
+
+    it('should resolve "ios.none" to IosDriver', () => {
+      const IosDriver = require('./drivers/ios/IosDriver');
+      const driver = registry.resolve('ios.none', opts);
+
+      expect(driver).toBeInstanceOf(IosDriver);
+      expect(IosDriver).toHaveBeenCalledWith(opts);
+    });
+
+    it('should resolve "ios.simulator" to SimulatorDriver', () => {
+      const SimulatorDriver = require('./drivers/ios/SimulatorDriver');
+      const driver = registry.resolve('ios.simulator', opts);
+
+      expect(driver).toBeInstanceOf(SimulatorDriver);
+      expect(SimulatorDriver).toHaveBeenCalledWith(opts);
+    });
+
+    it('should resolve "android.attached" to AttachedAndroidDriver', () => {
+      const AttachedAndroidDriver = require('./drivers/android/AttachedAndroidDriver');
+      const driver = registry.resolve('android.attached', opts);
+
+      expect(driver).toBeInstanceOf(AttachedAndroidDriver);
+      expect(AttachedAndroidDriver).toHaveBeenCalledWith(opts);
+    });
+
+    it('should resolve "android.emulator" to EmulatorDriver', () => {
+      const EmulatorDriver = require('./drivers/android/EmulatorDriver');
+      const driver = registry.resolve('android.emulator', opts);
+
+      expect(driver).toBeInstanceOf(EmulatorDriver);
+      expect(EmulatorDriver).toHaveBeenCalledWith(opts);
+    });
+
+    it('should try to resolve unknown driver as a node.js dependency', () => {
+      jest.mock('fake-driver', () => require('./drivers/__mocks__/FakeDriver'), { virtual: true });
+      // eslint-disable-next-line node/no-missing-require
+      const FakeDriver = require('fake-driver');
+      const driver = registry.resolve('fake-driver', opts);
+
+      expect(driver).toBeInstanceOf(FakeDriver);
+      expect(driver.constructorArgs).toEqual([opts]);
+    });
+  });
+
+  describe('constructor', () => {
+    it('should be extensible', () => {
+      const FakeDriver101 = require('./drivers/__mocks__/FakeDriver');
+      const registry = new DriverRegistry({ FakeDriver101 });
+      const driver = registry.resolve('FakeDriver101', opts);
+
+      expect(driver).toBeInstanceOf(FakeDriver101);
+      expect(driver.constructorArgs).toEqual([opts]);
+    });
   });
 });

--- a/detox/src/devices/DriverRegistry.test.js
+++ b/detox/src/devices/DriverRegistry.test.js
@@ -62,6 +62,11 @@ describe('DriverRegistry', () => {
       expect(driver).toBeInstanceOf(FakeDriver);
       expect(driver.constructorArgs).toEqual([opts]);
     });
+
+    it('should throw errors if it cannot resolve a driver', () => {
+      expect(() => registry.resolve('imaginary.driver', opts))
+        .toThrowError(/imaginary.driver.*not supported/);
+    });
   });
 
   describe('constructor', () => {

--- a/detox/src/devices/DriverRegistry.test.js
+++ b/detox/src/devices/DriverRegistry.test.js
@@ -1,0 +1,24 @@
+describe.skip('todo', () => {
+  it.todo('should handle ios.simulator');
+  it.todo('should handle ios.none');
+  it.todo('should handle android.attached');
+  it.todo('should handle android.emulator');
+  it('should handle a custom driver', async () => {
+    // let instantiated = false;
+    // class MockDriverPlugin {
+    //   constructor(config) {
+    //     instantiated = true;
+    //   }
+    //   on() {}
+    //   declareArtifactPlugins() {}
+    // }
+    // jest.mock('driver-plugin', () => MockDriverPlugin, { virtual: true });
+    // const pluginDeviceConfig = {
+    //   "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
+    //   "type": "driver-plugin",
+    //   "name": "MyPlugin"
+    // };
+    //
+    // expect(instantiated).toBe(true);
+  });
+});

--- a/detox/src/devices/__mocks__/Device.js
+++ b/detox/src/devices/__mocks__/Device.js
@@ -1,5 +1,17 @@
-class FakeDevice {
+const Deferred = require('../../utils/Deferred');
+const FakeDevice = jest.genMockFromModule('../Device');
 
-}
+FakeDevice.setInfiniteMethod = (methodName) => {
+  FakeDevice.mockImplementationOnce(() => {
+    const device = new FakeDevice();
+    device.deferred = new Deferred();
+    device[methodName].mockReturnValue(device.deferred.promise);
+    device._cleanup.mockImplementation(() => {
+      device.deferred.reject(`Fake error: aborted device.${methodName}()`);
+    });
+
+    return device;
+  });
+};
 
 module.exports = FakeDevice;

--- a/detox/src/devices/__mocks__/Device.js
+++ b/detox/src/devices/__mocks__/Device.js
@@ -1,0 +1,5 @@
+class FakeDevice {
+
+}
+
+module.exports = FakeDevice;

--- a/detox/src/devices/__mocks__/DriverRegistry.js
+++ b/detox/src/devices/__mocks__/DriverRegistry.js
@@ -1,0 +1,29 @@
+const DriverRegistry = jest.requireActual('../DriverRegistry');
+const DeviceDriverBase = jest.requireActual('../drivers/DeviceDriverBase');
+
+class FakeDriverRegistry extends DriverRegistry {
+  constructor(...args) {
+    super(...args);
+    jest.spyOn(this, 'resolve');
+  }
+}
+
+class FakeDriver extends DeviceDriverBase {
+  constructor(...args) {
+    super(...args);
+    this.matchers = FakeDriver.matchers;
+  }
+
+  declareArtifactPlugins() {
+    return FakeDriver.artifactsPlugins;
+  }
+}
+
+FakeDriver.matchers = {};
+FakeDriver.artifactsPlugins = {};
+FakeDriverRegistry.FakeDriver = FakeDriver;
+FakeDriverRegistry.default = new FakeDriverRegistry({
+  'fake.device': FakeDriver,
+});
+
+module.exports = FakeDriverRegistry;

--- a/detox/src/devices/__mocks__/DriverRegistry.js
+++ b/detox/src/devices/__mocks__/DriverRegistry.js
@@ -1,5 +1,5 @@
 const DriverRegistry = jest.requireActual('../DriverRegistry');
-const DeviceDriverBase = jest.requireActual('../drivers/DeviceDriverBase');
+const FakeDriver = jest.requireActual('../drivers/__mocks__/FakeDriver');
 
 class FakeDriverRegistry extends DriverRegistry {
   constructor(...args) {
@@ -8,19 +8,6 @@ class FakeDriverRegistry extends DriverRegistry {
   }
 }
 
-class FakeDriver extends DeviceDriverBase {
-  constructor(...args) {
-    super(...args);
-    this.matchers = FakeDriver.matchers;
-  }
-
-  declareArtifactPlugins() {
-    return FakeDriver.artifactsPlugins;
-  }
-}
-
-FakeDriver.matchers = {};
-FakeDriver.artifactsPlugins = {};
 FakeDriverRegistry.FakeDriver = FakeDriver;
 FakeDriverRegistry.default = new FakeDriverRegistry({
   'fake.device': FakeDriver,

--- a/detox/src/devices/drivers/__mocks__/FakeDriver.js
+++ b/detox/src/devices/drivers/__mocks__/FakeDriver.js
@@ -1,4 +1,4 @@
-const DeviceDriverBase = jest.requireActual('../DeviceDriverBase');
+const DeviceDriverBase = require('../DeviceDriverBase');
 
 class FakeDriver extends DeviceDriverBase {
   constructor(...args) {

--- a/detox/src/devices/drivers/__mocks__/FakeDriver.js
+++ b/detox/src/devices/drivers/__mocks__/FakeDriver.js
@@ -1,0 +1,19 @@
+const DeviceDriverBase = jest.requireActual('../DeviceDriverBase');
+
+class FakeDriver extends DeviceDriverBase {
+  constructor(...args) {
+    super(...args);
+
+    this.constructorArgs = args;
+    this.matchers = FakeDriver.matchers;
+  }
+
+  declareArtifactPlugins() {
+    return FakeDriver.artifactsPlugins;
+  }
+}
+
+FakeDriver.matchers = {};
+FakeDriver.artifactsPlugins = {};
+
+module.exports = FakeDriver;

--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -1,257 +1,180 @@
 const schemes = require('./configurations.mock');
 
-describe.skip('index', () => {
+jest.mock('./utils/logger');
+jest.mock('./configuration');
+jest.mock('./Detox');
+jest.mock('./utils/MissingDetox');
+
+describe('index', () => {
+  let logger;
+  let configuration;
+  let Detox;
   let detox;
-  let mockDevice;
-  let mockDetox;
+  let index;
 
   beforeEach(() => {
-    mockDevice = { launchApp: jest.fn() };
-    mockDetox = {
-      init: jest.fn(() => {
-        mockDetox.device = mockDevice;
-        mockDetox.by = {
-          id: jest.fn(),
-        };
-      }),
-      deviceName: jest.fn(),
-      cleanup: jest.fn(),
-      beforeEach: jest.fn(),
-      afterEach: jest.fn(),
-    };
+    logger = require('./utils/logger');
+    configuration = require('./configuration');
 
-    jest
-      .mock('./server/DetoxServer')
-      .mock('./devices/Device')
-      .mock('./utils/logger')
-      .mock('./client/Client')
-      .mock('./Detox', () => {
-        const MissingDetox = require('./utils/MissingDetox');
-        const none = new MissingDetox();
-        none.cleanupContext = () => {}; // avoid ruining global state
+    Detox = require('./Detox');
 
-        return Object.assign(jest.fn(() => mockDetox), { none });
-      });
+    const MissingDetox = require('./utils/MissingDetox');
+    Detox.none = new MissingDetox();
 
-    process.env.DETOX_UNIT_TEST = true;
-    detox = require('./index');
+    index = require('./index');
   });
 
-  afterEach(() => {
-    process.env = {};
-    jest
-      .unmock('./server/DetoxServer')
-      .unmock('./devices/Device')
-      .unmock('./client/Client')
-      .unmock('./Detox')
+  it(`should touch globals if behaviorConfig.init.exposeGlobals = true`, async () => {
+    configuration.composeDetoxConfig.mockReturnValue(Promise.resolve({
+      behaviorConfig: {
+        init: { exposeGlobals: true }
+      }
+    }));
+
+    await index.init();
+
+    expect(Detox.none.initContext).toHaveBeenCalledWith(global);
   });
 
-  it(`constructs detox without globals if initGlobals = false`, async () => {
-    const Detox = require('./Detox');
+  it(`should not touch globals if behaviorConfig.init.exposeGlobals = false`, async () => {
+    configuration.composeDetoxConfig.mockReturnValue(Promise.resolve({
+      behaviorConfig: {
+        init: { exposeGlobals: false }
+      }
+    }));
 
-    await detox.init(schemes.validOneDeviceNoSession, { initGlobals: false });
-
-    expect('by' in global).toBe(false);
+    await index.init();
+    expect(Detox.none.initContext).not.toHaveBeenCalled();
   });
 
-  it(`throws if there was no config passed`, async () => {
-    const logger = require('./utils/logger');
-    let exception = undefined;
+  // it(`throws if there was a config was invalid`, async () => {
+  //   let exception;
+  //
+  //   try {
+  //     await index.init();
+  //   } catch (e) {
+  //     exception = e;
+  //   }
+  //
+  //   expect(exception).toBeDefined();
+  //   expect(logger.error).toHaveBeenCalledWith({ event: 'DETOX_INIT_ERROR' }, '\n', exception);
+  // });
 
-    try {
-      await detox.init();
-    } catch (e) {
-      exception = e;
-    }
-
-    expect(exception).toBeDefined();
-    expect(logger.error).toHaveBeenCalledWith({ event: 'DETOX_INIT_ERROR' }, '\n', exception);
-  });
-
-  it(`throws if there is no devices in config`, async () => {
-    let exception = undefined;
-
-    try {
-      await detox.init(schemes.invalidNoDevice);
-    } catch (e) {
-      exception = e;
-    }
-
-    expect(exception).toBeDefined();
-  });
-
-  it(`constructs detox with device config`, async () => {
-    const Detox = require('./Detox');
-
-    await detox.init(schemes.validOneDeviceNoSession);
-
-    expect(Detox).toHaveBeenCalledWith({
-      artifactsConfig: expect.objectContaining({
-        plugins: schemes.pluginsDefaultsResolved,
-        pathBuilder: expect.objectContaining({
-          rootDir: expect.stringMatching(/^artifacts[\\\/]ios\.sim\.release/),
-        }),
-      }),
-      deviceConfig: schemes.validOneDeviceNoSession.configurations['ios.sim.release'],
-      session: undefined,
-    });
-  });
-
-  it(`constructs detox with device config passed in '--configuration' cli value`, async () => {
-    process.env.configuration = 'ios.sim.debug';
-    const Detox = require('./Detox');
-
-    await detox.init(schemes.validTwoDevicesNoSession);
-
-    expect(Detox).toHaveBeenCalledWith({
-      artifactsConfig: expect.objectContaining({
-        plugins: schemes.pluginsDefaultsResolved,
-        pathBuilder: expect.objectContaining({
-          rootDir: expect.stringMatching(/^artifacts[\\\/]ios\.sim\.debug/),
-        }),
-      }),
-      deviceConfig: schemes.validTwoDevicesNoSession.configurations['ios.sim.debug'],
-      session: undefined,
-    });
-  });
-
-  it(`throws if device passed in '--configuration' cli option doesn't exist`, async () => {
-    let exception = undefined;
-    process.env.configuration = 'nonexistent';
-
-    try {
-      await detox.init(schemes.validTwoDevicesNoSession);
-    } catch (e) {
-      exception = e;
-    }
-
-    expect(exception).toBeDefined();
-  });
-
-  it(`constructs detox with device name passed in '--device-name' cli value`, async () => {
-    process.env.deviceName = 'iPhone X';
-    const Detox = require('./Detox');
-
-    await detox.init(schemes.validOneDeviceNoSession);
-
-    const expectedConfig = {
-      ...schemes.validOneDeviceNoSession.configurations['ios.sim.release'],
-      device: 'iPhone X'
-    };
-
-    expect(Detox).toHaveBeenCalledWith({
-      artifactsConfig: expect.objectContaining({
-        plugins: schemes.pluginsDefaultsResolved,
-        pathBuilder: expect.objectContaining({
-          rootDir: expect.stringMatching(/^artifacts[\\\/]ios\.sim\.release/),
-        }),
-      }),
-      deviceConfig: expectedConfig,
-      session: undefined,
-    });
-  });
-
-  it(`throws if a device has no name`, async () => {
-    let exception = undefined;
-
-    try {
-      await detox.init(schemes.invalidDeviceNoDeviceName);
-    } catch (e) {
-      exception = e;
-    }
-
-    expect(exception).toBeDefined();
-  });
-
-  it(`throws if a device is invalid`, async () => {
-    let exception = undefined;
-
-    try {
-      await detox.init(schemes.invalidDeviceNoDeviceType);
-    } catch (e) {
-      exception = e;
-    }
-
-    expect(exception).toBeDefined();
-  });
-
-  it(`throws if a device is invalid`, async () => {
-    let exception = undefined;
-
-    try {
-      await detox.init(schemes.invalidDeviceNoDeviceType);
-    } catch (e) {
-      exception = e;
-    }
-
-    expect(exception).toBeDefined();
-  });
-
-  it(`initializes detox`, async () => {
-    const params = {};
-
-    await detox.init(schemes.validOneDeviceNoSession, params);
-
-    expect(mockDetox.init).toHaveBeenCalledWith(params);
-  });
-
-  it(`Basic usage`, async() => {
-    await detox.init(schemes.validOneDeviceNoSession);
-    await detox.cleanup();
-  });
-
-  it(`Basic usage with memorized exported objects`, async() => {
-    const { device, by } = detox;
-
-    expect(() => { device, by }).not.toThrowError();
-    expect(() => { device.launchApp }).toThrowError();
-    expect(() => { by.id }).toThrowError();
-
-    await detox.init(schemes.validOneDeviceNoSession);
-
-    expect(device.launchApp).toEqual(expect.any(Function));
-    expect(by.id).toEqual(expect.any(Function));
-
-    await detox.cleanup();
-
-    expect(() => { device, by }).not.toThrowError();
-    expect(() => { device.launchApp }).toThrowError();
-    expect(() => { by.id }).toThrowError();
-  });
-
-  it(`Basic usage, do not throw an error if cleanup is done twice`, async() => {
-    await detox.init(schemes.validOneDeviceNoSession);
-    await detox.cleanup();
-    await detox.cleanup();
-  });
-
-  it(`Basic usage, if detox is undefined, do not throw an error`, async() => {
-    await detox.cleanup();
-  });
-
-  it(`beforeEach() should be covered - with detox initialized`, async() => {
-    await detox.init(schemes.validOneDeviceNoSession);
-    await detox.beforeEach();
-  });
-
-  it(`beforeEach() should be covered - with detox not initialized`, async() => {
-    await expect(detox.beforeEach()).rejects.toThrow(/Make sure to call/);
-  });
-
-  it(`error message should be covered - with detox failed to initialize`, async() => {
-    mockDetox.init.mockReturnValue(Promise.reject(new Error('InitMe error')));
-
-    await expect(detox.init(schemes.validOneDeviceNoSession)).rejects.toThrow(/InitMe error/);
-    await detox.cleanup(); // cleaning up
-    await expect(detox.beforeEach()).rejects.toThrow(/There was an error[\s\S]*InitMe error/mg);
-  });
-
-  it(`afterEach() should be covered - with detox initialized`, async() => {
-    await detox.init(schemes.validOneDeviceNoSession);
-    await detox.afterEach();
-  });
-
-  it(`afterEach() should be covered - with detox not initialized`, async() => {
-    await expect(detox.afterEach()).rejects.toThrow(/Make sure to call/);
-  });
+//   it(`exposes detox globals by default`, async () => {
+//     await index.init(schemes.validOneDeviceNoSession, { initGlobals: false });
+//
+//     expect('by' in global).toBe(false);
+//   });
+//
+//   it(`exposes detox globals on configuration error`, async () => {
+//     await index.init(schemes.validOneDeviceNoSession, { initGlobals: false });
+//
+//     expect('by' in global).toBe(false);
+//   });
+//
+//   it(`does not exposes detox globals if behaviorConfig.init.exposeGlobals = false`, async () => {
+//     await index.init(schemes.validOneDeviceNoSession, { initGlobals: false });
+//
+//     expect('by' in global).toBe(false);
+//   });
+//
+//   it(`constructs detox without globals if initGlobals = false`, async () => {
+//     await index.init(schemes.validOneDeviceNoSession, { initGlobals: false });
+//
+//     expect('by' in global).toBe(false);
+//   });
+//
+//
+//   it(`constructs detox with a composed config`, async () => {
+//     await index.init(schemes.validOneDeviceNoSession);
+//
+//     // TODO: mock configuration and Detox
+//     expect(Detox).toHaveBeenCalledWith({
+//       artifactsConfig: expect.objectContaining({
+//         plugins: schemes.pluginsDefaultsResolved,
+//         pathBuilder: expect.objectContaining({
+//           rootDir: expect.stringMatching(/^artifacts[\\\/]ios\.sim\.release/),
+//         }),
+//       }),
+//       deviceConfig: schemes.validOneDeviceNoSession.configurations['ios.sim.release'],
+//       session: undefined,
+//     });
+//   });
+//
+//   it(`initializes detox redirects to configuration`, async () => {
+//     const params = {};
+//
+//     await index.init(schemes.validOneDeviceNoSession, params);
+//
+//     expect(mockDetox.init).toHaveBeenCalledWith(params);
+//   });
+//
+//   it(`Basic usage`, async() => {
+//     await index.init(schemes.validOneDeviceNoSession);
+//     await index.cleanup();
+//   });
+//
+//   it(`Basic usage with memorized exported objects`, async() => {
+//     const { device, by } = index;
+//
+//     expect(() => { device, by }).not.toThrowError();
+//     expect(() => { device.launchApp }).toThrowError();
+//     expect(() => { by.id }).toThrowError();
+//
+//     await index.init(schemes.validOneDeviceNoSession);
+//
+//     expect(device.launchApp).toEqual(expect.any(Function));
+//     expect(by.id).toEqual(expect.any(Function));
+//
+//     await index.cleanup();
+//
+//     expect(() => { device, by }).not.toThrowError();
+//     expect(() => { device.launchApp }).toThrowError();
+//     expect(() => { by.id }).toThrowError();
+//   });
+//
+//   it(`Basic usage, do not throw an error if cleanup is done twice`, async() => {
+//     await index.init(schemes.validOneDeviceNoSession);
+//     await index.cleanup();
+//     await index.cleanup();
+//   });
+//
+//   it(`Basic usage, if detox is undefined, do not throw an error`, async() => {
+//     await index.cleanup();
+//   });
+//
+//   it.each([
+//     'beforeEach',
+//     'afterEach',
+//     'suiteStart',
+//     'suiteEnd',
+//     'element',
+//     'expect',
+//     'waitFor',
+//   ])(`%s() method should throw if currently there is no detox instance`, async (method) => {
+//     await expect(index[method]()).rejects.toThrowError(/TODOTDO/);
+//   });
+//
+//   it.each([
+//     'beforeEach',
+//     'afterEach',
+//     'suiteStart',
+//     'suiteEnd',
+//     'element',
+//     'expect',
+//     'waitFor',
+// ])(`%s() method should be forwarded to the current detox instance`, async (method) => {
+//     let args = [Math.random(), Math.random()];
+//     await index.init(schemes.validOneDeviceNoSession);
+//     await index[method](...args);
+//     expect(detox()[method]).toHaveBeenCalledWith(...args);
+//   });
+//
+//   it(`error message should be covered - with detox failed to initialize`, async() => {
+//     mockDetox.init.mockReturnValue(Promise.reject(new Error('InitMe error')));
+//
+//     await expect(detox.init(schemes.validOneDeviceNoSession)).rejects.toThrow(/InitMe error/);
+//     await detox.cleanup(); // cleaning up
+//     await expect(detox.beforeEach()).rejects.toThrow(/There was an error[\s\S]*InitMe error/mg);
+//   });
 });

--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -1,6 +1,6 @@
 const schemes = require('./configurations.mock');
 
-describe('index', () => {
+describe.skip('index', () => {
   let detox;
   let mockDevice;
   let mockDetox;

--- a/detox/src/server/DetoxServer.js
+++ b/detox/src/server/DetoxServer.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
 const WebSocket = require('ws');
+const logger = require('../utils/logger').child({ __filename });
+
 const WebSocketServer = WebSocket.Server;
 
 const CLOSE_TIMEOUT = 10000;
@@ -7,12 +9,11 @@ const ROLE_TESTER = 'tester';
 const ROLE_TESTEE = 'testee';
 
 class DetoxServer {
-  constructor({ port, log, standalone = false }) {
+  constructor({ port, standalone = false }) {
     this.wss = new WebSocketServer({ port });
     this.sessions = {};
     this.standalone = standalone;
-    this.log = log.child({ __filename });
-    this.log.info(`server listening on localhost:${this.wss.options.port}...`);
+    logger.info(`server listening on localhost:${this.wss.options.port}...`);
     this._setup();
   }
 
@@ -30,28 +31,28 @@ class DetoxServer {
             if (action.params && action.params.sessionId && action.params.role) {
               sessionId = action.params.sessionId;
               role = action.params.role;
-              this.log.debug({ event: 'LOGIN' }, `role=${role}, sessionId=${sessionId}`);
+              logger.debug({ event: 'LOGIN' }, `role=${role}, sessionId=${sessionId}`);
               _.set(this.sessions, [sessionId, role], ws);
               action.type = 'loginSuccess';
               this.sendAction(ws, action);
-              this.log.debug({ event: 'LOGIN_SUCCESS' }, `role=${role}, sessionId=${sessionId}`);
+              logger.debug({ event: 'LOGIN_SUCCESS' }, `role=${role}, sessionId=${sessionId}`);
             }
           } else if (sessionId && role) {
-            this.log.trace({ event: 'MESSAGE', action: action.type }, `role=${role} action=${action.type} (sessionId=${sessionId})`);
+            logger.trace({ event: 'MESSAGE', action: action.type }, `role=${role} action=${action.type} (sessionId=${sessionId})`);
             this.sendToOtherRole(sessionId, role, action);
           }
         } catch (err) {
-          this.log.debug({ event: 'ERROR', err }, `Invalid JSON received, cannot parse`, err);
+          logger.debug({ event: 'ERROR', err }, `Invalid JSON received, cannot parse`, err);
         }
       });
 
       ws.on('error', (e) => {
-        this.log.warn({ event: 'WEBSOCKET_ERROR', role, sessionId }, `${e && e.message} (role=${role}, session=${sessionId})`);
+        logger.warn({ event: 'WEBSOCKET_ERROR', role, sessionId }, `${e && e.message} (role=${role}, session=${sessionId})`);
       });
 
       ws.on('close', () => {
         if (sessionId && role) {
-          this.log.debug({ event: 'DISCONNECT' }, `role=${role}, sessionId=${sessionId}`);
+          logger.debug({ event: 'DISCONNECT' }, `role=${role}, sessionId=${sessionId}`);
 
           if (role === ROLE_TESTEE) {
             this.sendToOtherRole(sessionId, role, { type: 'testeeDisconnected', messageId: -0xc1ea });
@@ -77,7 +78,7 @@ class DetoxServer {
     if (ws && ws.readyState === WebSocket.OPEN) {
       this.sendAction(ws, action);
     } else {
-      this.log.debug({ event: 'CANNOT_FORWARD' }, `role=${otherRole} not connected, cannot fw action (sessionId=${sessionId})`);
+      logger.debug({ event: 'CANNOT_FORWARD' }, `role=${otherRole} not connected, cannot fw action (sessionId=${sessionId})`);
 
       if (role === ROLE_TESTER && action.type === 'cleanup') {
         this.sendToOtherRole(sessionId, otherRole, {
@@ -95,12 +96,12 @@ class DetoxServer {
   _closeWithTimeout() {
     return new Promise((resolve) => {
       const handle = setTimeout(() => {
-        this.log.warn({ event: 'TIMEOUT' }, 'Detox server closed ungracefully on a timeout!!!');
+        logger.warn({ event: 'TIMEOUT' }, 'Detox server closed ungracefully on a timeout!!!');
         resolve();
       }, CLOSE_TIMEOUT);
 
       this.wss.close(() => {
-        this.log.debug({ event: 'WS_CLOSE' }, 'Detox server connections terminated gracefully');
+        logger.debug({ event: 'WS_CLOSE' }, 'Detox server connections terminated gracefully');
         clearTimeout(handle);
         resolve();
       });

--- a/detox/src/server/__mocks__/DetoxServer.js
+++ b/detox/src/server/__mocks__/DetoxServer.js
@@ -1,0 +1,5 @@
+class FakeDetoxServer {
+
+}
+
+module.exports = FakeDetoxServer;

--- a/detox/src/server/__mocks__/DetoxServer.js
+++ b/detox/src/server/__mocks__/DetoxServer.js
@@ -1,5 +1,0 @@
-class FakeDetoxServer {
-
-}
-
-module.exports = FakeDetoxServer;

--- a/detox/src/utils/resolveModuleFromPath.js
+++ b/detox/src/utils/resolveModuleFromPath.js
@@ -1,0 +1,6 @@
+function resolveModuleFromPath(modulePath) {
+  const resolvedModulePath = require.resolve(modulePath, { paths: [process.cwd()]});
+  return require(resolvedModulePath);
+}
+
+module.exports = resolveModuleFromPath;

--- a/detox/src/utils/resolveModuleFromPath.test.js
+++ b/detox/src/utils/resolveModuleFromPath.test.js
@@ -1,0 +1,27 @@
+const _ = require('lodash');
+const path = require('path');
+const resolveModuleFromPath = require('./resolveModuleFromPath');
+
+const RELATIVE_PATH_TO_PACKAGE_JSON = '../../package.json';
+
+describe('resolveModuleFromPath', () => {
+  let packageJson;
+
+  beforeEach(() => {
+    packageJson = require(RELATIVE_PATH_TO_PACKAGE_JSON);
+  });
+
+  it('should resolve absolute paths', async () => {
+    const absolutePath = require.resolve(RELATIVE_PATH_TO_PACKAGE_JSON);
+    expect(path.isAbsolute(absolutePath)).toBe(true); // an assertion to be on the safe side
+    expect(resolveModuleFromPath(absolutePath)).toBe(packageJson);
+  });
+
+  it('should resolve relative paths', async () => {
+    expect(resolveModuleFromPath(`./package.json`)).toBe(packageJson);
+  });
+
+  it('should resolve node modules', async () => {
+    expect(resolveModuleFromPath('lodash/map')).toBe(require('lodash/map'));
+  });
+});

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -48,6 +48,16 @@
   "detox": {
     "test-runner": "jest",
     "runner-config": "e2e/config.js",
+    "behavior": {
+      "init": {
+        "reinstallApp": true,
+        "launchApp": true,
+        "exportGlobals": true
+      },
+      "cleanup": {
+        "shutdownDevice": false
+      }
+    },
     "__session": {
       "server": "ws://localhost:8099",
       "sessionId": "test"

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -52,7 +52,7 @@
       "init": {
         "reinstallApp": true,
         "launchApp": true,
-        "exportGlobals": true
+        "exposeGlobals": false
       },
       "cleanup": {
         "shutdownDevice": false

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -52,7 +52,7 @@
       "init": {
         "reinstallApp": true,
         "launchApp": true,
-        "exposeGlobals": false
+        "exposeGlobals": true
       },
       "cleanup": {
         "shutdownDevice": false

--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -116,6 +116,54 @@ Below you can see mappings between the string presets and the corresponding obje
 | failing | `{ "enabled": true, "keepOnlyFailedTestsArtifacts": true } ` |
 | manual  | `{ "enabled": true, "shouldTakeAutomaticSnapshots": false }` |
 
+### Behavior Configuration
+
+If you need to tweak the flow of `detox.init()` or `detox.cleanup()` steps,
+you have a few options to change. These are the default behavior values:
+
+```json
+{
+  "detox": {
+    "behavior": {
+      "init": {
+        "reinstallApp": true,
+        "launchApp": true,
+        "exposeGlobals": true
+      },
+      "cleanup": {
+        "shutdownDevice": false
+      }
+    }
+  }
+}
+```
+
+For example, if you want to launch your tested app manually, e.g. via `device.launchApp()`,
+you should specify in `package.json`:
+
+```json
+{
+  "detox": {
+    "behavior": {
+      "init": {
+        "launchApp": false
+      }
+    }
+  }
+}
+```
+
+Setting `reinstallApp: false` will make the tests reuse the currently installed app on the device,
+provided you have installed it beforehand.
+
+If you do not wish to leak Detox globals (`expect`, `device`, `by`, etc.) to the global
+scope, you can set `"exposeGlobals": false` and destructure them respectively from the
+exported Detox interface:
+
+```js
+const { by, device, expect, element } = require('detox');
+```
+
 ### Server Configuration
 
 Detox can either initialize a server using a generated configuration, or can be overriden with a manual  configuration:

--- a/examples/demo-plugin/package.json
+++ b/examples/demo-plugin/package.json
@@ -18,7 +18,7 @@
           "foo": "bar"
         },
         "name": "plugin-example",
-        "type": "../../examples/demo-plugin/driver"
+        "type": "./driver"
       }
     }
   }


### PR DESCRIPTION
**Description:**

Prepares ground for landing #1910.

Slightly extends configuration capabilities, but the main point is that a configuration object for `new Detox` now contains all data it needs. No more scattering over places and files.

As a side effect, you can specify all that you previously could do via `detox.init(config, userParams)`, but now those params reside also in `package.json` Detox's section, called `behavior`.

```json
{
  "detox": {
    "behavior": {
      "init": {
        "reinstallApp": true,
        "launchApp": true,
        "exportGlobals": true
      },
      "cleanup": {
        "shutdownDevice": false
      }
    },
  }
}
```

Also, this PR fixes a partially incorrect custom driver require logic, where it was not using `process.cwd()` to resolve relative path dependencies.

I plan to add the new config object extension to the markdown docs, and merge.