### PR TITLE
Introduce expectation for matching toggleable widgets

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxMatcher.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxMatcher.java
@@ -8,9 +8,11 @@ import androidx.test.espresso.matcher.ViewMatchers.Visibility;
 
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
+import static androidx.test.espresso.matcher.ViewMatchers.isNotChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
@@ -45,6 +47,10 @@ public class DetoxMatcher {
 
     public static Matcher<View> matcherForTestId(String testId) {
         return allOf(withTagValue(is((Object) testId)), withEffectiveVisibility(Visibility.VISIBLE));
+    }
+
+    public static Matcher<View> matcherForToggleable(boolean value) {
+        return (value ? isChecked() : isNotChecked());
     }
 
     public static Matcher<View> matcherForAnd(Matcher<View> m1, Matcher<View> m2) {

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/matcher/ViewMatchers.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/matcher/ViewMatchers.kt
@@ -23,7 +23,7 @@ fun isOfClassName(className: String): Matcher<View> {
         // empty
     }
 
-    return object : BaseMatcher<View>() {
+    return object: BaseMatcher<View>() {
         override fun matches(item: Any) = false
         override fun describeTo(description: Description) {
             description.appendText("Class $className not found on classpath. Are you using full class name?")

--- a/detox/src/android/espressoapi/DetoxMatcher.js
+++ b/detox/src/android/espressoapi/DetoxMatcher.js
@@ -50,6 +50,21 @@ class DetoxMatcher {
     };
   }
 
+  static matcherForToggleable(value) {
+    if (typeof value !== "boolean") throw new Error("value should be a boolean, but got " + (value + (" (" + (typeof value + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.espresso.DetoxMatcher"
+      },
+      method: "matcherForToggleable",
+      args: [{
+        type: "boolean",
+        value: value
+      }]
+    };
+  }
+
   static matcherForAnd(m1, m2) {
     return {
       target: {

--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -363,7 +363,7 @@ class ExpectElement extends Expect {
     return await this.not.toHaveValue(value);
   }
 
-  async toHaveToggleableValue(value) {
+  async toHaveToggleValue(value) {
     return await new MatcherAssertionInteraction(this._invocationManager, this._element, this._notCondition ? new ToggleMatcher(value).not : new ToggleMatcher(value)).execute()
   }
 }

--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -2,22 +2,24 @@ const fs = require('fs-extra');
 const path = require('path');
 const tempfile = require('tempfile');
 const invoke = require('../invoke');
-const matchers = require('./matcher');
 const DetoxActionApi = require('./espressoapi/DetoxAction');
 const ViewActionsApi = require('./espressoapi/ViewActions');
 const DetoxViewActionsApi = require('./espressoapi/DetoxViewActions');
 const DetoxAssertionApi = require('./espressoapi/DetoxAssertion');
 const EspressoDetoxApi = require('./espressoapi/EspressoDetox');
 const DetoxMatcherApi = require('./espressoapi/DetoxMatcher');
-const Matcher = matchers.Matcher;
-const LabelMatcher = matchers.LabelMatcher;
-const IdMatcher = matchers.IdMatcher;
-const TypeMatcher = matchers.TypeMatcher;
-const TraitsMatcher = matchers.TraitsMatcher;
-const VisibleMatcher = matchers.VisibleMatcher;
-const ExistsMatcher = matchers.ExistsMatcher;
-const TextMatcher = matchers.TextMatcher;
-const ValueMatcher = matchers.ValueMatcher;
+const {
+  Matcher,
+  LabelMatcher,
+  IdMatcher,
+  TypeMatcher,
+  TraitsMatcher,
+  VisibleMatcher,
+  ExistsMatcher,
+  TextMatcher,
+  ValueMatcher,
+  ToggleMatcher,
+} = require('./matcher');
 
 function call(maybeAFunction) {
   return maybeAFunction instanceof Function ? maybeAFunction() : maybeAFunction;
@@ -359,6 +361,10 @@ class ExpectElement extends Expect {
 
   async toNotHaveValue(value) {
     return await this.not.toHaveValue(value);
+  }
+
+  async toHaveToggleableValue(value) {
+    return await new MatcherAssertionInteraction(this._invocationManager, this._element, this._notCondition ? new ToggleMatcher(value).not : new ToggleMatcher(value)).execute()
   }
 }
 

--- a/detox/src/android/expect.test.js
+++ b/detox/src/android/expect.test.js
@@ -38,6 +38,8 @@ describe('expect', () => {
     await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveValue('value');
     await e.expect(e.element(e.by.accessibilityLabel('test'))).toNotHaveValue('value');
     await e.expect(e.element(e.by.accessibilityLabel('test'))).not.toHaveValue('value');
+    await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveToggleableValue(true);
+    await e.expect(e.element(e.by.accessibilityLabel('test'))).not.toHaveToggleableValue(true);
   });
 
   it(`element by label (for backwards compat)`, async () => {
@@ -49,6 +51,8 @@ describe('expect', () => {
     await e.expect(e.element(e.by.label('test'))).toHaveLabel('label');
     await e.expect(e.element(e.by.label('test'))).toHaveId('id');
     await e.expect(e.element(e.by.label('test'))).toHaveValue('value');
+    await e.expect(e.element(e.by.label('test'))).toHaveToggleableValue(false);
+    await e.expect(e.element(e.by.label('test'))).not.toHaveToggleableValue(false);
   });
 
   it(`element by id`, async () => {
@@ -119,10 +123,9 @@ describe('expect', () => {
     await e.waitFor(e.element(e.by.id('id'))).toNotHaveValue('value');
     await e.waitFor(e.element(e.by.id('id'))).not.toHaveValue('value');
 
-
-
     await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).scroll(50, 'down');
     await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).scroll(50);
+
   });
 
   it(`waitFor (element) with wrong parameters should throw`, async () => {

--- a/detox/src/android/expect.test.js
+++ b/detox/src/android/expect.test.js
@@ -38,8 +38,8 @@ describe('expect', () => {
     await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveValue('value');
     await e.expect(e.element(e.by.accessibilityLabel('test'))).toNotHaveValue('value');
     await e.expect(e.element(e.by.accessibilityLabel('test'))).not.toHaveValue('value');
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveToggleableValue(true);
-    await e.expect(e.element(e.by.accessibilityLabel('test'))).not.toHaveToggleableValue(true);
+    await e.expect(e.element(e.by.accessibilityLabel('test'))).toHaveToggleValue(true);
+    await e.expect(e.element(e.by.accessibilityLabel('test'))).not.toHaveToggleValue(true);
   });
 
   it(`element by label (for backwards compat)`, async () => {
@@ -51,8 +51,8 @@ describe('expect', () => {
     await e.expect(e.element(e.by.label('test'))).toHaveLabel('label');
     await e.expect(e.element(e.by.label('test'))).toHaveId('id');
     await e.expect(e.element(e.by.label('test'))).toHaveValue('value');
-    await e.expect(e.element(e.by.label('test'))).toHaveToggleableValue(false);
-    await e.expect(e.element(e.by.label('test'))).not.toHaveToggleableValue(false);
+    await e.expect(e.element(e.by.label('test'))).toHaveToggleValue(false);
+    await e.expect(e.element(e.by.label('test'))).not.toHaveToggleValue(false);
   });
 
   it(`element by id`, async () => {

--- a/detox/src/android/matcher.js
+++ b/detox/src/android/matcher.js
@@ -92,6 +92,13 @@ class ValueMatcher extends Matcher {
   }
 }
 
+class ToggleMatcher extends Matcher {
+  constructor(toggleState) {
+    super();
+    this._call = invoke.callDirectly(DetoxMatcherApi.matcherForToggleable(toggleState));
+  }
+}
+
 // TODO
 // Please be aware, that this is just a dummy matcher
 class TraitsMatcher extends Matcher {
@@ -112,5 +119,6 @@ module.exports = {
   VisibleMatcher,
   ExistsMatcher,
   TextMatcher,
-  ValueMatcher
+  ValueMatcher,
+  ToggleMatcher,
 };

--- a/detox/src/ios/expectTwo.js
+++ b/detox/src/ios/expectTwo.js
@@ -60,7 +60,7 @@ class Expect {
     return this.expect('toHaveSliderPosition', position, tolerance);
   }
 
-  toHaveToggleableValue(value) {
+  toHaveToggleValue(value) {
     return this.toHaveValue(`${Number(value)}`);
   }
 

--- a/detox/src/ios/expectTwo.js
+++ b/detox/src/ios/expectTwo.js
@@ -60,6 +60,10 @@ class Expect {
     return this.expect('toHaveSliderPosition', position, tolerance);
   }
 
+  toHaveToggleableValue(value) {
+    return this.toHaveValue(`${Number(value)}`);
+  }
+
   get not() {
     this.modifiers.push('not');
     return this;

--- a/detox/src/ios/expectTwo.test.js
+++ b/detox/src/ios/expectTwo.test.js
@@ -300,8 +300,8 @@ describe('expectTwo', () => {
     expect(testCall).deepEquals(jsonOutput);
   });
 
-  it(`expect(element(by.id('switch'))).toHaveToggleableValue(value)`, () => {
-    const testCall = e.expect(e.element(e.by.id('switch'))).toHaveToggleableValue(true);
+  it(`expect(element(by.id('switch'))).toHaveToggleValue(value)`, () => {
+    const testCall = e.expect(e.element(e.by.id('switch'))).toHaveToggleValue(true);
     const jsonOutput = {
       'invocation': {
         'type': 'expectation',

--- a/detox/src/ios/expectTwo.test.js
+++ b/detox/src/ios/expectTwo.test.js
@@ -300,6 +300,23 @@ describe('expectTwo', () => {
     expect(testCall).deepEquals(jsonOutput);
   });
 
+  it(`expect(element(by.id('switch'))).toHaveToggleableValue(value)`, () => {
+    const testCall = e.expect(e.element(e.by.id('switch'))).toHaveToggleableValue(true);
+    const jsonOutput = {
+      'invocation': {
+        'type': 'expectation',
+        'predicate': {
+          'type': 'id',
+          'value': 'switch'
+        },
+        'expectation': 'toHaveValue',
+        'params': ['1']
+      }
+    };
+
+    expect(testCall).deepEquals(jsonOutput);
+  });
+
   it(`waitFor(element(by.text('Text5'))).toBeNotVisible().whileElement(by.id('ScrollView630')).scroll(50, 'down')`, () => {
     const testCall = e.waitFor(e.element(e.by.text('Text5'))).toBeNotVisible().whileElement(e.by.id('ScrollView630')).scroll(50, 'down');
     const jsonOutput = {

--- a/detox/test/e2e/04.assertions.test.js
+++ b/detox/test/e2e/04.assertions.test.js
@@ -43,9 +43,9 @@ describe('Assertions', () => {
   });
 
   it('assert toggle-switch widget', async () => {
-    await expect(element(by.id('UniqueId146'))).toHaveToggleableValue(false);
+    await expect(element(by.id('UniqueId146'))).toHaveToggleValue(false);
     await element(by.id('UniqueId146')).tap();
-    await expect(element(by.id('UniqueId146'))).toHaveToggleableValue(true);
-    await expect(element(by.id('UniqueId146'))).not.toHaveToggleableValue(false);
+    await expect(element(by.id('UniqueId146'))).toHaveToggleValue(true);
+    await expect(element(by.id('UniqueId146'))).not.toHaveToggleValue(false);
   });
 });

--- a/detox/test/e2e/04.assertions.test.js
+++ b/detox/test/e2e/04.assertions.test.js
@@ -41,4 +41,11 @@ describe('Assertions', () => {
     await element(by.id('UniqueId146')).tap();
     await expect(element(by.id('UniqueId146'))).toHaveValue('1');
   });
+
+  it('assert toggle-switch widget', async () => {
+    await expect(element(by.id('UniqueId146'))).toHaveToggleableValue(false);
+    await element(by.id('UniqueId146')).tap();
+    await expect(element(by.id('UniqueId146'))).toHaveToggleableValue(true);
+    await expect(element(by.id('UniqueId146'))).not.toHaveToggleableValue(false);
+  });
 });

--- a/detox/test/src/Screens/AssertionsScreen.js
+++ b/detox/test/src/Screens/AssertionsScreen.js
@@ -2,8 +2,22 @@ import React, { Component } from 'react';
 import {
   Text,
   View,
-  Switch
+  Switch,
 } from 'react-native';
+
+class TestSwitchWidget extends Switch {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: false
+    }
+    this.onChange = () => this.setState({ value: !this.state.value });
+  }
+
+  render() {
+    return <Switch testID={this.props.testID} onChange={this.onChange} value={this.state.value}/>
+  }
+}
 
 export default class AssertionsScreen extends Component {
 
@@ -17,17 +31,10 @@ export default class AssertionsScreen extends Component {
   render() {
     return (
       <View style={{flex: 1, paddingTop: 20, justifyContent: 'center', alignItems: 'center'}}>
-
         <Text testID='UniqueId204' style={{marginBottom: 20}} accessibilityLabel={'I contain some text'}>I contain some text</Text>
-
         <Text testID='UniqueId205' style={{marginBottom: 20, position: 'absolute', left: -200}}>I am not visible</Text>
-
-        <Switch testID='UniqueId146'
-          onValueChange={(value) => this.setState({switchValue: value})}
-          value={this.state.switchValue} />
-
+        <TestSwitchWidget testID='UniqueId146'/>
       </View>
     );
   }
-
 }

--- a/docs/APIRef.Expect.md
+++ b/docs/APIRef.Expect.md
@@ -13,6 +13,7 @@ Use [actions](APIRef.ActionsOnElement.md) to simulate use interaction with eleme
 - [`.toHaveId()`](#tohaveidid)
 - [`.toHaveValue()`](#tohavevaluevalue)
 - [`.toHaveSliderPosition()`](#tohavesliderpositionnormalizedposition-tolerance--ios-only) **iOS only**
+- [`.toHaveToggleableValue()`](#tohavetoggleablevaluevalue)
 - [`.not`](#not)
 - [`.withTimeout()`](#withtimeouttimeout)
 
@@ -71,6 +72,15 @@ Expects the slider element to have the specified normalized position ([0, 1]), w
 ```js
 await expect(element(by.id('slider'))).toHaveSliderPosition(0.75);
 await expect(element(by.id('slider'))).toHaveSliderPosition(0.3113, 0.00001);
+```
+
+### `toHaveToggleableValue(value)`
+
+Expects a toggleable element (e.g. a Switch or a Check-Box) to be on/checked or off/unchecked. In react-native, this is the [equivalent switch component](https://reactnative.dev/docs/switch).
+
+```js
+await expect(element(by.id('switch'))).toHaveToggleableValue(true);
+await expect(element(by.id('checkbox'))).toHaveToggleableValue(false);
 ```
 
 ### `not`

--- a/docs/APIRef.Expect.md
+++ b/docs/APIRef.Expect.md
@@ -13,7 +13,7 @@ Use [actions](APIRef.ActionsOnElement.md) to simulate use interaction with eleme
 - [`.toHaveId()`](#tohaveidid)
 - [`.toHaveValue()`](#tohavevaluevalue)
 - [`.toHaveSliderPosition()`](#tohavesliderpositionnormalizedposition-tolerance--ios-only) **iOS only**
-- [`.toHaveToggleableValue()`](#tohavetoggleablevaluevalue)
+- [`.toHaveToggleValue()`](#tohavetogglevaluevalue)
 - [`.not`](#not)
 - [`.withTimeout()`](#withtimeouttimeout)
 
@@ -74,13 +74,13 @@ await expect(element(by.id('slider'))).toHaveSliderPosition(0.75);
 await expect(element(by.id('slider'))).toHaveSliderPosition(0.3113, 0.00001);
 ```
 
-### `toHaveToggleableValue(value)`
+### `toHaveToggleValue(value)`
 
-Expects a toggleable element (e.g. a Switch or a Check-Box) to be on/checked or off/unchecked. In react-native, this is the [equivalent switch component](https://reactnative.dev/docs/switch).
+Expects a toggle-able element (e.g. a Switch or a Check-Box) to be on/checked or off/unchecked. As a reference, in react-native, this is the [equivalent switch component](https://reactnative.dev/docs/switch).
 
 ```js
-await expect(element(by.id('switch'))).toHaveToggleableValue(true);
-await expect(element(by.id('checkbox'))).toHaveToggleableValue(false);
+await expect(element(by.id('switch'))).toHaveToggleValue(true);
+await expect(element(by.id('checkbox'))).toHaveToggleValue(false);
 ```
 
 ### `not`


### PR DESCRIPTION
- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Fixes #1972 by introducing an explicit expect-API for supporting anything toggle-able, such as option-switches and check-boxes.