### PR TITLE
Fix Android React Native 0.63.0 testee not connected

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/reactnative/idlingresources/timers/DelegatedIdleInterrogationStrategy.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/reactnative/idlingresources/timers/DelegatedIdleInterrogationStrategy.kt
@@ -19,14 +19,14 @@ private class RN62TimingModuleReflected(private val timingModule: NativeModule) 
  * of RN v0.62 (followed by a previous refactor and rename of the class).
  */
 @RNDropSupportTodo(62, """
-    When min RN version supported by Detox is 0.62.x (or higher), 
-    | can (and should) remove any usage of reflection here. That 
+    When min RN version supported by Detox is 0.62.x (or higher),
+    | can (and should) remove any usage of reflection here. That
     | includes the unit test's stub being used for that reason in particular.
     """)
 class DelegatedIdleInterrogationStrategy(timingModule: NativeModule): IdleInterrogationStrategy {
     private val timingModuleReflected = RN62TimingModuleReflected(timingModule)
 
-    override fun isIdleNow(): Boolean = timingModuleReflected.hasActiveTimers()
+    override fun isIdleNow(): Boolean = !timingModuleReflected.hasActiveTimers()
 
     companion object {
         fun createIfSupported(reactContext: ReactContext): DelegatedIdleInterrogationStrategy? {

--- a/detox/android/detox/src/test/java/com/wix/detox/reactnative/idlingresources/timers/DelegatedIdleInterrogationStrategySpec.kt
+++ b/detox/android/detox/src/test/java/com/wix/detox/reactnative/idlingresources/timers/DelegatedIdleInterrogationStrategySpec.kt
@@ -37,12 +37,12 @@ object DelegatedIdleInterrogationStrategySpec : Spek({
         fun uut() = DelegatedIdleInterrogationStrategy(timingModule)
 
         it("should be idle if timing module has no active timers") {
-            givenActiveTimersInQueue()
+            givenNoActiveTimersInQueue()
             assertThat(uut().isIdleNow()).isTrue()
         }
 
         it("should be busy if timing module has active timers") {
-            givenNoActiveTimersInQueue()
+            givenActiveTimersInQueue()
             assertThat(uut().isIdleNow()).isFalse()
         }
 


### PR DESCRIPTION
Due to wrong logic in [DelegatedIdleInterrogationStrategy.kt#L29](https://github.com/wix/Detox/blob/master/detox/android/detox/src/main/java/com/wix/detox/reactnative/idlingresources/timers/DelegatedIdleInterrogationStrategy.kt#L29)

With this wrong logic make Detox in android for React Native 0.63.0 time out with 
IdlingPolicy	These resources are not idle: [com.wix.detox.reactnative.idlingresources.timers.TimersIdlingResource]
UiControllerImpl	Waiting for: DYNAMIC_TASKS_HAVE_IDLED for 1600 iterations.
UiControllerImpl	Waiting for: DYNAMIC_TASKS_HAVE_IDLED for 1700 iterations.
UiControllerImpl	Waiting for: DYNAMIC_TASKS_HAVE_IDLED for 1800 iterations.
UiControllerImpl	Waiting for: DYNAMIC_TASKS_HAVE_IDLED for 1800 iterations.
...

- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Logic to determine TimersIdlingResource is wrong in for React Native 0.63.0 in Android
The logic should be idle when has no active timer