### PR TITLE
Remove warning regarding Android parallel being experimental, add robust version check

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -67,11 +67,6 @@ function choosePrepareArgs({ cliConfig, detoxArgs, runner, platform }) {
   }
 
   if (runner === 'jest') {
-    if (platform === 'android' && hasMultipleWorkers(cliConfig)) {
-      log.warn('Multiple workers is an experimental feature on Android and requires an emulator binary of version 28.0.16 or higher. ' +
-        'Check your version by running: $ANDROID_HOME/tools/bin/sdkmanager --list');
-    }
-
     return prepareJestArgs;
   }
 

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -415,12 +415,6 @@ describe('CLI', () => {
       expect(cliCall().env).not.toHaveProperty('readOnlyEmu');
     });
 
-    test.each([['-w'], ['--workers']])('%s <value> should warn about experimental Android support', async (__workers) => {
-      singleConfig().type = 'android.emulator';
-      await run(`${__workers} 2`);
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('an experimental feature'));
-    });
-
     test.each([['-w'], ['--workers']])('%s <value> should put readOnlyEmu environment variable for Android if there is a single worker', async (__workers) => {
       singleConfig().type = 'android.emulator';
       await run(`${__workers} 1`);

--- a/detox/src/devices/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.js
@@ -25,7 +25,6 @@ const sleep = require('../../../utils/sleep');
 const retry = require('../../../utils/retry');
 const getAbsoluteBinaryPath = require('../../../utils/getAbsoluteBinaryPath');
 const DeviceRegistry = require('../../DeviceRegistry');
-const environment = require('../../../utils/environment');
 
 const ALLOCATE_DEVICE_LOG_EVT = 'ALLOCATE_DEVICE';
 

--- a/detox/src/devices/drivers/android/emulator/AVDValidator.js
+++ b/detox/src/devices/drivers/android/emulator/AVDValidator.js
@@ -1,15 +1,24 @@
 const _ = require('lodash');
 const path = require('path');
-const AVDsResolver = require('./AVDsResolver');
 const environment = require('../../../../utils/environment');
+const logger = require('../../../../utils/logger').child({ __filename });
+
+const REQUIRED_EMULATOR_MAJOR = 29;
 
 class AVDValidator {
-  constructor(emulatorExec) {
-    this._avdsResolver = new AVDsResolver(emulatorExec);
+  constructor(avdsResolver, emulatorVersionResolver) {
+    this._avdsResolver = avdsResolver;
+    this._emulatorVersionResolver = emulatorVersionResolver;
   }
 
   async validate(avdName) {
     const avds = await this._avdsResolver.resolve(avdName);
+    this._assertAVDs(avds);
+    await this._assertAVDMatch(avds, avdName);
+    await this._validateEmulatorVer();
+  }
+
+  _assertAVDs(avds) {
     if (!avds) {
       const avdmanagerPath = path.join(environment.getAndroidSDKPath(), 'tools', 'bin', 'avdmanager');
 
@@ -17,12 +26,29 @@ class AVDValidator {
         Try creating a device first, example: ${avdmanagerPath} create avd --force --name Pixel_API_28 --abi x86_64 --package "system-images;android-28;default;x86_64" --device "pixel"
         or go to https://developer.android.com/studio/run/managing-avds.html for details on how to create an Emulator.`);
     }
+  }
 
+  _assertAVDMatch(avds, avdName) {
     if (_.indexOf(avds, avdName) === -1) {
       throw new Error(`Can not boot Android Emulator with the name: '${avdName}',
         make sure you choose one of the available emulators: ${avds.toString()}`);
     }
   }
+
+  async _validateEmulatorVer() {
+    const emulatorVersion = await this._emulatorVersionResolver.resolve();
+    if (!emulatorVersion) {
+      logger.warn({ event: 'AVD_VALIDATION' }, 'Emulator version detection failed (See previous logs)');
+      return;
+    }
+
+    if (emulatorVersion.major < REQUIRED_EMULATOR_MAJOR) {
+      logger.warn({ event: 'AVD_VALIDATION' }, [
+          `Your installed emulator binary version (${emulatorVersion.toString()}) is too old, and may not be suitable for parallel test execution.`,
+          'We strongly recommend you upgrade to the latest version using the SDK manager: $ANDROID_HOME/tools/bin/sdkmanager --list'
+        ].join('\n'));
+    }
+  }
 }
 
- module.exports = AVDValidator;
+module.exports = AVDValidator;

--- a/detox/src/devices/drivers/android/emulator/AVDValidator.js
+++ b/detox/src/devices/drivers/android/emulator/AVDValidator.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
-const path = require('path');
 const environment = require('../../../../utils/environment');
+const DetoxRuntimeError = require('../../../../errors/DetoxRuntimeError');
 const logger = require('../../../../utils/logger').child({ __filename });
 
 const REQUIRED_EMULATOR_MAJOR = 29;
@@ -20,18 +20,19 @@ class AVDValidator {
 
   _assertAVDs(avds) {
     if (!avds) {
-      const avdmanagerPath = path.join(environment.getAndroidSDKPath(), 'tools', 'bin', 'avdmanager');
-
-      throw new Error(`Could not find any configured Android Emulator.\n
-        Try creating a device first, example: ${avdmanagerPath} create avd --force --name Pixel_API_28 --abi x86_64 --package "system-images;android-28;default;x86_64" --device "pixel"
-        or go to https://developer.android.com/studio/run/managing-avds.html for details on how to create an Emulator.`);
+      const usageExample = `${environment.getAvdManagerPath()} create avd --force --name Pixel_API_28 --abi x86_64 --package "system-images;android-28;default;x86_64" --device "pixel"`;
+      const message = 'Could not find any configured Android Emulator.';
+      const hint = `Try creating a device first (example: ${usageExample}),`
+        + ' or go to https://developer.android.com/studio/run/managing-avds.html for details on how to create an Emulator.';
+      throw new DetoxRuntimeError({ message, hint });
     }
   }
 
   _assertAVDMatch(avds, avdName) {
     if (_.indexOf(avds, avdName) === -1) {
-      throw new Error(`Can not boot Android Emulator with the name: '${avdName}',
-        make sure you choose one of the available emulators: ${avds.toString()}`);
+      const message = `Cannot boot Android Emulator with the name: '${avdName}'`;
+      const hint = `Make sure you choose one of the available emulators: ${avds.toString()}`;
+      throw new DetoxRuntimeError({ message, hint });
     }
   }
 
@@ -44,8 +45,8 @@ class AVDValidator {
 
     if (emulatorVersion.major < REQUIRED_EMULATOR_MAJOR) {
       logger.warn({ event: 'AVD_VALIDATION' }, [
-          `Your installed emulator binary version (${emulatorVersion.toString()}) is too old, and may not be suitable for parallel test execution.`,
-          'We strongly recommend you upgrade to the latest version using the SDK manager: $ANDROID_HOME/tools/bin/sdkmanager --list'
+          `Your installed emulator binary version (${emulatorVersion}) is too old, and may not be suitable for parallel test execution.`,
+          `We strongly recommend you upgrade to the latest version using the SDK manager: ${environment.getAndroidSdkManagerPath()} --list`
         ].join('\n'));
     }
   }

--- a/detox/src/devices/drivers/android/emulator/EmulatorDriver.js
+++ b/detox/src/devices/drivers/android/emulator/EmulatorDriver.js
@@ -30,8 +30,9 @@ class EmulatorDriver extends AndroidDriver {
     const emulatorExec = new EmulatorExec();
     this._emuVersionResolver = new EmulatorVersionResolver(emulatorExec);
     this._emuLauncher = new EmulatorLauncher(emulatorExec);
-    this._avdsResolver = new AVDsResolver(emulatorExec);
-    this._avdValidator = new AVDValidator(this._avdsResolver, this._emuVersionResolver);
+
+    const avdsResolver = new AVDsResolver(emulatorExec);
+    this._avdValidator = new AVDValidator(avdsResolver, this._emuVersionResolver);
     this._freeDeviceFinder = new FreeEmulatorFinder(this.adb, this.deviceRegistry);
 
     this.pendingBoots = {};

--- a/detox/src/devices/drivers/android/emulator/EmulatorDriver.js
+++ b/detox/src/devices/drivers/android/emulator/EmulatorDriver.js
@@ -5,6 +5,7 @@ const ini = require('ini');
 const AndroidDriver = require('../AndroidDriver');
 const FreeEmulatorFinder = require('./FreeEmulatorFinder');
 const AVDValidator = require('./AVDValidator');
+const AVDsResolver = require('./AVDsResolver');
 const EmulatorLauncher = require('./EmulatorLauncher');
 const EmulatorVersionResolver = require('./EmulatorVersionResolver');
 const { EmulatorExec } = require('../exec/EmulatorExec');
@@ -26,11 +27,12 @@ class EmulatorDriver extends AndroidDriver {
   constructor(config) {
     super(config);
 
-    this.freeDeviceFinder = new FreeEmulatorFinder(this.adb, this.deviceRegistry);
     const emulatorExec = new EmulatorExec();
     this._emuVersionResolver = new EmulatorVersionResolver(emulatorExec);
     this._emuLauncher = new EmulatorLauncher(emulatorExec);
-    this._avdValidator = new AVDValidator(emulatorExec);
+    this._avdsResolver = new AVDsResolver(emulatorExec);
+    this._avdValidator = new AVDValidator(this._avdsResolver, this._emuVersionResolver);
+    this._freeDeviceFinder = new FreeEmulatorFinder(this.adb, this.deviceRegistry);
 
     this.pendingBoots = {};
     this._name = 'Unspecified Emulator';
@@ -59,7 +61,7 @@ class EmulatorDriver extends AndroidDriver {
   }
 
   async doAllocateDevice(deviceQuery) {
-    const freeEmulatorAdbName = await this.freeDeviceFinder.findFreeDevice(deviceQuery);
+    const freeEmulatorAdbName = await this._freeDeviceFinder.findFreeDevice(deviceQuery);
     return freeEmulatorAdbName || this._createDevice();
   }
 

--- a/detox/src/devices/drivers/android/emulator/EmulatorVersionResolver.js
+++ b/detox/src/devices/drivers/android/emulator/EmulatorVersionResolver.js
@@ -42,6 +42,7 @@ class EmulatorVersionResolver {
       major: Number(major),
       minor: Number(minor),
       patch: Number(patch),
+      toString: () => versionRaw,
     };
   }
 }

--- a/detox/src/devices/drivers/android/emulator/EmulatorVersionResolver.test.js
+++ b/detox/src/devices/drivers/android/emulator/EmulatorVersionResolver.test.js
@@ -16,6 +16,7 @@ describe('Emulator binary version', () => {
     minor: 1,
     patch: 2,
   };
+  const expectedVersionRaw = '30.1.2.3';
 
   let MockQueryVersionCommand;
   let emulatorExec;
@@ -51,7 +52,8 @@ describe('Emulator binary version', () => {
 
   it('should extract version from common log', async () => {
     const version = await uut.resolve();
-    expect(version).toEqual(expectedVersion);
+    expect(version).toEqual(expect.objectContaining(expectedVersion));
+    expect(version.toString()).toEqual(expectedVersionRaw);
   });
 
   it('should return null for an empty query result', async () => {
@@ -90,11 +92,11 @@ describe('Emulator binary version', () => {
     const version = await uut.resolve();
 
     expect(emulatorExec.exec).toHaveBeenCalledTimes(1);
-    expect(version).toEqual(expectedVersion);
+    expect(version).toEqual(expect.objectContaining(expectedVersion));
   });
 
   it('should log the version', async () => {
     await uut.resolve();
-    expect(log.debug).toHaveBeenCalledWith({event: 'EMU_BIN_VERSION_DETECT', success: true}, expect.any(String), expectedVersion);
+    expect(log.debug).toHaveBeenCalledWith({event: 'EMU_BIN_VERSION_DETECT', success: true}, expect.any(String), expect.objectContaining(expectedVersion));
   });
 });

--- a/detox/src/utils/environment.js
+++ b/detox/src/utils/environment.js
@@ -49,6 +49,14 @@ function getAvdDir(avdName) {
   return avdIni.path;
 }
 
+function getAvdManagerPath() {
+  return path.join(getAndroidSDKPath(), 'tools', 'bin', 'avdmanager');
+}
+
+function getAndroidSdkManagerPath() {
+  return path.join(getAndroidSDKPath(), 'tools', 'bin', 'sdkmanager');
+}
+
 function getAndroidEmulatorPath() {
   const sdkRoot = getAndroidSDKPath();
   if (!sdkRoot) {
@@ -171,6 +179,8 @@ module.exports = {
   getAdbPath,
   getAvdHome,
   getAvdDir,
+  getAvdManagerPath,
+  getAndroidSdkManagerPath,
   getDetoxVersion,
   getFrameworkPath,
   getAndroidSDKPath,

--- a/detox/src/utils/environment.test.js
+++ b/detox/src/utils/environment.test.js
@@ -120,6 +120,40 @@ describe('Environment', () => {
       });
     });
 
+    describe('getAvdManagerPath', () => {
+      it('should return path to AVD-manager executable', () => {
+        process.env.ANDROID_SDK_ROOT = 'mock/path/to/sdk';
+
+        const avdManagerPath = Environment.getAvdManagerPath();
+        expect(avdManagerPath).toEqual('mock/path/to/sdk/tools/bin/avdmanager');
+      });
+
+      it('should fall back to using ANDROID_HOME instead of ANDROID_SDK_ROOT', () => {
+        delete process.env.ANDROID_SDK_ROOT;
+        process.env.ANDROID_HOME = 'mock/path/to/sdk';
+
+        const avdManagerPath = Environment.getAvdManagerPath();
+        expect(avdManagerPath).toEqual('mock/path/to/sdk/tools/bin/avdmanager');
+      });
+    });
+
+    describe('getAndroidSdkManagerPath', () => {
+      it('should return path to SDK-manager executable', () => {
+        process.env.ANDROID_SDK_ROOT = 'mock/path/to/sdk';
+
+        const sdkManagerPath = Environment.getAndroidSdkManagerPath();
+        expect(sdkManagerPath).toEqual('mock/path/to/sdk/tools/bin/sdkmanager');
+      });
+
+      it('should fall back to using ANDROID_HOME instead of ANDROID_SDK_ROOT', () => {
+        delete process.env.ANDROID_SDK_ROOT;
+        process.env.ANDROID_HOME = 'mock/path/to/sdk';
+
+        const sdkManagerPath = Environment.getAndroidSdkManagerPath();
+        expect(sdkManagerPath).toEqual('mock/path/to/sdk/tools/bin/sdkmanager');
+      });
+    });
+
     describe('getAndroidEmulatorPath', () => {
       describe('if $ANDROID_SDK_ROOT is set', () => {
         beforeEach(() => {


### PR DESCRIPTION
- [x] This is a small change 
- [x] This change has been discussed in issue #2297 and the solution has been agreed upon with maintainers.

---

**Description:**
Resolves #2297 