### PR TITLE
Allow for setting rn-context load time in DetoxTest

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -8,6 +8,9 @@ import android.os.Bundle;
 import android.os.Looper;
 import android.util.Log;
 
+import com.wix.detox.config.DetoxConfig;
+import com.wix.detox.config.DetoxIdlePolicyConfig;
+
 import java.util.concurrent.TimeUnit;
 
 import androidx.annotation.NonNull;
@@ -79,18 +82,23 @@ public final class Detox {
 
     /**
      * Specification of values to use for Espresso's {@link IdlingPolicies} timeouts.
-     * <br/>Overrides Espresso's defaults as they tend to be too short (e.g. when running on heavy-load app
+     * <br/>Overrides Espresso's defaults as they tend to be too short (e.g. when running a heavy-load app
      * on suboptimal CI machines).
+     *
+     * @deprecated Use {@link com.wix.detox.config.DetoxConfig}.
      */
+    @Deprecated
     public static class DetoxIdlePolicyConfig {
         /** Directly binds to {@link IdlingPolicies#setMasterPolicyTimeout(long, TimeUnit)}. Applied in seconds. */
         public Integer masterTimeoutSec = 120;
         /** Directly binds to {@link IdlingPolicies#setIdlingResourceTimeout(long, TimeUnit)}. Applied in seconds. */
         public Integer idleResourceTimeoutSec = 60;
 
-        void apply() {
-            IdlingPolicies.setMasterPolicyTimeout(masterTimeoutSec, TimeUnit.SECONDS);
-            IdlingPolicies.setIdlingResourceTimeout(idleResourceTimeoutSec, TimeUnit.SECONDS);
+        private com.wix.detox.config.DetoxIdlePolicyConfig toNewConfig() {
+            com.wix.detox.config.DetoxIdlePolicyConfig newConfig = new com.wix.detox.config.DetoxIdlePolicyConfig();
+            newConfig.setMasterTimeoutSec(masterTimeoutSec);
+            newConfig.setIdleResourceTimeoutSec(idleResourceTimeoutSec);
+            return newConfig;
         }
     }
 
@@ -115,11 +123,24 @@ public final class Detox {
 
     /**
      * Same as the default {@link #runTests(ActivityTestRule)} method, but allows for the explicit specification of
+     * various configurations. Note: review {@link DetoxConfig} for defaults.
+     *
+     * @param detoxConfig The configurations to apply.
+     */
+    public static void runTests(ActivityTestRule activityTestRule, DetoxConfig detoxConfig) {
+        runTests(activityTestRule, getAppContext(), detoxConfig);
+    }
+
+    /**
+     * Same as the default {@link #runTests(ActivityTestRule)} method, but allows for the explicit specification of
      * a custom idle-policy configuration. Note: review {@link DetoxIdlePolicyConfig} for defaults.
      *
      * @param idlePolicyConfig The custom idle-policy configuration to pass in; Will be applied into Espresso via
      *                         the {@link IdlingPolicies} API.
+     *
+     * @deprecated Use {@link #runTests(ActivityTestRule, DetoxConfig)}
      */
+    @Deprecated
     public static void runTests(ActivityTestRule activityTestRule, DetoxIdlePolicyConfig idlePolicyConfig) {
         runTests(activityTestRule, getAppContext(), idlePolicyConfig);
     }
@@ -140,7 +161,7 @@ public final class Detox {
      * @param context an object that has a {@code getReactNativeHost()} method
      */
     public static void runTests(ActivityTestRule activityTestRule, @NonNull final Context context) {
-        runTests(activityTestRule, context, new DetoxIdlePolicyConfig());
+        runTests(activityTestRule, context, new DetoxConfig());
     }
 
     /**
@@ -150,9 +171,26 @@ public final class Detox {
      *
      * @param idlePolicyConfig The custom idle-policy configuration to pass in; Will be applied into Espresso via
      *                         the {@link IdlingPolicies} API.
+     *
+     * @deprecated Use {@link #runTests(ActivityTestRule, Context, DetoxConfig)}
      */
+    @Deprecated
     public static void runTests(ActivityTestRule activityTestRule, @NonNull final Context context, DetoxIdlePolicyConfig idlePolicyConfig) {
-        idlePolicyConfig.apply();
+        DetoxConfig config = new DetoxConfig();
+        config.setIdlePolicyConfig(idlePolicyConfig.toNewConfig());
+
+        runTests(activityTestRule, context, config);
+    }
+
+    /**
+     * Same as {@link #runTests(ActivityTestRule, Context)}, but allows for the explicit specification of
+     * various configurations. Note: review {@link DetoxConfig} for defaults.
+     *
+     * @param detoxConfig The configurations to apply.
+     */
+    public static void runTests(ActivityTestRule activityTestRule, @NonNull final Context context, DetoxConfig detoxConfig) {
+        DetoxConfig.CONFIG = detoxConfig;
+        detoxConfig.apply();
 
         sActivityTestRule = activityTestRule;
 

--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -9,7 +9,6 @@ import android.os.Looper;
 import android.util.Log;
 
 import com.wix.detox.config.DetoxConfig;
-import com.wix.detox.config.DetoxIdlePolicyConfig;
 
 import java.util.concurrent.TimeUnit;
 
@@ -96,8 +95,8 @@ public final class Detox {
 
         private com.wix.detox.config.DetoxIdlePolicyConfig toNewConfig() {
             com.wix.detox.config.DetoxIdlePolicyConfig newConfig = new com.wix.detox.config.DetoxIdlePolicyConfig();
-            newConfig.setMasterTimeoutSec(masterTimeoutSec);
-            newConfig.setIdleResourceTimeoutSec(idleResourceTimeoutSec);
+            newConfig.masterTimeoutSec = masterTimeoutSec;
+            newConfig.idleResourceTimeoutSec = idleResourceTimeoutSec;
             return newConfig;
         }
     }
@@ -177,7 +176,7 @@ public final class Detox {
     @Deprecated
     public static void runTests(ActivityTestRule activityTestRule, @NonNull final Context context, DetoxIdlePolicyConfig idlePolicyConfig) {
         DetoxConfig config = new DetoxConfig();
-        config.setIdlePolicyConfig(idlePolicyConfig.toNewConfig());
+        config.idlePolicyConfig = idlePolicyConfig.toNewConfig();
 
         runTests(activityTestRule, context, config);
     }

--- a/detox/android/detox/src/main/java/com/wix/detox/common/DetoxErrors.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/common/DetoxErrors.java
@@ -1,12 +1,12 @@
-package com.wix.detox.espresso;
+package com.wix.detox.common;
 
-interface DetoxErrors {
+public interface DetoxErrors {
     class DetoxRuntimeException extends RuntimeException {
-        DetoxRuntimeException(Throwable cause) {
+        public DetoxRuntimeException(Throwable cause) {
             super(cause);
         }
 
-        DetoxRuntimeException(String message) {
+        public DetoxRuntimeException(String message) {
             super(message);
         }
     }
@@ -16,7 +16,7 @@ interface DetoxErrors {
      * example, scrolling a view when it's already at the scrollable limit.
      */
     class StaleActionException extends DetoxRuntimeException {
-        StaleActionException(Throwable cause) {
+        public StaleActionException(Throwable cause) {
             super(cause);
         }
     }

--- a/detox/android/detox/src/main/java/com/wix/detox/config/DetoxConfig.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/config/DetoxConfig.kt
@@ -1,11 +1,11 @@
 package com.wix.detox.config
 
 class DetoxConfig {
-    var idlePolicyConfig: DetoxIdlePolicyConfig? = DetoxIdlePolicyConfig()
-    var rnContextLoadTimeoutSec = 60
+    @JvmField var idlePolicyConfig: DetoxIdlePolicyConfig = DetoxIdlePolicyConfig()
+    @JvmField var rnContextLoadTimeoutSec = 60
 
     fun apply() {
-        idlePolicyConfig?.apply()
+        idlePolicyConfig.apply()
     }
 
     companion object {

--- a/detox/android/detox/src/main/java/com/wix/detox/config/DetoxConfig.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/config/DetoxConfig.kt
@@ -1,0 +1,14 @@
+package com.wix.detox.config
+
+class DetoxConfig {
+    var idlePolicyConfig: DetoxIdlePolicyConfig? = DetoxIdlePolicyConfig()
+    var rnContextLoadTimeoutSec = 60
+
+    fun apply() {
+        idlePolicyConfig?.apply()
+    }
+
+    companion object {
+        lateinit var CONFIG: DetoxConfig
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/config/DetoxIdlePolicyConfig.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/config/DetoxIdlePolicyConfig.kt
@@ -1,0 +1,23 @@
+package com.wix.detox.config
+
+import androidx.test.espresso.IdlingPolicies
+import java.util.concurrent.TimeUnit
+
+/**
+ * Specification of values to use for Espresso's {@link IdlingPolicies} timeouts.
+ *
+ * Overrides Espresso's defaults as they tend to be too short (e.g. when running a heavy-load app
+ * on suboptimal CI machines).
+ */
+class DetoxIdlePolicyConfig {
+    /** Directly binds to [IdlingPolicies.setMasterPolicyTimeout]. Applied in seconds.  */
+    var masterTimeoutSec = 120
+
+    /** Directly binds to [IdlingPolicies.setIdlingResourceTimeout]. Applied in seconds.  */
+    var idleResourceTimeoutSec = 60
+
+    fun apply() {
+        IdlingPolicies.setMasterPolicyTimeout(masterTimeoutSec.toLong(), TimeUnit.SECONDS)
+        IdlingPolicies.setIdlingResourceTimeout(idleResourceTimeoutSec.toLong(), TimeUnit.SECONDS)
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/config/DetoxIdlePolicyConfig.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/config/DetoxIdlePolicyConfig.kt
@@ -11,10 +11,10 @@ import java.util.concurrent.TimeUnit
  */
 class DetoxIdlePolicyConfig {
     /** Directly binds to [IdlingPolicies.setMasterPolicyTimeout]. Applied in seconds.  */
-    var masterTimeoutSec = 120
+    @JvmField var masterTimeoutSec = 120
 
     /** Directly binds to [IdlingPolicies.setIdlingResourceTimeout]. Applied in seconds.  */
-    var idleResourceTimeoutSec = 60
+    @JvmField var idleResourceTimeoutSec = 60
 
     fun apply() {
         IdlingPolicies.setMasterPolicyTimeout(masterTimeoutSec.toLong(), TimeUnit.SECONDS)

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxAction.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxAction.java
@@ -2,8 +2,8 @@ package com.wix.detox.espresso;
 
 import android.view.View;
 
-import com.wix.detox.espresso.DetoxErrors.DetoxRuntimeException;
-import com.wix.detox.espresso.DetoxErrors.StaleActionException;
+import com.wix.detox.common.DetoxErrors.DetoxRuntimeException;
+import com.wix.detox.common.DetoxErrors.StaleActionException;
 import com.wix.detox.espresso.action.DetoxMultiTap;
 import com.wix.detox.espresso.action.RNClickAction;
 import com.wix.detox.espresso.action.TakeViewScreenshotAction;

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxAssertion.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxAssertion.java
@@ -2,8 +2,8 @@ package com.wix.detox.espresso;
 
 import android.view.View;
 
-import com.wix.detox.espresso.DetoxErrors.DetoxRuntimeException;
-import com.wix.detox.espresso.DetoxErrors.StaleActionException;
+import com.wix.detox.common.DetoxErrors.DetoxRuntimeException;
+import com.wix.detox.common.DetoxErrors.StaleActionException;
 
 import junit.framework.AssertionFailedError;
 

--- a/detox/android/detox/src/main/java/com/wix/detox/reactnative/ReactNativeLoadingMonitor.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/reactnative/ReactNativeLoadingMonitor.kt
@@ -5,6 +5,8 @@ import android.util.Log
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.bridge.ReactContext
+import com.wix.detox.common.DetoxErrors
+import com.wix.detox.config.DetoxConfig
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -13,7 +15,8 @@ private const val LOG_TAG = "DetoxRNLoading"
 open class ReactNativeLoadingMonitor(
         private val instrumentation: Instrumentation,
         private val rnApplication: ReactApplication,
-        private val previousReactContext: ReactContext?) {
+        private val previousReactContext: ReactContext?,
+        private val config: DetoxConfig = DetoxConfig.CONFIG) {
     val countDownLatch = CountDownLatch(1)
 
     fun getNewContext(): ReactContext? {
@@ -50,10 +53,11 @@ open class ReactNativeLoadingMonitor(
             try {
                 if (!countDownLatch.await(1, TimeUnit.SECONDS)) {
                     i++
-                    if (i >= 60) {
+                    if (i >= config.rnContextLoadTimeoutSec) {
+
                         // First load can take a lot of time. (packager)
                         // Loads afterwards should take less than a second.
-                        throw RuntimeException("waited a whole minute for the new RN-context")
+                        throw DetoxErrors.DetoxRuntimeException("Waited for the new RN-context for too long! (${config.rnContextLoadTimeoutSec} seconds)")
                     }
                 } else {
                     break

--- a/detox/android/detox/src/main/java/com/wix/detox/reactnative/ReactNativeLoadingMonitor.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/reactnative/ReactNativeLoadingMonitor.kt
@@ -54,7 +54,6 @@ open class ReactNativeLoadingMonitor(
                 if (!countDownLatch.await(1, TimeUnit.SECONDS)) {
                     i++
                     if (i >= config.rnContextLoadTimeoutSec) {
-
                         // First load can take a lot of time. (packager)
                         // Loads afterwards should take less than a second.
                         throw DetoxErrors.DetoxRuntimeException("Waited for the new RN-context for too long! (${config.rnContextLoadTimeoutSec} seconds)")

--- a/detox/android/detox/src/main/java/com/wix/detox/reactnative/ReactNativeLoadingMonitor.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/reactnative/ReactNativeLoadingMonitor.kt
@@ -56,7 +56,10 @@ open class ReactNativeLoadingMonitor(
                     if (i >= config.rnContextLoadTimeoutSec) {
                         // First load can take a lot of time. (packager)
                         // Loads afterwards should take less than a second.
-                        throw DetoxErrors.DetoxRuntimeException("Waited for the new RN-context for too long! (${config.rnContextLoadTimeoutSec} seconds)")
+                        throw DetoxErrors.DetoxRuntimeException(
+                                """Waited for the new RN-context for too long! (${config.rnContextLoadTimeoutSec} seconds)
+                                  |If you think that's not long enough, consider applying a custom Detox runtime-config in DetoxTest.runTests()."""
+                                .trimMargin())
                     }
                 } else {
                     break

--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -5,6 +5,7 @@ import android.view.Surface;
 
 import com.linkedin.android.testbutler.TestButler;
 import com.wix.detox.Detox;
+import com.wix.detox.config.DetoxConfig;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -5,7 +5,6 @@ import android.view.Surface;
 
 import com.linkedin.android.testbutler.TestButler;
 import com.wix.detox.Detox;
-import com.wix.detox.config.DetoxConfig;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/examples/demo-react-native/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/examples/demo-react-native/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -2,6 +2,8 @@
 package com.example;
 
 import com.wix.detox.Detox;
+import com.wix.detox.config.DetoxConfig;
+import com.wix.detox.config.DetoxIdlePolicyConfig;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,7 +16,6 @@ import androidx.test.rule.ActivityTestRule;
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class DetoxTest {
-
     @Rule
     // Replace 'MainActivity' with the value of android:name entry in 
     // <activity> in AndroidManifest.xml
@@ -22,10 +23,14 @@ public class DetoxTest {
 
     @Test
     public void runDetoxTests() {
-        Detox.DetoxIdlePolicyConfig idlePolicyConfig = new Detox.DetoxIdlePolicyConfig();
-        idlePolicyConfig.masterTimeoutSec = 60;
-        idlePolicyConfig.idleResourceTimeoutSec = 30;
+        DetoxIdlePolicyConfig idlePolicyConfig = new DetoxIdlePolicyConfig();
+        idlePolicyConfig.setMasterTimeoutSec(90);
+        idlePolicyConfig.setIdleResourceTimeoutSec(60);
 
-        Detox.runTests(mActivityRule, idlePolicyConfig);
+        DetoxConfig detoxConfig = new DetoxConfig();
+        detoxConfig.setIdlePolicyConfig(idlePolicyConfig);
+        detoxConfig.setRnContextLoadTimeoutSec(com.example.BuildConfig.DEBUG ? 180 : 60);
+
+        Detox.runTests(mActivityRule, detoxConfig);
     }
 }

--- a/examples/demo-react-native/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/examples/demo-react-native/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -3,7 +3,6 @@ package com.example;
 
 import com.wix.detox.Detox;
 import com.wix.detox.config.DetoxConfig;
-import com.wix.detox.config.DetoxIdlePolicyConfig;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,13 +22,10 @@ public class DetoxTest {
 
     @Test
     public void runDetoxTests() {
-        DetoxIdlePolicyConfig idlePolicyConfig = new DetoxIdlePolicyConfig();
-        idlePolicyConfig.setMasterTimeoutSec(90);
-        idlePolicyConfig.setIdleResourceTimeoutSec(60);
-
         DetoxConfig detoxConfig = new DetoxConfig();
-        detoxConfig.setIdlePolicyConfig(idlePolicyConfig);
-        detoxConfig.setRnContextLoadTimeoutSec(com.example.BuildConfig.DEBUG ? 180 : 60);
+        detoxConfig.idlePolicyConfig.masterTimeoutSec = 90;
+        detoxConfig.idlePolicyConfig.idleResourceTimeoutSec = 60;
+        detoxConfig.rnContextLoadTimeoutSec = (com.example.BuildConfig.DEBUG ? 180 : 60);
 
         Detox.runTests(mActivityRule, detoxConfig);
     }


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Resolves #2197. Migrates Detox' idle-policy config to a more generic config structure (that handles idle-policy as well), such that it can also hold a custom timeout for waiting for RN's loading to complete. That enables, for example, the customization of the timeout based on whether the app running in debug mode rather than release - where this can take longer for large apps. See [here](https://github.com/wix/Detox/pull/2231/files#diff-8c8eebd6512cc7aeed7d36a9bdc0b170R32).