### PR TITLE
update docs to include latest kotlin version

### DIFF
--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -86,7 +86,7 @@ If your project does not already support Kotlin, add the Kotlin Gradle-plugin to
 ```groovy
 buildscript {
     // ...
-    ext.kotlinVersion = '1.3.0' // (check what the latest version is)
+    ext.kotlinVersion = '1.3.72' // (check what the latest version is)
 
     dependencies {
         // ...


### PR DESCRIPTION
following the current docs, the `detox build -c android.emu.release`, it will fail saying:
```
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.3.10 and higher.
The following dependencies do not satisfy the required version:
root project 'example' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.0
```

<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
