### PR TITLE
ci: nvm install 14

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -2,7 +2,9 @@
 
 source $(dirname "$0")/logger.sh
 
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 nvm install 14
+
 
 if [ ! -z ${REACT_NATIVE_VERSION} ]; then
   node scripts/change_react_native_version.js "detox/test" ${REACT_NATIVE_VERSION}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -2,8 +2,10 @@
 
 source $(dirname "$0")/logger.sh
 
+set -x
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 nvm install 14
+set +x
 
 
 if [ ! -z ${REACT_NATIVE_VERSION} ]; then

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -2,6 +2,8 @@
 
 source $(dirname "$0")/logger.sh
 
+nvm install 14
+
 if [ ! -z ${REACT_NATIVE_VERSION} ]; then
   node scripts/change_react_native_version.js "detox/test" ${REACT_NATIVE_VERSION}
 fi


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Upgrading to the next Node.js LTS version (14.x) might be useful, especially if we try to gather code coverage reports via V8 built-in mechanism. Our current 10.x has already entered maintenance mode, and sometimes I see different behavior for error stack traces between Node versions.