### PR TITLE
iOS: fix default scroll and ability to override params

### DIFF
--- a/detox/ios/Detox/Actions/UIScrollView+DetoxActions.m
+++ b/detox/ios/Detox/Actions/UIScrollView+DetoxActions.m
@@ -218,7 +218,7 @@ if(isnan(normalizedStartingPoint.other) || normalizedStartingPoint.other < 0 || 
 } \
 if(isnan(normalizedStartingPoint.main) || normalizedStartingPoint.main < 0 || normalizedStartingPoint.main > 1) \
 { \
-	normalizedStartingPoint.main = offset < 0 ? 0.97 : 0.03; \
+	normalizedStartingPoint.main = offset < 0 ? 0.95 : 0.05; \
 }
 
 - (void)dtx_scrollWithOffset:(CGPoint)offset normalizedStartingPoint:(CGPoint)normalizedStartingPoint

--- a/detox/src/ios/expectTwo.js
+++ b/detox/src/ios/expectTwo.js
@@ -66,13 +66,14 @@ class Expect {
   }
 
   createInvocation(expectation, ...params) {
+    params = _.map(params, (param) => _.isNaN(param) ? null : param);
     return {
       type: 'expectation',
       predicate: this.element.matcher.predicate,
       ...(this.element.index !== undefined && { atIndex: this.element.index }),
       ...(this.modifiers.length !== 0 && {modifiers: this.modifiers}),
       expectation,
-      ...(params.length !== 0 && { params: _.without(params, NaN, null, undefined) })
+      ...(params.length !== 0 && { params: _.without(params, undefined) })
     };
   }
 
@@ -206,11 +207,12 @@ class Element {
   }
 
   createInvocation(action, ...params) {
+    params = _.map(params, (param) => _.isNaN(param) ? null : param);
     return ({
       type: 'action',
       action,
       ...(this.index !== undefined && { atIndex: this.index }),
-      ...(_.without(params, NaN, null, undefined).length !== 0 && { params: _.without(params, NaN, null, undefined) }),
+      ...(_.without(params, undefined).length !== 0 && { params: _.without(params, undefined) }),
       predicate: this.matcher.predicate
     });
   }

--- a/detox/src/ios/expectTwo.js
+++ b/detox/src/ios/expectTwo.js
@@ -66,7 +66,6 @@ class Expect {
   }
 
   createInvocation(expectation, ...params) {
-    params = _.map(params, (param) => _.isNaN(param) ? null : param);
     return {
       type: 'expectation',
       predicate: this.element.matcher.predicate,

--- a/detox/src/ios/expectTwo.test.js
+++ b/detox/src/ios/expectTwo.test.js
@@ -306,7 +306,7 @@ describe('expectTwo', () => {
       invocation: {
         type: 'action',
         action: 'scroll',
-        params: [50, 'down'],
+        params: [50, 'down', null, null],
         predicate: {
           type: 'id',
           value: 'ScrollView630'


### PR DESCRIPTION
**Description:**
iOS: fix default scroll and ability to override params (NaN and null params were being deleted, they aren't anymore)