### PR TITLE
fix: prevent flooding currentStatus messages

### DIFF
--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -131,7 +131,7 @@ class Client {
   }
 
   async sendAction(action) {
-    if (this.slowInvocationTimeout) {
+    if (this.slowInvocationTimeout && action.type !== 'currentStatus') {
       this.slowInvocationStatusHandler = this.slowInvocationStatus();
     }
 

--- a/detox/src/client/Client.test.js
+++ b/detox/src/client/Client.test.js
@@ -234,6 +234,18 @@ describe('Client', () => {
       expect(client.ws.send).toHaveBeenCalledTimes(2);
     });
 
+    // NOTE: this test prevents geometrical progression of currentStatus calls
+    // when the device gets really busy. Otherwise, we can get 1000 pending currentStatus calls.
+    it(`slowInvocationStatus() - should not schedule currentStatus thrice`, async () => {
+      argparse.getArgValue.mockReturnValue(2); // set debug-slow-invocations
+      await connect();
+
+      jest.spyOn(client, 'slowInvocationStatus');
+      await executeWithSlowInvocation(3);
+
+      expect(client.slowInvocationStatus).toHaveBeenCalledTimes(2);
+    });
+
     async function executeWithSlowInvocation(invocationTime) {
       client.ws.send
         .mockImplementationOnce(async function () {


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Fixes flood of `currentStatus` messages when the app is really busy and cannot reply.
Each currentStatus request generates one extra currentStatus request, and that goes up quite fast.

Looks like a regression after https://github.com/wix/Detox/commit/41400bfc (kudos to @d4vidi for the investigation)


```
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [AsyncWebSocket.js/WEBSOCKET_SEND]  [90m{"type":"currentStatus","params":{},"messageId":63396} [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [AsyncWebSocket.js/WEBSOCKET_SEND]  [90m{"type":"currentStatus","params":{},"messageId":63397} [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [AsyncWebSocket.js/WEBSOCKET_SEND]  [90m{"type":"currentStatus","params":{},"messageId":63398} [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [AsyncWebSocket.js/WEBSOCKET_SEND]  [90m{"type":"currentStatus","params":{},"messageId":63399} [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [AsyncWebSocket.js/WEBSOCKET_SEND]  [90m{"type":"currentStatus","params":{},"messageId":63400} [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [AsyncWebSocket.js/WEBSOCKET_SEND]  [90m{"type":"currentStatus","params":{},"messageId":63401} [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [AsyncWebSocket.js/WEBSOCKET_SEND]  [90m{"type":"currentStatus","params":{},"messageId":63402} [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [AsyncWebSocket.js/WEBSOCKET_SEND]  [90m{"type":"currentStatus","params":{},"messageId":63403} [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [AsyncWebSocket.js/WEBSOCKET_SEND]  [90m{"type":"currentStatus","params":{},"messageId":63404} [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [DetoxServer.js/MESSAGE]  [90mrole=tester action=currentStatus (sessionId=511125a8-9f8c-4ef3-0667-e1740512d733) [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [DetoxServer.js/MESSAGE]  [90mrole=tester action=currentStatus (sessionId=511125a8-9f8c-4ef3-0667-e1740512d733) [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [DetoxServer.js/MESSAGE]  [90mrole=tester action=currentStatus (sessionId=511125a8-9f8c-4ef3-0667-e1740512d733) [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [DetoxServer.js/MESSAGE]  [90mrole=tester action=currentStatus (sessionId=511125a8-9f8c-4ef3-0667-e1740512d733) [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [DetoxServer.js/MESSAGE]  [90mrole=tester action=currentStatus (sessionId=511125a8-9f8c-4ef3-0667-e1740512d733) [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [DetoxServer.js/MESSAGE]  [90mrole=tester action=currentStatus (sessionId=511125a8-9f8c-4ef3-0667-e1740512d733) [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [DetoxServer.js/MESSAGE]  [90mrole=tester action=currentStatus (sessionId=511125a8-9f8c-4ef3-0667-e1740512d733) [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [DetoxServer.js/MESSAGE]  [90mrole=tester action=currentStatus (sessionId=511125a8-9f8c-4ef3-0667-e1740512d733) [39m
[09:17:40]W:		 [Phase: Tests] detox[3748] TRACE: [DetoxServer.js/MESSAGE]  [90mrole=tester action=currentStatus (sessionId=511125a8-9f8c-4ef3-0667-e1740512d733) [39m
```
