### PR TITLE
create flag to trigger --inspect-brk on test runner

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -142,7 +142,7 @@ module.exports.builder = {
     group: 'Execution:',
     describe: `Due to problems with the "adb install" command on Android, Detox resorts to a different scheme for install APK's. Setting true will disable that and force usage of "adb install", instead.`,
   },
-  'debug-test-runner': {
+  'inspect-brk': {
     group: 'Debugging:',
     describe: 'Allows debugging of the underlying test runner',
   }
@@ -203,7 +203,7 @@ module.exports.handler = async function test(program) {
       : 'config';
 
     const command = _.compact([
-      cliConfig.debugTestRunner ? 'node --inspect-brk' : '',
+      cliConfig.inspectBrk ? 'node --inspect-brk' : '',
       (path.join('node_modules', '.bin', runnerConfig.testRunner)),
       ...safeGuardArguments([
         (runnerConfig.runnerConfig ? `--${configParam} ${runnerConfig.runnerConfig}` : ''),
@@ -256,7 +256,7 @@ module.exports.handler = async function test(program) {
     }
 
     const command = _.compact([
-      cliConfig.debugTestRunner ? 'node --inspect-brk' : '',
+      cliConfig.inspectBrk ? 'node --inspect-brk' : '',
       path.join('node_modules', '.bin', runnerConfig.testRunner),
       ...safeGuardArguments([
         cliConfig.noColor ? ' --no-color' : '',

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -142,6 +142,10 @@ module.exports.builder = {
     group: 'Execution:',
     describe: `Due to problems with the "adb install" command on Android, Detox resorts to a different scheme for install APK's. Setting true will disable that and force usage of "adb install", instead.`,
   },
+  'debug-test-runner': {
+    group: 'Debugging:',
+    describe: 'Allows debugging of the underlying test runner',
+  }
 };
 
 const collectExtraArgs = require('./utils/collectExtraArgs')(module.exports.builder);
@@ -199,6 +203,7 @@ module.exports.handler = async function test(program) {
       : 'config';
 
     const command = _.compact([
+      cliConfig.debugTestRunner ? 'node --inspect-brk' : '',
       (path.join('node_modules', '.bin', runnerConfig.testRunner)),
       ...safeGuardArguments([
         (runnerConfig.runnerConfig ? `--${configParam} ${runnerConfig.runnerConfig}` : ''),
@@ -251,6 +256,7 @@ module.exports.handler = async function test(program) {
     }
 
     const command = _.compact([
+      cliConfig.debugTestRunner ? 'node --inspect-brk' : '',
       path.join('node_modules', '.bin', runnerConfig.testRunner),
       ...safeGuardArguments([
         cliConfig.noColor ? ' --no-color' : '',

--- a/detox/src/configuration/collectCliConfig.js
+++ b/detox/src/configuration/collectCliConfig.js
@@ -29,6 +29,7 @@ function collectCliConfig({ argv }) {
     runnerConfig: get('runner-config'),
     useCustomLogger: get('use-custom-logger'),
     workers: get('workers'),
+    debugTestRunner: get('debug-test-runner'),
   }, _.isUndefined);
 }
 

--- a/detox/src/configuration/collectCliConfig.js
+++ b/detox/src/configuration/collectCliConfig.js
@@ -29,7 +29,7 @@ function collectCliConfig({ argv }) {
     runnerConfig: get('runner-config'),
     useCustomLogger: get('use-custom-logger'),
     workers: get('workers'),
-    debugTestRunner: get('debug-test-runner'),
+    inspectBrk: get('inspect-brk'),
   }, _.isUndefined);
 }
 

--- a/detox/src/configuration/collectCliConfig.test.js
+++ b/detox/src/configuration/collectCliConfig.test.js
@@ -38,7 +38,7 @@ describe('collectCliConfig', () => {
     ['runnerConfig', 'runner-config'],
     ['useCustomLogger', 'use-custom-logger'],
     ['workers', 'workers'],
-    ['debugTestRunner', 'debug-test-runner'],
+    ['inspectBrk', 'inspect-brk'],
   ])('.%s property', (key, argName) => {
     beforeEach(() => {
       argv[argName] = Math.random();

--- a/detox/src/configuration/collectCliConfig.test.js
+++ b/detox/src/configuration/collectCliConfig.test.js
@@ -38,6 +38,7 @@ describe('collectCliConfig', () => {
     ['runnerConfig', 'runner-config'],
     ['useCustomLogger', 'use-custom-logger'],
     ['workers', 'workers'],
+    ['debugTestRunner', 'debug-test-runner'],
   ])('.%s property', (key, argName) => {
     beforeEach(() => {
       argv[argName] = Math.random();

--- a/docs/APIRef.DetoxCLI.md
+++ b/docs/APIRef.DetoxCLI.md
@@ -87,6 +87,7 @@ Initiating your test suite. <sup>[[1]](#notice-passthrough)</sup>
 | --no-color                                    | Disable colors in log output |
 | --use-custom-logger | Use Detox' custom console-logging implementation, for logging Detox (non-device) logs. Disabling will fallback to node.js / test-runner's implementation (e.g. Jest / Mocha).<br />*Default: true* |
 | --force-adb-install | Due to problems with the `adb install` command on Android, Detox resorts to a different scheme for install APK's. Setting true will disable that and force usage of `adb install`, instead.<br/>This flag is temporary until the Detox way proves stable.<br/>*Default: false* |
+| --inspect-brk | Uses [node's --inspect-brk](https://nodejs.org/en/docs/guides/debugging-getting-started/#enable-inspector) flag to let users debug the jest/mocha test runner <br />*Default: false* |
 | --help                                        | Show help |
 
 ##### Notices


### PR DESCRIPTION
- [x] This is a small change 

**Description:**

I added a flag to allow attaching a debugger to the underlying test runner.

Usage:
```
detox test --debug-test-runner
```

Haven't updated the docs yet, I wanted to get some initial feedback before doing so.