### PR TITLE
fix(cli): case-insensitive PATH key on Win32

### DIFF
--- a/detox-cli/cli.js
+++ b/detox-cli/cli.js
@@ -28,11 +28,12 @@ function spawnDetoxBinary(cliArgs) {
     return 1;
   }
 
+  const PATH = isWin32 ? findPathKey() : 'PATH';
   const spawnOptions = {
     stdio: 'inherit',
     env: {
       ...process.env,
-      PATH: [nodeBinariesPath, process.env.PATH].join(path.delimiter),
+      [PATH]: [nodeBinariesPath, process.env.PATH].join(path.delimiter),
     }
   };
 
@@ -55,6 +56,14 @@ function spawnRecorder([_recorder, ...recorderArgs]) {
     console.log(`Detox Recorder is not installed in this directory: ${detoxRecorderPath}`);
     return 1;
   }
+}
+
+function findPathKey() {
+  return Object.keys(process.env).find(isCaseInsensitivePath);
+}
+
+function isCaseInsensitivePath(key) {
+  return key.toLowerCase() === 'path';
 }
 
 process.exit(main(process.argv));


### PR DESCRIPTION
Supplements #2278.

Fixes non-effective `PATH` modification on Windows by taking into the account the following platform quirk:

> The command lookup will be performed using options.env.PATH environment variable if passed in options object, otherwise process.env.PATH will be used. To account for the fact that Windows environment variables are case-insensitive Node.js will lexicographically sort all env keys and choose the first one case-insensitively matching PATH to perform command lookup. This may lead to issues on Windows when passing objects to env option that have multiple variants of PATH variable.

See more details: https://nodejs.org/api/child_process.html