### PR TITLE
Apply missing flags to "pm install": reinstall, permissions, test

### DIFF
--- a/detox/src/devices/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.js
@@ -84,11 +84,6 @@ class AndroidDriver extends DeviceDriverBase {
     await uninstallHelper.uninstall(deviceId, bundleId);
   }
 
-  async uninstallAppByApk(deviceId, apkPath) {
-    const bundleId = await this.getBundleIdFromBinary(apkPath);
-    await this.uninstallApp(deviceId, bundleId);
-  }
-
   async launchApp(deviceId, bundleId, launchArgs, languageAndLocale) {
     await this.emitter.emit('beforeLaunchApp', { deviceId, bundleId, launchArgs });
 

--- a/detox/src/devices/drivers/android/EmulatorDriver.js
+++ b/detox/src/devices/drivers/android/EmulatorDriver.js
@@ -73,8 +73,6 @@ class EmulatorDriver extends AndroidDriver {
       testBinaryPath,
     } = this._getInstallPaths(_binaryPath, _testBinaryPath);
 
-    await this.uninstallAppByApk(deviceId, binaryPath);
-
     const installHelper = new AppInstallHelper(this.adb);
     await installHelper.install(deviceId, binaryPath, testBinaryPath);
   }

--- a/detox/src/devices/drivers/android/tools/ADB.js
+++ b/detox/src/devices/drivers/android/tools/ADB.js
@@ -105,7 +105,7 @@ class ADB {
   }
 
   /*async*/ remoteInstall(deviceId, path) {
-    return this.shell(deviceId, `pm install ${path}`);
+    return this.shell(deviceId, `pm install -r -g -t ${path}`);
   }
 
   async uninstall(deviceId, appId) {

--- a/detox/src/devices/drivers/android/tools/ADB.test.js
+++ b/detox/src/devices/drivers/android/tools/ADB.test.js
@@ -180,7 +180,7 @@ describe('ADB', () => {
     await adb.remoteInstall(deviceId, binaryPath);
 
     expect(exec).toHaveBeenCalledWith(
-      expect.stringContaining(`-s mockEmulator shell "pm install ${binaryPath}"`),
+      expect.stringContaining(`-s mockEmulator shell "pm install -r -g -t ${binaryPath}"`),
       undefined, undefined, expect.anything());
   });
 


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #2019 and the solution has been agreed upon with maintainers.

---

**Description:**
Add missing flags to recently instated `adb shell pm install` command (see #2019) - the same ones as used to be specified for `adb install`:
- `-r` to allow for the replacement of existing apps (hence no need to manually uninstall)
- `-t` to allow for test packages (seems useless, but nevertheless)
- `-g` to auto-allow for all runtime permissions.

This doesn't fix any reported issue in particular, but rather addresses [this comment](https://github.com/wix/Detox/pull/2019#issuecomment-623632126) in the original PR.