### PR TITLE
detoxrc key fix in documentation

### DIFF
--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -130,7 +130,7 @@ Either way the config should look like this:
 ```json
 {
   "configurations": {
-    "ios.sim.debug": {
+    "ios": {
       "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
       "build": "xcodebuild -project ios/example.xcodeproj -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
       "type": "ios.simulator",


### PR DESCRIPTION
`detox build --configuration ios` will fail due missing key "ios" in .detoxrc.json file. 
In this `getting started` documentation it says to use the same key as the package.json configuration "ios.sim.debug" that won't build.

<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
