### PR TITLE
Apply a clear, by-the-book impl. for taps and multi-taps on Android

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxMultiTap.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxMultiTap.kt
@@ -3,12 +3,13 @@ package com.wix.detox.espresso.action
 import androidx.test.espresso.UiController
 import androidx.test.espresso.action.Tapper
 import com.wix.detox.espresso.common.DetoxViewConfigurations.getDoubleTapMinTime
+import com.wix.detox.espresso.common.DetoxViewConfigurations.getPostTapCooldownTime
 
-class DetoxMultiTap(private val times: Int, private val interTapsDelayMs: Long?, delegatedTapperGenFn: () -> Tapper): Tapper {
+class DetoxMultiTap(private val times: Int, private val interTapsDelayMs: Long?, private val cooldownTime: Long, delegatedTapperGenFn: () -> Tapper): Tapper {
     private var delegateTapper: Tapper = delegatedTapperGenFn()
 
     constructor(times: Int)
-            : this(times, getDoubleTapMinTime(), { DetoxSingleTap(tapTimeout = 0) })
+            : this(times, getDoubleTapMinTime(), getPostTapCooldownTime(), { DetoxSingleTap(cooldownTime = 0) })
 
     override fun sendTap(uiController: UiController?, coordinates: FloatArray?, precision: FloatArray?)
             = sendTap(uiController, coordinates, precision, 0, 0)
@@ -29,6 +30,7 @@ class DetoxMultiTap(private val times: Int, private val interTapsDelayMs: Long?,
                 }
             }
         }
+        uiController.loopMainThreadForAtLeast(cooldownTime)
         return Tapper.Status.SUCCESS
     }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxMultiTap.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxMultiTap.kt
@@ -8,7 +8,7 @@ class DetoxMultiTap(private val times: Int, private val interTapsDelayMs: Long?,
     private var delegateTapper: Tapper = delegatedTapperGenFn()
 
     constructor(times: Int)
-            : this(times, getDoubleTapMinTime(), { DetoxSingleTap() })
+            : this(times, getDoubleTapMinTime(), { DetoxSingleTap(tapTimeout = 0) })
 
     override fun sendTap(uiController: UiController?, coordinates: FloatArray?, precision: FloatArray?)
             = sendTap(uiController, coordinates, precision, 0, 0)

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxSingleTap.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxSingleTap.kt
@@ -2,7 +2,7 @@ package com.wix.detox.espresso.action
 
 import androidx.test.espresso.UiController
 import androidx.test.espresso.action.Tapper
-import com.wix.detox.espresso.common.DetoxViewConfigurations.getPostTapTimeout
+import com.wix.detox.espresso.common.DetoxViewConfigurations.getPostTapCooldownTime
 import com.wix.detox.espresso.common.MotionEvents
 
 /**
@@ -19,7 +19,7 @@ import com.wix.detox.espresso.common.MotionEvents
  */
 class DetoxSingleTap(
         private val motionEvents: MotionEvents = MotionEvents(),
-        private val tapTimeout: Long = getPostTapTimeout())
+        private val cooldownTime: Long = getPostTapCooldownTime())
     : Tapper {
 
     override fun sendTap(uiController: UiController?, coordinates: FloatArray?, precision: FloatArray?): Tapper.Status
@@ -37,8 +37,8 @@ class DetoxSingleTap(
         try {
             val result = uiController.injectMotionEventSequence(arrayListOf(downEvent, upEvent))
             if (result) {
-                if (tapTimeout > 0) {
-                    uiController.loopMainThreadForAtLeast(tapTimeout)
+                if (cooldownTime > 0) {
+                    uiController.loopMainThreadForAtLeast(cooldownTime)
                 }
                 return Tapper.Status.SUCCESS
             }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxSingleTap.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxSingleTap.kt
@@ -2,7 +2,7 @@ package com.wix.detox.espresso.action
 
 import androidx.test.espresso.UiController
 import androidx.test.espresso.action.Tapper
-import com.wix.detox.espresso.common.DetoxViewConfigurations.getPracticalTapTimeout
+import com.wix.detox.espresso.common.DetoxViewConfigurations.getPostTapTimeout
 import com.wix.detox.espresso.common.MotionEvents
 
 /**
@@ -19,7 +19,7 @@ import com.wix.detox.espresso.common.MotionEvents
  */
 class DetoxSingleTap(
         private val motionEvents: MotionEvents = MotionEvents(),
-        private val tapTimeout: Long = getPracticalTapTimeout())
+        private val tapTimeout: Long = getPostTapTimeout())
     : Tapper {
 
     override fun sendTap(uiController: UiController?, coordinates: FloatArray?, precision: FloatArray?): Tapper.Status
@@ -37,7 +37,9 @@ class DetoxSingleTap(
         try {
             val result = uiController.injectMotionEventSequence(arrayListOf(downEvent, upEvent))
             if (result) {
-                uiController.loopMainThreadForAtLeast(tapTimeout)
+                if (tapTimeout > 0) {
+                    uiController.loopMainThreadForAtLeast(tapTimeout)
+                }
                 return Tapper.Status.SUCCESS
             }
             return Tapper.Status.FAILURE

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/common/DetoxViewConfiguration.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/common/DetoxViewConfiguration.kt
@@ -9,7 +9,7 @@ private const val LOG_TAG = "Detox-ViewConfig"
 
 object DetoxViewConfigurations {
 
-    fun getPracticalTapTimeout() = (ViewConfiguration.getTapTimeout() * 1.5).toLong()
+    fun getPostTapTimeout() = ViewConfiguration.getDoubleTapTimeout().toLong()
 
     /**
      * Taken from [androidx.test.espresso.action.Tap]

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/common/DetoxViewConfiguration.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/common/DetoxViewConfiguration.kt
@@ -9,7 +9,7 @@ private const val LOG_TAG = "Detox-ViewConfig"
 
 object DetoxViewConfigurations {
 
-    fun getPostTapTimeout() = ViewConfiguration.getDoubleTapTimeout().toLong()
+    fun getPostTapCooldownTime() = ViewConfiguration.getDoubleTapTimeout().toLong()
 
     /**
      * Taken from [androidx.test.espresso.action.Tap]

--- a/detox/android/detox/src/test/java/com/wix/detox/espresso/action/DetoxSingleTapSpec.kt
+++ b/detox/android/detox/src/test/java/com/wix/detox/espresso/action/DetoxSingleTapSpec.kt
@@ -37,6 +37,30 @@ object DetoxSingleTapSpec: Spek({
             }
         }
 
+        fun verifyMotionEventsInjected(vararg events: MotionEvent) {
+            verify(uiController).injectMotionEventSequence(events.asList())
+        }
+
+        fun verifyDownEventObtained(coordinates: FloatArray, precision: FloatArray) {
+            verify(motionEvents).obtainDownEvent(coordinates[0], coordinates[1], precision)
+        }
+
+        fun verifyUpEventObtained(coordinates: FloatArray) {
+            verify(motionEvents).obtainUpEvent(eq(downEvent), any(), eq(coordinates[0]), eq(coordinates[1]))
+        }
+
+        fun verifyUpEventObtainedWithTimestamp(expectedUpTime: Long) {
+            verify(motionEvents).obtainUpEvent(eq(downEvent), eq(expectedUpTime), any(), any())
+        }
+
+        fun verifyMainThreadSync(expectedSyncTime: Long) {
+            verify(uiController).loopMainThreadForAtLeast(eq(expectedSyncTime))
+        }
+
+        fun verifyMainThreadNeverSynced() {
+            verify(uiController, never()).loopMainThreadForAtLeast(any())
+        }
+
         fun uut() = DetoxSingleTap(motionEvents)
         fun uut(tapTimeout: Long) = DetoxSingleTap(motionEvents, tapTimeout)
 
@@ -46,7 +70,7 @@ object DetoxSingleTapSpec: Spek({
 
             uut().sendTap(uiController, coordinates, precision, 0, 0)
 
-            verify(uiController).injectMotionEventSequence(arrayListOf(downEvent, upEvent))
+            verifyMotionEventsInjected(downEvent, upEvent)
         }
 
         it("should create down event with proper coordinates and precision") {
@@ -55,7 +79,7 @@ object DetoxSingleTapSpec: Spek({
 
             uut().sendTap(uiController, coordinates, precision, 0, 0)
 
-            verify(motionEvents).obtainDownEvent(coordinates[0], coordinates[1], precision)
+            verifyDownEventObtained(coordinates, precision)
         }
 
         it("should create up event with proper coordinates") {
@@ -64,7 +88,7 @@ object DetoxSingleTapSpec: Spek({
 
             uut().sendTap(uiController, coordinates, precision, 0, 0)
 
-            verify(motionEvents).obtainUpEvent(eq(downEvent), any(), eq(coordinates[0]), eq(coordinates[1]))
+            verifyUpEventObtained(coordinates)
         }
 
         it("should create up event with a reasonable time-gap (30ms)") {
@@ -74,7 +98,7 @@ object DetoxSingleTapSpec: Spek({
 
             uut().sendTap(uiController, coordinates, precision, 0, 0)
 
-            verify(motionEvents).obtainUpEvent(eq(downEvent), eq(expectedUpEventTime), any(), any())
+            verifyUpEventObtainedWithTimestamp(expectedUpEventTime);
         }
 
         it("should recycle down+up events") {
@@ -132,7 +156,7 @@ object DetoxSingleTapSpec: Spek({
 
             uut().sendTap(uiController, coordinates, precision)
 
-            verify(uiController).injectMotionEventSequence(arrayListOf(downEvent, upEvent))
+            verifyMotionEventsInjected(downEvent, upEvent)
         }
 
         it("should idle-wait the tap-registration period following a successful tap injection") {
@@ -145,7 +169,7 @@ object DetoxSingleTapSpec: Spek({
 
             uut(expectedWait).sendTap(uiController, coordinates, precision, 0, 0)
 
-            verify(uiController).loopMainThreadForAtLeast(eq(expectedWait))
+            verifyMainThreadSync(expectedWait)
         }
 
         it("should not idle-wait the tap-registration period if tap injection fails") {
@@ -156,7 +180,18 @@ object DetoxSingleTapSpec: Spek({
 
             uut(111L).sendTap(uiController, coordinates, precision, 0, 0)
 
-            verify(uiController, never()).loopMainThreadForAtLeast(any())
+            verifyMainThreadNeverSynced()
+        }
+
+        it("should not idle-wait the tap-registration period if provided time is 0") {
+            whenever(uiController.injectMotionEventSequence(any())).doReturn(true)
+
+            val coordinates = dontCareCoordinates()
+            val precision = dontCarePrecision()
+
+            uut(0).sendTap(uiController, coordinates, precision, 0, 0)
+
+            verifyMainThreadNeverSynced()
         }
 
         it("should throw if no UI-controller provided") {

--- a/detox/android/detox/src/test/java/com/wix/detox/espresso/action/DetoxSingleTapSpec.kt
+++ b/detox/android/detox/src/test/java/com/wix/detox/espresso/action/DetoxSingleTapSpec.kt
@@ -37,29 +37,23 @@ object DetoxSingleTapSpec: Spek({
             }
         }
 
-        fun verifyMotionEventsInjected(vararg events: MotionEvent) {
-            verify(uiController).injectMotionEventSequence(events.asList())
-        }
+        fun verifyMotionEventsInjected(vararg events: MotionEvent)
+                = verify(uiController).injectMotionEventSequence(events.asList())
 
-        fun verifyDownEventObtained(coordinates: FloatArray, precision: FloatArray) {
-            verify(motionEvents).obtainDownEvent(coordinates[0], coordinates[1], precision)
-        }
+        fun verifyDownEventObtained(coordinates: FloatArray, precision: FloatArray)
+                = verify(motionEvents).obtainDownEvent(coordinates[0], coordinates[1], precision)
 
-        fun verifyUpEventObtained(coordinates: FloatArray) {
-            verify(motionEvents).obtainUpEvent(eq(downEvent), any(), eq(coordinates[0]), eq(coordinates[1]))
-        }
+        fun verifyUpEventObtained(coordinates: FloatArray)
+                = verify(motionEvents).obtainUpEvent(eq(downEvent), any(), eq(coordinates[0]), eq(coordinates[1]))
 
-        fun verifyUpEventObtainedWithTimestamp(expectedUpTime: Long) {
-            verify(motionEvents).obtainUpEvent(eq(downEvent), eq(expectedUpTime), any(), any())
-        }
+        fun verifyUpEventObtainedWithTimestamp(expectedUpTime: Long)
+                = verify(motionEvents).obtainUpEvent(eq(downEvent), eq(expectedUpTime), any(), any())
 
-        fun verifyMainThreadSync(expectedSyncTime: Long) {
-            verify(uiController).loopMainThreadForAtLeast(eq(expectedSyncTime))
-        }
+        fun verifyMainThreadSynced(expectedSyncTime: Long)
+                = verify(uiController).loopMainThreadForAtLeast(eq(expectedSyncTime))
 
-        fun verifyMainThreadNeverSynced() {
-            verify(uiController, never()).loopMainThreadForAtLeast(any())
-        }
+        fun verifyMainThreadNeverSynced()
+                = verify(uiController, never()).loopMainThreadForAtLeast(any())
 
         fun uut() = DetoxSingleTap(motionEvents)
         fun uut(tapTimeout: Long) = DetoxSingleTap(motionEvents, tapTimeout)
@@ -98,7 +92,7 @@ object DetoxSingleTapSpec: Spek({
 
             uut().sendTap(uiController, coordinates, precision, 0, 0)
 
-            verifyUpEventObtainedWithTimestamp(expectedUpEventTime);
+            verifyUpEventObtainedWithTimestamp(expectedUpEventTime)
         }
 
         it("should recycle down+up events") {
@@ -159,7 +153,7 @@ object DetoxSingleTapSpec: Spek({
             verifyMotionEventsInjected(downEvent, upEvent)
         }
 
-        it("should idle-wait the tap-registration period following a successful tap injection") {
+        it("should idle-wait the cooldown period following a successful tap injection") {
             whenever(uiController.injectMotionEventSequence(any())).doReturn(true)
 
             val expectedWait = 111L
@@ -169,7 +163,7 @@ object DetoxSingleTapSpec: Spek({
 
             uut(expectedWait).sendTap(uiController, coordinates, precision, 0, 0)
 
-            verifyMainThreadSync(expectedWait)
+            verifyMainThreadSynced(expectedWait)
         }
 
         it("should not idle-wait the tap-registration period if tap injection fails") {

--- a/detox/test/android/app/src/main/java/com/example/AnimationViewManager.java
+++ b/detox/test/android/app/src/main/java/com/example/AnimationViewManager.java
@@ -10,6 +10,7 @@ import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import com.example.utils.AnimatorListenerStub;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 

--- a/detox/test/android/app/src/main/java/com/example/DoubleTapsTextViewManager.java
+++ b/detox/test/android/app/src/main/java/com/example/DoubleTapsTextViewManager.java
@@ -1,0 +1,61 @@
+package com.example;
+
+import android.graphics.Color;
+import android.view.GestureDetector;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewGroup.LayoutParams;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import com.example.utils.DoubleTapListenerStub;
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+import androidx.annotation.NonNull;
+
+public class DoubleTapsTextViewManager extends SimpleViewManager<ViewGroup> {
+    private static class ViewState {
+        int taps = 0;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "DetoxDoubleTapsTextView";
+    }
+
+    @NonNull
+    @Override
+    protected ViewGroup createViewInstance(@NonNull ThemedReactContext reactContext) {
+        final ViewState viewState = new ViewState();
+
+        final FrameLayout layout = new FrameLayout(reactContext);
+        layout.setLayoutParams(new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+
+        final TextView textView = new TextView(reactContext);
+        textView.setTag("doubleTappableText");
+        textView.setLayoutParams(new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, Gravity.CENTER));
+        textView.setTextAlignment(View.TEXT_ALIGNMENT_CENTER);
+        textView.setGravity(Gravity.CENTER);
+        textView.setText("Double-Taps: "+viewState.taps);
+        textView.setTextColor(Color.BLUE);
+
+        final GestureDetector gestureDetector = new GestureDetector(reactContext, new GestureDetector.SimpleOnGestureListener());
+        gestureDetector.setOnDoubleTapListener(new DoubleTapListenerStub() {
+            @Override
+            public boolean onDoubleTap(MotionEvent e) {
+                viewState.taps++;
+                textView.setText("Double-Taps: "+viewState.taps);
+                return true;
+            }
+        });
+        textView.setOnTouchListener((v, event) -> gestureDetector.onTouchEvent(event));
+        textView.setOnClickListener(v -> {});
+
+        layout.addView(textView);
+        return layout;
+    }
+}

--- a/detox/test/android/app/src/main/java/com/example/DoubleTapsTextViewManager.java
+++ b/detox/test/android/app/src/main/java/com/example/DoubleTapsTextViewManager.java
@@ -14,22 +14,18 @@ import com.example.utils.DoubleTapListenerStub;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 
-import androidx.annotation.NonNull;
-
 public class DoubleTapsTextViewManager extends SimpleViewManager<ViewGroup> {
     private static class ViewState {
         int taps = 0;
     }
 
-    @NonNull
     @Override
     public String getName() {
         return "DetoxDoubleTapsTextView";
     }
 
-    @NonNull
     @Override
-    protected ViewGroup createViewInstance(@NonNull ThemedReactContext reactContext) {
+    protected ViewGroup createViewInstance(ThemedReactContext reactContext) {
         final ViewState viewState = new ViewState();
 
         final FrameLayout layout = new FrameLayout(reactContext);

--- a/detox/test/android/app/src/main/java/com/example/NativeModule.java
+++ b/detox/test/android/app/src/main/java/com/example/NativeModule.java
@@ -6,11 +6,11 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 import android.view.Gravity;
-import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.TextView;
 
+import com.example.utils.ViewSpies;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
@@ -18,11 +18,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.util.ReactFindViewUtil;
-import com.facebook.react.uimanager.util.ReactFindViewUtil.OnMultipleViewsFoundListener;
-
-import java.util.HashSet;
-import java.util.Set;
 
 public class NativeModule extends ReactContextBaseJavaModule {
 
@@ -97,7 +92,7 @@ public class NativeModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void spyLongTaps(final String testID) {
-        new LongTapCrasher(testID).attach();
+        new ViewSpies.LongTapCrasher(testID).attach();
     }
 
     @ReactMethod
@@ -117,40 +112,5 @@ public class NativeModule extends ReactContextBaseJavaModule {
         reactContext.getCurrentActivity().runOnUiThread(() -> {
             throw new RuntimeException("Simulated crash (native)");
         });
-    }
-
-    /**
-     * Implementation note: For this purpose, a simpler RN API exists in the same class -
-     * {@link ReactFindViewUtil#addViewListener(ReactFindViewUtil.OnViewFoundListener)}.
-     * However, it is found to be a bit buggy since it removes all listeners immediately
-     * after being called (i.e. while iterating) with no thread-sync mechanisms to protect it.
-     * If real life (CI), we've genuinely seen that it throws ConcurrentModificationException exceptions,
-     * on occasions (and why wouldn't it? - our demo app's ActionsScreen has multiple views subscribing and
-     * called concurrently; could it be that not always everything is run in the main thread?).
-     * Therefore, we use here {@link ReactFindViewUtil#addViewsListener(OnMultipleViewsFoundListener, Set)},
-     * which is too generic but nevertheless allows us to better control when we are to be removed.
-     */
-    private static class LongTapCrasher implements OnMultipleViewsFoundListener {
-
-        private final String testID;
-
-        private LongTapCrasher(String testID) {
-            this.testID = testID;
-        }
-
-        public void attach() {
-            final Set<String> nativeIds = new HashSet<>();
-            nativeIds.add(testID);
-
-            ReactFindViewUtil.addViewsListener(this, nativeIds);
-        }
-
-        @Override
-        public void onViewFound(View view, String nativeId) {
-            view.setOnLongClickListener(v -> {
-                throw new IllegalStateException("Validation failed: component \"" + testID + "\" was long-tapped!!!");
-            });
-            view.post(() -> ReactFindViewUtil.removeViewsListener(this));
-        }
     }
 }

--- a/detox/test/android/app/src/main/java/com/example/NativeModulePackage.java
+++ b/detox/test/android/app/src/main/java/com/example/NativeModulePackage.java
@@ -22,7 +22,8 @@ public class NativeModulePackage implements ReactPackage {
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.asList(
-                new AnimationViewManager()
+                new AnimationViewManager(),
+                new DoubleTapsTextViewManager()
         );
     }
 

--- a/detox/test/android/app/src/main/java/com/example/utils/AnimatorListenerStub.java
+++ b/detox/test/android/app/src/main/java/com/example/utils/AnimatorListenerStub.java
@@ -1,4 +1,4 @@
-package com.example;
+package com.example.utils;
 
 import android.animation.Animator;
 

--- a/detox/test/android/app/src/main/java/com/example/utils/DoubleTapListenerStub.java
+++ b/detox/test/android/app/src/main/java/com/example/utils/DoubleTapListenerStub.java
@@ -1,0 +1,21 @@
+package com.example.utils;
+
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+
+public class DoubleTapListenerStub implements GestureDetector.OnDoubleTapListener {
+    @Override
+    public boolean onSingleTapConfirmed(MotionEvent e) {
+        return false;
+    }
+
+    @Override
+    public boolean onDoubleTap(MotionEvent e) {
+        return false;
+    }
+
+    @Override
+    public boolean onDoubleTapEvent(MotionEvent e) {
+        return false;
+    }
+}

--- a/detox/test/android/app/src/main/java/com/example/utils/ViewSpies.java
+++ b/detox/test/android/app/src/main/java/com/example/utils/ViewSpies.java
@@ -1,0 +1,62 @@
+package com.example.utils;
+
+import android.view.View;
+
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public interface ViewSpies {
+
+    /**
+     * Implementation note: For this purpose, a simpler RN API exists in the same class -
+     * {@link ReactFindViewUtil#addViewListener(ReactFindViewUtil.OnViewFoundListener)}.
+     * However, it is found to be a bit buggy since it removes all listeners immediately
+     * after being called (i.e. while iterating) with no thread-sync mechanisms to protect it.
+     * If real life (CI), we've genuinely seen that it throws ConcurrentModificationException exceptions,
+     * on occasions (and why wouldn't it? - our demo app's ActionsScreen has multiple views subscribing and
+     * called concurrently; could it be that not always everything is run in the main thread?).
+     * Therefore, we use here {@link ReactFindViewUtil#addViewsListener(ReactFindViewUtil.OnMultipleViewsFoundListener, Set)},
+     * which is too generic but nevertheless allows us to better control when we are to be removed.
+     */
+    abstract class BaseViewSpy implements ReactFindViewUtil.OnMultipleViewsFoundListener {
+        private final String testID;
+
+        private BaseViewSpy(String testID) {
+            this.testID = testID;
+        }
+
+        public void attach() {
+            final Set<String> nativeIds = new HashSet<>();
+            nativeIds.add(testID);
+
+            ReactFindViewUtil.addViewsListener(this, nativeIds);
+        }
+
+        String getTestID() {
+            return testID;
+        }
+
+        abstract void handleViewFound(View view);
+
+        @Override
+        public void onViewFound(View view, String nativeId) {
+            handleViewFound(view);
+            view.post(() -> ReactFindViewUtil.removeViewsListener(this));
+        }
+    }
+
+    class LongTapCrasher extends BaseViewSpy {
+        public LongTapCrasher(String testID) {
+            super(testID);
+        }
+
+        @Override
+        protected void handleViewFound(View view) {
+            view.setOnLongClickListener(v -> {
+                throw new IllegalStateException("Validation failed: component \"" + getTestID() + "\" was long-tapped!!!");
+            });
+        }
+    }
+}

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -1,5 +1,35 @@
 const custom = require('./utils/custom-it');
 
+const driver = {
+  tapsElement: {
+    testId: 'UniqueId819',
+    coordinates: { x: 180, y: 160 },
+    multiTap: () => element(by.id(driver.tapsElement.testId)).multiTap(3),
+    tapAtPoint: () => element(by.id('View7990')).tapAtPoint(driver.tapsElement.coordinates),
+    assertTapsCount: (count) => expect(element(by.id(driver.tapsElement.testId))).toHaveText(`Taps: ${count}`),
+    assertTappedOnce: () => driver.tapsElement.assertTapsCount(1),
+    assertMultiTapped: () => driver.tapsElement.assertTapsCount(3),
+  },
+  doubleTapsElement: {
+    testId: 'doubleTappableText',
+    coordinates: { x: 180, y: 200 },
+    tapOnce: () => element(by.id(driver.doubleTapsElement.testId)).tap(),
+    tapTwice: async () => {
+      await driver.doubleTapsElement.tapOnce();
+      await driver.doubleTapsElement.tapOnce();
+    },
+    multiTapOnce: () => element(by.id(driver.doubleTapsElement.testId)).multiTap(1),
+    doubleTap: () => element(by.id(driver.doubleTapsElement.testId)).multiTap(2),
+    tapAtPointOnce: () => element(by.id('View7990')).tapAtPoint(driver.doubleTapsElement.coordinates),
+    tapAtPointTwice: async () => {
+      await driver.doubleTapsElement.tapAtPointOnce();
+      await driver.doubleTapsElement.tapAtPointOnce();
+    },
+    assertTapsCount: (count) => expect(element(by.id(driver.doubleTapsElement.testId))).toHaveText(`Double-Taps: ${count}`),
+    assertNoTaps: () => driver.doubleTapsElement.assertTapsCount(0),
+  }
+};
+
 describe('Actions', () => {
   beforeEach(async () => {
     await device.reloadReactNative();
@@ -22,57 +52,47 @@ describe('Actions', () => {
   });
 
   it('should tap on an element at point', async () => {
-    await element(by.id('View7990')).tapAtPoint({ x: 180, y: 160 });
-    await expect(element(by.id('UniqueId819'))).toHaveText('Taps: 1');
+    await driver.tapsElement.tapAtPoint();
+    await driver.tapsElement.assertTappedOnce();
   });
 
-  describe('multi-tapping', () => {
-    const testIdTappable = 'UniqueId819';
-    const testIdDoubleTappable = 'doubleTappableText';
-    const coordsDoubleTappable = { x: 180, y: 200 };
-
-    const doubleTap = () => element(by.id(testIdDoubleTappable)).multiTap(2)
-    const tapTwice = async () => {
-      await element(by.id(testIdDoubleTappable)).tap();
-      await element(by.id(testIdDoubleTappable)).tap();
-    }
-    const tapTwiceAtPoint = async () => {
-      await element(by.id('View7990')).tapAtPoint(coordsDoubleTappable);
-      await element(by.id('View7990')).tapAtPoint(coordsDoubleTappable);
-    };
-    const assertDoubleTapsCountText = (count) => expect(element(by.id(testIdDoubleTappable))).toHaveText(`Double-Taps: ${count}`);
-    const assertNoDoubleTapTextChanges = () => assertDoubleTapsCountText(0)
-
-    it(':ios: should multi tap on an element', async () => {
-      await element(by.id(testIdTappable)).multiTap(3);
-      await expect(element(by.id(testIdTappable))).toHaveText('Taps: 3');
+  describe.only('multi-tapping', () => {
+    it('should multi tap on an element', async () => {
+      await driver.tapsElement.multiTap();
+      await driver.tapsElement.assertMultiTapped();
     });
 
     it(':android: should properly double-tap on an element', async () => {
-      await doubleTap();
-      await assertDoubleTapsCountText(1);
+      await driver.doubleTapsElement.doubleTap();
+      await driver.doubleTapsElement.assertTapsCount(1);
 
-      await doubleTap();
-      await assertDoubleTapsCountText(2);
+      await driver.doubleTapsElement.doubleTap();
+      await driver.doubleTapsElement.assertTapsCount(2);
 
-      await doubleTap();
-      await assertDoubleTapsCountText(3);
+      await driver.doubleTapsElement.doubleTap();
+      await driver.doubleTapsElement.assertTapsCount(3);
     });
 
     it(':android: should fail to apply 2 distinct taps on a double-tap element', async () => {
-      await tapTwice();
-      await assertNoDoubleTapTextChanges();
+      await driver.doubleTapsElement.tapTwice();
+      await driver.doubleTapsElement.assertNoTaps();
 
-      await tapTwice();
-      await assertNoDoubleTapTextChanges();
+      await driver.doubleTapsElement.tapTwice();
+      await driver.doubleTapsElement.assertNoTaps();
 
-      await tapTwice();
-      await assertNoDoubleTapTextChanges();
+      await driver.doubleTapsElement.tapTwice();
+      await driver.doubleTapsElement.assertNoTaps();
+    });
+
+    it(':android: should fail to register a tap following a multi-tap as a double-tap', async () => {
+      await driver.doubleTapsElement.multiTapOnce();
+      await driver.doubleTapsElement.tapOnce();
+      await driver.doubleTapsElement.assertNoTaps();
     });
 
     it(':android: should fail to apply 2 distinct taps on a double-tap element at explicit point', async () => {
-      await tapTwiceAtPoint();
-      await assertNoDoubleTapTextChanges();
+      await driver.doubleTapsElement.tapAtPointTwice();
+      await driver.doubleTapsElement.assertNoTaps();
     });
   });
 

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -3,7 +3,10 @@ const custom = require('./utils/custom-it');
 const driver = {
   tapsElement: {
     testId: 'UniqueId819',
-    coordinates: { x: 180, y: 160 },
+    get coordinates() {
+      const x = (device.getPlatform() === 'ios' ? 180 : 125);
+      return { x, y: 160 };
+    },
     multiTap: () => element(by.id(driver.tapsElement.testId)).multiTap(3),
     tapAtPoint: () => element(by.id('View7990')).tapAtPoint(driver.tapsElement.coordinates),
     assertTapsCount: (count) => expect(element(by.id(driver.tapsElement.testId))).toHaveText(`Taps: ${count}`),
@@ -12,7 +15,7 @@ const driver = {
   },
   doubleTapsElement: {
     testId: 'doubleTappableText',
-    coordinates: { x: 180, y: 200 },
+    coordinates: { x: 200, y: 160 },
     tapOnce: () => element(by.id(driver.doubleTapsElement.testId)).tap(),
     tapTwice: async () => {
       await driver.doubleTapsElement.tapOnce();
@@ -56,7 +59,7 @@ describe('Actions', () => {
     await driver.tapsElement.assertTappedOnce();
   });
 
-  describe.only('multi-tapping', () => {
+  describe('multi-tapping', () => {
     it('should multi tap on an element', async () => {
       await driver.tapsElement.multiTap();
       await driver.tapsElement.assertMultiTapped();

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -21,14 +21,59 @@ describe('Actions', () => {
     await expect(element(by.text('Long Press With Duration Working!!!'))).toBeVisible();
   });
 
-  it('should multi tap on an element', async () => {
-    await element(by.id('UniqueId819')).multiTap(3);
-    await expect(element(by.id('UniqueId819'))).toHaveText('Taps: 3');
-  });
-
   it('should tap on an element at point', async () => {
     await element(by.id('View7990')).tapAtPoint({ x: 180, y: 160 });
     await expect(element(by.id('UniqueId819'))).toHaveText('Taps: 1');
+  });
+
+  describe('multi-tapping', () => {
+    const testIdTappable = 'UniqueId819';
+    const testIdDoubleTappable = 'doubleTappableText';
+    const coordsDoubleTappable = { x: 180, y: 200 };
+
+    const doubleTap = () => element(by.id(testIdDoubleTappable)).multiTap(2)
+    const tapTwice = async () => {
+      await element(by.id(testIdDoubleTappable)).tap();
+      await element(by.id(testIdDoubleTappable)).tap();
+    }
+    const tapTwiceAtPoint = async () => {
+      await element(by.id('View7990')).tapAtPoint(coordsDoubleTappable);
+      await element(by.id('View7990')).tapAtPoint(coordsDoubleTappable);
+    };
+    const assertDoubleTapsCountText = (count) => expect(element(by.id(testIdDoubleTappable))).toHaveText(`Double-Taps: ${count}`);
+    const assertNoDoubleTapTextChanges = () => assertDoubleTapsCountText(0)
+
+    it(':ios: should multi tap on an element', async () => {
+      await element(by.id(testIdTappable)).multiTap(3);
+      await expect(element(by.id(testIdTappable))).toHaveText('Taps: 3');
+    });
+
+    it(':android: should properly double-tap on an element', async () => {
+      await doubleTap();
+      await assertDoubleTapsCountText(1);
+
+      await doubleTap();
+      await assertDoubleTapsCountText(2);
+
+      await doubleTap();
+      await assertDoubleTapsCountText(3);
+    });
+
+    it(':android: should fail to apply 2 distinct taps on a double-tap element', async () => {
+      await tapTwice();
+      await assertNoDoubleTapTextChanges();
+
+      await tapTwice();
+      await assertNoDoubleTapTextChanges();
+
+      await tapTwice();
+      await assertNoDoubleTapTextChanges();
+    });
+
+    it(':android: should fail to apply 2 distinct taps on a double-tap element at explicit point', async () => {
+      await tapTwiceAtPoint();
+      await assertNoDoubleTapTextChanges();
+    });
   });
 
   it('should type in an element', async () => {

--- a/detox/test/src/Screens/ActionsScreen.js
+++ b/detox/test/src/Screens/ActionsScreen.js
@@ -9,8 +9,11 @@ import {
   Platform,
   Dimensions,
   StyleSheet,
+  requireNativeComponent,
 } from 'react-native';
 import TextInput from '../Views/TextInput';
+
+const DoubleTapsText = requireNativeComponent('DetoxDoubleTapsTextView');
 
 const { width } = Dimensions.get('window');
 
@@ -21,6 +24,9 @@ const styles = StyleSheet.create({
   item: { height: 30, backgroundColor: '#e8e8f8', padding: 5, margin: 10 },
   horizItem: { width: hItemWidth, backgroundColor: '#e8e8f8', margin: 10, textAlign: 'center', textAlignVertical: 'center' },
 });
+
+const isIos = Platform.OS === 'ios';
+const isAndroid = Platform.OS === 'android';
 
 export default class ActionsScreen extends Component {
 
@@ -58,7 +64,7 @@ export default class ActionsScreen extends Component {
           delayLongPress={1200}
           onLongPress={this.onButtonPress.bind(this, 'Long Press With Duration Working')}
         >
-          <Text style={{ color: 'blue', marginBottom: 20, textAlign: 'center' }}>Long Press Me 1.5s</Text>
+          <Text testID='longTappable' style={{ color: 'blue', marginBottom: 20, textAlign: 'center' }}>Long Press Me 1.5s</Text>
         </TouchableOpacity>
 
         <TouchableOpacity onPress={this.onLongTimeout.bind(this)}
@@ -67,9 +73,13 @@ export default class ActionsScreen extends Component {
         </TouchableOpacity>
 
         <TouchableOpacity onPress={this.onMultiTapPress.bind(this)}>
-          <Text style={{ color: 'blue', marginBottom: 20, textAlign: 'center' }}
+          <Text style={{ color: 'blue', marginBottom: (isIos ? 20 : 10), textAlign: 'center' }}
             testID='UniqueId819'>Taps: {this.state.numTaps}</Text>
         </TouchableOpacity>
+
+        {isAndroid && <View style={{ height: 30, width }}>
+            <DoubleTapsText style={{ flex: 1 }}/>
+          </View>}
 
         <View testID='UniqueId937_wrapper'>
           <TextInput style={{ height: 40, borderColor: 'gray', borderWidth: 1, marginBottom: 20, marginHorizontal: 20, padding: 5 }}
@@ -80,7 +90,7 @@ export default class ActionsScreen extends Component {
             />
         </View>
 
-        {Platform.OS === 'ios' && <TouchableOpacity style={{ height: 40, borderColor: 'gray', borderWidth: 1, marginBottom: 20, marginHorizontal: 20, padding: 5 }} testID='NoTextInputInside' />}
+        {isIos && <TouchableOpacity style={{ height: 40, borderColor: 'gray', borderWidth: 1, marginBottom: 20, marginHorizontal: 20, padding: 5 }} testID='NoTextInputInside' />}
 
         <TextInput style={{ height: 40, borderColor: 'gray', borderWidth: 1, marginBottom: 20, marginHorizontal: 20, padding: 5 }}
           onChangeText={this.onChangeClearText.bind(this)}

--- a/detox/test/src/Screens/ActionsScreen.js
+++ b/detox/test/src/Screens/ActionsScreen.js
@@ -64,7 +64,7 @@ export default class ActionsScreen extends Component {
           delayLongPress={1200}
           onLongPress={this.onButtonPress.bind(this, 'Long Press With Duration Working')}
         >
-          <Text testID='longTappable' style={{ color: 'blue', marginBottom: 20, textAlign: 'center' }}>Long Press Me 1.5s</Text>
+          <Text style={{ color: 'blue', marginBottom: 20, textAlign: 'center' }}>Long Press Me 1.5s</Text>
         </TouchableOpacity>
 
         <TouchableOpacity onPress={this.onLongTimeout.bind(this)}

--- a/detox/test/src/Screens/ActionsScreen.js
+++ b/detox/test/src/Screens/ActionsScreen.js
@@ -72,14 +72,17 @@ export default class ActionsScreen extends Component {
           <Text testID='WhyDoAllTheTestIDsHaveTheseStrangeNames' style={{ color: 'blue', marginBottom: 20, textAlign: 'center' }}>Tap Me For Long Timeout</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity onPress={this.onMultiTapPress.bind(this)}>
-          <Text style={{ color: 'blue', marginBottom: (isIos ? 20 : 10), textAlign: 'center' }}
-            testID='UniqueId819'>Taps: {this.state.numTaps}</Text>
-        </TouchableOpacity>
+        <View style={{flexDirection: 'row', justifyContent: 'center', marginBottom: 20}}>
+          <TouchableOpacity onPress={this.onMultiTapPress.bind(this)}>
+            <Text style={{ color: 'blue', textAlign: 'center' }}
+              testID='UniqueId819'>Taps: {this.state.numTaps}</Text>
+          </TouchableOpacity>
 
-        {isAndroid && <View style={{ height: 30, width }}>
+          {isAndroid && <Text style={{width: 10}}> | </Text>}
+          {isAndroid && <View style={{ width: 110 }}>
             <DoubleTapsText style={{ flex: 1 }}/>
           </View>}
+        </View>
 
         <View testID='UniqueId937_wrapper'>
           <TextInput style={{ height: 40, borderColor: 'gray', borderWidth: 1, marginBottom: 20, marginHorizontal: 20, padding: 5 }}

--- a/detox/test/src/Screens/NativeAnimationsScreen.js
+++ b/detox/test/src/Screens/NativeAnimationsScreen.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
-import { requireNativeComponent, View, Text } from 'react-native';
+import { requireNativeComponent, View } from 'react-native';
 
 const NativeAnimatingView = requireNativeComponent('DetoxNativeAnimatingView');
 
 class NativeAnimationsScreen extends Component {
   render() {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'stretch' }}>
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'stretch', backgroundColor: 'red' }}>
         <NativeAnimatingView style={{flex: 1}}/>
       </View>
     );

--- a/detox/test/src/Screens/NativeAnimationsScreen.js
+++ b/detox/test/src/Screens/NativeAnimationsScreen.js
@@ -6,7 +6,7 @@ const NativeAnimatingView = requireNativeComponent('DetoxNativeAnimatingView');
 class NativeAnimationsScreen extends Component {
   render() {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'stretch', backgroundColor: 'red' }}>
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'stretch' }}>
         <NativeAnimatingView style={{flex: 1}}/>
       </View>
     );

--- a/docs/APIRef.ActionsOnElement.md
+++ b/docs/APIRef.ActionsOnElement.md
@@ -41,7 +41,9 @@ await element(by.id('tappable')).longPress();
 ```
 
 ### `multiTap(times)`
-Simulates multiple taps on an element.
+Simulates a sequence of multiple taps on an element.
+
+**Note:** All taps are applied as a part of the same gesture -- so as to trigger UI actions registered with such special gestures, explicitly. In particular, `multiTap(2)` is not the same as calling `tap()` twice in a row, as the former typically invokes a [_double tap_ gesture](https://developer.android.com/training/gestures/detector#detect) if applicable. Therefore, it **should not be used in that way.**
 
 ```js
 await element(by.id('tappable')).multiTap(3);


### PR DESCRIPTION
- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

Improve implementation of `tap()` and `multiTap()` on Android so as to consider potential gesture-handler listening to complex gestures - double-taps in particular, that can hijack tap-events if not applied by-the-book.

Motivated for fixing now in the wake of related bugs recently found while integrating test-suites of newly joining internal projects (for execution on Android emulators) -- where an interesting sequence of taps has been applied in the beginning of each test.

---
As for implementation, most work was around creating e2e tests that would uncover the faulty behaviour. That required the creation of a custom native view, now rendered as a part of the test-app's actions screen (but only on Android), that would provide a simple impl. of a tappable text view that changes only when *double-tapped*, specifically.

The core of the matter was twofold:
1. Plain taps lacked the proper post-tap delay (was too short) such that consequent taps (coming from additional calls to `tap()` at test-level) can be mistakingly considered a continuation of them; The end-result being that 2 taps in a row can be mistakingly considered part of a single double-tap gesture.
2. Multi-tap handlers, on the other hand, has an inter-tap delay that was accumulatively too long so as to mistakingly prevent the multiple taps from _becoming_ a double/triple/etc. tap sequence, as they should.