### PR TITLE
fix(jest): resolve jest-cli relatively to jest itself

### DIFF
--- a/detox/local-cli/utils/splitArgv.js
+++ b/detox/local-cli/utils/splitArgv.js
@@ -1,4 +1,6 @@
 const _ = require('lodash');
+const path = require('path');
+const resolveFrom = require('resolve-from');
 const testCommandArgs = require('./testCommandArgs');
 
 function extractKnownKeys(yargsBuilder) {
@@ -49,7 +51,10 @@ function disengageBooleanArgs(argv, booleanKeys) {
 }
 
 function getJestBooleanArgs() {
-  return _(require('jest-cli/build/cli/args'))
+  const jestLocation = path.dirname(resolveFrom(process.cwd(), 'jest/package.json'));
+  const jestCliArgsPath = resolveFrom(jestLocation, 'jest-cli/build/cli/args');
+
+  return _(require(jestCliArgsPath))
     .thru(args => args.options)
     .pickBy(({ type }) => type === 'boolean')
     .thru(extractKnownKeys)

--- a/detox/local-cli/utils/splitArgv.js
+++ b/detox/local-cli/utils/splitArgv.js
@@ -1,7 +1,9 @@
 const _ = require('lodash');
 const path = require('path');
+const Module = require('module');
 const resolveFrom = require('resolve-from');
 const testCommandArgs = require('./testCommandArgs');
+const DetoxRuntimeError = require('../../src/errors/DetoxRuntimeError');
 
 function extractKnownKeys(yargsBuilder) {
   return Object.entries(yargsBuilder).reduce(
@@ -51,10 +53,7 @@ function disengageBooleanArgs(argv, booleanKeys) {
 }
 
 function getJestBooleanArgs() {
-  const jestLocation = path.dirname(resolveFrom(process.cwd(), 'jest/package.json'));
-  const jestCliArgsPath = resolveFrom(jestLocation, 'jest-cli/build/cli/args');
-
-  return _(require(jestCliArgsPath))
+  return _(resolveJestCliArgs())
     .thru(args => args.options)
     .pickBy(({ type }) => type === 'boolean')
     .thru(extractKnownKeys)
@@ -68,6 +67,33 @@ function getMochaBooleanArgs() {
     .flatMap(key => [key, ...(metadata.aliases[key] || [])])
     .thru(keys => new Set(keys))
     .value();
+}
+
+function resolveJestCliArgs() {
+  const cwd = process.cwd();
+  const getNodeModulePaths = (dir) => Module._nodeModulePaths(dir);
+
+  if (!resolveFrom.silent(cwd, 'jest')) {
+    throw new DetoxRuntimeError({
+      message: 'Could not resolve "jest" package from the current working directory.\n\n' +
+        'This means that Detox could not find it in any of the following locations:\n' +
+        getNodeModulePaths(cwd).map(p => `* ${p}`).join('\n'),
+      hint: `Try installing "jest": npm install jest --save-dev`,
+    });
+  }
+
+  const jestLocation = path.dirname(resolveFrom(cwd, 'jest/package.json'));
+
+  if (!resolveFrom.silent(jestLocation, 'jest-cli')) {
+    throw new DetoxRuntimeError({
+      message: 'Could not resolve "jest-cli" package from the "jest" npm package directory.\n\n' +
+        'This means that Detox could not find it in any of the following locations:\n' +
+        getNodeModulePaths(jestLocation).map(p => `* ${p}`).join('\n'),
+      hint: 'Consider reporting this as an issue at: https://github.com/wix/Detox/issues'
+    });
+  }
+
+  return require(resolveFrom(jestLocation, 'jest-cli/build/cli/args'));
 }
 
 function splitDetoxArgv(argv) {

--- a/detox/package.json
+++ b/detox/package.json
@@ -31,9 +31,9 @@
   "devDependencies": {
     "eslint": "^4.11.0",
     "eslint-plugin-node": "^6.0.1",
-    "jest-circus": ">=26.0.0",
-    "jest-cli": ">=25.0.0",
-    "jest-environment-node": ">=25.0.0",
+    "jest": "^26.0.0",
+    "jest-circus": "^26.0.0",
+    "jest-environment-node": "^26.0.0",
     "mocha": ">=6.0.0",
     "mockdate": "^2.0.1",
     "prettier": "1.7.0",
@@ -53,6 +53,7 @@
     "lodash": "^4.17.5",
     "minimist": "^1.2.0",
     "proper-lockfile": "^3.0.2",
+    "resolve-from": "^5.0.0",
     "sanitize-filename": "^1.6.1",
     "shell-utils": "^1.0.9",
     "signal-exit": "^3.0.3",
@@ -67,7 +68,6 @@
   },
   "peerDependencies": {
     "jest-circus": ">=26.0.0",
-    "jest-cli": ">=25.0.0",
     "jest-environment-node": ">=25.0.0",
     "mocha": ">=6.0.0"
   },


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Eliminates the need to explicitly install `jest-cli`.
Resolves `jest-cli` from `jest` npm package.