### PR TITLE
Apply custom, less tight, IdlePolicy timeouts

### DIFF
--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -38,6 +38,11 @@ public class DetoxTest {
 
     @Test
     public void runDetoxTests() {
+        final ActivityTestRule<?> rule = resolveTestRule();
+        Detox.runTests(rule);
+    }
+
+    private ActivityTestRule<?> resolveTestRule() {
         final Bundle arguments = InstrumentationRegistry.getArguments();
         final boolean useSingleTaskActivity = Boolean.parseBoolean(arguments.getString(USE_SINGLE_INSTANCE_ACTIVITY_ARG, "false"));
         final boolean useCrashingActivity = Boolean.parseBoolean(arguments.getString(USE_CRASHING_ACTIVITY_ARG, "false"));
@@ -47,6 +52,6 @@ public class DetoxTest {
                         : useCrashingActivity
                             ? mCrashingActivityTestRule
                             : mActivityRule;
-        Detox.runTests(rule);
+        return rule;
     }
 }

--- a/examples/demo-react-native/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/examples/demo-react-native/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -22,6 +22,10 @@ public class DetoxTest {
 
     @Test
     public void runDetoxTests() {
-        Detox.runTests(mActivityRule);
+        Detox.DetoxIdlePolicyConfig idlePolicyConfig = new Detox.DetoxIdlePolicyConfig();
+        idlePolicyConfig.masterTimeoutSec = 60;
+        idlePolicyConfig.idleResourceTimeoutSec = 30;
+
+        Detox.runTests(mActivityRule, idlePolicyConfig);
     }
 }


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
This has been discussed in the past in https://github.com/wix/Detox/issues/1782#issuecomment-560125814. After getting associated failures in internal projects, it's time to increase the defaults (yet allow for custom overrides).