### PR TITLE
Add support for Detox Recorder in Detox CLI

### DIFF
--- a/detox-cli/cli.js
+++ b/detox-cli/cli.js
@@ -15,14 +15,29 @@ if (fs.existsSync(detoxPackageJsonPath)) {
       { stdio: 'inherit' });
     process.exit(result.status);
   } else {
-    const result = cp.spawnSync(
-      path.join(process.cwd(), 'node_modules/.bin/detox'),
-      process.argv.slice(2),
-      { stdio: 'inherit' });
-    process.exit(result.status);
+    const cliArgs = process.argv.slice(2);
+    if(cliArgs.length == 0 || cliArgs[0] !== "recorder") {
+      //Detox
+      const result = cp.spawnSync(
+        path.join(process.cwd(), 'node_modules/.bin/detox'),
+        cliArgs,
+        { stdio: 'inherit' });
+      process.exit(result.status);
+    } else {
+      //Detox Recorder path
+      const detoxRecorderPath = path.join(process.cwd(), 'node_modules/detox-recorder');
+      const detoxRecorderCLIPath = path.join(detoxRecorderPath, "DetoxRecorderCLI");
+      
+      if (fs.existsSync(detoxRecorderCLIPath)) {
+        const result = cp.spawnSync(detoxRecorderCLIPath, cliArgs, { stdio: 'inherit' });
+        process.exit(result.status);
+      } else {
+        console.log(`Detox Recorder is not installed in this directory: ${detoxRecorderPath}`);
+        process.exit(1);
+      }
+    }
   }
 } else {
-  console.log(detoxPackageJsonPath);
-  console.log("detox is not installed in this directory");
+  console.log(`Detox is not installed in this directory: ${detoxPath}`);
   process.exit(1);
 }

--- a/detox-cli/cli.js
+++ b/detox-cli/cli.js
@@ -17,7 +17,7 @@ if (fs.existsSync(detoxPackageJsonPath)) {
   } else {
     const cliArgs = process.argv.slice(2);
     if(cliArgs.length == 0 || cliArgs[0] !== "recorder") {
-      //Detox
+      //Detox path
       const result = cp.spawnSync(
         path.join(process.cwd(), 'node_modules/.bin/detox'),
         cliArgs,
@@ -27,9 +27,10 @@ if (fs.existsSync(detoxPackageJsonPath)) {
       //Detox Recorder path
       const detoxRecorderPath = path.join(process.cwd(), 'node_modules/detox-recorder');
       const detoxRecorderCLIPath = path.join(detoxRecorderPath, "DetoxRecorderCLI");
+      const recorderCLIArgs = process.argv.slice(3);
       
       if (fs.existsSync(detoxRecorderCLIPath)) {
-        const result = cp.spawnSync(detoxRecorderCLIPath, cliArgs, { stdio: 'inherit' });
+        const result = cp.spawnSync(detoxRecorderCLIPath, recorderCLIArgs, { stdio: 'inherit' });
         process.exit(result.status);
       } else {
         console.log(`Detox Recorder is not installed in this directory: ${detoxRecorderPath}`);


### PR DESCRIPTION
This adds support for [DetoxRecorder](https://github.com/wix/DetoxRecorder) in Detox CLI.

Now, when running `detox recorder`, CLI will test to see if Recorder is installed and forward that binary the commands. Otherwise behave the same as before.