### PR TITLE
fix(cli): double dash -- argv forwarding

### DIFF
--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -344,8 +344,8 @@ describe('CLI', () => {
       cp.execSync.mockImplementation(() => { throw new Error; });
 
       await run(`-R 1 tests -- --debug`).catch(_.noop);
-      expect(cliCall(0).command).toMatch(/ --debug tests$/);
-      expect(cliCall(1).command).toMatch(/ --debug tests\/failing.test.js$/);
+      expect(cliCall(0).command).toMatch(/ --debug .* tests$/);
+      expect(cliCall(1).command).toMatch(/ --debug .* tests\/failing.test.js$/);
     });
 
     test.each([['-r'], ['--reuse']])('%s <value> should be passed as environment variable', async (__reuse) => {
@@ -574,8 +574,15 @@ describe('CLI', () => {
 
     test('-- <...explicitPassthroughArgs> should be forwarded to the test runner CLI as-is', async () => {
       await run('--device-launch-args detoxArgs e2eFolder -- a -a --a --device-launch-args runnerArgs');
-      expect(cliCall().command).toMatch(/a -a --a --device-launch-args runnerArgs e2eFolder$/);
+      expect(cliCall().command).toMatch(/a -a --a --device-launch-args runnerArgs .* e2eFolder$/);
       expect(cliCall().env).toEqual(expect.objectContaining({ deviceLaunchArgs: 'detoxArgs' }));
+    });
+
+    test('-- <...explicitPassthroughArgs> should omit double-dash "--" itself, when forwarding args', async () => {
+      await run('./detox -- --forceExit');
+
+      expect(cliCall().command).toMatch(/ --forceExit .* \.\/detox$/);
+      expect(cliCall().command).not.toMatch(/ -- --forceExit .* \.\/detox$/);
     });
 
     test('--inspect-brk should prepend "node --inspect-brk" to the command', async () => {

--- a/detox/local-cli/utils/splitArgv.js
+++ b/detox/local-cli/utils/splitArgv.js
@@ -30,7 +30,7 @@ function disengageBooleanArgs(argv, booleanKeys) {
 
   for (const entry of Object.entries(argv)) {
     const [key, value] = entry;
-    if (key === '_') {
+    if (key === '_' || key === '--') {
       continue;
     }
 
@@ -46,7 +46,7 @@ function disengageBooleanArgs(argv, booleanKeys) {
   return {
     specs: passthrough.concat(argv._),
     passthrough: {
-      _: [],
+      _: argv['--'] || [],
       ...result,
     },
   };


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

The recent refactor of `local-cli/test.js` in https://github.com/wix/Detox/pull/2269 has introduced the following bug concerning `-- <...direct passthrough args>` syntax. 

Expected:

```
> detox test ... e2e/mytest.js -- --forceExit
... jest --forceExit ... e2e/mytest.js
```

Actual:

```
> detox test ... e2e/mytest.js -- --forceExit
... jest ... -- --forceExit e2e/mytest.js
```

In other words, there should be just `--forceExit`, not `-- --forceExit` in this example.
Detox should not forward the double dash (`--`) itself, when this syntax is used.