### PR TITLE
Add reporting of a spec exec retry to spec-reporter

### DIFF
--- a/detox/runners/jest/SpecReporterCircus.js
+++ b/detox/runners/jest/SpecReporterCircus.js
@@ -22,8 +22,10 @@ class SpecReporterCircus extends CircusTestEventListenerBase {
   }
 
   _onTestStart(event) {
+    const { test } = event;
     this._specReporter.onTestStart({
-      description: event.test.name,
+      description: test.name,
+      invocations: test.invocations,
     });
   }
 

--- a/detox/runners/jest/SpecReporterCircus.js
+++ b/detox/runners/jest/SpecReporterCircus.js
@@ -31,6 +31,7 @@ class SpecReporterCircus extends CircusTestEventListenerBase {
     const { test } = event;
     const testInfo = {
       description: test.name,
+      invocations: test.invocations,
     };
     this._specReporter.onTestEnd(testInfo, test.errors.length ? 'failed' : 'success');
   }

--- a/detox/runners/jest/SpecReporterImpl.js
+++ b/detox/runners/jest/SpecReporterImpl.js
@@ -33,8 +33,8 @@ class SpecReporter extends ReporterBase {
     this._traceTest({description});
   }
 
-  onTestEnd({description}, result) {
-    let status = '';
+  onTestEnd({description, invocations = 1}, result) {
+    let status;
     switch (result) {
       case 'skipped': status = RESULT_SKIPPED; break;
       case 'failed': status = RESULT_FAILED; break;
@@ -42,7 +42,7 @@ class SpecReporter extends ReporterBase {
       case 'success': status = RESULT_SUCCESS; break;
       default: status = RESULT_OTHER; break;
     }
-    this._traceTest({description}, status);
+    this._traceTest({description, invocations}, status);
   }
 
   _regenerateSuitesDesc() {
@@ -58,8 +58,11 @@ class SpecReporter extends ReporterBase {
     this._suitesDesc = chalk.bold.white(this._suitesDesc);
   }
 
-  _traceTest({description}, status) {
-    const desc = this._suitesDesc + chalk.gray(description) + chalk.gray(status ? ` [${status}]` : '');
+  _traceTest({description, invocations}, _status = undefined) {
+    const testDescription = chalk.gray(description);
+    const retriesDescription = (invocations > 1) ? chalk.gray(` (retry #${invocations - 1})`) : '';
+    const status = chalk.gray(_status ? ` [${_status}]` : '');
+    const desc = this._suitesDesc + testDescription + retriesDescription + status;
     log.info({event: 'SPEC_STATE_CHANGE'}, desc);
   }
 }

--- a/detox/runners/jest/SpecReporterImpl.js
+++ b/detox/runners/jest/SpecReporterImpl.js
@@ -29,8 +29,8 @@ class SpecReporter extends ReporterBase {
     }
   }
 
-  onTestStart({description}) {
-    this._traceTest({description});
+  onTestStart({description, invocations = 1}) {
+    this._traceTest({description, invocations});
   }
 
   onTestEnd({description, invocations = 1}, result) {
@@ -60,7 +60,7 @@ class SpecReporter extends ReporterBase {
 
   _traceTest({description, invocations}, _status = undefined) {
     const testDescription = chalk.gray(description);
-    const retriesDescription = (invocations > 1) ? chalk.gray(` (retry #${invocations - 1})`) : '';
+    const retriesDescription = (invocations > 1) ? chalk.gray(` [Retry #${invocations - 1}]`) : '';
     const status = chalk.gray(_status ? ` [${_status}]` : '');
     const desc = this._suitesDesc + testDescription + retriesDescription + status;
     log.info({event: 'SPEC_STATE_CHANGE'}, desc);


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Associated with #2040. Adds reporting of retry attempt index, if applicable (e.g. when [`jest.retryTimes()`](https://jestjs.io/docs/en/jest-object#jestretrytimes) is used in conjunction with `jest-circus`). Example of what an output generated by the spec-reporter looks like with this change:

```
detox[60507] INFO:  Sanity is assigned to emulator-15200 (Pixel_API_28)
detox[60507] INFO:  Sanity: should have welcome screen
detox[60507] INFO:  Sanity: should have welcome screen [FAIL]
detox[60507] INFO:  Sanity: should show hello screen after tap
detox[60507] INFO:  Sanity: should show hello screen after tap [OK]
detox[60507] INFO:  Sanity: should have welcome screen
detox[60507] INFO:  Sanity: should have welcome screen (retry #1) [FAIL]
detox[60507] INFO:  Sanity: should have welcome screen
detox[60507] INFO:  Sanity: should have welcome screen (retry #2) [OK]

 PASS  e2e/01.sanity.test.js (15.223s)
  Sanity
    ✓ should have welcome screen (1342ms)
    ✓ should show hello screen after tap (1620ms)
```
namely, `(retry #X)` is appended to the test name, if applicable.