### PR TITLE
Restrict test-butler assertion to devices actually incorporating the TB service

### DIFF
--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -38,7 +38,7 @@ public class DetoxTest {
 
     @Test
     public void runDetoxTests() {
-        TestButlerProbe.assertTestButlerReady();
+        TestButlerProbe.assertReadyIfInstalled();
 
         final ActivityTestRule<?> rule = resolveTestRule();
         Detox.runTests(rule);

--- a/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/DetoxTest.java
@@ -1,9 +1,7 @@
 package com.example;
 
 import android.os.Bundle;
-import android.view.Surface;
 
-import com.linkedin.android.testbutler.TestButler;
 import com.wix.detox.Detox;
 
 import org.junit.Rule;
@@ -40,15 +38,10 @@ public class DetoxTest {
 
     @Test
     public void runDetoxTests() {
-        verifyTestButlerReady();
+        TestButlerProbe.assertTestButlerReady();
 
         final ActivityTestRule<?> rule = resolveTestRule();
         Detox.runTests(rule);
-    }
-
-    private void verifyTestButlerReady() {
-        // This has no effect if test-butler is running. However, if it is not, then unlike TestButler.setup(), it will hard-fail.
-        TestButler.setRotation(Surface.ROTATION_0);
     }
 
     private ActivityTestRule<?> resolveTestRule() {

--- a/detox/test/android/app/src/androidTest/java/com/example/TestButlerProbe.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/TestButlerProbe.java
@@ -1,0 +1,47 @@
+package com.example;
+
+import android.content.pm.PackageManager;
+import android.util.Log;
+import android.view.Surface;
+
+import com.linkedin.android.testbutler.TestButler;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+class TestButlerProbe {
+
+    private static final String LOG_TAG = TestButlerProbe.class.getSimpleName();
+    private static final String TEST_BUTLER_PACKAGE_NAME = "com.linkedin.android.testbutler";
+
+    private TestButlerProbe() {
+    }
+
+    static void assertTestButlerReady() {
+        Log.i(LOG_TAG, "Test butler service verification started...");
+
+        try {
+            assertTestButlerServiceInstalled();
+        } catch (Exception e) {
+            Log.w(LOG_TAG, "Test butler not installed on device - skipping verification");
+            return;
+        }
+
+        try {
+            assertTestButlerServiceReady();
+        } catch (Exception e) {
+            Log.w(LOG_TAG, "Test butler service is NOT ready!", e);
+            return;
+        }
+        Log.i(LOG_TAG, "Test butler service is up and running!");
+    }
+
+    static private void assertTestButlerServiceInstalled() throws PackageManager.NameNotFoundException {
+        PackageManager pm = InstrumentationRegistry.getInstrumentation().getTargetContext().getPackageManager();
+        pm.getPackageInfo(TEST_BUTLER_PACKAGE_NAME, 0);
+    }
+
+    static private void assertTestButlerServiceReady() {
+        // This has no effect if test-butler is running. However, if it is not, then unlike TestButler.setup(), it would hard-fail.
+        TestButler.setRotation(Surface.ROTATION_0);
+    }
+}

--- a/detox/test/android/app/src/androidTest/java/com/example/TestButlerProbe.java
+++ b/detox/test/android/app/src/androidTest/java/com/example/TestButlerProbe.java
@@ -16,32 +16,34 @@ class TestButlerProbe {
     private TestButlerProbe() {
     }
 
-    static void assertTestButlerReady() {
+    static void assertReadyIfInstalled() {
         Log.i(LOG_TAG, "Test butler service verification started...");
 
-        try {
-            assertTestButlerServiceInstalled();
-        } catch (Exception e) {
+        if (!isTestButlerServiceInstalled()) {
             Log.w(LOG_TAG, "Test butler not installed on device - skipping verification");
             return;
         }
 
-        try {
-            assertTestButlerServiceReady();
-        } catch (Exception e) {
-            Log.w(LOG_TAG, "Test butler service is NOT ready!", e);
-            return;
-        }
+        assertTestButlerServiceReady();
         Log.i(LOG_TAG, "Test butler service is up and running!");
     }
 
-    static private void assertTestButlerServiceInstalled() throws PackageManager.NameNotFoundException {
-        PackageManager pm = InstrumentationRegistry.getInstrumentation().getTargetContext().getPackageManager();
-        pm.getPackageInfo(TEST_BUTLER_PACKAGE_NAME, 0);
+    static private boolean isTestButlerServiceInstalled() {
+        try {
+            PackageManager pm = InstrumentationRegistry.getInstrumentation().getTargetContext().getPackageManager();
+            pm.getPackageInfo(TEST_BUTLER_PACKAGE_NAME, 0);
+            return true;
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
+        }
     }
 
     static private void assertTestButlerServiceReady() {
-        // This has no effect if test-butler is running. However, if it is not, then unlike TestButler.setup(), it would hard-fail.
-        TestButler.setRotation(Surface.ROTATION_0);
+        try {
+            // This has no effect if test-butler is running. However, if it is not, then unlike TestButler.setup(), it would hard-fail.
+            TestButler.setRotation(Surface.ROTATION_0);
+        } catch (Exception e) {
+            throw new RuntimeException("Test butler service is NOT ready!", e);
+        }
     }
 }


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
This isn't really essential for Detox itself, as test butler is hard-installed on the running device in each global setup (at least for the _test_ app). This is more of a reference for other projects. Nevertheless it's good practice to have, so keeping it nonetheless.