### PR TITLE
e2e: add .atIndex(100500) out-of-bounds test

### DIFF
--- a/detox/test/e2e/02.matchers.test.js
+++ b/detox/test/e2e/02.matchers.test.js
@@ -19,6 +19,17 @@ describe('Matchers', () => {
     await expect(element(by.text('First button pressed!!!'))).toBeVisible();
   });
 
+  it('should not crash after an attempt to tap an element with an out-of-bounds index', async () => {
+    try {
+      await element(by.text('Index')).atIndex(100500).tap();
+    } catch (e) {
+      console.log('Caught an expected error, now moving forward...');
+    }
+
+    await element(by.text('Index')).atIndex(0).tap();
+    await expect(element(by.text('First button pressed!!!'))).toBeVisible();
+  });
+
   it('should be able to swipe elements matched by index', async () => {
     await element(by.text('Index')).atIndex(0).swipe('down', 'fast', 0.7); //No need to do here anything, just let it not crash.
   });


### PR DESCRIPTION
- [x] This change has been discussed in issue #2362 and the solution has been agreed upon with maintainers.

---

**Description:**

Given the app:

<img src="https://user-images.githubusercontent.com/1962469/94535228-fdde3b00-0249-11eb-871c-b9e4a677f39c.png" width=320>

and the test:

```js
 it('should not crash after an attempt to tap an element with an out-of-bounds index', async () => {
   try {
     await element(by.text('Index')).atIndex(100500).tap();
   } catch (e) {
     console.log('Caught an expected error, now moving forward...');
   }

   await element(by.text('Index')).atIndex(0).tap();
   await expect(element(by.text('First button pressed!!!'))).toBeVisible();
 });
```

**Expected result:**

Should throw an assertion error with useful information, but recover within `try-catch` block and be able to proceed.

**Actual result:**

App crashes and freezes. The test is unable to complete.

<img src="https://user-images.githubusercontent.com/1962469/94535170-e737e400-0249-11eb-90ba-f6b2136cfbed.png">


@LeoNatan , could you please put a bugfix into this pull request, please? If you do – then we'll change the name of the PR to "fix(ios): ...something".