### PR TITLE
fix: biometric unmatching timeout

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -148,7 +148,6 @@ class Device {
 
   async unmatchFace() {
     await this.deviceDriver.unmatchFace(this._deviceId);
-    await this.deviceDriver.waitForActive();
   }
 
   async matchFinger() {
@@ -158,7 +157,6 @@ class Device {
 
   async unmatchFinger() {
     await this.deviceDriver.unmatchFinger(this._deviceId);
-    await this.deviceDriver.waitForActive();
   }
 
   async shake() {


### PR DESCRIPTION
- [x] This is a small change 

Related PR: https://github.com/wix/Detox/pull/1605

Currently attempting to _unmatch_ biometrics always times out. This is because of the `waitForActive` line: as the unmatch command allows the user to retry (up to 3 times), the biometric prompt is still active, so the device driver remains inactive, and `waitForActive` never resolves.