### PR TITLE
fix(mocha): use .mocharc when possible

### DIFF
--- a/detox/local-cli/init.js
+++ b/detox/local-cli/init.js
@@ -26,6 +26,7 @@ module.exports.handler = async function init(argv) {
       createMochaFolderE2E();
       patchDetoxConfigInPackageJSON({
         runner: 'mocha',
+        runnerConfig: 'e2e/.mocharc'
       });
       break;
     case 'jest':
@@ -76,7 +77,7 @@ function createFile(filename, content) {
 
 function createMochaFolderE2E() {
   createFolder('e2e', {
-    'mocha.opts': mochaTemplates.runnerConfig,
+    '.mocharc': mochaTemplates.runnerConfig,
     'init.js': mochaTemplates.initjs,
     'firstTest.spec.js': mochaTemplates.firstTest
   });
@@ -113,7 +114,7 @@ function savePackageJson(filepath, json) {
   }
 }
 
-function patchDetoxConfigInPackageJSON({ runner }) {
+function patchDetoxConfigInPackageJSON({ runner, runnerConfig }) {
   const packageJsonPath = path.join(process.cwd(), 'package.json');
 
   if (fs.existsSync(packageJsonPath)) {
@@ -122,6 +123,10 @@ function patchDetoxConfigInPackageJSON({ runner }) {
     const packageJson = parsePackageJson(packageJsonPath);
     if (packageJson) {
       loggedSet(packageJson, ['detox', 'test-runner'], runner);
+      if (runnerConfig) {
+        loggedSet(packageJson, ['detox', 'runner-config'], runnerConfig);
+      }
+
       savePackageJson(packageJsonPath, packageJson);
     }
   } else {

--- a/detox/local-cli/templates/mocha.js
+++ b/detox/local-cli/templates/mocha.js
@@ -1,5 +1,12 @@
 const firstTestContent = require('./firstTestContent');
-const mochaOptsContent = '--recursive --timeout 120000 --bail --file e2e/init.js\n';
+
+const mochaRcContent = JSON.stringify({
+  recursive: true,
+  timeout: 120000,
+  bail: true,
+  file: 'e2e/init.js',
+}, null, 4);
+
 const initjsContent = `const detox = require('detox');
 const config = require('../package.json').detox;
 const adapter = require('detox/runners/mocha/adapter');
@@ -23,4 +30,4 @@ after(async () => {
 
 exports.initjs = initjsContent;
 exports.firstTest = firstTestContent;
-exports.runnerConfig = mochaOptsContent;
+exports.runnerConfig = mochaRcContent;

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -217,10 +217,14 @@ module.exports.handler = async function test(program) {
       log.warn('Can not use -w, --workers. Parallel test execution is only supported with iOS and Jest');
     }
 
+    const configParam = path.extname(runnerConfig) === '.opts'
+      ? 'opts'
+      : 'config';
+
     const command = _.compact([
       (path.join('node_modules', '.bin', runner)),
       ...safeGuardArguments([
-        (runnerConfig ? `--opts ${runnerConfig}` : ''),
+        (runnerConfig ? `--${configParam} ${runnerConfig}` : ''),
         (program.configuration ? `--configuration ${program.configuration}` : ''),
         (program.loglevel ? `--loglevel ${program.loglevel}` : ''),
         (program.noColor ? '--no-colors' : ''),

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -27,15 +27,16 @@ describe('test', () => {
 
   const mockAndroidJestConfiguration = () => mockConfiguration('android.emulator', 'jest');
   const mockIOSJestConfiguration = () => mockConfiguration('ios.sim', 'jest');
-  const mockAndroidMochaConfiguration = () => mockConfiguration('android.emulator');
+  const mockAndroidMochaConfiguration = (overrides) => mockConfiguration('android.emulator', undefined, overrides);
   const mockIOSMochaConfiguration = () => mockConfiguration('ios.sim');
-  const mockConfiguration = (deviceType, runner) => mockPackageJson({
+  const mockConfiguration = (deviceType, runner, overrides) => mockPackageJson({
     'test-runner': runner,
     configurations: {
       only: {
         type: deviceType,
       }
-    }
+    },
+    ...overrides,
   });
 
   describe('mocha', () => {
@@ -51,6 +52,19 @@ describe('test', () => {
 
       expect(mockExec).toHaveBeenCalledWith(
         expect.stringMatching(/ "e2e"$/),
+        expect.anything()
+      );
+    });
+
+    it('changes --opts to --config, when given non ".opts" file extension', async () => {
+      mockAndroidMochaConfiguration({
+        'runner-config': 'e2e/.mocharc'
+      });
+
+      await callCli('./test', 'test');
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.stringContaining(`${normalize('node_modules/.bin/mocha')} --config e2e/.mocharc `),
         expect.anything()
       );
     });

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -90,7 +90,7 @@ class Client {
     // when this test run fails, we want a stack trace from up here where the
     // $callee is still available, and not inside the catch block where it isn't
     const potentialError = new Error();
-	  
+
     let stackArray = potentialError.stack.split('\n');
     let newStack = 'Error:\n';
     var i = 1; //First line is "Error:\n"

--- a/examples/demo-react-native/e2e/.mocharc
+++ b/examples/demo-react-native/e2e/.mocharc
@@ -1,0 +1,6 @@
+{
+    "recursive": true,
+    "timeout": 300000,
+    "bail": true,
+    "file": "e2e/init.js"
+}

--- a/examples/demo-react-native/e2e/mocha.opts
+++ b/examples/demo-react-native/e2e/mocha.opts
@@ -1,4 +1,0 @@
---recursive
---timeout 300000
---bail
---file e2e/init.js

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -28,7 +28,7 @@
   },
   "detox": {
     "test-runner": "mocha",
-    "runner-config": "e2e/mocha.opts",
+    "runner-config": "e2e/.mocharc",
     "configurations": {
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",


### PR DESCRIPTION
- [x] This change has been discussed in issue #2057 and the solution has been agreed upon with maintainers.

Resolves #2057 

---

**Description:**

1. In `detox` section of `package.json`, when `test-runner` is `mocha`, and `runner-config` field points to a file with an extension different from `.opts`, Detox CLI in `detox test` command will use `--config` option instead of `--opts`.

2. `detox init -r mocha`  generates a template with `e2e/.mocharc` file instead of the deprecated `e2e/mocha.opts`.