### PR TITLE
fix(jest): allow `-t, --testNamePattern` overriding

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -131,14 +131,14 @@ function prepareJestArgs({ cliConfig, runnerArgs, runnerConfig, platform }) {
   const platformFilter = getPlatformSpecificString(platform);
 
   return {
-    argv: {
+    argv: _.omitBy({
       color: !cliConfig.noColor && undefined,
       config: runnerConfig.runnerConfig /* istanbul ignore next */ || undefined,
       testNamePattern: platformFilter ? shellQuote(`^((?!${platformFilter}).)*$`) : undefined,
       maxWorkers: cliConfig.workers,
 
       ...passthrough,
-    },
+    }, _.isUndefined),
 
     env: _.omitBy({
       ..._.pick(cliConfig, _.compact([

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -24,7 +24,6 @@ module.exports.handler = async function test(argv) {
   const prepareArgs = choosePrepareArgs({
     cliConfig,
     runner,
-    platform,
     detoxArgs,
   });
 
@@ -49,7 +48,7 @@ module.exports.handler = async function test(argv) {
   await runTestRunnerWithRetries(forwardedArgs, retries);
 };
 
-function choosePrepareArgs({ cliConfig, detoxArgs, runner, platform }) {
+function choosePrepareArgs({ cliConfig, detoxArgs, runner }) {
   if (runner === 'mocha') {
     if (hasMultipleWorkers(cliConfig)) {
       log.warn('Cannot use -w, --workers. Parallel test execution is only supported with iOS and Jest');

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -403,6 +403,22 @@ describe('CLI', () => {
       expect(cliCall().command).toContain('--maxWorkers 2');
     });
 
+    test.each([['-w'], ['--workers']])('%s <value> should be replaced with --maxWorkers <value>', async (__workers) => {
+      await run(`${__workers} 2 --maxWorkers 3`);
+
+      const { command } = cliCall();
+      expect(command).toContain('--maxWorkers 3');
+      expect(command).not.toContain('--maxWorkers 2');
+    });
+
+    test.each([['-w'], ['--workers']])('%s <value> can be overriden by a later value', async (__workers) => {
+      await run(`${__workers} 2 ${__workers} 3`);
+
+      const { command } = cliCall();
+      expect(command).toContain('--maxWorkers 3');
+      expect(command).not.toContain('--maxWorkers 2');
+    });
+
     test.each([['-w'], ['--workers']])('%s <value> should not warn anything for iOS', async (__workers) => {
       singleConfig().type = 'ios.simulator';
       await run(`${__workers} 2`);
@@ -433,6 +449,14 @@ describe('CLI', () => {
 
       await run();
       expect(cliCall().command).not.toContain('--testNamePattern');
+    });
+
+    test.each([['-t'], ['--testNamePattern']])('should override --testNamePattern if a custom %s value is passed', async (__testNamePattern) => {
+      await run(`${__testNamePattern} customPattern`);
+      const { command } = cliCall();
+
+      expect(command).not.toMatch(/--testNamePattern .*(ios|android)/);
+      expect(command).toMatch(/--testNamePattern customPattern($| )/);
     });
 
     test('--jest-report-specs, by default, should be true, as environment variable', async () => {

--- a/detox/local-cli/utils/splitArgv.js
+++ b/detox/local-cli/utils/splitArgv.js
@@ -117,7 +117,16 @@ function splitMochaArgv(argv) {
 }
 
 function splitJestArgv(argv) {
-  return disengageBooleanArgs(argv, getJestBooleanArgs());
+  return realiasJestArgv(disengageBooleanArgs(argv, getJestBooleanArgs()));
+}
+
+function realiasJestArgv({ specs, passthrough }) {
+  if (passthrough.hasOwnProperty('t')) {
+    passthrough.testNamePattern = passthrough.t;
+    delete passthrough.t;
+  }
+
+  return { specs, passthrough };
 }
 
 module.exports = {


### PR DESCRIPTION
**Description:**

Resolves #1881.

E.g.:

```bash
detox test -c ios.sim.release -t hello.*tap
```

as expected, translates to:

```bash
configuration="ios.sim.release" ... jest ... --testNamePattern "hello.*tap"
```

instead of the former:

```bash
configuration="ios.sim.release" ... jest ...  --testNamePattern '^((?!:android:).)*$'  --testNamePattern "hello.*tap"
```

/cc @andy-zy 