### PR TITLE
Disable Android animations for all emulators

### DIFF
--- a/detox/src/devices/drivers/android/EmulatorDriver.js
+++ b/detox/src/devices/drivers/android/EmulatorDriver.js
@@ -57,6 +57,7 @@ class EmulatorDriver extends AndroidDriver {
     await this._boot(avdName, adbName);
 
     await this.adb.apiLevel(adbName);
+    await this.adb.disableAndroidAnimations(adbName);
     await this.adb.unlockScreen(adbName);
 
     this._name = `${adbName} (${avdName})`;

--- a/detox/src/devices/drivers/android/tools/ADB.js
+++ b/detox/src/devices/drivers/android/tools/ADB.js
@@ -157,6 +157,12 @@ class ADB {
     return lvl;
   }
 
+  async disableAndroidAnimations(deviceId) {
+    await this.shell(deviceId, `settings put global animator_duration_scale 0`);
+    await this.shell(deviceId, `settings put global window_animation_scale 0`);
+    await this.shell(deviceId, `settings put global transition_animation_scale 0`);
+  }
+
   async screencap(deviceId, path) {
     await this.shell(deviceId, `screencap ${path}`);
   }

--- a/detox/src/devices/drivers/android/tools/ADB.test.js
+++ b/detox/src/devices/drivers/android/tools/ADB.test.js
@@ -307,4 +307,21 @@ describe('ADB', () => {
     expect(adb.shell).toBeCalledWith('aDeviceId', 'pm list instrumentation');
     expect(result).toEqual(expectedRunner);
   });
+
+  describe('animation disabling', () => {
+    it('should disable animator (e.g. ObjectAnimator) animations', async () => {
+      await adb.disableAndroidAnimations();
+      expect(exec).toHaveBeenCalledWith(`"${adbBinPath}"  shell "settings put global animator_duration_scale 0"`, undefined, undefined, 1);
+    });
+
+    it('should disable window animations', async () => {
+      await adb.disableAndroidAnimations();
+      expect(exec).toHaveBeenCalledWith(`"${adbBinPath}"  shell "settings put global window_animation_scale 0"`, undefined, undefined, 1);
+    });
+
+    it('should disable transition (e.g. activity launch) animations', async () => {
+      await adb.disableAndroidAnimations();
+      expect(exec).toHaveBeenCalledWith(`"${adbBinPath}"  shell "settings put global transition_animation_scale 0"`, undefined, undefined, 1);
+    });
+  });
 });

--- a/detox/test/android/app/src/main/java/com/example/AnimationViewManager.java
+++ b/detox/test/android/app/src/main/java/com/example/AnimationViewManager.java
@@ -1,0 +1,50 @@
+package com.example;
+
+import android.animation.Animator;
+import android.animation.ObjectAnimator;
+import android.animation.ValueAnimator;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+public class AnimationViewManager extends SimpleViewManager<View> {
+
+    @Override
+    public String getName() {
+        return "DetoxNativeAnimatingView";
+    }
+
+    @Override
+    protected View createViewInstance(ThemedReactContext reactContext) {
+        final ViewGroup rootView = (ViewGroup) LayoutInflater.from(reactContext).inflate(R.layout.animation_test, null, false);
+        final ProgressBar progressBar = rootView.findViewById(R.id.animationTest_progressBar);
+        final TextView statusText = rootView.findViewById(R.id.animationTest_statusText);
+
+        final ValueAnimator animator = ObjectAnimator.ofInt(0, 100);
+        animator.setDuration(5000);
+        animator.addUpdateListener(animation -> {
+            Integer value = (Integer) animation.getAnimatedValue();
+            progressBar.setProgress(value);
+        });
+        animator.addListener(new AnimatorListenerStub() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                statusText.setVisibility(View.VISIBLE);
+            }
+        });
+
+        final Button button = rootView.findViewById(R.id.animationTest_button);
+        button.setOnClickListener(view -> {
+            button.setEnabled(false);
+            animator.start();
+        });
+
+        return rootView;
+    }
+}

--- a/detox/test/android/app/src/main/java/com/example/AnimatorListenerStub.java
+++ b/detox/test/android/app/src/main/java/com/example/AnimatorListenerStub.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import android.animation.Animator;
+
+public class AnimatorListenerStub implements Animator.AnimatorListener {
+    @Override
+    public void onAnimationStart(Animator animation) {
+    }
+
+    @Override
+    public void onAnimationEnd(Animator animation) {
+    }
+
+    @Override
+    public void onAnimationCancel(Animator animation) {
+    }
+
+    @Override
+    public void onAnimationRepeat(Animator animation) {
+    }
+}

--- a/detox/test/android/app/src/main/java/com/example/NativeModulePackage.java
+++ b/detox/test/android/app/src/main/java/com/example/NativeModulePackage.java
@@ -14,17 +14,19 @@ public class NativeModulePackage implements ReactPackage {
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        return Arrays.<NativeModule>asList(
+        return Arrays.asList(
                 new com.example.NativeModule(reactContext)
         );
     }
 
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Arrays.asList(
+                new AnimationViewManager()
+        );
+    }
+
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }
 }

--- a/detox/test/android/app/src/main/res/layout/animation_test.xml
+++ b/detox/test/android/app/src/main/res/layout/animation_test.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    >
+
+    <Button
+        android:id="@+id/animationTest_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Start"
+        android:tag="startButton"
+        android:layout_marginBottom="16dp"
+        />
+
+    <ProgressBar
+        android:id="@+id/animationTest_progressBar"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="32dp"
+        android:layout_marginHorizontal="16dp"
+        android:indeterminate="false"
+        android:max="100"
+        android:layout_marginBottom="16dp"
+        />
+
+    <TextView
+        android:id="@+id/animationTest_statusText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Animation Complete"
+        android:visibility="invisible"
+        />
+
+</LinearLayout>

--- a/detox/test/e2e/12.animations.test.js
+++ b/detox/test/e2e/12.animations.test.js
@@ -1,9 +1,9 @@
 let _ = require('lodash');
 
-describe('Animations', () => {
+describe('React-Native Animations', () => {
   beforeEach(async () => {
     await device.reloadReactNative();
-    await element(by.text('Animations')).tap();
+    await element(by.text('RN Animations')).tap();
   });
 
   async function _startTest(driver, options = {}) {
@@ -56,5 +56,15 @@ describe('Animations', () => {
       await _startTest(driver, {delay: 500});
       await expect(element(by.id('UniqueId_AnimationsScreen_afterAnimationText'))).toExist();
     });
+  });
+});
+
+describe(':android: Native animations', () => {
+  it('should expect a native android-animator animation to be short-circuited / fully-completed', async () => {
+    await device.reloadReactNative();
+    await element(by.text('Native Animation')).tap();
+
+    await element(by.id('startButton')).tap();
+    await expect(element(by.text('Animation Complete'))).toBeVisible();
   });
 });

--- a/detox/test/src/Screens/NativeAnimationsScreen.js
+++ b/detox/test/src/Screens/NativeAnimationsScreen.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+import { requireNativeComponent, View, Text } from 'react-native';
+
+const NativeAnimatingView = requireNativeComponent('DetoxNativeAnimatingView');
+
+class NativeAnimationsScreen extends Component {
+  render() {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'stretch' }}>
+        <NativeAnimatingView style={{flex: 1}}/>
+      </View>
+    );
+  }
+}
+
+module.exports = NativeAnimationsScreen;

--- a/detox/test/src/Screens/index.js
+++ b/detox/test/src/Screens/index.js
@@ -11,7 +11,8 @@ import TimeoutsScreen from './TimeoutsScreen';
 import Orientation from './Orientation';
 import Permissions from './Permissions';
 import NetworkScreen from './NetworkScreen';
-import AnimationsScreen from './AnimationsScreen';
+import RNAnimationsScreen from './AnimationsScreen';
+import NativeAnimationsScreen from './NativeAnimationsScreen';
 import LocationScreen from './LocationScreen';
 import ShakeScreen from './ShakeScreen';
 import DatePickerScreen from './DatePickerScreen';
@@ -34,7 +35,8 @@ export {
   Orientation,
   Permissions,
   NetworkScreen,
-  AnimationsScreen,
+  RNAnimationsScreen,
+  NativeAnimationsScreen,
   LocationScreen,
   ShakeScreen,
   DatePickerScreen,

--- a/detox/test/src/app.js
+++ b/detox/test/src/app.js
@@ -105,12 +105,13 @@ class example extends Component {
           {this.renderScreenButton('Orientation', Screens.Orientation)}
           {this.renderScreenButton('Permissions', Screens.Permissions)}
           {this.renderScreenButton('Network', Screens.NetworkScreen)}
-          {this.renderScreenButton('Animations', Screens.AnimationsScreen)}
+          {this.renderAnimationScreenButtons()}
           {this.renderScreenButton('Device', Screens.DeviceScreen)}
           {this.renderScreenButton('Location', Screens.LocationScreen)}
           {!isAndroid && this.renderScreenButton('DatePicker', Screens.DatePickerScreen)}
           {!isAndroid && this.renderScreenButton('Picker', Screens.PickerViewScreen)}
 
+          { /* TODO: Push this into a dedicated screen */ }
           <View style={{flexDirection: 'row', justifyContent: 'center'}}>
             {this.renderButton('Crash', () => {
               // Note: this crashes the native-modules thread (and thus an *uncaught* exception, on Android).
@@ -136,6 +137,16 @@ class example extends Component {
     const Screen = this.state.screen;
     return (
       <Screen/>
+    );
+  }
+
+  renderAnimationScreenButtons() {
+    return (
+      <View style={{flexDirection: 'row', justifyContent: 'center'}}>
+        {this.renderScreenButton('RN Animations', Screens.RNAnimationsScreen)}
+        {isAndroid && <Text style={{width: 10}}> | </Text>}
+        {this.renderScreenButton('Native Animation', Screens.NativeAnimationsScreen)}
+      </View>
     );
   }
 


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Addressing this has long-overdued, and its been recently incentivised for upon coming across related problems in internal apps. After making numerous futile attempts at creating an idling-resource that would fill in the missing gap<sup>*</sup>, it is now clear that the only option is to go with Google's recommendation and turn off animations across the board.

---
<sup>* System components such as `RenderThread` and the centralized (though thread-based) `AnimationHandler` (method `getAnimationCount()`) are all hidden and inaccessible even via reflection on actual devices.</sup>