### PR TITLE
Update docs across the board with respect to notification support on Android

### DIFF
--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -29,7 +29,7 @@ The value will be `undefined` until the device is properly _prepared_ (i.e. in `
 - [`device.uninstallApp()`](#deviceuninstallapp)
 - [`device.openURL(url)`](#deviceopenurlurl-sourceappoptional)
 - [`device.sendUserNotification(params)`](#devicesendusernotificationparams)
-- [`device.sendUserActivity(params)`](#devicesenduseractivityparams)
+- [`device.sendUserActivity(params)` **iOS Only**](#devicesenduseractivityparams)
 - [`device.setOrientation(orientation)`](#devicesetorientationorientation)
 - [`device.setLocation(lat, lon)`](#devicesetlocationlat-lon)
 - [`device.setURLBlacklist([urls])`](#deviceseturlblacklisturls)
@@ -60,7 +60,9 @@ Launch the app defined in the current [`configuration`](APIRef.Configuration.md)
 
 ##### 1. `newInstance`—Launching a New Instance of the App
 
-Terminates the app and launch it again. If set to `false`, the simulator will try to bring app from background, if the app isn't running, it will launch a new instance. Default is `false`.
+Terminate the app and launch it again. 
+
+If set to `false`, the device will try to resume the app (e.g. bring from foreground to background). If the app isn't running, **it will launch a new instance** nonetheless. **Default is `false`.**
 
 ```js
 await device.launchApp({newInstance: true});
@@ -80,29 +82,28 @@ Detox uses [AppleSimUtils](https://github.com/wix/AppleSimulatorUtils) to implem
 Launches the app with the specified URL to test your app's deep link handling mechanism.
 
 ```js
-await device.launchApp({url: url});
-await device.launchApp({url: url, newInstance: true}); //Launch a new instance of the app
-await device.launchApp({url: url, newInstance: false}); //Reuse existing instance
+await device.launchApp({url});
+await device.launchApp({url, newInstance: true}); // Launch a new instance of the app
+await device.launchApp({url, newInstance: false}); // Reuse existing instance
 ```
-This will launch the app from background and handle the deep link.
 
-Read more in [here](APIRef.MockingOpenWithURL.md).
+Read more [here](APIRef.MockingOpenWithURL.md). Go back to subsection 1 to read about the full effect of the `newInstance` argument.
 
-##### 4. `userNotification`—Launching with User Notifications (iOS Only)
+##### 4. `userNotification`—Launching with User Notifications
 
-Launches with the specified user notification
+Launches with the specified user notification.
 
 ```js
-await device.launchApp({userNotification: notification});
-await device.launchApp({userNotification: notification, newInstance: true}); //Launch a new instance of the app
-await device.launchApp({userNotification: notification, newInstance: false}); //Reuse existing instance
+await device.launchApp({userNotification});
+await device.launchApp({userNotification, newInstance: true}); // Launch a new instance of the app
+await device.launchApp({userNotification, newInstance: false}); // Reuse existing instance
 ```
 
-Read more in [here](APIRef.MockingUserNotifications.md).
+Read more [here](APIRef.MockingUserNotifications.md). Go back to subsection 1 to read about the full effect of the `newInstance` argument.
 
 ##### 5. `userActivity`—Launch with User Activity (iOS Only)
 
-Launches the app with the specified user activity
+Launches the app with the specified user activity.
 
 ```js
 await device.launchApp({userActivity: activity});
@@ -110,7 +111,7 @@ await device.launchApp({userActivity: activity, newInstance: true}); //Launch a 
 await device.launchApp({userActivity: activity, newInstance: false}); //Reuse existing instance
 ```
 
-Read more in [here](APIRef.MockingUserActivity.md).
+Read more in [here](APIRef.MockingUserActivity.md). Go back to subsection 1 to read about the full effect of the `newInstance` argument.
 
 ##### 6. `delete`—Delete and Reinstall Application Before Launching
 
@@ -211,7 +212,7 @@ await device.launchApp({
 
 ### `device.relaunchApp(params)`
 
-**Deprecated:** Use `device.launchApp(params)` instead. This method is now calling `launchApp({newInstance: true})` for backwards compatibility.
+**Deprecated:** Use `device.launchApp(params)` instead. The method calls `launchApp({newInstance: true})` for backwards compatibility.
 
 ### `device.terminateApp()`
 By default, `terminateApp()` with no params will terminate the app file defined in the current [`configuration`](APIRef.Configuration.md).
@@ -258,16 +259,21 @@ await device.uninstallApp('other.bundle.id');
 ```
 
 ### `device.openURL({url, sourceApp[optional]})`
-Mock opening the app from URL. `sourceApp` is an optional parameter to specify source application bundle id.
+Mock opening the app from URL. `sourceApp` is an optional **iOS-only** parameter to specify source application bundle id.
+
 Read more in [Mocking Open From URL](APIRef.MockingOpenFromURL.md) section.
 Check out Detox's [own test suite](../detox/test/e2e/15.urls.test.js)
 
 ### `device.sendUserNotification(params)`
-Mock handling of received user notification when app is in foreground.
+Mock handling of a user notification previously received in the system, while the app is already running.
+
 Read more in [Mocking User Notifications](APIRef.MockingUserNotifications.md) section.
 Check out Detox's [own test suite](../detox/test/e2e/11.user-notifications.test.js)
 
 ### `device.sendUserActivity(params)`
+
+> iOS-only API
+
 Mock handling of received user activity when app is in foreground.
 Read more in [Mocking User Activity](APIRef.MockingUserActivity.md) section.
 Check out Detox's [own test suite](../detox/test/e2e/18.user-activities.test.js)

--- a/docs/APIRef.MockingOpenWithURL.md
+++ b/docs/APIRef.MockingOpenWithURL.md
@@ -5,28 +5,27 @@ You can mock opening the app from URL to test your app's deep link handling mech
 ## Mocking App Launch with a URL
 
 ```js
-await device.launchApp({newInstance: true, url: url, sourceApp: bundleId}); //sourceApp is optional
+await device.launchApp({newInstance: true, url, sourceApp: bundleId}); // sourceApp is an optional iOS-only argument
 ```
 
 #### Example
 
 ```js
 describe('launch app from URL', () => {
-    before(async () => {
+    it('should handle URL successfully', async () => {
       await device.launchApp({
         newInstance: true,
         url: 'scheme://some.url',
         sourceApp: 'com.apple.mobilesafari'
       });
-    });
-
-    it('should tap successfully', async () => {
       await expect(element(by.text('a label'))).toBeVisible();
     });
   });
 ```
 
 ## Mocking Opening with a URL on a Launched App
+
+> iOS-only
 
 ```js
 await device.openURL({url: 'scheme://some.url', sourceApp: 'com.apple.mobilesafari'});

--- a/docs/APIRef.MockingUserNotifications.md
+++ b/docs/APIRef.MockingUserNotifications.md
@@ -1,12 +1,12 @@
 # Mocking User Notifications
 
-Detox supports mocking user notifications for iOS apps.
+Detox supports mocking user notifications.
 
->**Note:** The mocking mechanism will not mimic the UI of a user notification. Instead, it will only simulate a user interaction with the notification.
+>**Note:** The mocking mechanism will not mimic the UI of a user notification. Instead, it will only simulate a user interaction with the notification - namely, the "opening" of it (equivalent to a user's tap/swipe on it in the notification center).
 
 ## Mocking App Launch with a Notification
 
-Using `launchApp()` with custom params (e.g., `userNotification`) will trigger the mocking mechanism.
+`launchApp()` with custom parameters (i.e. `userNotification`) will trigger the mocking mechanism.
 
 ```js
 await device.launchApp({newInstance: true, userNotification: notification});
@@ -15,15 +15,12 @@ await device.launchApp({newInstance: true, userNotification: notification});
 #### Example
 
 ```js
-describe('Background push notification', () => {
-  beforeEach(async () => {
+describe('Launch with push notification', () => {
+  it('should handle the notification', async () => {
     await device.launchApp({
       newInstance: true,
       userNotification: userNotificationPushTrigger,
     });
-  });
-
-  it('push notification from background', async () => {
     await expect(element(by.text('From push'))).toBeVisible();
   });
 });
@@ -31,49 +28,46 @@ describe('Background push notification', () => {
 
 ## Mocking Notification Reception on a Running App
 
-Use the `sendUserNotification()` method to send notification to running app. Notifications can be sent to an active or a background app.
+Use the `sendUserNotification()` method to send notification to **running** app. Notifications can be sent to an active or a background app.
+
+> Note: while the name `sendUserNotification()` is not very idiodmatic on Android, as notification data is not "sent" to apps (rather, it is bundled into an Activity/Service launch Intent as Intent-extras), this unified API is used, for the time being, for both platforms equivalently. With [plans of a more extensive support](https://github.com/wix/Detox/issues/2141) for Android, we estimate it would be deprecated when the time comes.
 
 ```js
-await device.sendUserNotification(notification)
+await device.sendUserNotification(notification);
 ```
 
 **Example:**
 
 ```js
 describe('Foreground user notifications', () => {
-
-beforeEach(async () => {
-  await device.launchApp();
-});
-
-it('Local notification from inside the app', async () => {
-  await device.sendUserNotification(localNotification);
-  await expect(element(by.text('from local notificaton'))).toBeVisible();
- });
+  it('should handle the local notification from inside the app', async () => {
+    await device.launchApp();
+    await device.sendUserNotification(localNotification);
+    await expect(element(by.text('from local notificaton'))).toBeVisible();
+   });
 });
 ```
 
 ## Notification JSON Format
 
+User notifications are passed as JSON objects to Detox. The JSON object needs to provide some required data, but can also provide an additional, optional payload.
 
-User notifications are passed as JSON objects to Detox. The JSON object needs to provide some required data, but can also provide additional, optional data.
+**Mind the major difference here between the two platforms.** While on iOS many types of data fields are applicable, Android is very loosely defined - with support for just free-form user data in the `payload` field.
 
-<!--- Use http://www.tablesgenerator.com/markdown_tables to edit these tables. --->
+| Key | Required | Value Type | Platform | Description |
+|---------------------|----------|------------|---------------------------------------------------------------------------------------------------|---------------------|
+| `trigger` | Yes | Object | iOS | The conditions that trigger the delivery of the notification. See the [Triggers section](https://github.com/wix/detox/wiki/User-Notifications-JSON-Format-Documentation#triggers) below. |
+| `title` | No | String | iOS | A short description of the reason for the alert. |
+| `subtitle` | No | String | iOS | A secondary description of the reason for the alert. |
+| `body` | No | String | iOS | The body of the notification. |
+| `badge` | No | Integer | iOS | The number to display as the app’s icon badge. |
+| `payload` | iOS: No<br />Android: Yes | Object | iOS & Android | An object of custom information associated with the notification.<br />Android: see [full description below](#Payload) |
+| `category` | No | String | iOS | The identifier of the app-defined category object. |
+| `content-available` | No | Integer | iOS | Include this key with a value of 1 to configure a silent notification. |
+| `user-text` | No | String | iOS | The text response provided by the user. |
+| `action-identifier` | No | String | iOS | The identifier for the action that the user selected. |
 
-| Key | Required | Value Type | Description |
-|---------------------|----------|------------|---------------------------------------------------------------------------------------------------|
-| `trigger` | Yes | Object | The conditions that trigger the delivery of the notification. See the [Triggers section](https://github.com/wix/detox/wiki/User-Notifications-JSON-Format-Documentation#triggers) below. |
-| `title` | No | String | A short description of the reason for the alert. |
-| `subtitle` | No | String | A secondary description of the reason for the alert. |
-| `body` | No | String | The body of the notification. |
-| `badge` | No | Integer | The number to display as the app’s icon badge. |
-| `payload` | No | Object | An object of custom information associated with the notification. |
-| `category` | No | String | The identifier of the app-defined category object. |
-| `content-available` | No | Integer | Include this key with a value of 1 to configure a silent notification. |
-| `user-text` | No | String | The text response provided by the user. |
-| `action-identifier` | No | String | The identifier for the action that the user selected. |
-
-### Triggers
+### Triggers (iOS-only)
 
 Triggers are objects representing the trigger.
 
@@ -106,7 +100,7 @@ const userNotification = {
 }
 ```
 
-### Date Components
+### Date Components (iOS-only)
 
 | Key | Required | Value Type | Description |
 |------------------|----------|------------|-------------------------------------------------------|
@@ -123,7 +117,7 @@ const userNotification = {
 | `weekOfMonth` | No | Integer | The week number of the month for the receiver. |
 | `leapMonth` | No | Boolean | Indicates whether the month is a leap month. |
 
-### Region
+### Region (iOS-only)
 
 | Key | Required | Value Type | Description |
 |-----------------|----------|------------|------------------------------------------------------------------------------------|
@@ -132,12 +126,47 @@ const userNotification = {
 | `notifyOnEntry` | No | Boolean | Indicates that notifications are generated upon entry into the region. |
 | `notifyOnExit` | No | Boolean | Indicates that notifications are generated upon exit from the region. |
 
-### Coordinate
+### Coordinate (iOS-only)
 
 | Key | Required | Value Type | Description |
 |-------------|----------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `latitude` | Yes | Number | The latitude in degrees. Positive values indicate latitudes north of the equator. Negative values indicate latitudes south of the equator. |
 | `longitude` | Yes | Number | The longitude in degrees. Measurements are relative to the zero meridian, with positive values extending east of the meridian and negative values extending west of the meridian. |
+
+### Payload
+
+On Android, the content will be available via the activity's [`getIntent()`](https://developer.android.com/reference/android/app/Activity#getIntent()) API, inside the intent's _extra_ bundle. Under some limitations, that includes data-cascading so as to provide comprehensive support for Javascript's advanced object-hierarchy capabilities as much as possible. As an example, consider this payload:
+
+```javascript
+  const userNotification = {
+    payload: {
+      userData: 'userDataValue',
+      userDataNum: 111.2,
+      userDataFlag: true,
+      userDataArray: ['rock', 'paper', 'scissors'],
+      userDataObj: {
+        cascadedKey: 'cascadedValue'
+      },
+    },
+  };
+
+```
+
+The outcome on the native side will be such that all of these conditions evaluate to _true_:
+
+```java
+activity.getIntent().getStringExtra("userData") == "userDataValue";
+activity.getIntent().getDoubleExtra("userDataNum") == 111.2;
+activity.getIntent().getBooleanExtra("userDataFlag") == true;
+activity.getIntent().getStringArrayExtra("userDataArray")[0] == "rock";
+activity.getIntent().getBundleExtra("userDataObj").getString("cascadedKey") == "cascadedValue";
+```
+
+#### Handling at Runtime
+
+Note that on Android, data delivered through an intent at runtime, is typically received in your activity's [`onNewIntent`](https://developer.android.com/reference/android/app/Activity#onNewIntent(android.content.Intent)) callback. Be sure to consider what should be done in order to handle this type of a use case in your app: Namely, that `setIntent()` should be called in order for the data to be later available in your app through `getIntent()`, as explained earlier.
+
+>  **This isn't related to Detox in particular**, and is set here simply to help you consider all the use cases in your app so that tests coverage would be optimal.
 
 ### Examples
 


### PR DESCRIPTION
- [ ] This is a small change 
- [ ] This change has been discussed in issue #1192 and the solution has been agreed upon with maintainers.

---

**Description:**
Updates the missing documentation with respect to changes introduced in #2134 and #2138, both associated with #1192 (i.e. android notification mocking support). Resolves #1192.