### PR TITLE
Debug sync will be activated on all WS calls, not only on invoke.

### DIFF
--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -98,17 +98,11 @@ class Client {
       invocation = invocation();
     }
 
-    if (this.slowInvocationTimeout) {
-      this.slowInvocationStatusHandler = this.slowInvocationStatus();
-    }
-
     try {
       return await this.sendAction(new actions.Invoke(invocation));
     } catch (err) {
       this.successfulTestRun = false;
       throw removeInternalStackEntries(asError(err));
-    } finally {
-      clearTimeout(this.slowInvocationStatusHandler);
     }
   }
 
@@ -135,9 +129,16 @@ class Client {
   }
 
   async sendAction(action) {
+    if (this.slowInvocationTimeout) {
+      this.slowInvocationStatusHandler = this.slowInvocationStatus();
+    }
+
     const response = await this.ws.send(action, action.messageId);
     const parsedResponse = JSON.parse(response);
-    return await action.handle(parsedResponse);
+    const handledResponse = await action.handle(parsedResponse);
+
+    clearTimeout(this.slowInvocationStatusHandler);
+    return handledResponse;
   }
 
   slowInvocationStatus() {

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -135,9 +135,15 @@ class Client {
 
     const response = await this.ws.send(action, action.messageId);
     const parsedResponse = JSON.parse(response);
-    const handledResponse = await action.handle(parsedResponse);
+    let handledResponse;
+    try {
+      handledResponse = await action.handle(parsedResponse);
+    } catch (ex) {
+      throw ex;
+    } finally {
+      clearTimeout(this.slowInvocationStatusHandler);
+    }
 
-    clearTimeout(this.slowInvocationStatusHandler);
     return handledResponse;
   }
 

--- a/detox/src/client/Client.test.js
+++ b/detox/src/client/Client.test.js
@@ -220,7 +220,7 @@ describe('Client', () => {
     it(`execute() - slow invocation should trigger "slowInvocationStatus:`, async () => {
       argparse.getArgValue.mockReturnValue(2); // set debug-slow-invocations
       await connect();
-      await executeWithSlowInvocation(4);
+      await executeWithSlowInvocation(3);
       expect(client.ws.send).toHaveBeenLastCalledWith({"params": {}, "type": "currentStatus"}, undefined);
       expect(client.ws.send).toHaveBeenCalledTimes(3);
     });


### PR DESCRIPTION
- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Previously, `--debug-synchronization` was only triggered on `actions.Invoke()` commands. This PR adds support for debug sync over all slow websocket calls.
Still needs to polish over edge cases.