### PR TITLE
Update waitFor docs

### DIFF
--- a/docs/APIRef.waitFor.md
+++ b/docs/APIRef.waitFor.md
@@ -18,8 +18,6 @@ Test async code with waitFor.
 
 >NOTE: Every `waitFor` call must set a timeout using `withTimeout()`. Calling `waitFor` without setting a timeout **will do nothing**.
 
->NOTE: `waitFor` will not throw when reaching timeout, instead it will just continue to the next line. To make sure your tests work as you expect them to add `expect()` at the following line.  
-
 ### `toBeVisible()`
 Test will hang until expectation is met or a timeout has occurred.
 Wait for the view to be at least 75% visible.


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

#1473 fixed `waitFor().withTimeout()` so that an exception is raised when the assertion fails. That PR updated other sections of the doc to remove the note about using `expect()` but it looks like this line was missed.
