### PR TITLE
fix(jest-circus): reinitialize custom logger on every Environment.setup

### DIFF
--- a/detox/runners/jest-circus/environment.js
+++ b/detox/runners/jest-circus/environment.js
@@ -34,18 +34,15 @@ class DetoxCircusEnvironment extends NodeEnvironment {
     this.initTimeout = 300000;
   }
 
+  async setup() {
+    await super.setup();
+
+    this.global.detox = require('../../src')
+      ._setGlobal(this.global)
+      ._suppressLoggingInitErrors();
+  }
+
   get detox() {
-    if (!this.global.detox) {
-      // NOTE: require() is deferred on purpose,
-      // to enable calculating line hit coverage
-      // while running internal E2E tests in Detox.
-      // Ideally, it can happen in setup() method.
-
-      this.global.detox = require('../../src')
-        ._setGlobal(this.global)
-        ._suppressLoggingInitErrors();
-    }
-
     return this.global.detox;
   }
 

--- a/detox/src/DetoxExportWrapper.js
+++ b/detox/src/DetoxExportWrapper.js
@@ -34,7 +34,7 @@ class DetoxExportWrapper {
   async init(configOverride, userParams) {
     let configError, exposeGlobals, resolvedConfig;
 
-    log.ensureLogFiles();
+    log.reinitialize(Detox.global);
 
     try {
       resolvedConfig = await configuration.composeDetoxConfig({

--- a/detox/src/DetoxExportWrapper.js
+++ b/detox/src/DetoxExportWrapper.js
@@ -3,7 +3,8 @@ const funpermaproxy = require('funpermaproxy');
 const Detox = require('./Detox');
 const DetoxConstants = require('./DetoxConstants');
 const configuration = require('./configuration');
-const log = require('./utils/logger').child({ __filename });
+const logger = require('./utils/logger');
+const log = logger.child({ __filename });
 
 const _detox = Symbol('detox');
 const _shouldLogInitError = Symbol('shouldLogInitError');
@@ -34,7 +35,7 @@ class DetoxExportWrapper {
   async init(configOverride, userParams) {
     let configError, exposeGlobals, resolvedConfig;
 
-    log.reinitialize(Detox.global);
+    logger.reinitialize(Detox.global);
 
     try {
       resolvedConfig = await configuration.composeDetoxConfig({

--- a/detox/src/utils/__mocks__/logger.js
+++ b/detox/src/utils/__mocks__/logger.js
@@ -6,7 +6,7 @@ class FakeLogger {
   constructor(opts = {}) {
     this.opts = opts;
     this.log = jest.fn();
-    this.ensureLogFiles = jest.fn();
+    this.reinitialize = jest.fn();
 
     for (const method of METHODS) {
       this[method] = jest.fn().mockImplementation((...args) => {

--- a/detox/src/utils/callsites.js
+++ b/detox/src/utils/callsites.js
@@ -3,18 +3,33 @@ const {escapeRegExp} = require('lodash');
 const cwd = process.cwd() + path.sep;
 
 // Taken from https://github.com/sindresorhus/callsites
-module.exports = () => {
+function getCallSites() {
   const _prepareStackTrace = Error.prepareStackTrace;
   Error.prepareStackTrace = (_, stack) => stack;
   const stack = new Error().stack.slice(1);
   Error.prepareStackTrace = _prepareStackTrace;
   return stack;
-};
+}
 
-module.exports.stackdump = (endFrame = 0) => {
+function getStackDump(endFrame = 0) {
   return new Error().stack
     .split('\n')
     .slice(2 + endFrame) // 2 = 1 for 'Error:' prefix and 1 for this function's frame
     .join('\n')
     .replace(new RegExp(escapeRegExp(cwd), 'g'), '');
+}
+
+function getOrigin(frameIndex = 0) {
+  const userCallsite = getCallSites()[frameIndex];
+  const callsiteFilename = userCallsite && userCallsite.getFileName();
+  const callsiteLine = userCallsite && userCallsite.getLineNumber();
+  const callsiteCol = userCallsite && userCallsite.getColumnNumber();
+  const filename = callsiteFilename ? path.relative(process.cwd(), callsiteFilename) : '<unknown>';
+  return `at ${filename}:${callsiteLine || '?'}:${callsiteCol || '?'}`;
+}
+
+module.exports = {
+  getCallSites,
+  getOrigin,
+  getStackDump,
 };

--- a/detox/src/utils/callsites.js
+++ b/detox/src/utils/callsites.js
@@ -19,11 +19,10 @@ function getStackDump(endFrame = 0) {
     .replace(new RegExp(escapeRegExp(cwd), 'g'), '');
 }
 
-function getOrigin(frameIndex = 0) {
-  const userCallsite = getCallSites()[frameIndex];
-  const callsiteFilename = userCallsite && userCallsite.getFileName();
-  const callsiteLine = userCallsite && userCallsite.getLineNumber();
-  const callsiteCol = userCallsite && userCallsite.getColumnNumber();
+function getOrigin(callSite) {
+  const callsiteFilename = callSite && callSite.getFileName();
+  const callsiteLine = callSite && callSite.getLineNumber();
+  const callsiteCol = callSite && callSite.getColumnNumber();
   const filename = callsiteFilename ? path.relative(process.cwd(), callsiteFilename) : '<unknown>';
   return `at ${filename}:${callsiteLine || '?'}:${callsiteCol || '?'}`;
 }

--- a/detox/src/utils/callsites.test.js
+++ b/detox/src/utils/callsites.test.js
@@ -1,16 +1,15 @@
 const path = require('path');
 
 describe('callsites', () => {
-
   let callsites;
+
   beforeEach(() => {
     callsites = require('./callsites');
   });
 
-  describe('call-sites query', () => {
-    const callFromWrapperFn = () => callsites();
-
+  describe('.getCallSites()', () => {
     it('should return a query-able callsites array', function it() {
+      const callFromWrapperFn = () => callsites.getCallSites();
       const [callsite0, callsite1] = callFromWrapperFn();
 
       const expectedFileName = path.normalize('src/utils/callsites.test.js');
@@ -18,13 +17,23 @@ describe('callsites', () => {
       expect(callsite0.getFileName()).toEqual(expect.stringContaining(expectedFileName));
       expect(callsite0.getFunctionName()).toEqual('callFromWrapperFn');
       expect(callsite0.isToplevel()).toEqual(true);
+
       expect(callsite1.getFunctionName()).toEqual('it');
       expect(callsite1.isToplevel()).toEqual(false);
     });
   });
 
-  describe('stack-dump', () => {
-    const callStackDumpFromWrapperFn = (endFrame) => callsites.stackdump(endFrame);
+  describe('.getOrigin()', () => {
+    it('should return user code location', function it() {
+      expect(callsites.getOrigin(0)).toMatch(/^at (.*):(\d+):(\d+)$/);
+      expect(callsites.getOrigin(0)).toContain(path.normalize('src/utils/callsites.js'));
+      expect(callsites.getOrigin(1)).toMatch(/^at (.*):(\d+):(\d+)$/);
+      expect(callsites.getOrigin(1)).toContain(path.normalize('src/utils/callsites.test.js'));
+    });
+  });
+
+  describe('.getStackDump', () => {
+    const callStackDumpFromWrapperFn = (endFrame) => callsites.getStackDump(endFrame);
     const callStackDumpFromTwoWrapperFn = (endFrame) => callStackDumpFromWrapperFn(endFrame);
 
     const expectedTopFrameRegExp = /^ {4}at callStackDumpFromWrapperFn \(src[\\/]utils[\\/]callsites\.test\.js:[0-9][0-9]?:[0-9][0-9]?\)/;

--- a/detox/src/utils/customConsoleLogger.js
+++ b/detox/src/utils/customConsoleLogger.js
@@ -13,26 +13,31 @@ function override(console, method, bunyanLoggerFn) {
   }
 }
 
+function getOrigin() {
+  const userCallSite = callsites.getCallSites()[USER_STACK_FRAME_INDEX];
+  return callsites.getOrigin(userCallSite);
+}
+
+function getStackDump() {
+  return callsites.getStackDump(USER_STACK_FRAME_INDEX);
+}
+
 function proxyLog(bunyanLoggerFn) {
   return (...args) => {
-    const origin = callsites.getOrigin(USER_STACK_FRAME_INDEX);
-    bunyanLoggerFn({ event: 'USER_LOG' }, origin, '\n', util.format(...args));
+    bunyanLoggerFn({ event: 'USER_LOG' }, getOrigin(), '\n', util.format(...args));
   };
 }
 
 function proxyTracing(bunyanLoggerFn) {
   return (...args) => {
-    const origin = callsites.getOrigin(USER_STACK_FRAME_INDEX);
-    const stackDump = callsites.getStackDump(USER_STACK_FRAME_INDEX);
-    bunyanLoggerFn({ event: 'USER_LOG' }, origin, '\n  Trace:', util.format(...args), '\n\r' + stackDump);
+    bunyanLoggerFn({ event: 'USER_LOG' }, getOrigin(), '\n  Trace:', util.format(...args), '\n\r' + getStackDump());
   };
 }
 
 function proxyAssert(bunyanLoggerFn) {
   return (condition, ...args) => {
     if (!condition) {
-      const origin = callsites.getOrigin(USER_STACK_FRAME_INDEX);
-      bunyanLoggerFn({ event: 'USER_LOG' }, origin, '\n  AssertionError:', util.format(...args));
+      bunyanLoggerFn({ event: 'USER_LOG' }, getOrigin(), '\n  AssertionError:', util.format(...args));
     }
   };
 }

--- a/detox/src/utils/customConsoleLogger.test.js
+++ b/detox/src/utils/customConsoleLogger.test.js
@@ -30,8 +30,12 @@ describe('customConsoleLogger.overrideConsoleMethods(console, bunyanLogger)', ()
     });
 
     it('should not override console methods, if it has an internal property __detox_log__', () => {
-      fakeConsole.__detox_log__ = jest.fn();
+      fakeConsole.__detox_log__ = {};
       expect(overrideConsoleMethods({ ...fakeConsole }, bunyanLogger)).toEqual(fakeConsole);
+    });
+
+    it('should set an internal property __detox_log__ after override', () => {
+      expect(overrideConsoleMethods({ ...fakeConsole }, bunyanLogger).__detox_log__).toBeDefined();
     });
   });
 

--- a/detox/src/utils/customConsoleLogger.test.js
+++ b/detox/src/utils/customConsoleLogger.test.js
@@ -1,13 +1,18 @@
-const path = require('path');
-const ignored = expect.anything;
-const customConsoleLogger = require('./customConsoleLogger');
+jest.mock('./callsites');
 
-describe('customConsoleLogger', () => {
+describe('customConsoleLogger.overrideConsoleMethods(console, bunyanLogger)', () => {
+  let overrideConsoleMethods;
   let fakeConsole, bunyanLogger;
 
   const USER_LOG_EVENT = { event: 'USER_LOG' };
 
   beforeEach(() => {
+    const callSitesMock = require('./callsites');
+    callSitesMock.getOrigin.mockReturnValue('FAKE_ORIGIN');
+    callSitesMock.getStackDump.mockReturnValue('FAKE_STACK_DUMP');
+
+    overrideConsoleMethods = require('./customConsoleLogger').overrideConsoleMethods;
+
     fakeConsole = {
       log: jest.fn(),
       warn: jest.fn(),
@@ -25,48 +30,50 @@ describe('customConsoleLogger', () => {
     };
   });
 
-  it('should override console methods, if it has no internal property __detox_log__', () => {
-    expect(customConsoleLogger.overrideConsoleMethods({ ...fakeConsole }, bunyanLogger)).not.toEqual(fakeConsole);
+  describe('- override safety -', () => {
+    it('should override console methods, if it has no internal property __detox_log__', () => {
+      expect(overrideConsoleMethods({ ...fakeConsole }, bunyanLogger)).not.toEqual(fakeConsole);
+    });
+
+    it('should not override console methods, if it has an internal property __detox_log__', () => {
+      fakeConsole.__detox_log__ = jest.fn();
+      expect(overrideConsoleMethods({ ...fakeConsole }, bunyanLogger)).toEqual(fakeConsole);
+    });
   });
 
-  it('should not override console methods, if it has an internal property __detox_log__', () => {
-    fakeConsole.__detox_log__ = jest.fn();
-    expect(customConsoleLogger.overrideConsoleMethods({ ...fakeConsole }, bunyanLogger)).toEqual(fakeConsole);
-  });
-
-  describe('redirections', () => {
+  describe('- proxying to bunyan -', () => {
     beforeEach(() => {
-      customConsoleLogger.overrideConsoleMethods(fakeConsole, bunyanLogger);
+      overrideConsoleMethods(fakeConsole, bunyanLogger);
     });
 
     it('should connect: console.log -> logger.info', () => {
-      fakeConsole.log('OK', 200);
-      expect(bunyanLogger.info).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n', 'OK 200');
+      fakeConsole.log('OK %d', 200);
+      expect(bunyanLogger.info).toHaveBeenCalledWith(USER_LOG_EVENT, 'FAKE_ORIGIN', '\n', 'OK 200');
     });
 
     it('should connect: console.warn -> logger.warn', () => {
-      fakeConsole.warn('Warning', 301);
-      expect(bunyanLogger.warn).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n', 'Warning 301');
+      fakeConsole.warn('Warning %d', 301);
+      expect(bunyanLogger.warn).toHaveBeenCalledWith(USER_LOG_EVENT, 'FAKE_ORIGIN', '\n', 'Warning 301');
     });
 
     it('should connect: console.trace -> logger.info', () => {
-      fakeConsole.trace('TraceMe', 100500);
-      expect(bunyanLogger.info).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n  Trace:', 'TraceMe 100500', ignored());
+      fakeConsole.trace('TraceMe %d', 100500);
+      expect(bunyanLogger.info).toHaveBeenCalledWith(USER_LOG_EVENT, 'FAKE_ORIGIN', '\n  Trace:', 'TraceMe 100500', '\n\rFAKE_STACK_DUMP');
     });
 
     it('should connect: console.error -> logger.error', () => {
-      fakeConsole.error('MyError', 500);
-      expect(bunyanLogger.error).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n', 'MyError 500');
+      fakeConsole.error('MyError %d', 500);
+      expect(bunyanLogger.error).toHaveBeenCalledWith(USER_LOG_EVENT, 'FAKE_ORIGIN', '\n', 'MyError 500');
     });
 
     it('should connect: console.debug -> logger.debug', () => {
-      fakeConsole.debug('Debug', 0);
-      expect(bunyanLogger.debug).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n', 'Debug 0');
+      fakeConsole.debug('Debug %d', 0);
+      expect(bunyanLogger.debug).toHaveBeenCalledWith(USER_LOG_EVENT, 'FAKE_ORIGIN', '\n', 'Debug 0');
     });
 
     it('should connect: console.assert -> logger.error', () => {
-      fakeConsole.assert(false, 'Failed condition', false);
-      expect(bunyanLogger.error).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n  AssertionError:', 'Failed condition false');
+      fakeConsole.assert(false, 'Failed condition %s', false);
+      expect(bunyanLogger.error).toHaveBeenCalledWith(USER_LOG_EVENT, 'FAKE_ORIGIN', '\n  AssertionError:', 'Failed condition false');
     });
 
     it('should not connect console.assert to logger.error, if the condition is true', () => {
@@ -74,130 +81,4 @@ describe('customConsoleLogger', () => {
       expect(bunyanLogger.error).not.toHaveBeenCalled();
     });
   });
-
-
-  // it('should support string formatting', () => {
-  //   const logger = require('./customConsoleLogger');
-  //   logger.override('__log', bunyanLogger.mock);
-  //   console.__log('Tada! this %s', 'worx');
-
-  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), ignored(), ignored(), 'Tada! this worx');
-  // });
-
-  // it('should include log origin', () => {
-  //   mockCallsites({file: 'mockfilename', line: 'mocklinenumber', col: 'mockcolnumber'});
-
-  //   const expectedOrigin = 'mockfilename:mocklinenumber:mockcolnumber';
-
-  //   const logger = require('./customConsoleLogger');
-  //   logger.override('__log', bunyanLogger.mock);
-  //   console.__log('');
-
-  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining(expectedOrigin), ignored(), ignored());
-  // });
-
-  // it('should use relative file-name rather than absolute in origin', () => {
-  //   const expectedOrigin = `at ${path.normalize('src/utils/customConsoleLogger.test.js')}:`;
-
-  //   const logger = require('./customConsoleLogger');
-  //   logger.override('__log', bunyanLogger.mock);
-  //   console.__log('');
-
-  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining(expectedOrigin), ignored(), ignored());
-  // });
-
-  // it('should handle unknown file in origin', () => {
-  //   mockCallsites({file: undefined, line: undefined, col: undefined});
-
-  //   const logger = require('./customConsoleLogger');
-  //   logger.override('__log', bunyanLogger.mock);
-  //   console.__log('');
-
-  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining('<unknown>:?:?'), ignored(), ignored());
-  // });  
-  // 
-  // it('should handle missing file line/column in origin', () => {
-  //   mockCallsites({file: 'mockfilename', line: undefined, col: undefined});
-
-  //   const logger = require('./customConsoleLogger');
-  //   logger.override('__log', bunyanLogger.mock);
-  //   console.__log('');
-
-  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining('mockfilename:?:?'), ignored(), ignored());
-  // });
-
-  // it('should support assertion logging', () => {
-  //   const logger = require('./customConsoleLogger');
-  //   logger.overrideAssertion('__log', bunyanLogger.mock);
-  //   console.__log(false, 'Testing456');
-
-  //   expect(bunyanLogger.mock).toHaveBeenCalledWith({ event: 'USER_LOG' }, ignored(), ignored(), 'Testing456');
-  // });
-
-  // it('should limit assertion logging to false-conditions', () => {
-  //   const logger = require('./customConsoleLogger');
-  //   logger.overrideAssertion('__log', bunyanLogger.mock);
-  //   console.__log(true, 'Testing456');
-
-  //   expect(bunyanLogger.mock).not.toHaveBeenCalled();
-  // });
-
-  // it('should support trace-logging', () => {
-  //   const logger = require('./customConsoleLogger');
-  //   logger.overrideTrace('__log', bunyanLogger.mock);
-  //   console.__log('Testing789');
-
-  //   expect(bunyanLogger.mock).toHaveBeenCalledWith({ event: 'USER_LOG' }, ignored(), ignored(), 'Testing789', ignored());
-  // });
-
-  // it('should log stack-trace dump when trace-logging', () => {
-  //   mockCallsites();
-  //   const callsites = require('./callsites');
-  //   callsites.stackdump = jest.fn().mockReturnValue('mockstack\ntrace');
-
-  //   const logger = require('./customConsoleLogger');
-  //   logger.overrideTrace('__log', bunyanLogger.mock);
-  //   console.__log('');
-
-  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), ignored(), ignored(), ignored(), '\n\rmockstack\ntrace');
-  // });
-
-  // it('should override all levels', () => {
-  //   const bunyanLogger = {
-  //     debug: jest.fn(),
-  //     info: jest.fn(),
-  //     warn: jest.fn(),
-  //     error: jest.fn(),
-  //   };
-
-  //   const _console = console;
-
-  //   try {
-  //     global.console = {};
-
-  //     const logger = require('./customConsoleLogger');
-  //     logger.overrideAllLevels(bunyanLogger);
-
-  //     expect(console.debug).toEqual(expect.any(Function));
-  //     expect(console.log).toEqual(expect.any(Function));
-  //     expect(console.warn).toEqual(expect.any(Function));
-  //     expect(console.error).toEqual(expect.any(Function));
-  //     expect(console.trace).toEqual(expect.any(Function));
-  //     expect(console.assert).toEqual(expect.any(Function));
-  //   } finally {
-  //     global.console = _console;
-  //   }
-  // });
-
-  // const mockCallsites = (callsite) => {
-  //   const mockCallsite = mockACallsite(callsite);
-  //   jest.mock('./callsites', () => jest.fn().mockReturnValue([{}, {}, mockCallsite]));
-  // };
-
-  // const mockACallsite = ({func, file, line, col} = {}) => ({
-  //   getFunctionName: jest.fn().mockReturnValue(func || ''),
-  //   getFileName: jest.fn().mockReturnValue(file || ''),
-  //   getLineNumber: jest.fn().mockReturnValue(line),
-  //   getColumnNumber: jest.fn().mockReturnValue(col),
-  // });
 });

--- a/detox/src/utils/customConsoleLogger.test.js
+++ b/detox/src/utils/customConsoleLogger.test.js
@@ -1,159 +1,203 @@
 const path = require('path');
 const ignored = expect.anything;
+const customConsoleLogger = require('./customConsoleLogger');
 
 describe('customConsoleLogger', () => {
-  let bunyanLogger;
+  let fakeConsole, bunyanLogger;
+
+  const USER_LOG_EVENT = { event: 'USER_LOG' };
 
   beforeEach(() => {
-    jest.unmock('./callsites');
+    fakeConsole = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      trace: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      assert: jest.fn(),
+    };
 
     bunyanLogger = {
-      mock: jest.fn(),
-    };
-  });
-
-  afterEach(() => {
-    delete console.__log;
-  });
-
-  it('should log an event as the prefix', () => {
-    const logger = require('./customConsoleLogger');
-    logger.override('__log', bunyanLogger.mock);
-    console.__log();
-
-    expect(bunyanLogger.mock).toHaveBeenCalledWith({ event: 'USER_LOG' }, ignored(), ignored(), ignored());
-  });
-
-  it('should log multiple args', () => {
-    const logger = require('./customConsoleLogger');
-    logger.override('__log', bunyanLogger.mock);
-    console.__log('Testing123');
-
-    expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), ignored(), ignored(), 'Testing123');
-  });
-
-  it('should support string formatting', () => {
-    const logger = require('./customConsoleLogger');
-    logger.override('__log', bunyanLogger.mock);
-    console.__log('Tada! this %s', 'worx');
-
-    expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), ignored(), ignored(), 'Tada! this worx');
-  });
-
-  it('should include log origin', () => {
-    mockCallsites({file: 'mockfilename', line: 'mocklinenumber', col: 'mockcolnumber'});
-
-    const expectedOrigin = 'mockfilename:mocklinenumber:mockcolnumber';
-
-    const logger = require('./customConsoleLogger');
-    logger.override('__log', bunyanLogger.mock);
-    console.__log('');
-
-    expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining(expectedOrigin), ignored(), ignored());
-  });
-
-  it('should use relative file-name rather than absolute in origin', () => {
-    const expectedOrigin = `at ${path.normalize('src/utils/customConsoleLogger.test.js')}:`;
-
-    const logger = require('./customConsoleLogger');
-    logger.override('__log', bunyanLogger.mock);
-    console.__log('');
-
-    expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining(expectedOrigin), ignored(), ignored());
-  });
-
-  it('should handle unknown file in origin', () => {
-    mockCallsites({file: undefined, line: undefined, col: undefined});
-
-    const logger = require('./customConsoleLogger');
-    logger.override('__log', bunyanLogger.mock);
-    console.__log('');
-
-    expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining('<unknown>:?:?'), ignored(), ignored());
-  });  
-  
-  it('should handle missing file line/column in origin', () => {
-    mockCallsites({file: 'mockfilename', line: undefined, col: undefined});
-
-    const logger = require('./customConsoleLogger');
-    logger.override('__log', bunyanLogger.mock);
-    console.__log('');
-
-    expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining('mockfilename:?:?'), ignored(), ignored());
-  });
-
-  it('should support assertion logging', () => {
-    const logger = require('./customConsoleLogger');
-    logger.overrideAssertion('__log', bunyanLogger.mock);
-    console.__log(false, 'Testing456');
-
-    expect(bunyanLogger.mock).toHaveBeenCalledWith({ event: 'USER_LOG' }, ignored(), ignored(), 'Testing456');
-  });
-
-  it('should limit assertion logging to false-conditions', () => {
-    const logger = require('./customConsoleLogger');
-    logger.overrideAssertion('__log', bunyanLogger.mock);
-    console.__log(true, 'Testing456');
-
-    expect(bunyanLogger.mock).not.toHaveBeenCalled();
-  });
-
-  it('should support trace-logging', () => {
-    const logger = require('./customConsoleLogger');
-    logger.overrideTrace('__log', bunyanLogger.mock);
-    console.__log('Testing789');
-
-    expect(bunyanLogger.mock).toHaveBeenCalledWith({ event: 'USER_LOG' }, ignored(), ignored(), 'Testing789', ignored());
-  });
-
-  it('should log stack-trace dump when trace-logging', () => {
-    mockCallsites();
-    const callsites = require('./callsites');
-    callsites.stackdump = jest.fn().mockReturnValue('mockstack\ntrace');
-
-    const logger = require('./customConsoleLogger');
-    logger.overrideTrace('__log', bunyanLogger.mock);
-    console.__log('');
-
-    expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), ignored(), ignored(), ignored(), '\n\rmockstack\ntrace');
-  });
-
-  it('should override all levels', () => {
-    const bunyanLogger = {
       debug: jest.fn(),
-      info: jest.fn(),
       warn: jest.fn(),
+      info: jest.fn(),
       error: jest.fn(),
     };
-
-    const _console = console;
-
-    try {
-      global.console = {};
-
-      const logger = require('./customConsoleLogger');
-      logger.overrideAllLevels(bunyanLogger);
-
-      expect(console.debug).toEqual(expect.any(Function));
-      expect(console.log).toEqual(expect.any(Function));
-      expect(console.warn).toEqual(expect.any(Function));
-      expect(console.error).toEqual(expect.any(Function));
-      expect(console.trace).toEqual(expect.any(Function));
-      expect(console.assert).toEqual(expect.any(Function));
-    } finally {
-      global.console = _console;
-    }
   });
 
-  const mockCallsites = (callsite) => {
-    const mockCallsite = mockACallsite(callsite);
-    jest.mock('./callsites', () => jest.fn().mockReturnValue([{}, {}, mockCallsite]));
-  };
-
-  const mockACallsite = ({func, file, line, col} = {}) => ({
-    getFunctionName: jest.fn().mockReturnValue(func || ''),
-    getFileName: jest.fn().mockReturnValue(file || ''),
-    getLineNumber: jest.fn().mockReturnValue(line),
-    getColumnNumber: jest.fn().mockReturnValue(col),
+  it('should override console methods, if it has no internal property __detox_log__', () => {
+    expect(customConsoleLogger.overrideConsoleMethods({ ...fakeConsole }, bunyanLogger)).not.toEqual(fakeConsole);
   });
+
+  it('should not override console methods, if it has an internal property __detox_log__', () => {
+    fakeConsole.__detox_log__ = jest.fn();
+    expect(customConsoleLogger.overrideConsoleMethods({ ...fakeConsole }, bunyanLogger)).toEqual(fakeConsole);
+  });
+
+  describe('redirections', () => {
+    beforeEach(() => {
+      customConsoleLogger.overrideConsoleMethods(fakeConsole, bunyanLogger);
+    });
+
+    it('should connect: console.log -> logger.info', () => {
+      fakeConsole.log('OK', 200);
+      expect(bunyanLogger.info).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n', 'OK 200');
+    });
+
+    it('should connect: console.warn -> logger.warn', () => {
+      fakeConsole.warn('Warning', 301);
+      expect(bunyanLogger.warn).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n', 'Warning 301');
+    });
+
+    it('should connect: console.trace -> logger.info', () => {
+      fakeConsole.trace('TraceMe', 100500);
+      expect(bunyanLogger.info).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n  Trace:', 'TraceMe 100500', ignored());
+    });
+
+    it('should connect: console.error -> logger.error', () => {
+      fakeConsole.error('MyError', 500);
+      expect(bunyanLogger.error).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n', 'MyError 500');
+    });
+
+    it('should connect: console.debug -> logger.debug', () => {
+      fakeConsole.debug('Debug', 0);
+      expect(bunyanLogger.debug).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n', 'Debug 0');
+    });
+
+    it('should connect: console.assert -> logger.error', () => {
+      fakeConsole.assert(false, 'Failed condition', false);
+      expect(bunyanLogger.error).toHaveBeenCalledWith(USER_LOG_EVENT, ignored(), '\n  AssertionError:', 'Failed condition false');
+    });
+
+    it('should not connect console.assert to logger.error, if the condition is true', () => {
+      fakeConsole.assert(true, 'Nothing to say');
+      expect(bunyanLogger.error).not.toHaveBeenCalled();
+    });
+  });
+
+
+  // it('should support string formatting', () => {
+  //   const logger = require('./customConsoleLogger');
+  //   logger.override('__log', bunyanLogger.mock);
+  //   console.__log('Tada! this %s', 'worx');
+
+  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), ignored(), ignored(), 'Tada! this worx');
+  // });
+
+  // it('should include log origin', () => {
+  //   mockCallsites({file: 'mockfilename', line: 'mocklinenumber', col: 'mockcolnumber'});
+
+  //   const expectedOrigin = 'mockfilename:mocklinenumber:mockcolnumber';
+
+  //   const logger = require('./customConsoleLogger');
+  //   logger.override('__log', bunyanLogger.mock);
+  //   console.__log('');
+
+  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining(expectedOrigin), ignored(), ignored());
+  // });
+
+  // it('should use relative file-name rather than absolute in origin', () => {
+  //   const expectedOrigin = `at ${path.normalize('src/utils/customConsoleLogger.test.js')}:`;
+
+  //   const logger = require('./customConsoleLogger');
+  //   logger.override('__log', bunyanLogger.mock);
+  //   console.__log('');
+
+  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining(expectedOrigin), ignored(), ignored());
+  // });
+
+  // it('should handle unknown file in origin', () => {
+  //   mockCallsites({file: undefined, line: undefined, col: undefined});
+
+  //   const logger = require('./customConsoleLogger');
+  //   logger.override('__log', bunyanLogger.mock);
+  //   console.__log('');
+
+  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining('<unknown>:?:?'), ignored(), ignored());
+  // });  
+  // 
+  // it('should handle missing file line/column in origin', () => {
+  //   mockCallsites({file: 'mockfilename', line: undefined, col: undefined});
+
+  //   const logger = require('./customConsoleLogger');
+  //   logger.override('__log', bunyanLogger.mock);
+  //   console.__log('');
+
+  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), expect.stringContaining('mockfilename:?:?'), ignored(), ignored());
+  // });
+
+  // it('should support assertion logging', () => {
+  //   const logger = require('./customConsoleLogger');
+  //   logger.overrideAssertion('__log', bunyanLogger.mock);
+  //   console.__log(false, 'Testing456');
+
+  //   expect(bunyanLogger.mock).toHaveBeenCalledWith({ event: 'USER_LOG' }, ignored(), ignored(), 'Testing456');
+  // });
+
+  // it('should limit assertion logging to false-conditions', () => {
+  //   const logger = require('./customConsoleLogger');
+  //   logger.overrideAssertion('__log', bunyanLogger.mock);
+  //   console.__log(true, 'Testing456');
+
+  //   expect(bunyanLogger.mock).not.toHaveBeenCalled();
+  // });
+
+  // it('should support trace-logging', () => {
+  //   const logger = require('./customConsoleLogger');
+  //   logger.overrideTrace('__log', bunyanLogger.mock);
+  //   console.__log('Testing789');
+
+  //   expect(bunyanLogger.mock).toHaveBeenCalledWith({ event: 'USER_LOG' }, ignored(), ignored(), 'Testing789', ignored());
+  // });
+
+  // it('should log stack-trace dump when trace-logging', () => {
+  //   mockCallsites();
+  //   const callsites = require('./callsites');
+  //   callsites.stackdump = jest.fn().mockReturnValue('mockstack\ntrace');
+
+  //   const logger = require('./customConsoleLogger');
+  //   logger.overrideTrace('__log', bunyanLogger.mock);
+  //   console.__log('');
+
+  //   expect(bunyanLogger.mock).toHaveBeenCalledWith(ignored(), ignored(), ignored(), ignored(), '\n\rmockstack\ntrace');
+  // });
+
+  // it('should override all levels', () => {
+  //   const bunyanLogger = {
+  //     debug: jest.fn(),
+  //     info: jest.fn(),
+  //     warn: jest.fn(),
+  //     error: jest.fn(),
+  //   };
+
+  //   const _console = console;
+
+  //   try {
+  //     global.console = {};
+
+  //     const logger = require('./customConsoleLogger');
+  //     logger.overrideAllLevels(bunyanLogger);
+
+  //     expect(console.debug).toEqual(expect.any(Function));
+  //     expect(console.log).toEqual(expect.any(Function));
+  //     expect(console.warn).toEqual(expect.any(Function));
+  //     expect(console.error).toEqual(expect.any(Function));
+  //     expect(console.trace).toEqual(expect.any(Function));
+  //     expect(console.assert).toEqual(expect.any(Function));
+  //   } finally {
+  //     global.console = _console;
+  //   }
+  // });
+
+  // const mockCallsites = (callsite) => {
+  //   const mockCallsite = mockACallsite(callsite);
+  //   jest.mock('./callsites', () => jest.fn().mockReturnValue([{}, {}, mockCallsite]));
+  // };
+
+  // const mockACallsite = ({func, file, line, col} = {}) => ({
+  //   getFunctionName: jest.fn().mockReturnValue(func || ''),
+  //   getFileName: jest.fn().mockReturnValue(file || ''),
+  //   getLineNumber: jest.fn().mockReturnValue(line),
+  //   getColumnNumber: jest.fn().mockReturnValue(col),
+  // });
 });

--- a/detox/src/utils/logger.js
+++ b/detox/src/utils/logger.js
@@ -42,6 +42,10 @@ function createPlainBunyanStream({ logPath, level }) {
     out: process.stderr,
     prefixers: {
       '__filename': (filename, { entry }) => {
+        if (entry.event === 'USER_LOG') {
+          return '';
+        }
+
         const suffix = entry.event ? `/${entry.event}` : '';
         return path.basename(filename) + suffix;
       },
@@ -113,7 +117,7 @@ function init() {
 
   tryOverrideConsole(logger, global);
 
-  Object.getPrototypeOf(logger).reinitialize = (global) => {
+  logger.reinitialize = (global) => {
     if (jsonFileStreamPath) {
       fs.ensureFileSync(jsonFileStreamPath);
     }

--- a/detox/src/utils/logger.js
+++ b/detox/src/utils/logger.js
@@ -25,11 +25,6 @@ function adaptLogLevelName(level) {
   }
 }
 
-function overrideConsoleLogger(logger) {
-  const log = logger.child({component: 'USER_LOG'});
-  customConsoleLogger.overrideAllLevels(log);
-}
-
 function createPlainBunyanStream({ logPath, level }) {
   const options = {
     showDate: false,
@@ -110,7 +105,7 @@ function init() {
   }
 
   if (argparse.getArgValue('use-custom-logger') === 'true') {
-    overrideConsoleLogger(logger);
+    customConsoleLogger.overrideConsoleMethods(console, logger.child({component: 'USER_LOG'}));
   }
 
   Object.getPrototypeOf(logger).ensureLogFiles = () => {

--- a/detox/src/utils/logger.js
+++ b/detox/src/utils/logger.js
@@ -105,7 +105,8 @@ function init() {
   }
 
   if (argparse.getArgValue('use-custom-logger') === 'true') {
-    customConsoleLogger.overrideConsoleMethods(console, logger.child({component: 'USER_LOG'}));
+    const userLogger = logger.child({ component: 'USER_LOG' });
+    customConsoleLogger.overrideConsoleMethods(console, userLogger);
   }
 
   Object.getPrototypeOf(logger).ensureLogFiles = () => {

--- a/detox/test/e2e/config.js
+++ b/detox/test/e2e/config.js
@@ -16,7 +16,6 @@ module.exports = {
     "!**/*.mock.js",
     "!**/*.test.js"
   ],
-  "coverageProvider": "v8",
   "coverageDirectory": "test/coverage",
   "coverageReporters": [["lcov", {"projectRoot": "../.." }], "html"]
 };


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Fixes a regression bug that has popped after DetoxCircusEnvironment rewrite.

Before the fix (regression):

![Screenshot from 2020-06-19 19-11-35](https://user-images.githubusercontent.com/1962469/85154907-be727c80-b260-11ea-9a17-88d60a40d3ff.png)

After the fix:

![Screenshot from 2020-06-19 19-11-11](https://user-images.githubusercontent.com/1962469/85154932-c7634e00-b260-11ea-9f24-74bfce5eda6f.png)
