### PR TITLE
Android driver refactor 1.1: Clean up android-driver and periphery even further

### DIFF
--- a/detox/src/devices/drivers/android/tools/Instrumentation.js
+++ b/detox/src/devices/drivers/android/tools/Instrumentation.js
@@ -42,6 +42,11 @@ class Instrumentation {
     this.userLogListenFn = userLogListenFn || _.noop;
   }
 
+  clearAllCallbackFn() {
+    this.setTerminationFn(null);
+    this.setLogListenFn(null);
+  }
+
   _getSpawnArgs(userLaunchArgs) {
     const launchArgs = prepareInstrumentationArgs(userLaunchArgs);
     const additionalLaunchArgs = prepareInstrumentationArgs({ debug: false });

--- a/detox/src/devices/drivers/android/tools/Instrumentation.test.js
+++ b/detox/src/devices/drivers/android/tools/Instrumentation.test.js
@@ -250,6 +250,16 @@ describe('Instrumentation', () => {
     expect(logListenCallback).not.toHaveBeenCalled();
   });
 
+  it('should allow for clearing of all user-callbacks', async () => {
+    uut.clearAllCallbackFn();
+
+    await uut.launch(deviceId, bundleId, []);
+    await invokeDataCallbackWith('data');
+    await invokeTerminationCallback();
+    expect(userTerminationCallback).not.toHaveBeenCalled();
+    expect(logListenCallback).not.toHaveBeenCalled();
+  });
+
   const extractDataCallback = () => childProcess.stdout.on.mock.calls[0][1];
   const invokeDataCallbackWith = async (data) => {
     const fn = extractDataCallback();

--- a/detox/src/utils/retry.js
+++ b/detox/src/utils/retry.js
@@ -3,6 +3,11 @@ const sleep = require('./sleep');
 const DEFAULT_RETRIES = 9;
 const DEFAULT_INTERVAL = 500;
 const DEFAULT_CONDITION_FN = () => true;
+const DEFAULT_BACKOFF_MODE = 'linear';
+const backoffModes = {
+  'linear': () => ({ interval, totalRetries }) => totalRetries * interval,
+  'none': () => ({ interval }) => interval,
+};
 
 async function retry(options, func) {
   if (typeof options === 'function') {
@@ -13,8 +18,11 @@ async function retry(options, func) {
   const {
     retries = DEFAULT_RETRIES,
     interval = DEFAULT_INTERVAL,
+    backoff = DEFAULT_BACKOFF_MODE,
     conditionFn = DEFAULT_CONDITION_FN,
   } = options;
+
+  const backoffFn = backoffModes[backoff]();
 
   for (let totalRetries = 1; true; totalRetries++) {
     try {
@@ -23,7 +31,7 @@ async function retry(options, func) {
       if (!conditionFn(e) || (totalRetries > retries)) {
         throw e;
       }
-      await sleep(totalRetries * interval);
+      await sleep(backoffFn({ interval, totalRetries }));
     }
   }
 }


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Following work on #1192 -- need to break some of the AndroidDriver monolith into sub-units. This is a post-refactor step - 1.1, following #2146, #2148 and #2149: tidy-up work in driver itself, and some periphery.