### PR TITLE
View hierarchy dumping on demand and on error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,3 +15,6 @@
 [submodule "detox/ios/DTXObjectiveCHelpers"]
 	path = detox/ios/DTXObjectiveCHelpers
 	url = https://github.com/wix/DTXObjectiveCHelpers.git
+[submodule "detox/ios/LNViewHierarchyDumper"]
+	path = detox/ios/LNViewHierarchyDumper
+	url = https://github.com/LeoNatan/LNViewHierarchyDumper.git

--- a/detox/ios/Detox.xcodeproj/project.pbxproj
+++ b/detox/ios/Detox.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		394767D51DBF98D900D72256 /* WXRunLoopIdlingResource.m in Sources */ = {isa = PBXBuildFile; fileRef = 394767CC1DBF98D900D72256 /* WXRunLoopIdlingResource.m */; };
 		394767F61DBF994200D72256 /* SocketRocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 394767E71DBF992400D72256 /* SocketRocket.framework */; };
 		394767F71DBF994500D72256 /* EarlGrey.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 394767DC1DBF991E00D72256 /* EarlGrey.framework */; };
+		39477C2824D1C92700D87E1C /* LNViewHierarchyDumper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39477C2224D1C91B00D87E1C /* LNViewHierarchyDumper.framework */; };
+		39477C2924D1C92700D87E1C /* LNViewHierarchyDumper.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 39477C2224D1C91B00D87E1C /* LNViewHierarchyDumper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		394D589C1E50B59400556DB9 /* NSBundle+TestsFix.m in Sources */ = {isa = PBXBuildFile; fileRef = 394D589B1E50B59400556DB9 /* NSBundle+TestsFix.m */; };
 		396EA67A22E0AE7D0087E4D4 /* ___DTXAddressInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 396EA67222E0AE7C0087E4D4 /* ___DTXAddressInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		396EA67B22E0AE7D0087E4D4 /* ___DTXAddressInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 396EA67922E0AE7C0087E4D4 /* ___DTXAddressInfo.mm */; };
@@ -216,6 +218,20 @@
 			remoteGlobalIDString = FD1000E81C5B466F00B2DB0A;
 			remoteInfo = EarlGrey;
 		};
+		39477C2124D1C91B00D87E1C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 39477C1C24D1C91B00D87E1C /* LNViewHierarchyDumper.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 39CA7FF524AEA316009883BC;
+			remoteInfo = LNViewHierarchyDumper;
+		};
+		39477C2A24D1C93000D87E1C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 39477C1C24D1C91B00D87E1C /* LNViewHierarchyDumper.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 39CA7FF424AEA316009883BC;
+			remoteInfo = LNViewHierarchyDumper;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -225,6 +241,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				39477C2924D1C92700D87E1C /* LNViewHierarchyDumper.framework in CopyFiles */,
 				39319D7A1FCA0DA70045BC17 /* COSTouchVisualizer.framework in CopyFiles */,
 				39C3C3531DBF9A19008177E1 /* SocketRocket.framework in CopyFiles */,
 				39C3C3511DBF9A13008177E1 /* EarlGrey.framework in CopyFiles */,
@@ -278,6 +295,7 @@
 		394767CC1DBF98D900D72256 /* WXRunLoopIdlingResource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WXRunLoopIdlingResource.m; sourceTree = "<group>"; };
 		394767D71DBF991E00D72256 /* EarlGrey.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = EarlGrey.xcodeproj; path = EarlGrey/EarlGrey.xcodeproj; sourceTree = "<group>"; };
 		394767DD1DBF992400D72256 /* SocketRocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SocketRocket.xcodeproj; path = SocketRocket/SocketRocket.xcodeproj; sourceTree = "<group>"; };
+		39477C1C24D1C91B00D87E1C /* LNViewHierarchyDumper.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LNViewHierarchyDumper.xcodeproj; path = LNViewHierarchyDumper/LNViewHierarchyDumper/LNViewHierarchyDumper.xcodeproj; sourceTree = "<group>"; };
 		394D589A1E50B59400556DB9 /* NSBundle+TestsFix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSBundle+TestsFix.h"; sourceTree = "<group>"; };
 		394D589B1E50B59400556DB9 /* NSBundle+TestsFix.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+TestsFix.m"; sourceTree = "<group>"; };
 		396EA67222E0AE7C0087E4D4 /* ___DTXAddressInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "___DTXAddressInfo.h"; sourceTree = "<group>"; };
@@ -386,6 +404,7 @@
 			files = (
 				39C32A6D247AC31100C1BC96 /* libswiftCore.tbd in Frameworks */,
 				393E66ED1FC5F3F40092EE89 /* COSTouchVisualizer.framework in Frameworks */,
+				39477C2824D1C92700D87E1C /* LNViewHierarchyDumper.framework in Frameworks */,
 				394767F71DBF994500D72256 /* EarlGrey.framework in Frameworks */,
 				394767F61DBF994200D72256 /* SocketRocket.framework in Frameworks */,
 				3980D12E244C41E1004812DD /* IOKit.framework in Frameworks */,
@@ -562,6 +581,7 @@
 		394767D61DBF990F00D72256 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				39477C1C24D1C91B00D87E1C /* LNViewHierarchyDumper.xcodeproj */,
 				39C32A6C247AC31100C1BC96 /* libswiftCore.tbd */,
 				3980D12D244C41E1004812DD /* IOKit.framework */,
 				393E66E11FC5F3E90092EE89 /* COSTouchVisualizer.xcodeproj */,
@@ -588,6 +608,14 @@
 				394767ED1DBF992400D72256 /* SocketRocket.framework */,
 				394767EF1DBF992400D72256 /* SocketRocketTests-iOS.xctest */,
 				394767F11DBF992400D72256 /* TestChat.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		39477C1D24D1C91B00D87E1C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				39477C2224D1C91B00D87E1C /* LNViewHierarchyDumper.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -792,6 +820,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				39477C2B24D1C93000D87E1C /* PBXTargetDependency */,
 				393E67021FC728360092EE89 /* PBXTargetDependency */,
 				394767F51DBF993900D72256 /* PBXTargetDependency */,
 				394767F31DBF993400D72256 /* PBXTargetDependency */,
@@ -841,6 +870,10 @@
 				{
 					ProductGroup = 394767D81DBF991E00D72256 /* Products */;
 					ProjectRef = 394767D71DBF991E00D72256 /* EarlGrey.xcodeproj */;
+				},
+				{
+					ProductGroup = 39477C1D24D1C91B00D87E1C /* Products */;
+					ProjectRef = 39477C1C24D1C91B00D87E1C /* LNViewHierarchyDumper.xcodeproj */;
 				},
 				{
 					ProductGroup = 394767DE1DBF992400D72256 /* Products */;
@@ -910,6 +943,13 @@
 			fileType = wrapper.application;
 			path = TestChat.app;
 			remoteRef = 394767F01DBF992400D72256 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		39477C2224D1C91B00D87E1C /* LNViewHierarchyDumper.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = LNViewHierarchyDumper.framework;
+			remoteRef = 39477C2124D1C91B00D87E1C /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -1035,6 +1075,11 @@
 			isa = PBXTargetDependency;
 			name = EarlGrey;
 			targetProxy = 394767F41DBF993900D72256 /* PBXContainerItemProxy */;
+		};
+		39477C2B24D1C93000D87E1C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = LNViewHierarchyDumper;
+			targetProxy = 39477C2A24D1C93000D87E1C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/detox/ios/Detox/Next/DetoxManager.swift
+++ b/detox/ios/Detox/Next/DetoxManager.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import EarlGrey
+import LNViewHierarchyDumper
 
 fileprivate let recordingManager : DetoxInstrumentsManager = {
 	return DetoxInstrumentsManager()
@@ -258,6 +259,12 @@ public class DetoxManager : NSObject, WebSocketDelegate {
 						let params: NSMutableDictionary = ["details": error.localizedDescription]
 						params.addEntries(from: (error as NSError).userInfo)
 						
+						let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("\(NSUUID().uuidString).viewhierarchy")
+						do {
+							try LNViewHierarchyDumper.shared.dumpViewHierarchy(to: url)
+							params["viewHierarchyURL"] = url.path
+						} catch {}
+						
 						self.safeSend(action: "testFailed", params: params as! [String : Any], messageId: messageId)
 					} else {
 						self.safeSend(action: "invokeResult", params: result ?? [:], messageId: messageId)
@@ -368,6 +375,16 @@ public class DetoxManager : NSObject, WebSocketDelegate {
 		case "loginSuccess":
 			log.info("Successfully logged in")
 			return
+		case "captureViewHierarchy":
+			let url = URL(fileURLWithPath: params["viewHierarchyURL"] as! String)
+			precondition(url.lastPathComponent.hasSuffix(".viewhierarchy"), "Provided view Hierarchy URL is not in the expected format, ending with “.viewhierarchy”")
+			var rvParams: [String: Any] = [:]
+			do {
+				try LNViewHierarchyDumper.shared.dumpViewHierarchy(to: url)
+			} catch {
+				rvParams["captureViewHierarchyError"] = error.localizedDescription
+			}
+			self.webSocket.sendAction(done, params: rvParams, messageId: messageId)
 		default:
 			fatalError("Unknown action type received: \(type)")
 		}

--- a/detox/ios/Detox/Next/Utilities/UIView+DetoxUtils.m
+++ b/detox/ios/Detox/Next/Utilities/UIView+DetoxUtils.m
@@ -140,50 +140,6 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 	return [self hitTest:point withEvent:event];
 }
 
-- (UIView*)dtx_visTest_faster:(CGPoint)point withEvent:(UIEvent *)event lookingFor:(UIView*)lookingFor
-{
-	if(self.isHiddenOrHasHiddenAncestor == YES)
- 	{
- 		return nil;
- 	}
-
- 	if(self.alpha == 0.0)
- 	{
- 		return nil;
- 	}
-
- 	if([self pointInside:point withEvent:event] == NO)
- 	{
- 		return nil;
- 	}
-
- 	__block UIView* rv;
-
- 	NSMutableOrderedSet<UIView*>* candidates = [NSMutableOrderedSet new];
-
- 	//Front-most views get priority
- 	[self.subviews enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(__kindof UIView * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
- 		CGPoint localPoint = [self convertPoint:point toView:obj];
-
- 		UIView* candidate = [obj dtx_visTest:localPoint withEvent:event lookingFor:lookingFor];
-
- 		if(candidate != nil)
- 		{
- 			[candidates addObject:candidate];
- 		}
- 	}];
-
- 	//TODO: Consider some strategy to tackle "visible" views under transparent views.
- 	rv = candidates.firstObject;
-
- 	if(rv == nil)
- 	{
- 		rv = self;
- 	}
-
- 	return rv;
-}
-
 - (UIView*)dtx_visTest:(CGPoint)point withEvent:(UIEvent *)event lookingFor:(UIView*)lookingFor
 {
 	if(self.isHiddenOrHasHiddenAncestor == YES)
@@ -228,7 +184,7 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 	{
 		//Check the candidate view for transparency
 		UIImage* img = [self dtx_imageAroundPoint:point];
-		[UIImagePNGRepresentation(img) writeToFile:@"/Users/lnatan/Desktop/view.png" atomically:YES];
+//		[UIImagePNGRepresentation(img) writeToFile:@"/Users/lnatan/Desktop/view.png" atomically:YES];
 		if([UIView _dtx_isImageTransparent:img] == NO)
 		{
 			//If a view is not transparent around the hit point, take it as the visible view.
@@ -467,7 +423,7 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 	CGFloat x = MAX(0, point.x - width / 2.0);
 	CGFloat y = MAX(0, point.y - height / 2.0);
 	
-	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+	CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
 	if (colorSpace == NULL)
 	{
 		return nil;
@@ -476,7 +432,7 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 		CGColorSpaceRelease(colorSpace);
 	};
 	
-	CGContextRef context = CGBitmapContextCreate(NULL, width, height, 8, width * 4, colorSpace, (CGBitmapInfo)kCGImageAlphaPremultipliedFirst);
+	CGContextRef context = CGBitmapContextCreate(NULL, width, height, 8, width * 4, colorSpace, (CGBitmapInfo)kCGImageAlphaPremultipliedLast);
 	if(context == NULL)
 	{
 		return nil;

--- a/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.js
+++ b/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.js
@@ -1,0 +1,81 @@
+const Client = require('../../client/Client');
+const ArtifactPlugin = require('../templates/plugin/ArtifactPlugin');
+const FileArtifact = require('../templates/artifact/FileArtifact');
+const setUniqueProperty = require('../../utils/setUniqueProperty');
+
+class IosUIHierarchyPlugin extends ArtifactPlugin {
+  /**
+   * @param {ArtifactsApi} api
+   * @param {Client} client
+   */
+  constructor({ api, client }) {
+    super({ api });
+
+    this._artifacts = {
+      perTest: {},
+      perSession: {},
+    };
+
+    client.setEventCallback('testFailed', this._onInvokeFailure.bind(this));
+  }
+
+  async onCreateExternalArtifact(e) {
+    if (!e.artifact) {
+      throw new Error('Internal error: expected Artifact instance in the event');
+    }
+
+    this._registerSnapshot(e.name, e.artifact);
+  }
+
+  _onInvokeFailure({ params: { viewHierarchyURL } }) {
+    this._registerSnapshot('ui', new FileArtifact({
+      temporaryPath: viewHierarchyURL,
+    }));
+  }
+
+  _registerSnapshot(name, artifact) {
+    const scope = this.context.testSummary ? 'perTest' : 'perSession';
+    setUniqueProperty(this._artifacts[scope], name, artifact);
+  }
+
+  async onTestStart(testSummary) {
+    this.context.testSummary = null;
+    await this._flushArtifacts();
+    await super.onTestStart(testSummary);
+  }
+
+  async onTestDone(testSummary) {
+    await super.onTestDone(testSummary);
+    await this._flushArtifacts(testSummary);
+
+    this.context.testSummary = null;
+    await this._flushArtifacts();
+  }
+
+  async onBeforeCleanup() {
+    await this._flushArtifacts();
+    await super.onBeforeCleanup();
+  }
+
+  async _flushArtifacts(testSummary) {
+    const scope = testSummary ? 'perTest' : 'perSession';
+    const artifacts = this._artifacts[scope];
+    const promises = Object.entries(artifacts).map(async ([key, artifact]) => {
+      const destination = await this.api.preparePathForArtifact(`${key}.viewhierarchy`, testSummary);
+      await artifact.save(destination);
+    });
+
+    this._artifacts[scope] = {};
+    await Promise.all(promises);
+  }
+
+  /** @param {string} config */
+  static parseConfig(config) {
+    return {
+      enabled: config === 'enabled',
+      keepOnlyFailedTestsArtifacts: false,
+    };
+  }
+}
+
+module.exports = IosUIHierarchyPlugin;

--- a/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.test.js
+++ b/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.test.js
@@ -1,0 +1,129 @@
+const testSummaries = require('../__mocks__/testSummaries.mock');
+
+jest.mock('../templates/artifact/FileArtifact');
+jest.mock('../../client/Client');
+
+describe('IosUIHierarchyPlugin', () => {
+  let Client, FileArtifact, IosUIHierarchyPlugin;
+  let plugin, api, client, onTestFailed;
+
+  beforeEach(() => {
+    Client = require('../../client/Client');
+    FileArtifact = require('../templates/artifact/FileArtifact');
+    IosUIHierarchyPlugin = require('./IosUIHierarchyPlugin');
+
+    client = new Client();
+    client.setEventCallback.mockImplementation((event, callback) => {
+      if (event === 'testFailed') {
+        onTestFailed = callback;
+      }
+    });
+
+    api = {
+      preparePathForArtifact: jest.fn((name, testSummary) => {
+        if (testSummary) {
+          return 'artifacts/test/' + name;
+        } else {
+          return 'artifacts/' + name;
+        }
+      }),
+      userConfig: {
+        enabled: true,
+        keepOnlyFailedTestsArtifacts: false,
+      },
+    };
+
+    plugin = new IosUIHierarchyPlugin({ api, client });
+  });
+
+  describe('behavior for "testFailed" client events', () => {
+    it('should ignore empty view hierarchy on test failure', () => {
+      onTestFailed({ params: {} });
+      expect(FileArtifact.mock.instances.length).toBe(0);
+    });
+
+    it('should capture view hierarchy inside and outside of running test', async () => {
+      onTestFailed(aTestFailedPayload(0));
+
+      await plugin.onTestStart(testSummaries.running());
+      onTestFailed(aTestFailedPayload(1));
+      onTestFailed(aTestFailedPayload(2));
+      await plugin.onTestDone(testSummaries.failed());
+
+      onTestFailed(aTestFailedPayload(3));
+
+      await plugin.onBeforeCleanup();
+
+      const [session1, test1, test2, session2] = FileArtifact.mock.instances;
+
+      expect(session1.save).toHaveBeenCalledWith('artifacts/ui.viewhierarchy');
+      expect(session2.save).toHaveBeenCalledWith('artifacts/ui2.viewhierarchy');
+      expect(test1.save).toHaveBeenCalledWith('artifacts/test/ui.viewhierarchy');
+      expect(test2.save).toHaveBeenCalledWith('artifacts/test/ui2.viewhierarchy');
+    }); });
+
+  describe('behavior for externally created artifacts', () => {
+    it('should validate event.artifact', async () => {
+      const artifacts = [0, 1, 2, 3].map(() => new FileArtifact());
+
+      await expect(plugin.onCreateExternalArtifact({ name: 'invalid' }))
+        .rejects
+        .toThrowError(/Internal error/);
+    });
+
+    it('should register snapshots inside and outside of running test', async () => {
+      const artifacts = [0, 1, 2, 3].map(() => new FileArtifact());
+
+      await plugin.onCreateExternalArtifact({ name: 'session', artifact: artifacts[0] });
+      await plugin.onTestStart(testSummaries.running());
+      await plugin.onCreateExternalArtifact({ name: 'test', artifact: artifacts[1] });
+      await plugin.onCreateExternalArtifact({ name: 'test', artifact: artifacts[2] });
+      await plugin.onTestDone(testSummaries.failed());
+      await plugin.onCreateExternalArtifact({ name: 'session', artifact: artifacts[3] });
+      await plugin.onBeforeCleanup();
+
+      expect(artifacts[0].save).toHaveBeenCalledWith('artifacts/session.viewhierarchy');
+      expect(artifacts[1].save).toHaveBeenCalledWith('artifacts/test/test.viewhierarchy');
+      expect(artifacts[2].save).toHaveBeenCalledWith('artifacts/test/test2.viewhierarchy');
+      expect(artifacts[3].save).toHaveBeenCalledWith('artifacts/session2.viewhierarchy');
+    });
+  });
+
+  describe('when disabled', () => {
+    beforeEach(() => {
+      api.userConfig.enabled = false;
+      plugin = new IosUIHierarchyPlugin({ api, client });
+    });
+
+    it('should remove the file artifact', () => {
+      onTestFailed(aTestFailedPayload(1));
+      const [fileArtifact] = FileArtifact.mock.instances;
+
+      expect(fileArtifact.discard).toHaveBeenCalled();
+    });
+  });
+
+  describe('static parseConfig(config)', () => {
+    it('should return .enabled === true if config === "enabled"', () => {
+      expect(IosUIHierarchyPlugin.parseConfig('enabled')).toEqual({
+        enabled: true,
+        keepOnlyFailedTestsArtifacts: false,
+      });
+    });
+
+    it('should return .enabled === false if config === "enabled"', () => {
+      expect(IosUIHierarchyPlugin.parseConfig('enabled')).toEqual({
+        enabled: true,
+        keepOnlyFailedTestsArtifacts: false,
+      });
+    });
+  });
+
+  function aTestFailedPayload(index) {
+    return {
+      params: {
+        viewHierarchyURL: `/tmp/${index}.viewhierarchy`
+      },
+    };
+  }
+});

--- a/detox/src/artifacts/utils/temporaryPath.js
+++ b/detox/src/artifacts/utils/temporaryPath.js
@@ -7,6 +7,7 @@ module.exports = {
     log: () => tempfile('.detox.log'),
     mp4: () => tempfile('.detox.mp4'),
     dtxrec: () => tempfile('.detox.dtxrec'),
+    viewHierarchy: () => tempfile('.viewhierarchy'),
   },
   mask: () => path.join(tempfile(), '..') + path.sep + '*.detox.*',
 };

--- a/detox/src/artifacts/utils/temporaryPath.js
+++ b/detox/src/artifacts/utils/temporaryPath.js
@@ -7,7 +7,7 @@ module.exports = {
     log: () => tempfile('.detox.log'),
     mp4: () => tempfile('.detox.mp4'),
     dtxrec: () => tempfile('.detox.dtxrec'),
-    viewHierarchy: () => tempfile('.viewhierarchy'),
+    viewhierarchy: () => tempfile('.detox.viewhierarchy'),
   },
   mask: () => path.join(tempfile(), '..') + path.sep + '*.detox.*',
 };

--- a/detox/src/artifacts/utils/temporaryPath.test.js
+++ b/detox/src/artifacts/utils/temporaryPath.test.js
@@ -6,7 +6,8 @@ describe('temporaryPath', () => {
   it('should create a temporary file like *.detox.png for .png', expectTemporaryFile('png'));
   it('should create a temporary file like *.detox.log for .log', expectTemporaryFile('log'));
   it('should create a temporary file like *.detox.mp4 for .mp4', expectTemporaryFile('mp4'));
-  it('should create a temporary file like *.detox.dtxrec for .dtxrec', expectTemporaryFile('dtxrec'));
+  it('should create a temporary file like *.detox.viewhierarchy for .dtxrec', expectTemporaryFile('dtxrec'));
+  it('should create a temporary file like *.detox.viewhierarchy for .viewhierarchy', expectTemporaryFile('viewhierarchy'));
 
   it('should generate a glob mask for those temporary files', () => {
     expect(temporaryPath.mask()).toMatch(/\*\.detox\.\*$/);

--- a/detox/src/client/AsyncWebSocket.test.js
+++ b/detox/src/client/AsyncWebSocket.test.js
@@ -165,7 +165,7 @@ describe('AsyncWebSocket', () => {
     }
   });
 
-  it(`eventCallback should be triggered on a registered messageId when sent from testee`, async () => {
+  it(`eventCallback should be triggered on a registered action.type when sent from testee`, async () => {
     const mockCallback = jest.fn();
     const mockedResponse = generateResponse('someEvent', -10000);
     await connect(client);
@@ -173,6 +173,21 @@ describe('AsyncWebSocket', () => {
 
     client.ws.onmessage(mockedResponse);
     expect(mockCallback).toHaveBeenCalledWith(JSON.parse(mockedResponse.data));
+  });
+
+  it(`multiple eventCallbacks can be triggered on the same action.type`, async () => {
+    const mockCallbacks = [0, 1].map(i => jest.fn());
+    const mockedResponse = generateResponse('someEvent', -10000);
+    const mockResponseData = JSON.parse(mockedResponse.data);
+
+    await connect(client);
+    client.setEventCallback('someEvent', mockCallbacks[0]);
+    client.setEventCallback('someEvent', mockCallbacks[1]);
+
+    client.ws.onmessage(mockedResponse);
+
+    expect(mockCallbacks[0]).toHaveBeenCalledWith(mockResponseData);
+    expect(mockCallbacks[1]).toHaveBeenCalledWith(mockResponseData);
   });
 
   it(`rejectAll should throw error to all pending promises`, async () => {

--- a/detox/src/client/AsyncWebSocket.test.js
+++ b/detox/src/client/AsyncWebSocket.test.js
@@ -167,12 +167,12 @@ describe('AsyncWebSocket', () => {
 
   it(`eventCallback should be triggered on a registered messageId when sent from testee`, async () => {
     const mockCallback = jest.fn();
-    const mockedResponse = generateResponse('onmessage', -10000);
+    const mockedResponse = generateResponse('someEvent', -10000);
     await connect(client);
-    client.setEventCallback(-10000, mockCallback);
+    client.setEventCallback('someEvent', mockCallback);
 
     client.ws.onmessage(mockedResponse);
-    expect(mockCallback).toHaveBeenCalledWith(mockedResponse.data);
+    expect(mockCallback).toHaveBeenCalledWith(JSON.parse(mockedResponse.data));
   });
 
   it(`rejectAll should throw error to all pending promises`, async () => {
@@ -208,6 +208,12 @@ describe('AsyncWebSocket', () => {
   }
 
   function generateResponse(message, messageId) {
-    return {data: JSON.stringify({response: message, messageId: messageId})};
+    return {
+      data: JSON.stringify({
+        type: message,
+        response: message,
+        messageId: messageId
+      })
+    };
   }
 });

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -43,6 +43,12 @@ class Client {
     await this.sendAction(new actions.WaitForActive());
   }
 
+  async captureViewHierarchy({ viewHierarchyURL }) {
+    return await this.sendAction(new actions.CaptureViewHierarchy({
+      viewHierarchyURL
+    }));
+  }
+
   async cleanup() {
     clearTimeout(this.slowInvocationStatusHandler);
     if (this.isConnected && !this.pandingAppCrash) {
@@ -118,15 +124,14 @@ class Client {
   }
 
   setActionListener(action, clientCallback) {
-    this.ws.setEventCallback(action.messageId, (response) => {
-      const parsedResponse = JSON.parse(response);
-      action.handle(parsedResponse);
-
-      /* istanbul ignore next */
-      if (clientCallback) {
-        clientCallback(parsedResponse);
-      }
+    this.setEventCallback(action.type, (response) => {
+      action.handle(response);
+      clientCallback(response);
     });
+  }
+
+  setEventCallback(event, callback) {
+    this.ws.setEventCallback(event, callback);
   }
 
   async sendAction(action) {

--- a/detox/src/client/Client.test.js
+++ b/detox/src/client/Client.test.js
@@ -345,7 +345,7 @@ describe('Client', () => {
 
     function triggerAppWillTerminateWithError() {
       const event = createAppWillTerminateEvent();
-      client.ws.setEventCallback.mock.calls[0][1](JSON.stringify(event));
+      client.ws.setEventCallback.mock.calls[0][1](event);
     }
   });
 
@@ -367,7 +367,7 @@ describe('Client', () => {
 
     function triggerAppNonresponsiveEvent() {
       const event = createAppNonresponsiveEvent();
-      client.ws.setEventCallback.mock.calls[0][1](JSON.stringify(event));
+      client.ws.setEventCallback.mock.calls[0][1](event);
       return event;
     }
   });

--- a/detox/src/client/Client.test.js
+++ b/detox/src/client/Client.test.js
@@ -96,6 +96,29 @@ describe('Client', () => {
     }), undefined);
   });
 
+  it(`captureViewHierarchy() - should receive "captureViewHierarchyDone" from device and resolve`, async () => {
+    await connect();
+    client.ws.send.mockReturnValueOnce(response("captureViewHierarchyDone", {}, 1));
+
+    const viewHierarchyURL = tempfile('.viewhierarchy');
+    await client.captureViewHierarchy({ viewHierarchyURL });
+
+    expect(client.ws.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'captureViewHierarchy',
+      params: expect.objectContaining({ viewHierarchyURL }),
+    }), undefined);
+  });
+
+  it(`captureViewHierarchy() - should throw an error if the response has "captureViewHierarchyError" in params`, async () => {
+    await connect();
+    client.ws.send.mockReturnValueOnce(response("captureViewHierarchyDone", {
+      captureViewHierarchyError: 'Test error to check',
+    }, 1));
+
+    const viewHierarchyURL = tempfile('.viewhierarchy');
+    await expect(client.captureViewHierarchy({ viewHierarchyURL })).rejects.toThrowError(/Test error to check/m);
+  });
+
   it(`waitUntilReady() - should receive ready from device and resolve`, async () => {
     await connect();
     client.ws.send.mockReturnValueOnce(response("ready", {}, 1));

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -197,6 +197,17 @@ class AppNonresponsive extends Action {
   }
 }
 
+class CaptureViewHierarchy extends Action {
+  constructor(params) {
+    super('captureViewHierarchy', params);
+  }
+
+  async handle(response) {
+    this.expectResponseOfType(response, 'captureViewHierarchyDone');
+    return response;
+  }
+}
+
 module.exports = {
   Login,
   WaitForBackground,
@@ -213,4 +224,5 @@ module.exports = {
   SetInstrumentsRecordingState,
   AppWillTerminateWithError,
   AppNonresponsive,
+  CaptureViewHierarchy,
 };

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -175,8 +175,8 @@ class SetInstrumentsRecordingState extends Action {
 }
 
 class AppWillTerminateWithError extends Action {
-  constructor(params) {
-    super(params);
+  constructor() {
+    super('AppWillTerminateWithError');
     this.messageId = -10000;
   }
 
@@ -187,8 +187,8 @@ class AppWillTerminateWithError extends Action {
 }
 
 class AppNonresponsive extends Action {
-  constructor(params) {
-    super(params);
+  constructor() {
+    super('AppNonresponsiveDetected');
     this.messageId = -10001;
   }
 

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const log = require('../../utils/logger').child({ __filename });
 const bunyan = require('bunyan');
+const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
 
 class Action {
   constructor(type, params = {}) {
@@ -204,6 +205,15 @@ class CaptureViewHierarchy extends Action {
 
   async handle(response) {
     this.expectResponseOfType(response, 'captureViewHierarchyDone');
+
+    const {captureViewHierarchyError} = response.params;
+    if (captureViewHierarchyError) {
+      throw new DetoxRuntimeError({
+        message: 'Failed to capture view hierarchy. Reason:\n',
+        debugInfo: captureViewHierarchyError,
+      });
+    }
+
     return response;
   }
 }

--- a/detox/src/configuration/composeArtifactsConfig.js
+++ b/detox/src/configuration/composeArtifactsConfig.js
@@ -7,6 +7,7 @@ const InstrumentsArtifactPlugin = require('../artifacts/instruments/InstrumentsA
 const LogArtifactPlugin = require('../artifacts/log/LogArtifactPlugin');
 const ScreenshotArtifactPlugin = require('../artifacts/screenshot/ScreenshotArtifactPlugin');
 const VideoArtifactPlugin = require('../artifacts/video/VideoArtifactPlugin');
+const IosUIHierarchyPlugin = require('../artifacts/uiHierarchy/IosUIHierarchyPlugin');
 const ArtifactPathBuilder = require('../artifacts/utils/ArtifactPathBuilder');
 
 function composeArtifactsConfig({
@@ -66,6 +67,7 @@ function extendArtifactsConfig(config) {
       video: ifString(p.video, VideoArtifactPlugin.parseConfig),
       instruments: ifString(p.instruments, InstrumentsArtifactPlugin.parseConfig),
       timeline: ifString(p.timeline, TimelineArtifactPlugin.parseConfig),
+      uiHierarchy: ifString(p.uiHierarchy, IosUIHierarchyPlugin.parseConfig),
     },
   };
 }

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -100,6 +100,10 @@ class Device {
     return this.deviceDriver.takeScreenshot(this._deviceId, name);
   }
 
+  async captureViewHierarchy(name = 'capture') {
+    return this.deviceDriver.captureViewHierarchy(this._deviceId, name);
+  }
+
   _createPayloadFileAndUpdatesParamsObject(key, launchKey, params, baseLaunchArgs) {
     const payloadFilePath = this.deviceDriver.createPayloadFile(params[key]);
     baseLaunchArgs[launchKey] = payloadFilePath;

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -776,6 +776,20 @@ describe('Device', () => {
     expect(device.deviceDriver.takeScreenshot).toHaveBeenCalledWith(device._deviceId, 'name');
   });
 
+  it('captureViewHierarchy(name) should delegate the work to the driver', async () => {
+    device = validDevice();
+
+    await device.captureViewHierarchy('name');
+    expect(device.deviceDriver.captureViewHierarchy).toHaveBeenCalledWith(device._deviceId, 'name');
+  });
+
+  it('captureViewHierarchy([name]) should set name = "capture" by default', async () => {
+    device = validDevice();
+
+    await device.captureViewHierarchy();
+    expect(device.deviceDriver.captureViewHierarchy).toHaveBeenCalledWith(device._deviceId, 'capture');
+  });
+
   async function launchAndTestBinaryPath(configuration) {
     const device = schemeDevice(configurationsMock.pathsTests, configuration);
 

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -199,6 +199,9 @@ class DeviceDriverBase {
   async resetStatusBar(deviceId) {
   }
 
+  async captureViewHierarchy() {
+    return '';
+  }
 }
 
 module.exports = DeviceDriverBase;

--- a/detox/src/devices/drivers/ios/IosDriver.js
+++ b/detox/src/devices/drivers/ios/IosDriver.js
@@ -8,6 +8,7 @@ const SimulatorScreenshotPlugin = require('../../../artifacts/screenshot/Simulat
 const SimulatorRecordVideoPlugin = require('../../../artifacts/video/SimulatorRecordVideoPlugin');
 const SimulatorInstrumentsPlugin = require('../../../artifacts/instruments/ios/SimulatorInstrumentsPlugin');
 const TimelineArtifactPlugin = require('../../../artifacts/timeline/TimelineArtifactPlugin');
+const IosUIHierarchyPlugin = require('../../../artifacts/uiHierarchy/IosUIHierarchyPlugin');
 
 class IosDriver extends DeviceDriverBase {
   constructor(config) {
@@ -26,6 +27,7 @@ class IosDriver extends DeviceDriverBase {
       screenshot: (api) => new SimulatorScreenshotPlugin({ api, appleSimUtils }),
       video: (api) => new SimulatorRecordVideoPlugin({ api, appleSimUtils }),
       timeline: (api) => new TimelineArtifactPlugin({api, appleSimUtils}),
+      uiHierarchy: (api) => new IosUIHierarchyPlugin({ api, client }),
     };
   }
 

--- a/detox/src/devices/drivers/ios/SimulatorDriver.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.js
@@ -182,6 +182,28 @@ class SimulatorDriver extends IosDriver {
     return tempPath;
   }
 
+  async captureViewHierarchy(_udid, artifactName) {
+    const viewHierarchyURL = await temporaryPath.for.viewHierarchy();
+    const { params } = await this.client.captureViewHierarchy({
+      viewHierarchyURL
+    });
+
+    if (params.captureViewHierarchyError) {
+      throw new DetoxRuntimeError({
+        message: 'Failed to capture view hierarchy. Reason:\n',
+        debugInfo: params.captureViewHierarchyError,
+      })
+    }
+
+    await this.emitter.emit('createExternalArtifact', {
+      pluginId: 'uiHierarchy',
+      artifactName: artifactName,
+      artifactPath: viewHierarchyURL,
+    });
+
+    return viewHierarchyURL;
+  }
+
   /***
    * @private
    * @param {String | Object} rawDeviceQuery

--- a/detox/src/devices/drivers/ios/SimulatorDriver.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.js
@@ -183,17 +183,8 @@ class SimulatorDriver extends IosDriver {
   }
 
   async captureViewHierarchy(_udid, artifactName) {
-    const viewHierarchyURL = await temporaryPath.for.viewHierarchy();
-    const { params } = await this.client.captureViewHierarchy({
-      viewHierarchyURL
-    });
-
-    if (params.captureViewHierarchyError) {
-      throw new DetoxRuntimeError({
-        message: 'Failed to capture view hierarchy. Reason:\n',
-        debugInfo: params.captureViewHierarchyError,
-      })
-    }
+    const viewHierarchyURL = temporaryPath.for.viewhierarchy();
+    await this.client.captureViewHierarchy({ viewHierarchyURL });
 
     await this.emitter.emit('createExternalArtifact', {
       pluginId: 'uiHierarchy',

--- a/detox/src/devices/drivers/ios/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.test.js
@@ -1,6 +1,7 @@
 const AsyncEmitter = require('../../../utils/AsyncEmitter');
 
 describe('IOS simulator driver', () => {
+  let MockClient;
   let uut, sim, emitter;
 
   const deviceId = 'device-id-mock';
@@ -13,6 +14,8 @@ describe('IOS simulator driver', () => {
       events: ['beforeLaunchApp'],
       onError: (e) => { throw e },
     });
+
+    MockClient = jest.requireMock('../../../client/Client');
   });
 
   describe('launch args', () => {
@@ -45,6 +48,33 @@ describe('IOS simulator driver', () => {
         ...launchArgs,
         dog3: 'Chika, from plugin',
       }, '');
+    });
+  });
+
+  describe('.captureViewHierarchy', () => {
+    let client;
+
+    beforeEach(async () => {
+      const SimulatorDriver = require('./SimulatorDriver');
+      client = new MockClient();
+      jest.spyOn(emitter, 'emit');
+
+      uut = new SimulatorDriver({ client, emitter });
+      await uut.captureViewHierarchy('', 'named hierarchy');
+    });
+
+    it('should call client.captureViewHierarchy', async () => {
+      expect(client.captureViewHierarchy).toHaveBeenCalledWith({
+        viewHierarchyURL: expect.any(String),
+      });
+    });
+
+    it('should emit "createExternalArtifact" event for uiHierarchy plugin', async () => {
+      expect(emitter.emit).toHaveBeenCalledWith('createExternalArtifact', {
+        pluginId: 'uiHierarchy',
+        artifactName: 'named hierarchy',
+        artifactPath: expect.any(String),
+      });
     });
   });
 

--- a/detox/src/utils/setUniqueProperty.js
+++ b/detox/src/utils/setUniqueProperty.js
@@ -1,0 +1,13 @@
+function setUniqueProperty(obj, key, value) {
+  let index = 0;
+  const suffixed = () => index > 0 ? `${key}${index + 1}` : key;
+
+  while (obj.hasOwnProperty(suffixed())) {
+    index++;
+  }
+
+  obj[suffixed()] = value;
+  return obj;
+}
+
+module.exports = setUniqueProperty;

--- a/detox/src/utils/setUniqueProperty.test.js
+++ b/detox/src/utils/setUniqueProperty.test.js
@@ -1,0 +1,15 @@
+const setUniqueProperty = require('./setUniqueProperty');
+
+describe('setUniqueProperty(obj, key, value', () => {
+  it("should set obj[key] = value", () => {
+    expect(setUniqueProperty({}, 'a', 1)).toEqual({ a: 1 });
+  });
+
+  it("should set obj[key + 2] = value if obj[key] exists", () => {
+    expect(setUniqueProperty({ a: 1 }, 'a', 2)).toEqual({ a: 1, a2: 2 });
+  });
+
+  it("should set obj[key + 3] = value if obj[key] and obj[key + 2] exist", () => {
+    expect(setUniqueProperty({ a: 1, a2: 2 }, 'a', 3)).toEqual({ a: 1, a2: 2, a3: 3 });
+  });
+});

--- a/detox/test/e2e/19.crash-handling.test.js
+++ b/detox/test/e2e/19.crash-handling.test.js
@@ -8,16 +8,14 @@ describe('Crash Handling', () => {
 
   it('Should throw error upon internal app crash', async () => {
     await device.reloadReactNative();
-    let failed = false;
 
     try {
       await element(by.text('Crash')).tap();
       await element(by.text('Crash')).tap();
-    } catch (ex) { // Note: exception will be logged as an APP_CRASH event
-      failed = true;
+      fail('Test should have thrown an error, but did not');
+    } catch (_ex) {
+      // Note: exception will be logged as an APP_CRASH event
     }
-
-    if (!failed) throw new Error('Test should have thrown an error, but did not');
   });
 
   it('Should recover from app crash', async () => {
@@ -27,29 +25,24 @@ describe('Crash Handling', () => {
 
   it(':android: should throw error upon invoke crash', async () => {
     await device.reloadReactNative();
-    let failed = false;
 
     try {
       await element(by.text('UI Crash')).tap();
+      fail('Test should have thrown an error, but did not');
     } catch (ex) {
       console.error(ex); // Log explicitly or it wouldn't show
-      failed = true;
     }
-
-    if (!failed) throw new Error('Test should have thrown an error, but did not');
   });
 
   it(':android: Should throw error upon app bootstrap crash', async () => {
-    let failed = false;
     try {
       await device.launchApp({ newInstance: true, launchArgs: { detoxAndroidCrashingActivity: true }});
+      fail('Test should have thrown an error, but did not');
     } catch (ex) {
       console.error(ex); // Log explicitly or it wouldn't show
-      failed = true;
     }
 
     // This is not effectively needed, as if crash handling doesn't go right launchApp would typically
     // just hang forever (and thus a timeout will fail the test - not this assertion).
-    if (!failed) throw new Error('Test should have thrown an error, but did not');
   }, 60000);
 });

--- a/detox/test/e2e/21.artifacts.test.js
+++ b/detox/test/e2e/21.artifacts.test.js
@@ -3,48 +3,91 @@ const path = require('path');
 const { PNG } = require('pngjs');
 
 describe('Artifacts', () => {
-  beforeAll(async () => {
-    await device.sendToHome();
-    await device.takeScreenshot('Artifacts/before all').then(printDimensions);
-    await device.launchApp({newInstance: true});
+  describe('screenshots', () => {
+    beforeAll(async () => {
+      await device.sendToHome();
+      await device.takeScreenshot('Artifacts/before all').then(printDimensions);
+      await device.launchApp({newInstance: true});
+    });
+
+    beforeEach(async () => {
+      // implicitly taking screenshot - beforeEach.png
+      await device.reloadReactNative();
+      await device.takeScreenshot('in main menu').then(printDimensions);
+
+      await element(by.text('Actions')).tap();
+      await device.takeScreenshot('Actions').then(printDimensions);
+    });
+
+    it('should take screenshots inside test', async () => {
+      await element(by.id('UniqueId819')).tap();
+      await device.takeScreenshot('taps - 1').then(printDimensions);
+
+      await element(by.id('UniqueId819')).tap();
+      await device.takeScreenshot('taps - 2').then(printDimensions);
+    });
+
+    afterEach(async () => {
+      await element(by.text('Tap Me')).tap();
+      await device.takeScreenshot('tap working').then(printDimensions);
+
+      await device.reloadReactNative();
+      // implicitly taking screenshot - afterEach.png
+    });
+
+    afterAll(async () => {
+      await device.sendToHome();
+      await device.takeScreenshot('Artifacts/after all').then(printDimensions);
+      await device.launchApp();
+    });
+
+    function printDimensions(pathToScreenshot) {
+      const buffer = fs.readFileSync(pathToScreenshot);
+      const filename = path.basename(pathToScreenshot);
+      const {width, height} = PNG.sync.read(buffer);
+
+      console.log(`Took a screenshot: ${filename} (${width}x${height})`);
+    }
   });
 
-  beforeEach(async () => {
-    // implicitly taking screenshot - beforeEach.png
-    await device.reloadReactNative();
-    await device.takeScreenshot('in main menu').then(printDimensions);
+  describe(':ios: View Hierarchy', () => {
+    beforeAll(async () => {
+      await device.launchApp({newInstance: true});
 
-    await element(by.text('Actions')).tap();
-    await device.takeScreenshot('Actions').then(printDimensions);
+      [
+        await device.captureViewHierarchy(), // = 'capture'
+        await device.captureViewHierarchy('before tests'),
+      ].forEach(assertDirExists);
+    });
+
+    it('should capture view hierarchies in test and upon multiple invocation failures', async () => {
+      try {
+        await element(by.id('nonExistentId')).tap();
+        fail('should have failed');
+      } catch (e) {
+        [
+          await device.captureViewHierarchy(), // = 'capture'
+          await device.captureViewHierarchy('named capture'),
+        ].forEach(assertDirExists);
+      }
+
+      try {
+        await element(by.id('nonExistentId2')).tap();
+        fail('should have failed too');
+      } catch (e) {
+        [
+          await device.captureViewHierarchy(), // = 'capture'
+          await device.captureViewHierarchy('named capture'),
+        ].forEach(assertDirExists);
+      }
+
+      // Artifacts folder should contain the following *.viewhierarchy folders: ui, capture, named capture, ui2, capture2, named capture2
+    });
   });
 
-  it('should take screenshots inside test', async () => {
-    await element(by.id('UniqueId819')).tap();
-    await device.takeScreenshot('taps - 1').then(printDimensions);
-
-    await element(by.id('UniqueId819')).tap();
-    await device.takeScreenshot('taps - 2').then(printDimensions);
-  });
-
-  afterEach(async () => {
-    await element(by.text('Tap Me')).tap();
-    await device.takeScreenshot('tap working').then(printDimensions);
-
-    await device.reloadReactNative();
-    // implicitly taking screenshot - afterEach.png
-  });
-
-  afterAll(async () => {
-    await device.sendToHome();
-    await device.takeScreenshot('Artifacts/after all').then(printDimensions);
-    await device.launchApp();
-  });
-
-  function printDimensions(pathToScreenshot) {
-    const buffer = fs.readFileSync(pathToScreenshot);
-    const filename = path.basename(pathToScreenshot);
-    const {width, height} = PNG.sync.read(buffer);
-
-    console.log(`Took a screenshot: ${filename} (${width}x${height})`);
+  function assertDirExists(dirPath) {
+    if (!fs.statSync(dirPath).isDirectory()) {
+      throw new Error('Expected to find a directory at path: ' + dirPath);
+    }
   }
 });

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -76,7 +76,8 @@
             "testDone": true
           }
         },
-        "timeline": "all"
+        "timeline": "all",
+        "uiHierarchy": "enabled"
       }
     },
     "configurations": {


### PR DESCRIPTION
When an invocation error occurs, an attempt to dump view hierarchy will be attempted, and on success, the resulting URL will be placed in `viewHierarchyURL` in returned params.

New invoke command `captureViewHierarchy` has been added, where `viewHierarchyURL` is expected to hold the URL to place the view hierarchy. The URL must have “path/name.viewhierarchy” syntax.

- [x] Needs JS support
- [ ] Needs docs

Closes #2181
#2078