### PR TITLE
Introduce basic support for all user-notification API's in all relevant use cases

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -110,8 +110,7 @@ public final class Detox {
      * @param activityTestRule the activityTestRule
      */
     public static void runTests(ActivityTestRule activityTestRule) {
-        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
-        runTests(activityTestRule, appContext);
+        runTests(activityTestRule, getAppContext());
     }
 
     /**
@@ -122,8 +121,7 @@ public final class Detox {
      *                         the {@link IdlingPolicies} API.
      */
     public static void runTests(ActivityTestRule activityTestRule, DetoxIdlePolicyConfig idlePolicyConfig) {
-        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
-        runTests(activityTestRule, appContext, idlePolicyConfig);
+        runTests(activityTestRule, getAppContext(), idlePolicyConfig);
     }
 
     /**
@@ -194,6 +192,12 @@ public final class Detox {
         launchActivitySync(sIntentsFactory.intentWithUrl(url, false));
     }
 
+    public static void startActivityFromNotification(String dataFilePath) {
+        Bundle notificationData = new NotificationDataParser(dataFilePath).parseNotificationData();
+        Intent intent = sIntentsFactory.intentWithNotificationData(getAppContext(), notificationData, false);
+        launchActivitySync(intent);
+    }
+
     private static Intent extractInitialIntent() {
         Intent intent;
 
@@ -201,7 +205,7 @@ public final class Detox {
             intent = sIntentsFactory.intentWithUrl(sLaunchArgs.getUrlOverride(), true);
         } else if (sLaunchArgs.hasNotificationPath()) {
             Bundle notificationData = new NotificationDataParser(sLaunchArgs.getNotificationPath()).parseNotificationData();
-            intent = sIntentsFactory.intentWithNotificationData(notificationData, true);
+            intent = sIntentsFactory.intentWithNotificationData(getAppContext(), notificationData, true);
         } else {
             intent = sIntentsFactory.cleanIntent();
         }
@@ -230,5 +234,9 @@ public final class Detox {
         activity.startActivity(intent);
         instrumentation.addMonitor(activityMonitor);
         instrumentation.waitForMonitorWithTimeout(activityMonitor, ACTIVITY_LAUNCH_TIMEOUT);
+    }
+
+    private static Context getAppContext() {
+        return InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
     }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/LaunchIntentsFactory.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/LaunchIntentsFactory.kt
@@ -1,6 +1,7 @@
 package com.wix.detox
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -21,9 +22,9 @@ internal class LaunchIntentsFactory {
         }
 
     /**
-     * Constructs a near-empty, activity-anonymous intent, assuming an ActivityTestRule instance that would handle it will fill in all the missing details -
-     * namely, the activity class (aka component), which is taken from activityTestRule's own activityClass data member
-     * which was set in the c'tor by the user (outside of Detox)
+     * Constructs a near-empty, activity-anonymous intent, assuming an ActivityTestRule instance that would handle it
+     * and fill in all the missing details. Namely, the activity class (aka component), which is taken from activityTestRule's
+     * own activityClass data member which was set in the c'tor by the user (outside of Detox).
      *
      * @return The resulting intent.
      */
@@ -67,9 +68,10 @@ internal class LaunchIntentsFactory {
      *
      * @return The resulting intent.
      */
-    fun intentWithNotificationData(data: Bundle, initialLaunch: Boolean)
+    fun intentWithNotificationData(appContext: Context, data: Bundle, initialLaunch: Boolean)
         = Intent(Intent.ACTION_MAIN).apply {
             addCategory(Intent.CATEGORY_LAUNCHER)
+            setPackage(appContext.packageName)
             putExtras(data)
             flags = coreFlags
             if (initialLaunch) {

--- a/detox/src/android/espressoapi/Detox.js
+++ b/detox/src/android/espressoapi/Detox.js
@@ -46,6 +46,18 @@ class Detox {
     };
   }
 
+  static startActivityFromNotification(dataFilePath) {
+    if (typeof dataFilePath !== "string") throw new Error("dataFilePath should be a string, but got " + (dataFilePath + (" (" + (typeof dataFilePath + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.Detox"
+      },
+      method: "startActivityFromNotification",
+      args: [dataFilePath]
+    };
+  }
+
   static extractInitialIntent() {
     return {
       target: {
@@ -53,6 +65,17 @@ class Detox {
         value: "com.wix.detox.Detox"
       },
       method: "extractInitialIntent",
+      args: []
+    };
+  }
+
+  static getAppContext() {
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.Detox"
+      },
+      method: "getAppContext",
       args: []
     };
   }

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -56,7 +56,7 @@ class Device {
     const _bundleId = bundleId || this._bundleId;
     if (this._isAppInBackground(params, _bundleId)) {
       if (hasPayload) {
-        await this.deviceDriver.predeliverPayload({...params});
+        await this.deviceDriver.deliverPayload({...params, delayPayload: true});
       }
     }
 

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -308,7 +308,7 @@ describe('Device', () => {
       await device.launchApp({newInstance: true});
       await device.launchApp({newInstance: false});
 
-      expect(driverMock.driver.predeliverPayload).not.toHaveBeenCalled();
+      expect(driverMock.driver.deliverPayload).not.toHaveBeenCalled();
     });
 
     it(`with a url should check if process is in background and use openURL() instead of launch args`, async () => {
@@ -321,7 +321,7 @@ describe('Device', () => {
       await device.launchApp({newInstance: true});
       await device.launchApp({url: 'url://me'});
 
-      expect(driverMock.driver.predeliverPayload).toHaveBeenCalledTimes(1);
+      expect(driverMock.driver.deliverPayload).toHaveBeenCalledTimes(1);
     });
 
     it(`with a url should check if process is in background and if not use launch args`, async () => {
@@ -336,7 +336,7 @@ describe('Device', () => {
       await device.prepare();
       await device.launchApp(launchParams);
 
-      expect(driverMock.driver.predeliverPayload).not.toHaveBeenCalled();
+      expect(driverMock.driver.deliverPayload).not.toHaveBeenCalled();
     });
 
     it(`with a url should check if process is in background and use openURL() instead of launch args`, async () => {
@@ -351,7 +351,7 @@ describe('Device', () => {
       await device.launchApp({newInstance: true});
       await device.launchApp(launchParams);
 
-      expect(driverMock.driver.predeliverPayload).toHaveBeenCalledWith({url: 'url://me'});
+      expect(driverMock.driver.deliverPayload).toHaveBeenCalledWith({delayPayload: true, url: 'url://me'});
     });
 
     it(`should keep user params unmodified`, async () => {
@@ -382,7 +382,7 @@ describe('Device', () => {
       await device.launchApp({newInstance: true});
       await device.launchApp(launchParams);
 
-      expect(driverMock.driver.predeliverPayload).toHaveBeenCalledWith({detoxUserActivityDataURL: 'url'});
+      expect(driverMock.driver.deliverPayload).toHaveBeenCalledWith({delayPayload: true, detoxUserActivityDataURL: 'url'});
     });
 
 
@@ -399,7 +399,7 @@ describe('Device', () => {
       await device.launchApp({newInstance: true});
       await device.launchApp(launchParams);
 
-      expect(driverMock.driver.predeliverPayload).toHaveBeenCalledTimes(1);
+      expect(driverMock.driver.deliverPayload).toHaveBeenCalledTimes(1);
     });
 
     it(`with userNotification should check if process is in background and if not use launch args`, async () => {
@@ -414,7 +414,7 @@ describe('Device', () => {
       await device.prepare();
       await device.launchApp(launchParams);
 
-      expect(driverMock.driver.predeliverPayload).not.toHaveBeenCalled();
+      expect(driverMock.driver.deliverPayload).not.toHaveBeenCalled();
     });
 
     it(`with userNotification and url should fail`, async () => {
@@ -434,7 +434,7 @@ describe('Device', () => {
         expect(ex).toBeDefined();
       }
 
-      expect(device.deviceDriver.predeliverPayload).not.toHaveBeenCalled();
+      expect(device.deviceDriver.deliverPayload).not.toHaveBeenCalled();
     });
   });
 

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -308,7 +308,7 @@ describe('Device', () => {
       await device.launchApp({newInstance: true});
       await device.launchApp({newInstance: false});
 
-      expect(driverMock.driver.deliverPayload).not.toHaveBeenCalled();
+      expect(driverMock.driver.predeliverPayload).not.toHaveBeenCalled();
     });
 
     it(`with a url should check if process is in background and use openURL() instead of launch args`, async () => {
@@ -321,7 +321,7 @@ describe('Device', () => {
       await device.launchApp({newInstance: true});
       await device.launchApp({url: 'url://me'});
 
-      expect(driverMock.driver.deliverPayload).toHaveBeenCalledTimes(1);
+      expect(driverMock.driver.predeliverPayload).toHaveBeenCalledTimes(1);
     });
 
     it(`with a url should check if process is in background and if not use launch args`, async () => {
@@ -336,7 +336,7 @@ describe('Device', () => {
       await device.prepare();
       await device.launchApp(launchParams);
 
-      expect(driverMock.driver.deliverPayload).not.toHaveBeenCalled();
+      expect(driverMock.driver.predeliverPayload).not.toHaveBeenCalled();
     });
 
     it(`with a url should check if process is in background and use openURL() instead of launch args`, async () => {
@@ -351,7 +351,7 @@ describe('Device', () => {
       await device.launchApp({newInstance: true});
       await device.launchApp(launchParams);
 
-      expect(driverMock.driver.deliverPayload).toHaveBeenCalledWith({delayPayload: true, url: 'url://me'});
+      expect(driverMock.driver.predeliverPayload).toHaveBeenCalledWith({url: 'url://me'});
     });
 
     it(`should keep user params unmodified`, async () => {
@@ -382,7 +382,7 @@ describe('Device', () => {
       await device.launchApp({newInstance: true});
       await device.launchApp(launchParams);
 
-      expect(driverMock.driver.deliverPayload).toHaveBeenCalledWith({delayPayload: true, detoxUserActivityDataURL: 'url'});
+      expect(driverMock.driver.predeliverPayload).toHaveBeenCalledWith({detoxUserActivityDataURL: 'url'});
     });
 
 
@@ -399,7 +399,7 @@ describe('Device', () => {
       await device.launchApp({newInstance: true});
       await device.launchApp(launchParams);
 
-      expect(driverMock.driver.deliverPayload).toHaveBeenCalledTimes(1);
+      expect(driverMock.driver.predeliverPayload).toHaveBeenCalledTimes(1);
     });
 
     it(`with userNotification should check if process is in background and if not use launch args`, async () => {
@@ -414,7 +414,7 @@ describe('Device', () => {
       await device.prepare();
       await device.launchApp(launchParams);
 
-      expect(driverMock.driver.deliverPayload).not.toHaveBeenCalled();
+      expect(driverMock.driver.predeliverPayload).not.toHaveBeenCalled();
     });
 
     it(`with userNotification and url should fail`, async () => {
@@ -434,7 +434,7 @@ describe('Device', () => {
         expect(ex).toBeDefined();
       }
 
-      expect(device.deviceDriver.deliverPayload).not.toHaveBeenCalled();
+      expect(device.deviceDriver.predeliverPayload).not.toHaveBeenCalled();
     });
   });
 
@@ -573,7 +573,7 @@ describe('Device', () => {
     const device = validDevice();
     await device.openURL({url: 'url'});
 
-    expect(driverMock.driver.deliverPayload).toHaveBeenCalledWith({url: 'url'});
+    expect(driverMock.driver.deliverPayload).toHaveBeenCalledWith({url: 'url'}, device._deviceId);
   });
 
   it(`openURL(notAnObject) should pass to device driver`, async () => {

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -71,10 +71,6 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
-  async predeliverPayload(params) {
-    return await this.client.deliverPayload(params);
-  }
-
   async deliverPayload(params) {
     return await this.client.deliverPayload(params);
   }

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -71,6 +71,10 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
+  async predeliverPayload(params) {
+    return await this.client.deliverPayload(params);
+  }
+
   async deliverPayload(params) {
     return await this.client.deliverPayload(params);
   }

--- a/detox/src/devices/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.js
@@ -120,11 +120,11 @@ class AndroidDriver extends DeviceDriverBase {
     return pid;
   }
 
-  async predeliverPayload() {
-    // Override the super implementation - this isn't needed on Android
-  }
-
   async deliverPayload(params, deviceId) {
+    if (params.delayPayload) {
+      return;
+    }
+
     const {url, detoxUserNotificationDataURL} = params;
     if (url) {
       await this._startActivityWithUrl(url);

--- a/detox/src/devices/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.js
@@ -50,8 +50,6 @@ class AndroidDriver extends DeviceDriverBase {
     this.aapt = new AAPT();
     this.fileXfer = new TempFileXfer(this.adb);
     this.devicePathBuilder = new AndroidDevicePathBuilder();
-
-    this.pendingUrl = undefined;
   }
 
   declareArtifactPlugins() {
@@ -87,27 +85,27 @@ class AndroidDriver extends DeviceDriverBase {
   }
 
   async launchApp(deviceId, bundleId, launchArgs, languageAndLocale) {
+    let notificationPayloadTargetPath;
+
     await this.emitter.emit('beforeLaunchApp', { deviceId, bundleId, launchArgs });
 
     if (launchArgs.detoxUserNotificationDataURL) {
-      await this.fileXfer.prepareDestinationDir(deviceId);
-      const destNotificationDataFile = await this.fileXfer.send(deviceId, launchArgs.detoxUserNotificationDataURL, 'notification.json');
-
+      notificationPayloadTargetPath = await this._sendNotificationDataToDevice(launchArgs.detoxUserNotificationDataURL, deviceId);
       launchArgs = {
         ...launchArgs,
-        detoxUserNotificationDataURL: destNotificationDataFile,
+        detoxUserNotificationDataURL: notificationPayloadTargetPath,
       }
     }
 
     if (!this._isInstrumentationRunning()) {
       await this._launchInstrumentationProcess(deviceId, bundleId, launchArgs);
       await sleep(500);
+    } else if (launchArgs.detoxURLOverride) {
+      await this._startActivityWithUrl(launchArgs.detoxURLOverride);
+    } else if (launchArgs.detoxUserNotificationDataURL) {
+      await this._startActivityFromNotification(launchArgs.detoxUserNotificationDataURL);
     } else {
-      if (this.pendingUrl) {
-        await this._startActivityWithUrl(this._getAndClearPendingUrl());
-      } else {
-        await this._resumeMainActivity();
-      }
+      await this._resumeMainActivity();
     }
 
     let pid = NaN;
@@ -122,14 +120,18 @@ class AndroidDriver extends DeviceDriverBase {
     return pid;
   }
 
-  async deliverPayload(params) {
-    const {delayPayload, url} = params;
+  async predeliverPayload() {
+    // Override the super implementation - this isn't needed on Android
+  }
 
+  async deliverPayload(params, deviceId) {
+    const {url, detoxUserNotificationDataURL} = params;
     if (url) {
-      await (delayPayload ? this._setPendingUrl(url) : this._startActivityWithUrl(url));
+      await this._startActivityWithUrl(url);
+    } else if (detoxUserNotificationDataURL) {
+      const payloadPathOnDevice = await this._sendNotificationDataToDevice(detoxUserNotificationDataURL, deviceId);
+      await this._startActivityFromNotification(payloadPathOnDevice);
     }
-
-    // Other payload content types are not yet supported.
   }
 
   async waitUntilReady() {
@@ -314,18 +316,17 @@ class AndroidDriver extends DeviceDriverBase {
     return NaN;
   }
 
-  _setPendingUrl(url) {
-    this.pendingUrl = url;
-  }
-
-  _getAndClearPendingUrl() {
-    const pendingUrl = this.pendingUrl;
-    this.pendingUrl = undefined;
-    return pendingUrl;
+  async _sendNotificationDataToDevice(dataFileLocalPath, deviceId) {
+    await this.fileXfer.prepareDestinationDir(deviceId);
+    return await this.fileXfer.send(deviceId, dataFileLocalPath, 'notification.json');
   }
 
   _startActivityWithUrl(url) {
     return this.invocationManager.execute(DetoxApi.startActivityFromUrl(url));
+  }
+
+  _startActivityFromNotification(dataFilePath) {
+    return this.invocationManager.execute(DetoxApi.startActivityFromNotification(dataFilePath));
   }
 
   _resumeMainActivity() {

--- a/detox/test/android/app/src/main/java/com/example/MainActivity.java
+++ b/detox/test/android/app/src/main/java/com/example/MainActivity.java
@@ -1,5 +1,7 @@
 package com.example;
 
+import android.content.Intent;
+
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
@@ -11,5 +13,11 @@ public class MainActivity extends ReactActivity {
     @Override
     protected String getMainComponentName() {
         return "example";
+    }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
     }
 }

--- a/detox/test/e2e/11.user-notifications.test.js
+++ b/detox/test/e2e/11.user-notifications.test.js
@@ -48,6 +48,9 @@ describe(':android: User Notifications', () => {
       from: googleProjectId,
       userData: 'userDataValue',
       userDataArray: ['rock', 'paper', 'scissors'],
+      sub: {
+        objects: 'are supported as well'
+      },
       'google.sent_time': 1592133826891,
       'google.ttl': 2419200,
       'google.original_priority': 'high',
@@ -64,6 +67,7 @@ describe(':android: User Notifications', () => {
     await assertNotificationDataField('from', googleProjectId.toString());
     await assertNotificationDataField('userData', userNotification.payload.userData);
     await assertNotificationDataField('userDataArray', JSON.stringify(userNotification.payload.userDataArray));
+    await assertNotificationDataField('sub', JSON.stringify(userNotification.payload.sub));
   }
 
   async function assertNotificationData() {

--- a/detox/test/e2e/11.user-notifications.test.js
+++ b/detox/test/e2e/11.user-notifications.test.js
@@ -42,29 +42,65 @@ describe(':ios: User Notifications', () => {
 });
 
 describe(':android: User Notifications', () => {
-  async function assertNotificationData(key, expectedValue) {
+  const googleProjectId = 284440699462;
+  const userNotification = {
+    payload: {
+      from: googleProjectId,
+      userData: 'userDataValue',
+      userDataArray: ['rock', 'paper', 'scissors'],
+      'google.sent_time': 1592133826891,
+      'google.ttl': 2419200,
+      'google.original_priority': 'high',
+      'collapse_key': 'com.wix.detox.test',
+    },
+  };
+
+  async function assertNotificationDataField(key, expectedValue) {
     await expect(element(by.id(`notificationData-${key}.name`))).toBeVisible();
     await expect(element(by.id(`notificationData-${key}.value`))).toHaveText(expectedValue);
   }
 
-  it('should launch app with extras', async () => {
-    const googleProjectId = 284440699462;
-    const userNotification = {
-      payload: {
-        from: googleProjectId,
-        userData: 'userDataValue',
-        userDataArray: ['rock', 'paper', 'scissors'],
-        'google.sent_time': 1592133826891,
-        'google.ttl': 2419200,
-        'google.original_priority': 'high',
-        'collapse_key': 'com.wix.reactnativenotifications.app',
-      },
-    };
+  async function assertNotificationDataExtensively() {
+    await assertNotificationDataField('from', googleProjectId.toString());
+    await assertNotificationDataField('userData', userNotification.payload.userData);
+    await assertNotificationDataField('userDataArray', JSON.stringify(userNotification.payload.userDataArray));
+  }
+
+  async function assertNotificationData() {
+    await assertNotificationDataField('userData', userNotification.payload.userData);
+  }
+
+  it('should launch app with data', async () => {
     await device.launchApp({ newInstance: true, userNotification });
     await element(by.text('Launch-Notification')).tap();
     await expect(element(by.text('Launch-notification Data'))).toBeVisible();
-    await assertNotificationData('from', googleProjectId.toString());
-    await assertNotificationData('userData', userNotification.payload.userData);
-    await assertNotificationData('userDataArray', JSON.stringify(userNotification.payload.userDataArray));
+    await assertNotificationDataExtensively();
+  });
+
+  it('should resume app with data', async () => {
+    await device.launchApp({ newInstance: true });
+    console.log('Sending app to background...');
+    await device.sendToHome();
+    console.log('Resuming app with user notification');
+    await device.launchApp({ newInstance: false, userNotification });
+    await element(by.text('Launch-Notification')).tap();
+    await assertNotificationData();
+  });
+
+  it('should apply notification using sendUserNotification() when in foreground', async () => {
+    await device.launchApp({newInstance: true});
+    await device.sendUserNotification(userNotification);
+    await element(by.text('Launch-Notification')).tap();
+    await assertNotificationData();
+  });
+
+  it('should apply notification using sendUserNotification() when in background', async () => {
+    await device.launchApp({newInstance: true});
+    console.log('Sending app to background...');
+    await device.sendToHome();
+    console.log('Sending notification data...');
+    await device.sendUserNotification(userNotification);
+    await element(by.text('Launch-Notification')).tap();
+    await assertNotificationData();
   });
 });

--- a/detox/test/e2e/11.user-notifications.test.js
+++ b/detox/test/e2e/11.user-notifications.test.js
@@ -73,7 +73,6 @@ describe(':android: User Notifications', () => {
   it('should launch app with data', async () => {
     await device.launchApp({ newInstance: true, userNotification });
     await element(by.text('Launch-Notification')).tap();
-    await expect(element(by.text('Launch-notification Data'))).toBeVisible();
     await assertNotificationDataExtensively();
   });
 
@@ -87,18 +86,8 @@ describe(':android: User Notifications', () => {
     await assertNotificationData();
   });
 
-  it('should apply notification using sendUserNotification() when in foreground', async () => {
+  it('should apply notification using sendUserNotification() when app is running', async () => {
     await device.launchApp({newInstance: true});
-    await device.sendUserNotification(userNotification);
-    await element(by.text('Launch-Notification')).tap();
-    await assertNotificationData();
-  });
-
-  it('should apply notification using sendUserNotification() when in background', async () => {
-    await device.launchApp({newInstance: true});
-    console.log('Sending app to background...');
-    await device.sendToHome();
-    console.log('Sending notification data...');
     await device.sendUserNotification(userNotification);
     await element(by.text('Launch-Notification')).tap();
     await assertNotificationData();

--- a/detox/test/src/Screens/AbstractArgsListScreen.js
+++ b/detox/test/src/Screens/AbstractArgsListScreen.js
@@ -51,12 +51,13 @@ export default class AbstractArgsListScreen extends Component {
 
   renderArgsList() {
     return _.reduce(this.state.argsList, (result, argValue, argName) => {
+      const _argValue = (_.isArray(argValue) || _.isObject(argValue) ? JSON.stringify(argValue) : argValue);
       const itemId = `${this.contextName}-${argName}`;
       const nameId = itemId + '.name';
       const valueId = itemId + '.value';
       result.push(
         <Text key={nameId} testID={nameId} style={{fontWeight: 'bold'}}>{argName}:</Text>,
-        <Text key={valueId} testID={valueId} style={{paddingBottom: 4}}>{_.isArray(argValue) ? JSON.stringify(argValue) : argValue}</Text>,
+        <Text key={valueId} testID={valueId} style={{paddingBottom: 4}}>{_argValue}</Text>,
       );
       return result;
     }, []);


### PR DESCRIPTION
- [ ] This is a small change 
- [x] This change has been discussed in issue #1192 and the solution has been agreed upon with maintainers.

---

**Description:**
Resolves #1192, by filling the missing gaps - as described in #2134, namely, by adding support for these two API usage cases:

```js
await device.launchApp({ newInstance: false, userNotification });
```

and:
```js
await device.sendUserNotification(userNotification);
```

---
In the process, I've also cleaned up and aligned the way URL-based launches are done. Formerly, the driver used to hold a transient pending-url property for the time between `deliverPayload` and `launchApp()` are called (by `device.launchApp()`). This has been removed, and `deliverPayload` is now completely ignored in this use case, as it is effectively irrelevant for Android.