### PR TITLE
Update Android network-security in example app

### DIFF
--- a/examples/demo-react-native/android/app/src/main/AndroidManifest.xml
+++ b/examples/demo-react-native/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme"
-      android:usesCleartextTraffic="true"
+      android:networkSecurityConfig="@xml/network_security_config"
       >
       <activity
         android:name=".MainActivity"

--- a/examples/demo-react-native/android/app/src/main/res/xml/network_security_config.xml
+++ b/examples/demo-react-native/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">10.0.3.2</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
This is a follow-up on #2061:
- Integrates the proper Android network-security configuration for Detox.
- Update setup docs accordingly.
