### PR TITLE
Add binaryPath troubleshooting

### DIFF
--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -441,3 +441,8 @@ detox[12345] DEBUG: [DetoxServer.js/CANNOT_FORWARD] role=testee not connected, c
 
 * Alternatively, the `android:usesCleartextTraffic="true"` attribute can be configured in the `<application>` tag of the app's `AndroidManifest.xml`, but **that is highly discouraged**.
 
+### Problem: Detox can't find the test APK
+
+You may see an error message like this: `detox[53027] ERROR: Error: 'android/app/build/outputs/androidTest/x86_64/debug/app-x86_64-debug-androidTest.apk' could not be found, did you run './gradlew assembleAndroidTest'?`
+
+You can use `testBinaryPath` in your configuration to override `binaryPath` and point directly at your test APK.


### PR DESCRIPTION
`binaryPath` is *not* the path that Detox should use for the binary.  Rather, Detox uses this as a base path and tries to transform it to determine its own test binary path via the internal function `getTestApkPath`.  This tripped me up and also a number of other users:

https://stackoverflow.com/questions/53984667/detox-app-could-not-be-found-did-you-run-gradlew-assembleandroidtest/63414420#63414420
https://stackoverflow.com/questions/58951816/detox-build-successful-but-detox-test-fails/63414275#63414275

Adding to troubleshooting here to try and help future users solve this more quickly.

<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
