### PR TITLE
refactor(cli): use DeviceRegistry instead direct fs operations

### DIFF
--- a/detox/src/devices/DeviceRegistry.js
+++ b/detox/src/devices/DeviceRegistry.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const environment = require('../utils/environment');
 const ExclusiveLockfile = require('../utils/ExclusiveLockfile');
 const safeAsync = require('../utils/safeAsync');
 
@@ -10,6 +11,13 @@ class DeviceRegistry {
      */
     this._lockfile = new ExclusiveLockfile(lockfilePath, {
       getInitialState: this._getInitialLockFileState.bind(this),
+    });
+  }
+
+  async reset() {
+    await this._lockfile.exclusively(() => {
+      const empty = this._getInitialLockFileState();
+      this._lockfile.write(empty);
     });
   }
 
@@ -58,6 +66,18 @@ class DeviceRegistry {
       : _.without(state, deviceId);
 
     this._lockfile.write(newState);
+  }
+
+  static forIOS() {
+    return new DeviceRegistry({
+      lockfilePath: environment.getDeviceLockFilePathIOS(),
+    });
+  }
+
+  static forAndroid() {
+    return new DeviceRegistry({
+      lockfilePath: environment.getDeviceLockFilePathAndroid(),
+    });
   }
 }
 

--- a/detox/src/devices/DeviceRegistry.test.js
+++ b/detox/src/devices/DeviceRegistry.test.js
@@ -1,13 +1,15 @@
 const fs = require('fs-extra');
 const tempfile = require('tempfile');
-const DeviceRegistry = require('./DeviceRegistry');
+const environment = require('../utils/environment');
 
-describe('DeviceRegistry', () => {
+describe('DeviceRegistry instance', () => {
+  let DeviceRegistry;
   let lockfilePath;
   let registry;
 
   beforeEach(() => {
     lockfilePath = tempfile('.test');
+    DeviceRegistry = require('./DeviceRegistry');
     registry = new DeviceRegistry({ lockfilePath });
   });
 
@@ -42,5 +44,47 @@ describe('DeviceRegistry', () => {
     }).catch(() => {});
 
     assertForbiddenOutOfContext();
+  });
+
+  describe('.reset() method', () => {
+    it('should create a lock file with an empty array if it does not exist', async () => {
+      expect(await fs.exists(lockfilePath)).toBe(false);
+      await registry.reset();
+      expect(await fs.readFile(lockfilePath, 'utf8')).toBe('[]');
+    });
+
+    it('should overwrite a lock file contents with an empty array if it exists', async () => {
+      await fs.writeFile(lockfilePath, '{ something }');
+      await registry.reset();
+      expect(await fs.readFile(lockfilePath, 'utf8')).toBe('[]');
+    });
+  })
+});
+
+describe('DeviceRegistry static methods', () => {
+  let ExclusiveLockFile;
+  let DeviceRegistry;
+
+  beforeEach(() => {
+    jest.mock('../utils/ExclusiveLockFile');
+
+    ExclusiveLockFile = require('../utils/ExclusiveLockfile');
+    DeviceRegistry = require('./DeviceRegistry');
+  });
+
+  it('should expose static convenience method DeviceRegistry.forIOS()', () => {
+    expect(DeviceRegistry.forIOS()).toBeInstanceOf(DeviceRegistry);
+    expect(ExclusiveLockFile).toHaveBeenCalledWith(
+      environment.getDeviceLockFilePathIOS(),
+      expect.anything(),
+    );
+  });
+
+  it('should expose static convenience method DeviceRegistry.forAndroid()', async () => {
+    expect(DeviceRegistry.forAndroid()).toBeInstanceOf(DeviceRegistry);
+    expect(ExclusiveLockFile).toHaveBeenCalledWith(
+      environment.getDeviceLockFilePathAndroid(),
+      expect.anything(),
+    );
   });
 });

--- a/detox/src/devices/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.js
@@ -45,9 +45,7 @@ class AndroidDriver extends DeviceDriverBase {
 
     this.instrumentation = new MonitoredInstrumentation(this.adb, logger);
 
-    this.deviceRegistry = new DeviceRegistry({
-      lockfilePath: environment.getDeviceLockFilePathAndroid()
-    });
+    this.deviceRegistry = DeviceRegistry.forAndroid();
   }
 
   declareArtifactPlugins() {

--- a/detox/src/devices/drivers/android/AndroidDriver.test.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.test.js
@@ -559,6 +559,8 @@ describe('Android driver', () => {
 
     jest.mock('../../DeviceRegistry');
     DeviceRegistryClass = require('../../DeviceRegistry');
+    const createRegistry = jest.fn(() => new DeviceRegistryClass());
+    DeviceRegistryClass.forIOS = DeviceRegistryClass.forAndroid = createRegistry;
   };
 
   const mockGetAbsoluteBinaryPathImpl = (x) => `absolutePathOf(${x})`;

--- a/detox/src/devices/drivers/ios/SimulatorDriver.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.js
@@ -16,10 +16,7 @@ class SimulatorDriver extends IosDriver {
   constructor(config) {
     super(config);
 
-    this.deviceRegistry = new DeviceRegistry({
-      lockfilePath: environment.getDeviceLockFilePathIOS(),
-    });
-
+    this.deviceRegistry = DeviceRegistry.forIOS();
     this._name = 'Unspecified Simulator';
   }
 

--- a/detox/src/utils/ExclusiveLockfile.js
+++ b/detox/src/utils/ExclusiveLockfile.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const fs = require('fs');
+const fs = require('fs-extra');
 const plockfile = require('proper-lockfile');
 const retry = require('./retry');
 
@@ -37,7 +37,7 @@ class ExclusiveLockfile {
     try {
       return (await fn());
     } finally {
-      this._unlock();
+      await this._unlock();
     }
   }
 
@@ -117,6 +117,7 @@ class ExclusiveLockfile {
    */
   _ensureFileExists() {
     if (!fs.existsSync(this._lockFilePath)) {
+      fs.ensureFileSync(this._lockFilePath);
       const initialState = this._options.getInitialState();
       this._doWrite(initialState);
     }


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Trying to minimize scope of the PR #2269. It grew too big, probably.

I'd like to avoid direct FS I/O operations in `detox/local-cli/test.js`  for clearing lock file in favor of reusing `DeviceRegistry` façade, to keep single responsibility principle.

