### PR TITLE
Integrate test-butler with ANR disabling

### DIFF
--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -26,7 +26,7 @@ android {
             abiFilters 'armeabi-v7a', 'x86', 'x86_64'
         }
         testBuildType System.getProperty('testBuildType', 'debug')
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunner 'com.example.DetoxTestAppJUnitRunner'
 
         /*
         testInstrumentationRunnerArguments = [
@@ -92,6 +92,8 @@ dependencies {
     fromBinImplementation 'com.facebook.react:react-native:+'
 
     androidTestImplementation(project(path: ':detox'))
+    androidTestImplementation 'com.linkedin.testbutler:test-butler-library:2.1.0'
+    androidTestUtil 'com.linkedin.testbutler:test-butler-app:2.1.0'
 }
 
 if (rnInfo.isRN60OrHigher) {

--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTestAppJUnitRunner.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTestAppJUnitRunner.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import android.os.Bundle;
+
+import com.linkedin.android.testbutler.TestButler;
+
+import androidx.test.runner.AndroidJUnitRunner;
+
+public class DetoxTestAppJUnitRunner extends AndroidJUnitRunner {
+    @Override
+    public void onStart() {
+        TestButler.setup(getTargetContext());
+        super.onStart();
+    }
+
+    @Override
+    public void finish(int resultCode, Bundle results) {
+        TestButler.teardown(getTargetContext());
+        super.finish(resultCode, results);
+    }
+}


### PR DESCRIPTION
- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Integrate Linkedin's awesome test-butler, which - among many other things, disables ANR's 🚀  (takes the assumption that a stock-android image is used... lucky us).
First creating a draft just to see how the CI responds.