### PR TITLE
Android driver refactor 1.0

### DIFF
--- a/detox/src/devices/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.js
@@ -11,7 +11,7 @@ const AAPT = require('./exec/AAPT');
 const APKPath = require('./tools/APKPath');
 const TempFileXfer = require('./tools/TempFileXfer');
 const AppUninstallHelper = require('./tools/AppUninstallHelper');
-const { prepareInstrumentationArgs } = require('./tools/instrumentationArgs');
+const Instrumentation = require('./tools/Instrumentation');
 const DetoxApi = require('../../../android/espressoapi/Detox');
 const EspressoDetoxApi = require('../../../android/espressoapi/EspressoDetox');
 const UiDeviceProxy = require('../../../android/espressoapi/UiDeviceProxy');
@@ -25,22 +25,13 @@ const temporaryPath = require('../../../artifacts/utils/temporaryPath');
 const DetoxRuntimeError = require('../../../errors/DetoxRuntimeError');
 const sleep = require('../../../utils/sleep');
 const retry = require('../../../utils/retry');
-const { interruptProcess } = require('../../../utils/exec');
 const getAbsoluteBinaryPath = require('../../../utils/getAbsoluteBinaryPath');
 const AndroidExpect = require('../../../android/expect');
 const { InstrumentationLogsParser } = require('./InstrumentationLogsParser');
 
-const reservedInstrumentationArgs = ['class', 'package', 'func', 'unit', 'size', 'perf', 'debug', 'log', 'emma', 'coverageFile'];
-const isReservedInstrumentationArg = (arg) => reservedInstrumentationArgs.includes(arg);
-
 class AndroidDriver extends DeviceDriverBase {
   constructor(config) {
     super(config);
-
-    this.instrumentationLogsParser = null;
-    this.instrumentationProcess = null;
-    this.instrumentationStackTrace = '';
-    this.instrumentationCloseListener = _.noop;
 
     this.invocationManager = new InvocationManager(this.client);
     this.matchers = new AndroidExpect(this.invocationManager);
@@ -50,6 +41,11 @@ class AndroidDriver extends DeviceDriverBase {
     this.aapt = new AAPT();
     this.fileXfer = new TempFileXfer(this.adb);
     this.devicePathBuilder = new AndroidDevicePathBuilder();
+
+    this.instrumentationLogsParser = null;
+    this.instrumentationStackTrace = '';
+    this.instrumentationCloseListener = _.noop;
+    this.instrumentation = new Instrumentation(this.adb, logger);
   }
 
   declareArtifactPlugins() {
@@ -97,7 +93,7 @@ class AndroidDriver extends DeviceDriverBase {
       }
     }
 
-    if (!this._isInstrumentationRunning()) {
+    if (!this.instrumentation.isRunning()) {
       await this._launchInstrumentationProcess(deviceId, bundleId, launchArgs);
       await sleep(500);
     } else if (launchArgs.detoxURLOverride) {
@@ -140,7 +136,7 @@ class AndroidDriver extends DeviceDriverBase {
           super.waitUntilReady(),
           new Promise((resolve, reject) => {
             this.instrumentationCloseListener = () => reject(this._getInstrumentationCrashError());
-            !this._isInstrumentationRunning() && this.instrumentationCloseListener();
+            !this.instrumentation.isRunning() && this.instrumentationCloseListener();
           }),
         ]);
       } finally {
@@ -158,21 +154,9 @@ class AndroidDriver extends DeviceDriverBase {
 
   async terminate(deviceId, bundleId) {
     await this.emitter.emit('beforeTerminateApp', { deviceId, bundleId });
-    await this._terminateInstrumentation();
+    await this.instrumentation.terminate();
     await this.adb.terminate(deviceId, bundleId);
     await this.emitter.emit('terminateApp', { deviceId, bundleId });
-  }
-
-  async _terminateInstrumentation() {
-    if (this._isInstrumentationRunning()) {
-      await interruptProcess(this.instrumentationProcess);
-      this.instrumentationProcess = null;
-      this.instrumentationCloseListener();
-    }
-  }
-
-  _isInstrumentationRunning() {
-    return !!this.instrumentationProcess;
   }
 
   _getInstrumentationCrashError() {
@@ -190,7 +174,7 @@ class AndroidDriver extends DeviceDriverBase {
   }
 
   async cleanup(deviceId, bundleId) {
-    await this._terminateInstrumentation();
+    await this.instrumentation.terminate();
     await super.cleanup(deviceId, bundleId);
   }
 
@@ -272,24 +256,22 @@ class AndroidDriver extends DeviceDriverBase {
     return testApkPath;
   }
 
-  async _launchInstrumentationProcess(deviceId, bundleId, rawLaunchArgs) {
-    const launchArgs = prepareInstrumentationArgs(rawLaunchArgs);
-    const additionalLaunchArgs = prepareInstrumentationArgs({ debug: false });
-    this._warnReservedArgsUsedIfNeeded(launchArgs);
-
+  async _launchInstrumentationProcess(deviceId, bundleId, userLaunchArgs) {
     const serverPort = new URL(this.client.configuration.server).port;
     await this.adb.reverse(deviceId, serverPort);
-    const testRunner = await this.adb.getInstrumentationRunner(deviceId, bundleId);
-    const spawnFlags = [...launchArgs.args, ...additionalLaunchArgs.args];
 
     this.instrumentationLogsParser = new InstrumentationLogsParser();
-    this.instrumentationProcess = this.adb.spawnInstrumentation(deviceId, spawnFlags, testRunner);
-    this.instrumentationProcess.childProcess.stdout.setEncoding('utf8');
-    this.instrumentationProcess.childProcess.stdout.on('data', this._extractStackTraceFromInstrumLogs.bind(this));
-    this.instrumentationProcess.childProcess.on('close', async () => {
-      await this._terminateInstrumentation();
-      await this.adb.reverseRemove(deviceId, serverPort);
-    });
+    this.instrumentation.setTerminationFn(() => this._onInstrumentationTermination(deviceId, serverPort));
+    this.instrumentation.setLogListenFn(this._extractStackTraceFromInstrumLogs.bind(this));
+    await this.instrumentation.launch(deviceId, bundleId, userLaunchArgs);
+  }
+
+  async _onInstrumentationTermination(deviceId, serverPort) {
+    await this.adb.reverseRemove(deviceId, serverPort);
+    this.instrumentationCloseListener();
+
+    this.instrumentation.setTerminationFn(null);
+    this.instrumentation.setLogListenFn(null);
   }
 
   _extractStackTraceFromInstrumLogs(logsDump) {
@@ -333,16 +315,6 @@ class AndroidDriver extends DeviceDriverBase {
 
   _resumeMainActivity() {
     return this.invocationManager.execute(DetoxApi.launchMainActivity());
-  }
-
-  _warnReservedArgsUsedIfNeeded(preparedArgs) {
-    if (preparedArgs.usedReservedArgs.length) {
-      logger.warn([`Arguments [${preparedArgs.usedReservedArgs}] were passed in as launchArgs to device.launchApp() `,
-        'but are reserved to Android\'s test-instrumentation and will not be passed into the app. ',
-        'Ignore this message if this is what you meant to do. Refer to ',
-        'https://developer.android.com/studio/test/command-line#AMOptionsSyntax for ',
-        'further details.'].join(''));
-    }
   }
 }
 

--- a/detox/src/devices/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.js
@@ -2,7 +2,6 @@ const fs = require('fs');
 const URL = require('url').URL;
 const _ = require('lodash');
 const DeviceDriverBase = require('../DeviceDriverBase');
-const { encodeBase64 } = require('../../../utils/encoding');
 const logger = require('../../../utils/logger');
 const log = logger.child({ __filename });
 const invoke = require('../../../invoke');

--- a/detox/src/devices/drivers/android/tools/Instrumentation.js
+++ b/detox/src/devices/drivers/android/tools/Instrumentation.js
@@ -1,0 +1,60 @@
+const { interruptProcess } = require('../../../../utils/exec');
+const { prepareInstrumentationArgs } = require('./instrumentationArgs');
+
+class Instrumentation {
+  constructor(adb, logger, userTerminationFn, userLogListenFn) {
+    this.adb = adb;
+    this.logger = logger;
+    this.userTerminationFn = userTerminationFn;
+    this.userLogListenFn = userLogListenFn;
+    this.instrumentationProcess = null;
+    this._onTerminated = this._onTerminated.bind(this);
+  }
+
+  async launch(deviceId, bundleId, userLaunchArgs) {
+    const spawnArgs = this._getSpawnArgs(userLaunchArgs);
+
+    const testRunner = await this.adb.getInstrumentationRunner(deviceId, bundleId);
+
+    this.instrumentationProcess = this.adb.spawnInstrumentation(deviceId, spawnArgs, testRunner);
+    this.instrumentationProcess.childProcess.stdout.setEncoding('utf8');
+    this.instrumentationProcess.childProcess.stdout.on('data', this.userLogListenFn);
+    this.instrumentationProcess.childProcess.on('close', this._onTerminated);
+  }
+
+  /*async*/ terminate() {
+    return this._onTerminated();
+  }
+
+  isRunning() {
+    return !!this.instrumentationProcess;
+  }
+
+  _getSpawnArgs(userLaunchArgs) {
+    const launchArgs = prepareInstrumentationArgs(userLaunchArgs);
+    const additionalLaunchArgs = prepareInstrumentationArgs({ debug: false });
+    this._warnReservedArgsUsedIfNeeded(launchArgs);
+
+    return [...launchArgs.args, ...additionalLaunchArgs.args];
+  }
+
+  async _onTerminated() {
+    if (this.instrumentationProcess) {
+      await interruptProcess(this.instrumentationProcess);
+      this.instrumentationProcess = null;
+      await this.userTerminationFn();
+    }
+  }
+
+  _warnReservedArgsUsedIfNeeded(preparedArgs) {
+    if (preparedArgs.usedReservedArgs.length) {
+      this.logger.warn([`Arguments [${preparedArgs.usedReservedArgs}] were passed in as launchArgs to device.launchApp() `,
+        'but are reserved to Android\'s test-instrumentation and will not be passed into the app. ',
+        'Ignore this message if this is what you meant to do. Refer to ',
+        'https://developer.android.com/studio/test/command-line#AMOptionsSyntax for ',
+        'further details.'].join(''));
+    }
+  }
+}
+
+module.exports = Instrumentation;

--- a/detox/src/devices/drivers/android/tools/Instrumentation.js
+++ b/detox/src/devices/drivers/android/tools/Instrumentation.js
@@ -24,8 +24,10 @@ class Instrumentation {
     this.instrumentationProcess.childProcess.on('close', this._onTerminated);
   }
 
-  /*async*/ terminate() {
-    return this._onTerminated();
+  async terminate() {
+    if (this.instrumentationProcess) {
+      await this._killProcess();
+    }
   }
 
   isRunning() {
@@ -54,10 +56,14 @@ class Instrumentation {
 
   async _onTerminated() {
     if (this.instrumentationProcess) {
-      await interruptProcess(this.instrumentationProcess);
-      this.instrumentationProcess = null;
+      await this._killProcess();
       await this.userTerminationFn();
     }
+  }
+
+  async _killProcess() {
+    await interruptProcess(this.instrumentationProcess);
+    this.instrumentationProcess = null;
   }
 
   _warnReservedArgsUsedIfNeeded(preparedArgs) {

--- a/detox/src/devices/drivers/android/tools/Instrumentation.test.js
+++ b/detox/src/devices/drivers/android/tools/Instrumentation.test.js
@@ -1,0 +1,225 @@
+describe('Instrumentation', () => {
+  const deviceId = 'mock-device-id';
+  const bundleId = 'mock-bundle-id';
+
+  let exec;
+  let adb;
+  let instrumentationArgs;
+  let logger;
+  beforeEach(() => {
+    const ADB = jest.genMockFromModule('../exec/ADB');
+    adb = new ADB();
+
+    jest.mock('../../../../utils/exec');
+    exec = require('../../../../utils/exec');
+
+    jest.mock('./instrumentationArgs');
+    instrumentationArgs = require('./instrumentationArgs');
+    instrumentationArgs.prepareInstrumentationArgs.mockReturnValue({args: [], usedReservedArgs: []});
+
+    logger = {
+      warn: jest.fn(),
+    }
+  });
+
+  let childProcess;
+  let instrumentationProcess;
+  let logListenCallback;
+  let userTerminationCallback;
+  let uut;
+  beforeEach(() => {
+    childProcess = {
+      on: jest.fn(),
+      stdout: {
+        setEncoding: jest.fn(),
+        on: jest.fn(),
+      },
+    };
+    instrumentationProcess = {
+      childProcess,
+    };
+    adb.spawnInstrumentation.mockReturnValue(instrumentationProcess);
+
+    logListenCallback = jest.fn();
+    userTerminationCallback = jest.fn();
+
+    const Instrumentation = require('./Instrumentation');
+    uut = new Instrumentation(adb, logger, userTerminationCallback, logListenCallback);
+  });
+
+  it('should spawn Android instrumentation with device ID', async () => {
+    await uut.launch(deviceId, bundleId, []);
+    expect(adb.spawnInstrumentation).toHaveBeenCalledWith(deviceId, expect.anything(), undefined);
+  });
+
+  it('should spawn instrumentation with test runner', async () => {
+    const testRunner = 'mock-android-test-runner-name';
+    adb.getInstrumentationRunner.mockResolvedValue(testRunner);
+
+    await uut.launch(deviceId, bundleId, []);
+    expect(adb.spawnInstrumentation).toHaveBeenCalledWith(expect.anything(), expect.anything(), testRunner);
+    expect(adb.getInstrumentationRunner).toHaveBeenCalledWith(deviceId, bundleId);
+  });
+
+  describe('spawning launch-arguments processing', () => {
+    it('should prepare user launch-arguments', async () => {
+      instrumentationArgs.prepareInstrumentationArgs.mockReturnValue({args: [], usedReservedArgs: []});
+      const userArgs = {
+        arg1: 'value1',
+      };
+      await uut.launch(deviceId, bundleId, userArgs);
+
+      expect(instrumentationArgs.prepareInstrumentationArgs).toHaveBeenCalledWith(userArgs);
+    });
+
+    it('should prepare forced debug=false launch argument', async () => {
+      instrumentationArgs.prepareInstrumentationArgs.mockReturnValue({args: [], usedReservedArgs: []});
+      await uut.launch(deviceId, bundleId, { });
+      expect(instrumentationArgs.prepareInstrumentationArgs).toHaveBeenCalledWith({ debug: false });
+    });
+
+    it('should spawn instrumentation with processed user launch-arguments', async () => {
+      const mockedPreparedUserArgs = ['mocked', 'prepared-args'];
+      const mockedPreparedDebugArg = ['debug', 'mocked'];
+      instrumentationArgs.prepareInstrumentationArgs
+        .mockReturnValueOnce({ args: mockedPreparedUserArgs, usedReservedArgs: [] })
+        .mockReturnValueOnce({ args: mockedPreparedDebugArg, usedReservedArgs: [] });
+
+      await uut.launch(deviceId, bundleId, {});
+      expect(adb.spawnInstrumentation).toHaveBeenCalledWith(expect.anything(), [...mockedPreparedUserArgs, ...mockedPreparedDebugArg], undefined);
+    });
+
+    it('should log reserved instrumentation args usage if used in user args', async () => {
+      const mockedPreparedUserArgs = ['mocked', 'prepared-args'];
+      const mockedPreparedDebugArg = ['debug', 'mocked'];
+      const usedReservedArgs = ['aaa', 'zzz'];
+      instrumentationArgs.prepareInstrumentationArgs
+        .mockReturnValueOnce({ args: mockedPreparedUserArgs, usedReservedArgs })
+        .mockReturnValueOnce({ args: mockedPreparedDebugArg, usedReservedArgs: ['shouldnt', 'care'] });
+
+      await uut.launch(deviceId, bundleId, {});
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Arguments [aaa,zzz] were passed in as launchArgs to device.launchApp()'));
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT log reserved instrumentation args usage if none used by user', async () => {
+      const mockedPreparedUserArgs = ['mocked', 'prepared-args'];
+      const mockedPreparedDebugArg = ['debug', 'mocked'];
+      instrumentationArgs.prepareInstrumentationArgs
+        .mockReturnValueOnce({ args: mockedPreparedUserArgs, usedReservedArgs: [] })
+        .mockReturnValueOnce({ args: mockedPreparedDebugArg, usedReservedArgs: ['shouldnt', 'care'] });
+
+      await uut.launch(deviceId, bundleId, {});
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('instrumentation child-process unplanned termination', () => {
+    it('should terminate instrumentation', async () => {
+      await uut.launch(deviceId, bundleId, []);
+
+      expect(childProcess.on).toHaveBeenCalledWith('close', expect.any(Function));
+
+      await invokeTerminationCallback();
+      expect(exec.interruptProcess).toHaveBeenCalledWith(instrumentationProcess);
+    });
+
+    it('should fail if termination callback breaks', async () => {
+      exec.interruptProcess.mockRejectedValue(new Error());
+
+      await uut.launch(deviceId, bundleId, []);
+
+      try {
+        await invokeTerminationCallback();
+        fail();
+      } catch(error) {}
+    });
+
+    it('should not terminate if dispatched twice', async () => {
+      await uut.launch(deviceId, bundleId, []);
+      await invokeTerminationCallback();
+      await invokeTerminationCallback();
+      expect(exec.interruptProcess).toHaveBeenCalledTimes(1);
+    });
+
+    it('should exec user\'s top-level custom termination callback', async () => {
+      await uut.launch(deviceId, bundleId, []);
+      await invokeTerminationCallback();
+      expect(userTerminationCallback).toHaveBeenCalled();
+    });
+  });
+
+  describe('user-initiated termination', () => {
+    it('should terminate upon a termination API call', async () => {
+      await uut.launch(deviceId, bundleId, []);
+      await uut.terminate();
+      expect(exec.interruptProcess).toHaveBeenCalledWith(instrumentationProcess);
+    });
+
+    it('should break if process interruption fails', async () => {
+      exec.interruptProcess.mockRejectedValue(new Error());
+      await uut.launch(deviceId, bundleId, []);
+
+      try {
+        await uut.terminate();
+        fail();
+      } catch(error) {}
+    });
+
+    it('should not terminate if not running', async () => {
+      await uut.terminate();
+      expect(exec.interruptProcess).not.toHaveBeenCalled();
+    });
+
+    it('should not terminate if already terminated', async () => {
+      await uut.launch(deviceId, bundleId, []);
+      await uut.terminate();
+      await uut.terminate();
+      expect(exec.interruptProcess).toHaveBeenCalledTimes(1);
+    });
+
+    it('should exec user\'s top-level custom termination callback', async () => {
+      await uut.launch(deviceId, bundleId, []);
+      await uut.terminate();
+      expect(userTerminationCallback).toHaveBeenCalled();
+    });
+  });
+
+  describe('instrumentation run-status querying', () => {
+    it('should be true when running', async () => {
+      await uut.launch(deviceId, bundleId, []);
+      expect(uut.isRunning()).toEqual(true);
+    });
+
+    it('should false if terminated', async () => {
+      await uut.launch(deviceId, bundleId, []);
+      await uut.terminate();
+      expect(uut.isRunning()).toEqual(false);
+    });
+  });
+
+  describe('instrumentation output-log tapping', () => {
+    it('should be made possible to tap into, with utf-8 encoding', async () => {
+      await uut.launch(deviceId, bundleId, []);
+      expect(childProcess.stdout.on).toHaveBeenCalledWith('data', expect.any(Function));
+      expect(childProcess.stdout.setEncoding).toHaveBeenCalledWith('utf8');
+
+      await invokeDataCallbackWith('mock data');
+      expect(logListenCallback).toHaveBeenCalledWith('mock data');
+    });
+  });
+
+  const extractDataCallback = () => childProcess.stdout.on.mock.calls[0][1];
+  const invokeDataCallbackWith = async (data) => {
+    const fn = extractDataCallback();
+    await fn(data);
+  }
+
+  const extractTerminationCallback = () => childProcess.on.mock.calls[0][1];
+  const invokeTerminationCallback = async () => {
+    const terminationFn = extractTerminationCallback();
+    await terminationFn();
+  }
+});

--- a/detox/src/devices/drivers/android/tools/Instrumentation.test.js
+++ b/detox/src/devices/drivers/android/tools/Instrumentation.test.js
@@ -180,10 +180,10 @@ describe('Instrumentation', () => {
       expect(exec.interruptProcess).toHaveBeenCalledTimes(1);
     });
 
-    it('should exec user\'s top-level custom termination callback', async () => {
+    it('should NOT exec user\'s top-level custom termination callback', async () => {
       await uut.launch(deviceId, bundleId, []);
       await uut.terminate();
-      expect(userTerminationCallback).toHaveBeenCalled();
+      expect(userTerminationCallback).not.toHaveBeenCalled();
     });
   });
 
@@ -216,10 +216,9 @@ describe('Instrumentation', () => {
 
     const Instrumentation = require('./Instrumentation');
     uut = new Instrumentation(adb, logger, undefined, undefined);
-    await uut.launch(deviceId, bundleId, []);
-
     uut.setTerminationFn(runtimeCallback);
-    await uut.terminate();
+    await uut.launch(deviceId, bundleId, []);
+    await invokeTerminationCallback();
 
     expect(runtimeCallback).toHaveBeenCalled();
   });

--- a/detox/src/devices/drivers/android/tools/Instrumentation.test.js
+++ b/detox/src/devices/drivers/android/tools/Instrumentation.test.js
@@ -211,6 +211,46 @@ describe('Instrumentation', () => {
     });
   });
 
+  it('should allow for runtime setup of termination callback', async () => {
+    const runtimeCallback = jest.fn();
+
+    const Instrumentation = require('./Instrumentation');
+    uut = new Instrumentation(adb, logger, undefined, undefined);
+    await uut.launch(deviceId, bundleId, []);
+
+    uut.setTerminationFn(runtimeCallback);
+    await uut.terminate();
+
+    expect(runtimeCallback).toHaveBeenCalled();
+  });
+
+  it('should allow for clearing of termination callback', async () => {
+    uut.setTerminationFn(null);
+    await uut.launch(deviceId, bundleId, []);
+    await uut.terminate();
+    expect(userTerminationCallback).not.toHaveBeenCalled();
+  });
+
+  it('should allow for runtime setup of log-tapping callback', async () => {
+    const runtimeCallback = jest.fn();
+
+    const Instrumentation = require('./Instrumentation');
+    uut = new Instrumentation(adb, logger, undefined, undefined);
+    await uut.launch(deviceId, bundleId, []);
+
+    uut.setLogListenFn(runtimeCallback);
+    await invokeDataCallbackWith('mock data');
+
+    expect(runtimeCallback).toHaveBeenCalledWith('mock data');
+  });
+
+  it('should allow for clearing of log-tapping callback', async () => {
+    uut.setLogListenFn(null);
+    await uut.launch(deviceId, bundleId, []);
+    await invokeDataCallbackWith('data');
+    expect(logListenCallback).not.toHaveBeenCalled();
+  });
+
   const extractDataCallback = () => childProcess.stdout.on.mock.calls[0][1];
   const invokeDataCallbackWith = async (data) => {
     const fn = extractDataCallback();


### PR DESCRIPTION
- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Following work on #1192 -- need to break some of the AndroidDriver monolith into sub-units. This is the main step - 1.0, following #2146 and #2148: refactor away all the core of instrumentation process management.