### PR TITLE
Consolidate (and split) setup onto a single getting-start guide [ci skip]

### DIFF
--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -1,6 +1,22 @@
 # Configuration Options
 
-## Configuring package.json
+## Configration file
+
+In order for Detox to know what device & app to use (and a lot more, actually), it needs some configuration to be statically available in a configuration file. It supports both standalone configuration files, and a configuration bundling inside the project's `package.json`.
+
+In essence, Detox scans for the configuration to use, through multiple files. It starts from the current working directory, and runs over the following options, in this order:
+
+1. `.detoxrc.js`
+1. `.detoxrc.json`
+1. `.detoxrc`
+1. `detox.config.js`
+1. `detox.config.json`
+1. `package.json` (`"detox"` section)
+
+Options 1-5 allow for a standalone Detox configuration in either a `json` format or using Javascript syntax.
+Option 6 means the configuration is available in `json` format inside the project's `package.json`, which is more suitable if you like having all of your project's configurations in one place.
+
+Please find the [Detox example app](/examples/demo-react-native/detox.config.js) as a reference.
 
 ### Device Configuration
 
@@ -11,7 +27,7 @@
 |`type`| Device type, available options are `ios.simulator`, `ios.none`, `android.emulator`, and `android.attached`. |
 |`binaryPath`| Relative path to the ipa/app due to be  tested (make sure you build the app in a project relative path)|
 |`testBinaryPath`| (optional, Android only): relative path to the test app (apk) |
-|`device`| Device query, e.g. `{ "byType": "iPhone 11 Pro" }` for iOS simulator or `{ "avdName": "Nexus_5X_API_29" }` |
+|`device`| Device query, e.g. `{ "byType": "iPhone 11 Pro" }` for iOS simulator or `{ "avdName": "Pixel_2_API_29" }` |
 |`build`| **[optional]** Build command (either `xcodebuild`, `react-native run-ios`, etc...), will be later available through detox CLI tool.|
 
 **Example:**
@@ -38,7 +54,7 @@
         "build": "...",
         "type": "android.emulator",
         "device": {
-          "avdName": "Nexus_5X_API_29",
+          "avdName": "Pixel_2_API_29",
         }
       },
       "android.att.release": {

--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -16,7 +16,7 @@ In essence, Detox scans for the configuration to use, through multiple files. It
 Options 1-5 allow for a standalone Detox configuration in either a `json` format or using Javascript syntax.
 Option 6 means the configuration is available in `json` format inside the project's `package.json`, which is more suitable if you like having all of your project's configurations in one place.
 
-Please find the [Detox example app](/examples/demo-react-native/detox.config.js) as a reference.
+Please find the [Detox example app](/examples/demo-react-native/detox.config.js) as a working reference.
 
 ### Device Configuration
 
@@ -72,44 +72,42 @@ Please find the [Detox example app](/examples/demo-react-native/detox.config.js)
 
 ### Artifacts Configuration
 
-Detox can control artifacts collection via settings from `package.json`:
+Detox can store artifacts such as transient screenshots and device logs. You can control artifacts collection via Detox configuration:
 
 ```js
 {
-  "detox": {
-    "artifacts": {
-      "rootDir": ".artifacts",
-      "pathBuilder": "./config/pathbuilder.js",
-      "plugins": {
-        "instruments": { "enabled": false },
-        "log": { "enabled": true },
-        "screenshot": {
-          "shouldTakeAutomaticSnapshots": true,
-          "keepOnlyFailedTestsArtifacts": true,
-          "takeWhen": {
-            "testStart": false,
-            "testDone": true,
-          },
+  "artifacts": {
+    "rootDir": ".artifacts",
+    "pathBuilder": "./config/pathbuilder.js",
+    "plugins": {
+      "instruments": { "enabled": false },
+      "log": { "enabled": true },
+      "screenshot": {
+        "shouldTakeAutomaticSnapshots": true,
+        "keepOnlyFailedTestsArtifacts": true,
+        "takeWhen": {
+          "testStart": false,
+          "testDone": true,
         },
-        "video": {
-          "android": {
-            "bitRate": 4000000
-          },
-          "simulator": {
-            "codec": "hevc"
-          }
+      },
+      "video": {
+        "android": {
+          "bitRate": 4000000
+        },
+        "simulator": {
+          "codec": "hevc"
         }
       }
-    },
-    "configurations": {
-      "ios.sim.release": {
-        "binaryPath": "/path/to/app",
-        "device": { /* ... */ },
-        "artifacts": {
-          "rootDir": ".artifacts/ios",
-          "plugins": {
-            "instruments": "all"
-          }
+    }
+  },
+  "configurations": {
+    "ios.sim.release": {
+      "binaryPath": "/path/to/app",
+      "device": { /* ... */ },
+      "artifacts": {
+        "rootDir": ".artifacts/ios",
+        "plugins": {
+          "instruments": "all"
         }
       }
     }
@@ -155,15 +153,13 @@ you have a few options to change. These are the default behavior values:
 ```
 
 For example, if you want to launch your tested app manually, e.g. via `device.launchApp()`,
-you should specify in `package.json`:
+you should specify in the Detox configuration:
 
 ```json
 {
-  "detox": {
-    "behavior": {
-      "init": {
-        "launchApp": false
-      }
+  "behavior": {
+    "init": {
+      "launchApp": false
     }
   }
 }
@@ -182,59 +178,33 @@ const { by, device, expect, element } = require('detox');
 
 ### Server Configuration
 
-Detox can either initialize a server using a generated configuration, or can be overriden with a manual  configuration:
+Detox can either initialize a server using a generated configuration, or can be overriden with a manual configuration:
 
 ```json
-  "detox": {
-    ...
-    "session": {
-    "server": "ws://localhost:8099",
-    "sessionId": "YourProjectSessionId"
-    }
-  }
+{
+  "session": {
+  "server": "ws://localhost:8099",
+  "sessionId": "YourProjectSessionId"
+}
 ```
 
 Session can also be set per configuration:
 
 ```json
-  "detox": {
-  ...
-    "configurations": {
-      "ios.sim.debug": {
-        ...
-        "session": {
-          "server": "ws://localhost:8099",
-          "sessionId": "YourProjectSessionId"
-        }
+{  
+  "configurations": {
+    "ios.sim.debug": {
+      ...
+      "session": {
+        "server": "ws://localhost:8099",
+        "sessionId": "YourProjectSessionId"
       }
     }
   }
+}
 ```
 
-### Test Runner Configuration
 
-##### Jest (recommended)
-
-```json
-  "detox": {
-    ...
-    "test-runner": "jest"
-    "runner-config": "path/to/jest-config"
-  }
-```
-
-`path/to/jest-config` refers to `--config` in https://facebook.github.io/jest/docs/en/configuration.html
-
-##### Mocha
-```json
-  "detox": {
-    ...
-    "test-runner": "mocha",
-    "runner-config": "path/to/.mocharc.json"
-  }
-```
-
-`.mocharc.json` refers to `--config` in https://mochajs.org/#-config-path
 
 ## detox-cli
 

--- a/docs/Guide.Jest.md
+++ b/docs/Guide.Jest.md
@@ -22,19 +22,18 @@ For its part, Detox supports only one Jest's concrete runner, which is [`jest-ci
 
 ### 1. Install Jest
 
-Before starting with Jest setup, please go over [Getting Started](Introduction.GettingStarted.md) guide,
-especially **steps 1 and 2**.
+Before starting with Jest setup, be sure to complete the preliminary sections of the [Getting Started](Introduction.GettingStarted.md) guide.
 
 Afterward, install the respective npm packages:
 
 ```sh
-npm install --save-dev jest jest-circus
+npm install jest jest-circus --save-dev --no-package-lock
 ```
 
 If you are already using Jest in your project,
 make sure that `jest` and `jest-circus` package versions match (e.g., both are `26.0.1`).
 
-### 2. Set up test-code scaffolds
+### 2. Set up test-code scaffolds :building_construction:
 
 Run the automated init script:
 
@@ -42,6 +41,13 @@ Run the automated init script:
 detox init -r jest
 ```
 > **Note:** errors occurring in the process may appear in red.
+
+If things go well, you should to have this set up:
+
+- An `e2e/` folder in your project root
+- An `e2e/config.json` file; [example](/examples/demo-react-native-jest/e2e/config.json)
+- An `e2e/environment.js` file; [example](/examples/demo-react-native-jest/e2e/environment.js)
+- An `e2e/firstTest.e2e.js` file with content similar to [this](/examples/demo-react-native-jest/e2e/app-hello.e2e.js).
 
 ### 3. Fix / Verify
 

--- a/docs/Guide.Mocha.md
+++ b/docs/Guide.Mocha.md
@@ -1,0 +1,35 @@
+# Mocha setup guide
+
+This guide describes how to install [Mocha](mochajs.org) as a test runner to be used by Detox for running the E2E tests.
+
+**Disclaimer:**
+
+* Here we focus on installing Detox on _new projects_. If you're migrating a project with an existing Detox installation, please apply some common sense while using this guide.
+
+
+
+## Installation
+
+### 1. Install Mocha :coffee:
+
+Before starting with Mocha setup, be sure to complete the preliminary sections of the [Getting Started](Introduction.GettingStarted.md) guide.
+
+```sh
+npm install mocha --save-dev --no-package-lock
+```
+
+### 2. Set up test-code scaffolds :building_construction:
+
+```sh
+detox init -r mocha
+```
+
+> **Note:** errors occurring in the process may appear in red.
+
+If things go well, you should to have this set up:
+
+- An `e2e/` folder in your project root
+- An `e2e/.mocharc.json` file; [example](/examples/demo-react-native/e2e/.mocharc.json)
+- An `e2e/init.js` file; [example](/examples/demo-react-native/e2e/init.js)
+- An `e2e/firstTest.spec.js` file with content similar to [this](/examples/demo-react-native/e2e/example.spec.js).
+

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -2,7 +2,7 @@
 
 ## Breaking Changes :warning:
 
-> If you are installing Detox for Android for the first time, you can skip right over to the setup section.
+**If you are installing Detox for Android for the first time, you can skip right over to the setup section.**
 
 > Follow our [Migration Guide](Guide.Migration.md) for instructions on how to upgrade from older versions.
 
@@ -16,19 +16,85 @@
 
   For older Android gradle plugin support use `detox@6.x.x` instead ([previous setup guide here](https://github.com/wix/detox/blob/97654071573053def90e8207be8eba011408f977/docs/Introduction.Android.md)).
 
-  **Note: As a rule of thumb, we consider all old major versions discontinued; We only support the latest Detox major version.**
 
-
+**Note: As a rule of thumb, we consider all old major versions discontinued; We only support the latest Detox major version.**
 
 ## Setup :gear:
 
-### 1. Run through the initial _Getting Started_ Guide
+### 1. Preliminary
 
-- [Getting Started](Introduction.GettingStarted.md)
+Run through the basic steps of the [Getting Started guide](Introduction.GettingStarted.md), such as the environment and tools setup.
+
+### 2. Apply Detox Configuration
+
+Whether you've selected to apply the configuration in a  `.detoxrc.json` or bundle it into your project's `package.json` (under the `detox` section), this is what the configuration should roughly look like for Android:
+
+```json
+{
+  "configurations": {
+      "android.emu.debug": {
+          "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
+          "build":
+            "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
+          "type": "android.emulator",
+          "device": {
+            "avdName": "Pixel_API_28"
+          }
+      },
+      "android.emu.release": {
+          "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
+          "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
+          "type": "android.emulator",
+          "device": {
+            "avdName": "Pixel_API_28"
+          }
+      }
+  }
+}
+```
+
+>For a comprehensive explanation of Detox configuration, refer to the [dedicated API-reference guide](APIRef.Configuration.md).
+
+Pay attention to `-DtestBuildType`, set either to `debug` or `release` according to the main apk type.
 
 
+Following device types could be used to control Android devices:
 
-### 2. Add Detox dependency to an Android project
+- `android.emulator`. Boot stock Android-SDK emulator (AVD) with provided `name`, for example `Pixel_API_28`.
+
+- `android.attached`. Connect to already-attached android device. The device should be listed in the output of `adb devices` command under provided `name`.
+  Use this type to connect to Genymotion emulator.
+
+For a complete, working example, refer to the [Detox example app](/examples/demo-react-native/detox.config.js).
+
+#### 2a. Using product flavors
+
+If you are using custom [productFlavors](https://developer.android.com/studio/build/build-variants#product-flavors) the config needs to be applied a bit differently. This example shows how a `beta` product flavor would look for both debug and release build types:
+
+```json
+"detox" : {
+    "configurations": {
+        "android.emu.beta.debug": {
+        "binaryPath": "android/app/build/outputs/apk/beta/debug/app-beta-debug.apk",
+        "build": "cd android && ./gradlew assembleBetaDebug assembleBetaDebugAndroidTest -DtestBuildType=debug && cd ..",
+        "type": "android.emulator",
+        "device": {
+          "avdName": "Pixel_API_28"
+        }
+      },
+      "android.emu.beta.release": {
+        "binaryPath": "android/app/build/outputs/apk/beta/release/app-beta-release.apk",
+        "build": "cd android && ./gradlew assembleBetaRelease assembleBetaReleaseAndroidTest -DtestBuildType=release && cd ..",
+        "type": "android.emulator",
+        "device": {
+          "avdName": "Pixel_API_28"
+        }
+      }
+    }
+}
+```
+
+### 3. Add the Native Detox dependency
 
 > **Starting Detox 12.5.0, Detox is shipped as a precompiled `.aar`.**
 > To configure Detox as a _compiling dependency_, nevertheless -- refer to the _Setting Detox up as a compiling dependency_ section at the bottom.
@@ -60,9 +126,7 @@ dependencies {
 }
 ```
 
-
-
-In your app's buildscript (i.e. `app/build.gradle`)  add this to the `defaultConfig` subsection:
+... and add this to the `defaultConfig` subsection:
 
 ```groovy
 android {
@@ -79,7 +143,7 @@ Please be aware that the `minSdkVersion` needs to be at least 18.
 
 
 
-### 3. Add Kotlin
+### 4. Add Kotlin
 
 If your project does not already support Kotlin, add the Kotlin Gradle-plugin to your classpath in the root build-script (i.e.`android/build.gradle`):
 
@@ -87,7 +151,6 @@ If your project does not already support Kotlin, add the Kotlin Gradle-plugin to
 buildscript {
     // ...
     ext.kotlinVersion = '1.3.0' // (check what the latest version is!)
-
     dependencies {
         // ...
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
@@ -101,75 +164,11 @@ _Note: most guides advise of defining a global `kotlinVersion` constant - as in 
 
 
 
-### 4. Create Android Test class
+### 5. Create a Detox-Test Class
 
 Add the file `android/app/src/androidTest/java/com/[your.package]/DetoxTest.java` and fill as in [the detox example app for NR](../examples/demo-react-native/android/app/src/androidTest/java/com/example/DetoxTest.java). **Don't forget to change the package name to your project's**.
 
 
-
-### 5. Add Android configuration
-
-Add this part to your `package.json`:
-
-```json
-"detox" : {
-    "configurations": {
-        "android.emu.debug": {
-            "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
-            "build":
-            "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
-            "type": "android.emulator",
-            "device": {
-              "avdName": "Pixel_API_28"
-            }
-        },
-        "android.emu.release": {
-            "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
-            "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
-            "type": "android.emulator",
-            "device": {
-              "avdName": "Pixel_API_28"
-            }
-        }
-    }
-}
-```
-Pay attention to `-DtestBuildType`, set either to `debug` or `release` according to the main apk type.
-
-
-Following device types could be used to control Android devices:
-
-`android.emulator`. Boot stock SDK emulator with provided `name`, for example `Nexus_5X_API_25`. After booting connect to it.
-
-`android.attached`. Connect to already-attached android device. The device should be listed in the output of `adb devices` command under provided `name`.
-Use this type to connect to Genymotion emulator.
-
-#### 5a. Using product flavors
-
-If you are using custom [productFlavors](https://developer.android.com/studio/build/build-variants#product-flavors) the config needs to be applied a bit differently. This example shows how a `beta` product flavor would look for both debug and release build types:
-
-```json
-"detox" : {
-    "configurations": {
-        "android.emu.beta.debug": {
-        "binaryPath": "android/app/build/outputs/apk/beta/debug/app-beta-debug.apk",
-        "build": "cd android && ./gradlew assembleBetaDebug assembleBetaDebugAndroidTest -DtestBuildType=debug && cd ..",
-        "type": "android.emulator",
-        "device": {
-          "avdName": "Pixel_API_28"
-        }
-      },
-      "android.emu.beta.release": {
-        "binaryPath": "android/app/build/outputs/apk/beta/release/app-beta-release.apk",
-        "build": "cd android && ./gradlew assembleBetaRelease assembleBetaReleaseAndroidTest -DtestBuildType=release && cd ..",
-        "type": "android.emulator",
-        "device": {
-          "avdName": "Pixel_API_28"
-        }
-      }
-    }
-}
-```
 
 ### 6. Enable clear-text (unencrypted) traffic for Detox
 
@@ -207,25 +206,6 @@ For Detox to work, Detox test code running on the device must connect to the tes
 For full details, refer to [Android's security-config guide](https://developer.android.com/training/articles/security-config), and the dedicated article in the [Android developers blog](https://android-developers.googleblog.com/2016/04/protecting-against-unintentional.html). 
 
 > *(\*) 10.0.2.2 for Google emulators, 10.0.3.2 for Genymotion emulators.*
-
-
-
-### 7. Setup your test environment
-
-Being able to execute tests requires a properly set-up computer. Walk through the [environment setup guide](Introduction.AndroidDevEnv.md) in order to employ the best practices and avoid common pitfalls when doing so.
-
-
-
-### 8. Run the tests
-
-Using the `android.emu.debug` configuration from above, you can invoke it in the standard way:
-
-```sh
-# build:
-$ detox build -c android.emu.release
-# run tests:
-$ detox test -c android.emu.release
-```
 
 
 

--- a/docs/Introduction.AndroidDevEnv.md
+++ b/docs/Introduction.AndroidDevEnv.md
@@ -2,29 +2,13 @@
 
 This guide provides some core practices to follow in setting up a stable, reliable environment for running automated UI tests using Android emulators (using Detox, in particular) -- be it on a personal, _local_ computer, or a powerful CI machine.
 
-It addresses mostly React Native developers - which are not necessarily familiar with all of Android's quirks, but also contains general recommendations regardless of the underlying dev-framework being used, as running automated UI test on Android is not the same as developing Android apps.
+Note that running automated UI tests is _not the same_ as developing Android apps. Hence, you may find yourself not 100% aligned with the recommendations here, and should consider being so.
 
 ## Java Setup
 
-This is the most fundamental step in the process, as without a proper Java SDK installed, nothing Android-ish works -- at least not from command-line, which is mandatory for executing `Detox`. For example, on a Mac with an improper Java version, we've come across cryptic errors such as this one when trying to launch Android's `sdkmanager`:
+This is the most basic step in the process, as without a proper Java SDK installed, nothing Android-ish works -- at least not from command-line, which is mandatory for executing `Detox`. 
 
-```
-Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
-	at com.android.repository.api.SchemaModule$SchemaModuleVersion.<init>(SchemaModule.java:156)
-	at com.android.repository.api.SchemaModule.<init>(SchemaModule.java:75)
-	at com.android.sdklib.repository.AndroidSdkHandler.<clinit>(AndroidSdkHandler.java:81)
-	at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:73)
-	at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:48)
-Caused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlSchema
-	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
-	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
-	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
-	... 5 more
-```
-
-While the stacktrace might seem intriguing for some, what matters here is the solution: **Android needs Java 1.8 installed**.
-
-On MacOS, in particular, java comes from both the OS _and_ possibly other installers such as `homebrew`, so you are more likely to go into a mess: see [this Stackoverflow post](https://stackoverflow.com/questions/24342886/how-to-install-java-8-on-mac).
+*The bottom line is that **Android needs Java 1.8 installed**.*
 
 To check for your real java-executable's version, in a command-line console, run:
 
@@ -43,6 +27,8 @@ Namely, that the version is `1.8.x_abc`.
 
 > Note: Do not be confused by the Java version potentially used by your browsers, etc. For `Detox`, what the command-line sees is what matters.
 
+On MacOS, in particular, java comes from both the OS _and_ possibly other installers such as `homebrew`, so you are more likely to go into a mess: see [this Stackoverflow post](https://stackoverflow.com/questions/24342886/how-to-install-java-8-on-mac).
+
 ---
 
 If `java` isn't in your path or not even installed (i.e. the command failed altogher), try [this guide](https://www.java.com/en/download/help/path.xml).
@@ -53,9 +39,24 @@ If otherwise the version is simply wrong, try these refs for Macs; consider empl
 * https://www.java.com/en/download/help/version_manual.xml
 * https://medium.com/notes-for-geeks/java-home-and-java-home-on-macos-f246cab643bd
 
-## Android AOSP Emulators
+## Android SDK
 
-We've long proven that for automation - which requires a stable and deterministic environment, Google's emulators running with Google API's simply don't deliver what it takes. Be it the preinstalled Google play-services - which tend to take up a lot of CPU, or even Google's `gboard` Keyboard - which is full-featured but overly bloated: These encourage flakiness in tests, which we are desperate to avoid in automation.
+If you have Android Studio installed - as most of us do, then the SDK should be available for you somewhere on your machine<sup>*</sup>. However, for CI agents -- possibly running with no GUI, or if you simply don't want the somewhat bloated piece of software on your computer, it is possible to simply download the SDK and tool-set, purely. Both cases are covered in the [Android guide about Android Studio](https://developer.android.com/studio/). For the pure-tools option, refer to the `Command line tools only` section at the bottom.
+
+For more help on setting the SDK up, [this guide might be helpful](https://www.androidcentral.com/installing-android-sdk-windows-mac-and-linux-tutorial).
+
+Whatever option you choose, and whichever platform you're running on (Mac, Linux, Windows), we strongly recommend that eventually you would have 2 additional things set up:
+
+* The path to the SDK's root directory is set into the `ANDROID_SDK_ROOT` [environment variable](https://developer.android.com/studio/command-line/variables).
+* The path to the SDK's root directory is set into the global [`PATH`](https://superuser.com/questions/284342/what-are-path-and-other-environment-variables-and-how-can-i-set-or-use-them) on your computer.
+
+_<sup>* Inspect the content of your `ANDROID_SDK_ROOT` and `ANDROID_HOME` environment variables.</sup>_
+
+## Android (AOSP) Emulators
+
+Mobile-apps' automation needs an Android device to run on. If you haven't already done so, you should  [set up an Emulator](https://developer.android.com/studio/run/emulator). But, wait - don't install the default one, just yet: read through.
+
+We've long proven that for automation - which requires a stable and deterministic environment, Google's emulators running with Google API's simply don't deliver what's needed. Be it the preinstalled Google play-services - which tend to take up a lot of CPU, or even Google's `gboard` Keyboard - which is full-featured but overly bloated: These encourage flakiness in tests, which we are desperate to avoid in automation.
 
 Fortunately, the Android team at Google offers a pretty decent alternative: **AOSP emulators** (Android Open-Source Project). While possibly lacking some of the extended Google services, and a bit less fancy overall, **we strongly recommend** to strictly use this flavor of emulators for running automation/Detox tests. They can be installed alongside regular emulators.
 

--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -1,68 +1,49 @@
 # Getting Started
 
-**This guide is focused on iOS. For installing Detox for Android, be sure to also go over the [Android guide](Introduction.Android.md)**.
+**Welcome to Detox! :tada:**
 
-This is a step-by-step guide for adding Detox to your React Native project.
+In this guide, we will walk you through setting Detox up in your project, one step at a time.
 
-> TIP: You can also check out this [awesome tutorial](https://medium.com/@bogomolnyelad/how-to-test-your-react-native-app-like-a-real-user-ecfc72e9b6bc) on Medium with video by [@bogomolnyelad](https://medium.com/@bogomolnyelad)
+You will find that some steps are longer than the others: some are just one-paragraph long, while for others we have a dedicated multistep guide worked out. Bear with us - it is all necessary, and once set-up, it is easy to move forward with writing tests very rapidly.
 
-## Prerequisites
+## Step 1: Environment Setup
 
-Running Detox (on iOS) requires the following:
+### Install [Node.js](https://nodejs.org/en/)
 
-* Mac with macOS (at least macOS High Sierra 10.13.6)
+`Node.js` is the JavaScript runtime Detox will run on. **Install Node `8.3.0` or above**.
 
-* Xcode 10.2+ with Xcode command line tools
-> TIP: Verify Xcode command line tools is installed by typing `gcc -v` in terminal (shows a popup if not installed)
+There's more than one way to install node.js:
 
-* A working [React Native](https://facebook.github.io/react-native/docs/getting-started.html) app you want to test
+1. Download from the [official download page](https://nodejs.org/en/download/)
+2. Use [homebrew](https://formulae.brew.sh/formula/node)
+3. Use `nvm` - if you need to allow for several versions to be installed on a single machine
 
-## Step 1: Install dependencies
-
-#### 1. Install the latest version of [Homebrew](http://brew.sh)
-
-Homebrew is a package manager for macOS, we'll need it to install other command line tools.
-
-To ensure everything needed for Homebrew tool installation is installed, run
-
-```sh
-xcode-select --install
-```
-
-> TIP: Verify it works by typing in terminal `brew -h` to output list of available commands
-
-#### 2. Install [Node.js](https://nodejs.org/en/)
-
-Node is the JavaScript runtime Detox will run on. **Install Node 8.3.0 or above**
+We recommened using homebrew:
 
  ```sh
- brew update && brew install node
+brew update && brew install node
  ```
 
-> TIP: Verify it works by typing in terminal `node -v` to output current node version, should be 8.3.0 or higher
+> Tip: Verify installation succeeded by typing in `node -v` in the terminal to output current node version. Should be `8.3.0` or higher.
 
-#### 3. Install [applesimutils](https://github.com/wix/AppleSimulatorUtils)
-
-A collection of utils for Apple simulators, Detox uses it to communicate with the simulator.
-
-```sh
-brew tap wix/brew
-brew install applesimutils
-```
-
-> TIP: Verify it works by typing in terminal `applesimutils` to output the tool help screen
-
-#### 4. Install Detox command line tools (detox-cli)
+### Install Detox command line tools (`detox-cli`)
 
 This package makes it easier to operate Detox from the command line. `detox-cli` should be installed globally, enabling usage of the command line tools outside of your npm scripts. `detox-cli` is merely a script that passes commands through to a the command line tool shipped inside `detox` package (in `node_modules/.bin/detox`).
 
   ```sh
-  npm install -g detox-cli
+npm install -g detox-cli
   ```
+
+### Install platform-specific dependencies, tools and dev-kits
+
+Depending on the platform/s you're aiming at (iOS, Android), take the time to run through these environment setup guides:
+
+* [Android](Introduction.AndroidDevEnv.md)
+* [iOS](Introduction.IosDevEnv.md)
 
 ## Step 2: Add Detox to your project
 
-#### 1. Install detox
+### Install the Detox node-module
 
 If you have a React Native project, go to its root folder (where `package.json` is found) and type the following command:
 
@@ -70,7 +51,7 @@ If you have a React Native project, go to its root folder (where `package.json` 
 npm install detox --save-dev
 ```
 
-If you have a project without Node integration (such as a native project), add the following package.json file to the root folder of your project:
+If you have a project without Node integration (such as a native project), add the following `package.json` file to the root folder of your project:
 
 ```json
 {
@@ -79,18 +60,30 @@ If you have a project without Node integration (such as a native project), add t
 }
 ```
 
-Now run the following command:
+Name your project in `package.json` and then run the following command:
 
 ```sh
-npm install detox --save-dev
+npm install detox --save-dev --no-package-lock
 ```
 
-> TIP: Remember to add the "node_modules" folder to your git ignore.
+**You should now have Detox available in `node_modules/detox`**
 
-#### 2. Add Detox config
+> Tip: Remember to add the `node_modules` folder to your git-ignore file (e.g. `.gitignore`).
 
-Detox searches for its configuration, starting from the current working directory,
-in the following places:
+### Set Up a Test Runner :running_man:
+
+Detox delegates the actual Javascript test-code execution to a dedicated test-runner. It supports the popular `Jest` and `Mocha` out of the box. You need to choose and set up one of them now, but it *is* possible to switch later on, should you change your mind.
+
+* **[Jest](https://jestjs.io/) is the recommended choice**, since it provides parallel test execution and a complete lifecycle integration for Detox. To set up, follow [our comprehensive guide for Jest](Guide.Jest.md).
+* [Mocha](https://mochajs.org/), albeit its integration is less complete, is still lightweight, and a bit easier to set up. To set up, follow [our guide for Mocha](Guide.Mocha.md).
+
+> **Note:** Detox is coupled to neither Mocha or Jest, nor with a specific directory structure. Both runners are just a recommendation — with some effort, they can be replaced without touching the internal implementation of Detox itself.
+
+### Apply Detox Configuration
+
+If you've completed the test-runner setup successfully using `detox init`, you should have a `.detoxrc.json` file containing a skeletal configuration for Detox to use. This configuration is only half-baked and needs to be set up properly. You now need to either create or edit that file, and apply the actual configuration suitable for your specific project.
+
+*Note that Detox scans for a configuration through multiple files. It starts from the current working directory, and runs over the following options, in this order:*
 
 1. `.detoxrc.js`
 1. `.detoxrc.json`
@@ -99,98 +92,14 @@ in the following places:
 1. `detox.config.json`
 1. `package.json` (`"detox"` section)
 
-If you prefer to keep all configs in one place, you can create a "detox" section in
-your`package.json`. Otherwise, if you prefer separating configs, see the available
-config file names above.
+*If you prefer to use something other than `.detoxrc.json` - for example, would like to keep all project configs in one place, you can create a `detox` section in your`package.json`. If you otherwise prefer separating configs, all of the other options are valid.*
 
-To get some help with creating your first Detox config file, you can try running Detox CLI:
-`detox init -r jest` (or `-r mocha`).
+Depending on the platform/s you're aiming at (iOS, Android), for a complete, platform-specific configuration explanation (and a bunch of other platform-specific things, where applicable), refer to the dedicated guides:
 
-Either way the config should look like this:
+* [Android](Introduction.Android.md)
+* [iOS](Introduction.Ios.md)
 
-##### in package.json
-
-```json
-"detox": {
-  "configurations": {
-    "ios.sim.debug": {
-      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
-      "build": "xcodebuild -project ios/example.xcodeproj -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
-      "type": "ios.simulator",
-      "device": {
-        "type": "iPhone 11 Pro"
-      }
-    }
-  }
-}
-```
-
-##### in .detoxrc.json or another separate config file
-
-```json
-{
-  "configurations": {
-    "ios.sim.debug": {
-      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
-      "build": "xcodebuild -project ios/example.xcodeproj -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
-      "type": "ios.simulator",
-      "name": "iPhone 7"
-    }
-  }
-}
-```
-
-In the above configuration example, change `example` to your actual project name. Under the key `"binaryPath"`, `example.app` should be `<your_project_name>.app`. Under the key `"build"`, `example.xcodeproj` should be `<your_project_name>.xcodeproj` and `-scheme example` should be `-scheme <your_project_name>`.
-
-For React Native 0.60 or above, or any other iOS apps in a workspace (eg: CocoaPods) use `-workspace ios/example.xcworkspace` instead of `-project`.
-
-Also make sure the simulator model specified under the key `device.type` (e.g. `iPhone 11 Pro` above) is actually available on your machine (it was installed by Xcode). Check this by typing `applesimutils --list` in terminal to display all available simulators.
-
-> TIP: To test a release version, replace 'Debug' with 'Release' in the binaryPath and build properties. For full configuration options see Configuration under the API Reference.
-
-## Step 3: Create your first test
-
-#### 1. Install a test runner :running_man:
-
-Detox CLI supports Jest and Mocha out of the box. You need to choose one now, but it *is* possible to replace it later on.
-
-* **Jest is the recommended choice**, since it provides parallel test execution and complete lifecycle integration for Detox.
-* Mocha, albeit its integration is less complete, is still lightweight, and a bit easier to set up.
-
-**Note:** Detox is coupled neither with Mocha or Jest nor with a specific directory structure. Both runners are just a recommendation — with some effort, they can be replaced without touching the internal implementation of Detox itself.
-
-##### [Jest](https://jestjs.io/)
-
-Follow the [Guide.Jest.md](Guide.Jest.md) documentation.
-
-##### [Mocha](https://mochajs.org/)
-
-```sh
-npm install mocha --save-dev
-```
-
-#### 2. Set up test-code scaffolds (automated) :building_construction:
-
-The Detox CLI has a `detox init` convenience method to automate a setup for your first test. Depending on your test runner of choice, run one of these commands:
-
-Note: `detox init` runs these steps, which you can reproduce manually:
-
-- Creates an `e2e/` folder in your project root
-- Inside `e2e` folder, creates `mocha.opts` (for `mocha`) or `config.json` (for `jest`). See examples: [mocha.opts](/examples/demo-react-native/e2e/mocha.opts), [config.json](/examples/demo-react-native-jest/e2e/config.json)
-- Inside `e2e` folder, creates `init.js` file. See examples for [Mocha](/examples/demo-react-native/e2e/init.js) and [Jest](/examples/demo-react-native-jest/e2e/init.js).
-- Inside `e2e` folder, creates `firstTest.e2e.js` with content similar to [this](/examples/demo-react-native-jest/e2e/app-hello.e2e.js).
-
-##### Mocha
-
-```sh
-detox init -r mocha
-```
-
-##### Jest
-
-Follow the [Guide.Jest.md](Guide.Jest.md) documentation.
-
-## Step 4: Build your app and run Detox tests
+## Step 3: Build your app and run Detox tests
 
 #### 1. Build your app
 
@@ -200,10 +109,11 @@ Use a convenience method in Detox command line tools to build your project easil
 detox build
 ```
 
-> TIP: Notice that the actual build command was specified in the Detox configuration in `package.json` .   
-See `"build": "xcodebuild -project ..."` inside `ios.sim.debug` configuration (step 2.3).
+> Tip: Notice that the actual build command was specified in the Detox configuration (e.g. in `.detoxrc.json` or `package.json` ).
+>
+> See `"build": "xcodebuild -project ..."` inside `ios.sim.debug`, or `./gradlew assembleDebug assembleAndroidTest` in `android.emu.debug`.
 
-#### 2. Run the tests (finally) :tada:
+#### 2. Run the tests (finally!) :beers:
 
 Use the Detox command line tools to test your project easily:
 
@@ -215,6 +125,4 @@ That's it. Your first failing Detox test is running!
 
 Next, we'll go over usage and how to make this test [actually pass](Introduction.WritingFirstTest.md).
 
-## Step 5: Android Setup
 
-If you haven't already done so - now is the time to set Android up using the [Android guide](Introduction.Android.md).

--- a/docs/Introduction.Ios.md
+++ b/docs/Introduction.Ios.md
@@ -1,0 +1,37 @@
+# Detox for iOS
+
+### 1. Preliminary
+
+Run through the basic steps of the [Getting Started guide](Introduction.GettingStarted.md), such as the environment and tools setup.
+
+### 2. Apply Detox Configuration
+
+Whether you've selected to apply the configuration in a  `.detoxrc.json` or bundle it into your project's `package.json` (under the `detox` section), this is what the configuration should roughly look like for iOS:
+
+```json
+{
+  "configurations": {
+    "ios.sim.debug": {
+      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
+      "build": "xcodebuild -project ios/example.xcodeproj -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
+      "type": "ios.simulator",
+      "device": {
+        "type": "iPhone 11 Pro"
+      }
+    }
+  }
+}
+```
+
+> For a comprehensive explanation of Detox configuration, refer to the [dedicated API-reference guide](APIRef.Configuration.md).
+
+In the above configuration example, change `example` to your actual project name. Under the key `"binaryPath"`, `example.app` should be `<your_project_name>.app`. Under the key `"build"`, `example.xcodeproj` should be `<your_project_name>.xcodeproj` and `-scheme example` should be `-scheme <your_project_name>`.
+
+For React Native 0.60 or above, or any other iOS apps in a workspace (eg: CocoaPods) use `-workspace ios/example.xcworkspace` instead of `-project`.
+
+Also make sure the simulator model specified under the key `device.type` (e.g. `iPhone 11 Pro` above) is actually available on your machine (it was installed by Xcode). Check this by typing `applesimutils --list` in terminal to display all available simulators.
+
+> Tip: To test a release version, replace 'Debug' with 'Release' in the binaryPath and build properties.
+
+For a complete, working example, refer to the [Detox example app](/examples/demo-react-native/detox.config.js).
+

--- a/docs/Introduction.IosDevEnv.md
+++ b/docs/Introduction.IosDevEnv.md
@@ -1,0 +1,40 @@
+# Setting Up an iOS Environment
+
+This guide sums up the tools required for an environment for running automated UI tests using iOS simulators (using Detox, in particular).
+
+## Prerequisites
+
+Running Detox (on iOS) requires the following:
+
+* Mac with macOS (at least macOS High Sierra 10.13.6)
+
+* Xcode 10.2+ with Xcode command line tools.
+  Xcode can be installed from the App Store, or the online [Apple developers page](https://developer.apple.com/download/more/) (requires a valid Apple ID to login).
+
+> Tip: Verify Xcode command line tools is installed by typing `gcc -v` in terminal (shows a popup if not installed)
+
+## Dependencies
+
+#### Install the latest version of [Homebrew](http://brew.sh)
+
+Homebrew is a package manager for macOS, we'll need it to install other command line tools.
+
+To ensure everything needed for Homebrew tool installation is installed, run
+
+```sh
+xcode-select --install
+```
+
+> Tip: Verify it works by typing in `brew -h` in a terminal to output list of available commands
+
+#### Install [applesimutils](https://github.com/wix/AppleSimulatorUtils)
+
+A collection of utils for Apple simulators, Detox uses it to communicate with the simulator.
+
+```sh
+brew tap wix/brew
+brew install applesimutils
+```
+
+> Tip: Verify it works by typing in `applesimutils` in a terminal to output the tool help screen
+

--- a/docs/More.AndroidSupportStatus.md
+++ b/docs/More.AndroidSupportStatus.md
@@ -1,5 +1,7 @@
 # Android Support - Status Page
 
+> The content in this page is out of date. We apologize, and hope to have it updated soon.
+
 As we are wrapping up Android support for Detox, there's already a pretty hefty chunk of Detox for Android already implemented, we decided to start releasing it as we go along, just like we did with the iOS implementation.
 
 This page should give an updated status of what's working and what's not (yet)...

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,11 @@
 ## Introduction
 
 - [Getting Started](Introduction.GettingStarted.md)
-- [Writing Your First Passing Test](Introduction.WritingFirstTest.md)
-- [Adding Android](Introduction.Android.md)
+- [iOS Environment Setup](Introduction.IosDevEnv.md)
 - [Android Environment Setup](Introduction.AndroidDevEnv.md)
+- [iOS Setup](Introduction.Ios.md)
+- [Android Setup](Introduction.Android.md)
+- [Writing Your First Passing Test](Introduction.WritingFirstTest.md)
 - [How Detox Works](Introduction.HowDetoxWorks.md)
 - [Recommended Workflows With Detox](Introduction.Workflows.md)
 
@@ -41,7 +43,8 @@
 - [Debugging Apps in Xcode During a Test](Guide.DebuggingInXcode.md)
 - [Advanced Mocking With Detox](Guide.Mocking.md)
 - [Migration Between Detox Versions](Guide.Migration.md)
-- [Use Jest as Test Runner](Guide.Jest.md)
+- [Using Jest as Test Runner](Guide.Jest.md)
+- [Using Mocha as a Test Runner](Guide.Mocha.md)
 - [Using Cucumber with Detox](https://github.com/mathanpec/react-native-detox-cucumber)
 - [Parallel Test Execution](Guide.ParallelTestExecution.md)
 


### PR DESCRIPTION
- [ ] This is a small change 
- [x] This change has been discussed in issue #2115 and the solution has been agreed upon with maintainers.

---

**Description:**
Resolves #2115. The change in a nutshell is as follows:
- Extraction of iOS specific instructions into equivalent android guides (dev-env, configuration+general setup)
- Generalization of getting-started guide with pointers to delegated guides where necessary
- Slight reorganization of the getting-start guide.

In order to review, consider simply going over the getting-started as a new detox user - as the diffs are impossible to interpret.

---
Rules of thumb I followed:
- DRY: tried my best not to have anything repeated. I managed to do so for the most part, except for two similar explanations regarding the configuration files resolution.
- (Somewhat related): Unify what's possible onto the main guide, and delegate onto platform-specific guides where things should be done in a platform-specific way. In the future, this would make it fairly easy to make the leap onto a single page with cascaded tabs (like react native's).
- Did my best to keep a workflow that makes sense: At any given point in the guide - tried not to address any worked-out detail if it hasn't been mentioned and explained, previously.
- Tried to be user-friendly about things 😄 
