### PR TITLE
Fail undesired longpress

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/common/JsonConverter.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/common/JsonConverter.kt
@@ -5,27 +5,25 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 class JsonConverter(private val json: JSONObject) {
-    fun toBundle(): Bundle {
-        val bundle = Bundle()
+    fun toBundle(): Bundle = Bundle().apply {
         json.keys().forEach { key: String ->
             when (val value = json.get(key)) {
-                is Boolean -> bundle.putBoolean(key, value)
-                is Integer -> bundle.putInt(key, value as Int)
-                is java.lang.Long -> bundle.putLong(key, value as Long)
-                is java.lang.Double -> bundle.putDouble(key, value as Double)
-                is String -> bundle.putString(key, value)
+                is Boolean -> putBoolean(key, value)
+                is Integer -> putInt(key, value as Int)
+                is java.lang.Long -> putLong(key, value as Long)
+                is java.lang.Double -> putDouble(key, value as Double)
+                is String -> putString(key, value)
                 is JSONObject -> {
                     val subObject = json.getJSONObject(key)
                     val subBundle = JsonConverter(subObject).toBundle()
-                    bundle.putBundle(key, subBundle)
+                    putBundle(key, subBundle)
                 }
                 is JSONArray -> {
                     val stringArray = parseJsonArrayAsStringsList(value)
-                    bundle.putStringArrayList(key, stringArray)
+                    putStringArrayList(key, stringArray)
                 }
             }
         }
-        return bundle
     }
 
     private fun parseJsonArrayAsStringsList(array: JSONArray)

--- a/detox/android/detox/src/main/java/com/wix/detox/common/TimeUtils.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/common/TimeUtils.kt
@@ -1,0 +1,13 @@
+package com.wix.detox.common
+
+import com.wix.detox.espresso.DetoxErrors.DetoxRuntimeException
+
+fun <T> runWithinTimeFrame(maxTime: Long, message: String? = null, block: () -> T): T {
+    val startTime = System.currentTimeMillis()
+    return block().also {
+        val actualTime = System.currentTimeMillis() - startTime
+        if (actualTime >= maxTime) {
+            throw DetoxRuntimeException(message ?: "Action failed to complete within the expected time-frame (${actualTime}ms)")
+        }
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxErrors.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxErrors.java
@@ -1,12 +1,12 @@
 package com.wix.detox.espresso;
 
-interface DetoxErrors {
+public interface DetoxErrors {
     class DetoxRuntimeException extends RuntimeException {
-        DetoxRuntimeException(Throwable cause) {
+        public DetoxRuntimeException(Throwable cause) {
             super(cause);
         }
 
-        DetoxRuntimeException(String message) {
+        public DetoxRuntimeException(String message) {
             super(message);
         }
     }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/common/DetoxViewConfiguration.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/common/DetoxViewConfiguration.kt
@@ -9,7 +9,8 @@ private const val LOG_TAG = "Detox-ViewConfig"
 
 object DetoxViewConfigurations {
 
-    fun getPostTapCooldownTime() = ViewConfiguration.getDoubleTapTimeout().toLong()
+    fun getMaxTapTime(): Long = ViewConfiguration.getLongPressTimeout().toLong()
+    fun getPostTapCooldownTime(): Long = ViewConfiguration.getDoubleTapTimeout().toLong()
 
     /**
      * Taken from [androidx.test.espresso.action.Tap]

--- a/detox/test/android/app/src/main/java/com/example/NativeModulePackage.java
+++ b/detox/test/android/app/src/main/java/com/example/NativeModulePackage.java
@@ -23,7 +23,8 @@ public class NativeModulePackage implements ReactPackage {
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.asList(
                 new AnimationViewManager(),
-                new DoubleTapsTextViewManager()
+                new DoubleTapsTextViewManager(),
+                new SluggishTextTextViewManager()
         );
     }
 

--- a/detox/test/android/app/src/main/java/com/example/SluggishTextTextViewManager.java
+++ b/detox/test/android/app/src/main/java/com/example/SluggishTextTextViewManager.java
@@ -1,0 +1,50 @@
+package com.example;
+
+import android.graphics.Color;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
+import android.view.ViewGroup.LayoutParams;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+public class SluggishTextTextViewManager extends SimpleViewManager<ViewGroup> {
+    @Override
+    public String getName() {
+        return "DetoxSluggishTapsTextView";
+    }
+
+    @Override
+    protected ViewGroup createViewInstance(ThemedReactContext reactContext) {
+        final FrameLayout layout = new FrameLayout(reactContext);
+        layout.setLayoutParams(new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+
+        final TextView textView = new TextView(reactContext);
+        textView.setTag("sluggishTappableText");
+        textView.setLayoutParams(new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, Gravity.CENTER));
+        textView.setTextAlignment(View.TEXT_ALIGNMENT_CENTER);
+        textView.setGravity(Gravity.CENTER);
+        textView.setText("Slow-Tap");
+        textView.setTextColor(Color.BLUE);
+
+        textView.setOnTouchListener((v, event) -> {
+            if (event.getAction() == MotionEvent.ACTION_DOWN) {
+                try {
+                    Thread.sleep(ViewConfiguration.getLongPressTimeout());
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return false;
+        });
+        textView.setOnClickListener(v -> {});
+
+        layout.addView(textView);
+        return layout;
+    }
+}

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -67,6 +67,15 @@ describe('Actions', () => {
     });
   });
 
+  it(':android: should throw if tap handling is too slow', async () => {
+    try {
+      await driver.sluggishTapElement.tap();
+      fail('Expected an error');
+    } catch (e) {
+      console.log('Got an expected error', e);
+    }
+  });
+
   it('should type in an element', async () => {
     const typedText = device.getPlatform() === 'ios' ? 'Type Working 123 אֱבּג абв!!!' : "Type Working!!!";
     await element(by.id('UniqueId937')).typeText(typedText);

--- a/detox/test/e2e/drivers/actions-driver.js
+++ b/detox/test/e2e/drivers/actions-driver.js
@@ -5,7 +5,7 @@ const driver = {
     testId: 'UniqueId819',
     get coordinates() {
       return {
-        x: (device.getPlatform() === 'ios' ? 180 : 125),
+        x: (device.getPlatform() === 'ios' ? 180 : 80),
         y: 107,
       };
     },
@@ -18,7 +18,7 @@ const driver = {
 
   doubleTapsElement: {
     testId: 'doubleTappableText',
-    coordinates: { x: 200, y: 160 },
+    coordinates: { x: 150, y: 160 },
     tapOnce: () => element(by.id(driver.doubleTapsElement.testId)).tap(),
     tapTwice: async () => {
       await driver.doubleTapsElement.tapOnce();
@@ -33,6 +33,11 @@ const driver = {
     },
     assertTapsCount: (count) => expect(element(by.id(driver.doubleTapsElement.testId))).toHaveText(`Double-Taps: ${count}`),
     assertNoTaps: () => driver.doubleTapsElement.assertTapsCount(0),
+  },
+
+  sluggishTapElement: {
+    testId: 'sluggishTappableText',
+    tap: () => element(by.id(driver.sluggishTapElement.testId)).tap(),
   }
 };
 

--- a/detox/test/src/Screens/ActionsScreen.js
+++ b/detox/test/src/Screens/ActionsScreen.js
@@ -16,6 +16,7 @@ import {
 import TextInput from '../Views/TextInput';
 
 const DoubleTapsText = requireNativeComponent('DetoxDoubleTapsTextView');
+const SluggishTapsText = requireNativeComponent('DetoxSluggishTapsTextView');
 
 const { width } = Dimensions.get('window');
 
@@ -83,6 +84,10 @@ export default class ActionsScreen extends Component {
           {isAndroid && <Text style={{width: 10}}> | </Text>}
           {isAndroid && <View style={{ width: 110 }}>
             <DoubleTapsText style={{ flex: 1 }}/>
+          </View>}
+          {isAndroid && <Text style={{width: 10}}> | </Text>}
+          {isAndroid && <View style={{ width: 110 }}>
+            <SluggishTapsText style={{ flex: 1 }}/>
           </View>}
         </View>
 


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #2092 and the solution has been agreed upon with maintainers.

---

**Description:**
Fixes #2092: Improved `DetoxSingleTap` such that it would monitor the time it takes to inject all events.
Note: that makes sense, since the down event is injected async'ly, and only the up event is injected sync'ly.

Applied some kotlin magic in the process. Kotlin is awesome.