### PR TITLE
fix: custom apk path without build

### DIFF
--- a/detox/src/devices/drivers/android/tools/APKPath.js
+++ b/detox/src/devices/drivers/android/tools/APKPath.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
 const string = require('../../../../utils/string');
@@ -5,6 +6,18 @@ const string = require('../../../../utils/string');
 class APKPath {
 
   static getTestApkPath(originalApkPath) {
+    // fix: custom apk path without build
+    // for example:
+    // "android.att.release": {
+    //   "binaryPath": "./debugger_app/app-20200415.apk",
+    //   "type": "android.attached",
+    //   "device": { "adbName": "123456789" }
+    // }
+    const fullApkPath = path.resolve(originalApkPath);
+    if (fs.existsSync(fullApkPath)) {
+      return fullApkPath;
+    }
+
     const originalApkPathObj = path.parse(originalApkPath);
     let tempPath = originalApkPathObj.dir.split(path.sep);
     const splitFileName = originalApkPathObj.name.split('-');


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

fix custom apk path without build, for example:
```json
 "android.att.release": {
   "binaryPath": "./debugger_app/app-20200415.apk",
   "type": "android.attached",
   "device": { "adbName": "123456789" }
 }
```
