### PR TITLE
hotfix(cli): backward compatible path handling

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -10,6 +10,7 @@ const log = require('../src/utils/logger').child({ __filename });
 const shellQuote = require('./utils/shellQuote');
 const splitArgv = require('./utils/splitArgv');
 const { getPlatformSpecificString, printEnvironmentVariables } = require('./utils/misc');
+const { prependNodeModulesBinToPATH } = require('./utils/misc');
 
 module.exports.command = 'test';
 module.exports.desc = 'Run your test suite with the test runner specified in package.json';
@@ -195,10 +196,12 @@ function launchTestRunner({ argv, env, specs, rerunIndex }) {
 
   cp.execSync(fullCommand, {
     stdio: 'inherit',
-    env: _.omitBy({
-      ...process.env,
-      ...env,
-    }, _.isUndefined),
+    env: _({})
+      .assign(process.env)
+      .assign(env)
+      .omitBy(_.isUndefined)
+      .tap(prependNodeModulesBinToPATH)
+      .value()
   });
 }
 

--- a/detox/local-cli/utils/misc.js
+++ b/detox/local-cli/utils/misc.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 function getPlatformSpecificString(platform) {
   switch (platform) {
     case 'ios': return ':android:';
@@ -16,7 +18,20 @@ function printEnvironmentVariables(envObject) {
   }, '');
 }
 
+function prependNodeModulesBinToPATH(env) {
+  const PATH = Object.keys(env).find(key => `${key.toUpperCase()}` === 'PATH');
+  if (!PATH) {
+    return;
+  }
+
+  const nodeBinariesPath = path.dirname(process.argv[1]) + path.delimiter;
+  if (!env[PATH].startsWith(nodeBinariesPath)) {
+    env[PATH] = nodeBinariesPath + env[PATH];
+  }
+}
+
 module.exports = {
   getPlatformSpecificString,
   printEnvironmentVariables,
+  prependNodeModulesBinToPATH,
 };


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

In case if users call `detox test` in a direct way, i.e.: `node_modules/.bin/detox test ...`, it fixes errors like:

```
/bin/sh: mocha: command not found
```

