### PR TITLE
fix: minor race condition bugs

### DIFF
--- a/detox/runners/jest/DetoxAdapterImpl.js
+++ b/detox/runners/jest/DetoxAdapterImpl.js
@@ -22,8 +22,10 @@ class DetoxAdapterImpl {
       throw new DetoxRuntimeError(this._describeInitError());
     }
 
+    const currentTest = this._currentTest;
+
     await this._flush();
-    await this.detox.beforeEach(this._currentTest);
+    await this.detox.beforeEach(currentTest);
   }
 
   async afterAll() {

--- a/detox/src/artifacts/templates/plugin/WholeTestRecorderPlugin.js
+++ b/detox/src/artifacts/templates/plugin/WholeTestRecorderPlugin.js
@@ -23,12 +23,13 @@ class WholeTestRecorderPlugin extends ArtifactPlugin {
     await super.onTestDone(testSummary);
 
     if (this.testRecording) {
-      await this.testRecording.stop();
+      const testRecording = this.testRecording;
+      await testRecording.stop();
 
       if (this.shouldKeepArtifactOfTest(testSummary)) {
-        this._startSavingTestRecording(this.testRecording, testSummary)
+        this._startSavingTestRecording(testRecording, testSummary)
       } else {
-        this._startDiscardingTestRecording(this.testRecording);
+        this._startDiscardingTestRecording(testRecording);
       }
 
       this.testRecording = null;


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

When tests burst into failures on the very beginning in Jasmine, I saw a few errors which had to do with race conditions.
Hence, I decided why don't we fix that, to be on the safe side.

Bug 1 (in the Jest-Jasmine adapter):

```
FAIL  e2e/specs/owner/ChallengesScreen/challengesScreen.spec.ts
  ● Test suite failed to run

    DetoxRuntimeError: Invalid test summary was passed to detox.beforeEach(testSummary)
    Expected to get an object of type: { title: string; fullName: string; status: "running" | "passed" | "failed"; }

    HINT: Maybe you are still using an old undocumented signature detox.beforeEach(string, string, string) in init.js ?
    See the article for the guidance: https://github.com/wix/detox/blob/master/docs/APIRef.TestLifecycle.md

    testSummary was: null

      at Detox._validateTestSummary (../node_modules/detox/src/Detox.js:220:13)
      at Detox.beforeEach (../node_modules/detox/src/Detox.js:113:10)
```

Bug 2 (in the LogArtifacts):

```
detox[10682] WARN:  [ArtifactsManager.js/SUPPRESS_PLUGIN_ERROR] Suppressed error inside function call: SimulatorLogPlugin.onIdleCallback()
  err: TypeError: Cannot read property 'save' of null
      at api.requestIdleCallback (/Users/yaroslavs/Projects/project/node_modules/detox/src/artifacts/templates/plugin/WholeTestRecorderPlugin.js:62:27)
      at process._tickCallback (internal/process/next_tick.js:68:7)
```

I'll reiterate, that happens when the tests are failing in the very beginning, and something fails asynchronously.
The goal is to make logs clearer and less prone to "surprise" crashes.