### PR TITLE
Bump top-level matchers api to upper Detox layer (where they should be)

### DIFF
--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -403,7 +403,7 @@ class WaitForElement extends WaitFor {
 }
 
 class AndroidExpect {
-  constructor(invocationManager) {
+  constructor({ invocationManager }) {
     this._invocationManager = invocationManager;
 
     this.by = {

--- a/detox/src/android/expect.test.js
+++ b/detox/src/android/expect.test.js
@@ -3,7 +3,9 @@ describe('expect', () => {
 
   beforeEach(() => {
     const AndroidExpect = require('./expect');
-    e = new AndroidExpect(new MockExecutor());
+    e = new AndroidExpect({
+      invocationManager: new MockExecutor(),
+    });
   });
 
   it(`element by accessibilityLabel`, async () => {

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -89,6 +89,10 @@ class Device {
     return this.deviceDriver.name;
   }
 
+  get type() {
+    return this._deviceConfig.type;
+  }
+
   async takeScreenshot(name) {
     if (!name) {
       throw new Error('Cannot take a screenshot with an empty name.');

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -111,6 +111,11 @@ describe('Device', () => {
     expect(device.name).toEqual('mock-device-name-from-driver');
   });
 
+  it('should return the type from the configuration', async () => {
+    const device = validDevice();
+    expect(device.type).toEqual('ios.simulator');
+  });
+
   it('should return an undefined ID for an unprepared device', async() => {
     const device = validDevice();
     expect(device.id).toBeUndefined();

--- a/detox/src/devices/DriverRegistry.js
+++ b/detox/src/devices/DriverRegistry.js
@@ -10,7 +10,7 @@ class DriverRegistry {
 
     if (!DeviceDriverClass) {
       try {
-        DeviceDriverClass = resolveModuleFromPath(deviceType);
+        DeviceDriverClass = resolveModuleFromPath(deviceType).DriverClass;
       } catch (e) {
         // noop, if we don't find a module to require, we'll hit the unsupported error below
       }

--- a/detox/src/devices/DriverRegistry.test.js
+++ b/detox/src/devices/DriverRegistry.test.js
@@ -56,10 +56,12 @@ describe('DriverRegistry', () => {
 
     it('should try to resolve unknown driver as a node.js dependency', () => {
       require('../utils/resolveModuleFromPath').mockImplementation(() => {
-        return require('./drivers/__mocks__/FakeDriver');
+        return {
+          DriverClass: require('./drivers/__mocks__/FakeDriver'),
+        };
       });
 
-      const FakeDriver = require('./drivers/__mocks__/FakeDriver')
+      const FakeDriver = require('./drivers/__mocks__/FakeDriver');
       const driver = registry.resolve('fake-driver', opts);
 
       expect(driver).toBeInstanceOf(FakeDriver);

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -8,7 +8,6 @@ class DeviceDriverBase {
   constructor({ client, emitter }) {
     this.client = client;
     this.emitter = emitter;
-    this.matchers = null;
   }
 
   get name() {

--- a/detox/src/devices/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.js
@@ -4,8 +4,6 @@ const _ = require('lodash');
 const DeviceDriverBase = require('../DeviceDriverBase');
 const logger = require('../../../utils/logger');
 const log = logger.child({ __filename });
-const invoke = require('../../../invoke');
-const InvocationManager = invoke.InvocationManager;
 const ADB = require('./exec/ADB');
 const AAPT = require('./exec/AAPT');
 const APKPath = require('./tools/APKPath');
@@ -26,14 +24,12 @@ const temporaryPath = require('../../../artifacts/utils/temporaryPath');
 const sleep = require('../../../utils/sleep');
 const retry = require('../../../utils/retry');
 const getAbsoluteBinaryPath = require('../../../utils/getAbsoluteBinaryPath');
-const AndroidExpect = require('../../../android/expect');
 
 class AndroidDriver extends DeviceDriverBase {
   constructor(config) {
     super(config);
 
-    this.invocationManager = new InvocationManager(this.client);
-    this.matchers = new AndroidExpect(this.invocationManager);
+    this.invocationManager = config.invocationManager;
     this.uiDevice = new UiDeviceProxy(this.invocationManager).getUIDevice();
 
     this.adb = new ADB();

--- a/detox/src/devices/drivers/android/AndroidDriver.test.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.test.js
@@ -18,6 +18,7 @@ describe('Android driver', () => {
   let exec;
   let emitter;
   let detoxApi;
+  let invocationManager;
   beforeEach(() => {
     jest.mock('fs', () => ({
       existsSync: jest.fn(),
@@ -69,6 +70,9 @@ describe('Android driver', () => {
 
     jest.mock('../../../android/espressoapi/Detox');
     detoxApi = require('../../../android/espressoapi/Detox');
+
+    const InvocationManager = jest.genMockFromModule('../../../invoke').InvocationManager;
+    invocationManager = new InvocationManager();
   });
 
   let instrumentation;
@@ -139,21 +143,6 @@ describe('Android driver', () => {
     jest.mock('./tools/TempFileXfer', () => MockTempFileXferClass);
   });
 
-  let invocationManager;
-  beforeEach(() => {
-    class MockInvocationManagerClass {
-      constructor() {
-        Object.assign(this, invocationManager);
-      }
-    }
-
-    const InvocationManager = jest.genMockFromModule('../../../invoke').InvocationManager;
-    invocationManager = new InvocationManager();
-    jest.mock('../../../invoke', () => ({
-      InvocationManager: MockInvocationManagerClass,
-    }))
-  });
-
   let appInstallHelper;
   beforeEach(() => {
     class MockAppInstallHelperClass {
@@ -174,6 +163,7 @@ describe('Android driver', () => {
     const AndroidDriver = require('./AndroidDriver');
     uut = new AndroidDriver({
       client,
+      invocationManager,
       emitter,
     });
   });

--- a/detox/src/devices/drivers/ios/IosDriver.js
+++ b/detox/src/devices/drivers/ios/IosDriver.js
@@ -1,8 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const log = require('../../../utils/logger').child({ __filename });
 const DeviceDriverBase = require('../DeviceDriverBase');
-const InvocationManager = require('../../../invoke').InvocationManager;
 const AppleSimUtils = require('./tools/AppleSimUtils');
 
 const SimulatorLogPlugin = require('../../../artifacts/log/ios/SimulatorLogPlugin');
@@ -10,16 +8,12 @@ const SimulatorScreenshotPlugin = require('../../../artifacts/screenshot/Simulat
 const SimulatorRecordVideoPlugin = require('../../../artifacts/video/SimulatorRecordVideoPlugin');
 const SimulatorInstrumentsPlugin = require('../../../artifacts/instruments/ios/SimulatorInstrumentsPlugin');
 const TimelineArtifactPlugin = require('../../../artifacts/timeline/TimelineArtifactPlugin');
-const IosExpectTwo = require('../../../ios/expectTwo');
-
 
 class IosDriver extends DeviceDriverBase {
   constructor(config) {
     super(config);
 
     this.applesimutils = new AppleSimUtils();
-    this.matchers = new IosExpectTwo(new InvocationManager(this.client));
-    // this.matchers = new IosExpect(new InvocationManager(this.client));
   }
 
   declareArtifactPlugins() {

--- a/detox/src/ios/expectTwo.js
+++ b/detox/src/ios/expectTwo.js
@@ -540,7 +540,7 @@ function waitFor(element) {
 let _invocationManager;
 
 class IosExpect {
-  constructor(invocationManager) {
+  constructor({ invocationManager }) {
     _invocationManager = invocationManager;
     this.element = this.element.bind(this);
     this.expect = this.expect.bind(this);

--- a/detox/src/ios/expectTwo.test.js
+++ b/detox/src/ios/expectTwo.test.js
@@ -3,7 +3,9 @@ const _ = require('lodash');
 describe('expectTwo', () => {
   beforeEach(() => {
     const IosExpect = require('./expectTwo');
-    e = new IosExpect(new MockExecutor());
+    e = new IosExpect({
+      invocationManager: new MockExecutor(),
+    });
   });
 
   it(`element(by.text('tapMe')).tap()`, () => {

--- a/detox/src/ios/expectTwoApiCoverage.test.js
+++ b/detox/src/ios/expectTwoApiCoverage.test.js
@@ -3,7 +3,9 @@ describe('expectTwo API Coverage', () => {
 
   beforeEach(() => {
     const IosExpect = require('./expectTwo');
-    e = new IosExpect(new MockExecutor());
+    e = new IosExpect({
+      invocationManager: new MockExecutor(),
+    });
   });
 
 

--- a/detox/src/matchersRegistry.js
+++ b/detox/src/matchersRegistry.js
@@ -1,0 +1,15 @@
+const resolveModuleFromPath = require('./utils/resolveModuleFromPath');
+
+function resolve(device, opts) {
+  let MatcherClass;
+  switch (device.getPlatform()) {
+    case 'android': MatcherClass = require('./android/expect'); break;
+    case 'ios': MatcherClass = require('./ios/expectTwo'); break;
+    default: MatcherClass = resolveModuleFromPath(device.type).ExpectClass; break;
+  }
+  return new MatcherClass(opts);
+}
+
+module.exports = {
+  resolve,
+};

--- a/detox/src/matchersRegistry.test.js
+++ b/detox/src/matchersRegistry.test.js
@@ -1,0 +1,94 @@
+describe('Detox matchers registry', () => {
+
+  const opts = {
+    some: 'object',
+  };
+
+  let androidExpect;
+  let iosExpect;
+  let device;
+  let resolveModuleFromPath;
+  let uut;
+  beforeEach(() => {
+    androidExpect = {
+      ctor: jest.fn(),
+    };
+
+    class MockAndroidExpect {
+      constructor(...args) {
+        this.mockName = 'mock-android-expect';
+        androidExpect.ctor(...args);
+      }
+    }
+    jest.mock('./android/expect', () => MockAndroidExpect);
+
+    iosExpect = {
+      ctor: jest.fn(),
+    }
+    class MockIosExpect {
+      constructor(...args) {
+        this.mockName = 'mock-ios-expect';
+        iosExpect.ctor(...args);
+      }
+    }
+    jest.mock('./ios/expectTwo', () => MockIosExpect);
+
+    class MockExternalModuleExpect {
+      constructor() {
+        this.mockName = 'external-module-expect';
+      }
+    }
+    jest.mock('./utils/resolveModuleFromPath');
+    resolveModuleFromPath = require('./utils/resolveModuleFromPath');
+    resolveModuleFromPath.mockReturnValue({
+      ExpectClass: MockExternalModuleExpect,
+    });
+
+    device = {
+      getPlatform: jest.fn(),
+    };
+
+    uut = require('./matchersRegistry');
+  });
+
+  const withAndroidDevice = () => device.getPlatform.mockReturnValue('android');
+  const withIosDevice = () => device.getPlatform.mockReturnValue('ios');
+  const withUnknownDevice = (deviceType) => {
+    device.getPlatform.mockReturnValue(undefined);
+    device.type = deviceType;
+  }
+
+  it('should resolve the Android matchers', () => {
+    withAndroidDevice();
+    const result = uut.resolve(device);
+    expect(result.mockName).toEqual('mock-android-expect');
+  });
+
+  it('should init the matchers with opts', () => {
+    withAndroidDevice();
+
+    uut.resolve(device, opts);
+    expect(androidExpect.ctor).toHaveBeenCalledWith(opts);
+  });
+
+  it('should resolve the iOS matchers', () => {
+    withIosDevice();
+    const result = uut.resolve(device);
+    expect(result.mockName).toEqual('mock-ios-expect');
+  });
+
+  it('should init the ios-matchers with opts', () => {
+    withIosDevice();
+    uut.resolve(device, opts);
+    expect(iosExpect.ctor).toHaveBeenCalledWith(opts);
+  });
+
+  it('should resort to type-as-path based resolution if platform is not recognized', () => {
+    const deviceType = './path/to/external/module/index.js';
+    withUnknownDevice(deviceType);
+
+    const result = uut.resolve(device, opts);
+    expect(result.mockName).toEqual('external-module-expect');
+    expect(resolveModuleFromPath).toHaveBeenCalledWith(deviceType);
+  });
+});

--- a/examples/demo-plugin/driver.js
+++ b/examples/demo-plugin/driver.js
@@ -2,7 +2,7 @@ const DeviceDriverBase = require('detox/src/devices/drivers/DeviceDriverBase');
 const Client = require('detox/src/client/Client');
 
 class Expect {
-  constructor(invocationManager) {
+  constructor({ invocationManager }) {
     this._invocationManager = invocationManager;
 
     this.by = {
@@ -106,9 +106,8 @@ class PluginTestee {
 class PluginDriver extends DeviceDriverBase {
   constructor(config) {
     super(config);
-    this.matchers = {};
+
     this.testee = new PluginTestee(config);
-    this.matchers = new Expect();
   }
 
   async launchApp(deviceId, bundleId, launchArgs, languageAndLocale) {
@@ -146,4 +145,7 @@ class PluginDriver extends DeviceDriverBase {
   }
 }
 
-module.exports = PluginDriver;
+module.exports = {
+  DriverClass: PluginDriver,
+  ExpectClass: Expect,
+};


### PR DESCRIPTION
- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

## Description

Relates to #2012: lays some preliminary ground work so that we could introduce it with proper API.

### Dive-in

Looking at the current software architecture of Detox at a high-level perspective, we see two main **distinct** units, top-to-bottom:
1. A framework for providing `expect` and element-interactions as a top-level, user-facing API (e.g. `element(by.id(testId)).tap()`), which in turn uses a distinct, platform-specific node-side (JS) implementation that eventually directly triggers device-side logic using `invoke`.
2. A framework for providing element-less, device-scope, top-level, user-facing APIs (e.g. `device.takeScreenshot()`), which are provided mainly by the (currently) singleton `Device` object, that in turns delegates platform-specific logic to Drivers.

While the two global _units_ are, in principle, agnostic, we've nevertheless created an artificial coupling between them, as the top-level implementation of unit 1 is created via the drivers of unit 2, due to convenience ([example](https://github.com/wix/Detox/blob/78bc945bc5dbf15c116cceb790c8ae5c9aac9af4/detox/src/devices/drivers/android/AndroidDriver.js#L36)). Unfortunately, this type of an unnecessary coupling - as a rule of thumb, damages flexibility, and we can see it in the case of elements' screenshot.

The pseudo-code implementation of taking an element screenshot is as follows:
a. `Invoke` an on-test-device, native method that creates an on-device `.png` file.
b. Pull the image back to the host through the driver (e.g. using `adb`) and provide the path back to the caller.

Ideally, this top-level API for doing this would be amazing:
```js
const screenshotFilePath = await element(by.id('fancy-element-id')).takeScreenshot()`
```

But due to the coupling mentioned earlier, this cannot be done, as the underlying `Element.takeScreenshot()` function that would implement this -- originally generated by driver, cannot access the `device` in _part b_ of the pseudo-code (!) It more so artificially forces us onto this kind of an API, which is largely undesired as it is both not friendly and would encourage code duplication and single-responsibility breakage in Detox itself:

```js
const screenshotFilePath = await device.takeScreenshot( element(by.id('fancy-element-id')) );
```

If we want to nevertheless stick to the API that we really want - and with that, empower high flexibility in Detox (yes, gimme all those things!), we need to break the coupling.

**This is the scope of this PR:** 100% Separating drivers and matchers, and their creation. Instead of having the matchers created by the drivers, we delegate the proper matcher resolution to a new util called `matchersRegistry` (equilvant to `driverRegistry`), which is utilized in the Detox class (aka our Detox _main_ layer).

Unfortunately, the main drawback is a minor breakage of external-drivers implementation: Whichever plugin-driver implementations that exist out there in the wild -- they _still provide the matchers through the driver._ Fortunately, I've made the migration pretty easy. Given a plugin `driver.js`, users will have to apply these minor changes:
```diff
class Expect {
-  constructor(invocationManager) {
+  constructor({ invocationManager }) {
     this._invocationManager = invocationManager;
  }
}

class PluginDriver {
  constructor() {
-    this.matchers = new Expect(new invocationManager());
+    // no this.matchers init here...
  }
}

-module.exports = PluginDriver;
+module.exports = {
+  DriverClass: PluginDriver,
+  ExpectClass: Expect,
+}
```