### PR TITLE
fix(android): installing issue on Windows

### DIFF
--- a/detox/src/devices/drivers/android/tools/FileXfer.js
+++ b/detox/src/devices/drivers/android/tools/FileXfer.js
@@ -12,7 +12,7 @@ class FileXfer {
   }
 
   async send(deviceId, sourcePath, destinationFilename) {
-    const destinationPath = path.join(this._dir, destinationFilename);
+    const destinationPath = path.posix.join(this._dir, destinationFilename);
     await this._adb.push(deviceId, sourcePath, destinationPath);
     return destinationPath;
   }


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Fixes #2178 

No idea how I can cover this with tests, honestly. E2E on Windows would do the job much better than faking the `path` module. 🤷 