### PR TITLE
fix(windows): remove correctly internal stack traces

### DIFF
--- a/detox/src/utils/errorUtils.js
+++ b/detox/src/utils/errorUtils.js
@@ -1,7 +1,4 @@
-const S = require('path').sep;
 const { isError } = require('lodash');
-
-const DETOX_SRC_PATH =  `${S}detox${S}src`;
 
 function removeInternalStackEntries(error) {
   const lines = error.stack.split('\n');
@@ -9,7 +6,7 @@ function removeInternalStackEntries(error) {
   const filtered = lines.filter(rawLine => {
     const line = rawLine.trim();
 
-    if (line.startsWith('at ') && line.includes(DETOX_SRC_PATH)) {
+    if (line.startsWith('at ') && line.includes('/detox/src')) {
       return false;
     }
 


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Just realized, when testing on a Windows laptop, that error stack traces use Unix path separator (`/`) nevertheless, so I've fixed both unit tests here and the production behavior too. This code is used for improving error stack traces, so they don't point to Detox internals but places in user e2e tests.
