### PR TITLE
fix(jest-circus): explicit require('detox') should not fail

### DIFF
--- a/detox/runners/jest-circus/environment.js
+++ b/detox/runners/jest-circus/environment.js
@@ -35,9 +35,18 @@ class DetoxCircusEnvironment extends NodeEnvironment {
   }
 
   get detox() {
-    return require('../../src')
-      ._setGlobal(this.global)
-      ._suppressLoggingInitErrors();
+    if (!this.global.detox) {
+      // NOTE: require() is deferred on purpose,
+      // to enable calculating line hit coverage
+      // while running internal E2E tests in Detox.
+      // Ideally, it can happen in setup() method.
+
+      this.global.detox = require('../../src')
+        ._setGlobal(this.global)
+        ._suppressLoggingInitErrors();
+    }
+
+    return this.global.detox;
   }
 
   async handleTestEvent(event, state) {

--- a/examples/demo-react-native-jest/detox.config.js
+++ b/examples/demo-react-native-jest/detox.config.js
@@ -1,6 +1,12 @@
-{
+module.exports = {
   "testRunner": "jest",
-  "runnerConfig": "e2e/config.json",
+  "runnerConfig": process.env.DETOX_EXPOSE_GLOBALS === '0' ? 'e2eExplicitRequire/config.json' : 'e2e/config.json',
+  "specs": process.env.DETOX_EXPOSE_GLOBALS === '0' ? 'e2eExplicitRequire' : 'e2e',
+  "behavior": {
+    "init": {
+      "exposeGlobals": process.env.DETOX_EXPOSE_GLOBALS === '0' ? false : true,
+    },
+  },
   "configurations": {
     "ios.sim.release": {
       "type": "ios.simulator",
@@ -23,4 +29,4 @@
       }
     }
   }
-}
+};

--- a/examples/demo-react-native-jest/e2eExplicitRequire/config.json
+++ b/examples/demo-react-native-jest/e2eExplicitRequire/config.json
@@ -1,0 +1,8 @@
+{
+    "testEnvironment": "./environment",
+    "testRunner": "jest-circus/runner",
+    "testTimeout": 120000,
+    "testRegex": "\\.e2e\\.js$",
+    "reporters": ["detox/runners/jest/streamlineReporter"],
+    "verbose": true
+}

--- a/examples/demo-react-native-jest/e2eExplicitRequire/environment.js
+++ b/examples/demo-react-native-jest/e2eExplicitRequire/environment.js
@@ -1,0 +1,23 @@
+const {
+  DetoxCircusEnvironment,
+  SpecReporter,
+  WorkerAssignReporter,
+} = require('detox/runners/jest-circus');
+
+class CustomDetoxEnvironment extends DetoxCircusEnvironment {
+  constructor(config) {
+    super(config);
+
+    // Can be safely removed, if you are content with the default value (=300000ms)
+    this.initTimeout = 300000;
+
+    // This takes care of generating status logs on a per-spec basis. By default, Jest only reports at file-level.
+    // This is strictly optional.
+    this.registerListeners({
+      SpecReporter,
+      WorkerAssignReporter,
+    });
+  }
+}
+
+module.exports = CustomDetoxEnvironment;

--- a/examples/demo-react-native-jest/e2eExplicitRequire/example.e2e.js
+++ b/examples/demo-react-native-jest/e2eExplicitRequire/example.e2e.js
@@ -1,0 +1,26 @@
+const {device, expect, element, by, waitFor} = require('detox');
+
+describe('Example (explicit)', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+  });
+  
+  it('should have welcome screen', async () => {
+    await expect(element(by.id('welcome'))).toBeVisible();
+  });
+  
+  it('should show hello screen after tap', async () => {
+    await element(by.id('hello_button')).tap();
+    await expect(element(by.text('Hello!!!'))).toBeVisible();
+  });
+  
+  it('should show world screen after tap', async () => {
+    await element(by.id('world_button')).tap();
+    await expect(element(by.text('World!!!'))).toBeVisible();
+  });
+
+  it('waitFor should be exported', async () => {
+    await waitFor(element(by.id('welcome'))).toExist().withTimeout(2000);
+    await expect(element(by.id('welcome'))).toExist();
+  });
+});

--- a/examples/demo-react-native/detox.config.js
+++ b/examples/demo-react-native/detox.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   "test-runner": "mocha",
   "runner-config": "e2e/.mocharc.json",
+  "specs": process.env.DETOX_EXPOSE_GLOBALS === '0' ? 'e2eExplicitRequire' : 'e2e',
   "behavior": {
     "init": {
       "exposeGlobals": process.env.DETOX_EXPOSE_GLOBALS === '0' ? false : true,

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -12,8 +12,6 @@
     "test:android-debug": "detox test --configuration android.emu.debug",
     "test:android-release": "detox test --configuration android.emu.release",
     "test:android-release-ci": "detox test --configuration android.emu.release -l verbose --headless --record-logs all --take-screenshots all",
-    "test:android-explicit-require": "DETOX_EXPOSE_GLOBALS=0 detox test e2eExplicitRequire -c android.emu.release",
-    "test:android-explicit-require-ci": "DETOX_EXPOSE_GLOBALS=0 detox test e2eExplicitRequire -c android.emu.release -l verbose --headless --record-logs all --take-screenshots all",
     "e2e:ios": "npm run build:ios && npm run test:ios",
     "e2e:android-debug": "npm run build:android-debug && npm run test:android-debug",
     "e2e:android-release": "npm run build:android-release && npm run test:android-release"

--- a/scripts/demo-projects.android.sh
+++ b/scripts/demo-projects.android.sh
@@ -17,11 +17,12 @@ popd
 # as it runs tests in parallel.
 pushd examples/demo-react-native-jest
 run_f "npm run test:android-release-ci"
+DETOX_EXPOSE_GLOBALS=0 run_f "npm run test:android-release-ci"
 popd
 
 pushd examples/demo-react-native
 run_f "npm run test:android-release-ci"
-run_f "npm run test:android-explicit-require-ci"
+DETOX_EXPOSE_GLOBALS=0 run_f "npm run test:android-release-ci"
 popd
 
 pushd examples/demo-plugin

--- a/scripts/demo-projects.ios.sh
+++ b/scripts/demo-projects.ios.sh
@@ -11,11 +11,12 @@ HOMEBREW_NO_AUTO_UPDATE=1 brew cask reinstall detox-instruments
 pushd examples/demo-react-native
 run_f "detox build -c ios.sim.release"
 run_f "detox test -c ios.sim.release"
-DETOX_EXPOSE_GLOBALS=0 run_f "detox test -c ios.sim.release e2eExplicitRequire"
+DETOX_EXPOSE_GLOBALS=0 run_f "detox test -c ios.sim.release"
 popd
 
 pushd examples/demo-react-native-jest
 run_f "npm run test:ios-release-ci"
+DETOX_EXPOSE_GLOBALS=0 run_f "npm run test:ios-release-ci"
 popd
 
 pushd examples/demo-react-native-detox-instruments


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

This is a common use case, when users explicitly destructure our facade:

```js
const { device, expect, /* ... so on ... */ } = require('detox');
```

It appears that our `demo-react-native-jest` example project had no `e2eExplicitRequire` checks, and a bug slipped into production:

![image](https://user-images.githubusercontent.com/1962469/84899652-9c86c780-b0b1-11ea-93e4-dd3526d9f81a.png)

The new DetoxCircusEnvironment relies on the existence of `global.detox` variable, to prevent creating new and new Detox facade instances every time the `require` sandbox is reset by Jest for every next test file.

https://github.com/wix/Detox/blob/53d46b9a31d88f224b6593d89800cdf96e6485b6/detox/src/index.js#L1-L3

That's why this PR:

1. Fixes the issue by setting `detox` global variable after environment setup, like it was planned initially in #2009. It simply was never set, or more precisely it got lost after a few implementation rewrites. :man_shrugging: 
2. Adds CI checks to never let this bug slip in again.
