### PR TITLE
Add localhost to android network_security_config.xml (both in example and docs) to fix tests stuck on attached devices

### DIFF
--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -184,6 +184,7 @@ For Detox to work, Detox test code running on the device must connect to the tes
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">localhost</domain>
     </domain-config>
 </network-security-config>
 ```

--- a/examples/demo-react-native/android/app/src/main/res/xml/network_security_config.xml
+++ b/examples/demo-react-native/android/app/src/main/res/xml/network_security_config.xml
@@ -3,5 +3,6 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">10.0.2.2</domain>
         <domain includeSubdomains="true">10.0.3.2</domain>
+        <domain includeSubdomains="true">localhost</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
This PR adds `localhost` to android `network_security_config` in example app and docs. This rule is required to run tests on attached device (because `adb reverse` exposes ports on localhost) and its absence is discouraged for newbies  