### PR TITLE
fix(cli): proper quoting args

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -2,12 +2,12 @@ const _ = require('lodash');
 const cp = require('child_process');
 const path = require('path');
 const unparse = require('yargs-unparser');
+const { quote } = require('shell-quote');
 const DetoxRuntimeError = require('../src/errors/DetoxRuntimeError');
 const DeviceRegistry = require('../src/devices/DeviceRegistry');
 const { loadLastFailedTests, resetLastFailedTests } = require('../src/utils/lastFailedTests');
 const { composeDetoxConfig } = require('../src/configuration');
 const log = require('../src/utils/logger').child({ __filename });
-const shellQuote = require('./utils/shellQuote');
 const splitArgv = require('./utils/splitArgv');
 const { getPlatformSpecificString, printEnvironmentVariables } = require('./utils/misc');
 const { prependNodeModulesBinToPATH } = require('./utils/misc');
@@ -134,7 +134,7 @@ function prepareJestArgs({ cliConfig, runnerArgs, runnerConfig, platform }) {
     argv: _.omitBy({
       color: !cliConfig.noColor && undefined,
       config: runnerConfig.runnerConfig /* istanbul ignore next */ || undefined,
-      testNamePattern: platformFilter ? shellQuote(`^((?!${platformFilter}).)*$`) : undefined,
+      testNamePattern: platformFilter ? `^((?!${platformFilter}).)*$` : undefined,
       maxWorkers: cliConfig.workers,
 
       ...passthrough,
@@ -182,9 +182,9 @@ async function resetLockFile({ platform }) {
   }
 }
 
-function launchTestRunner({ argv, env, specs, rerunIndex }) {
+function launchTestRunner({ argv, env, specs }) {
   const { $0: command, ...restArgv } = argv;
-  const fullCommand = [command, ...unparse(restArgv), ...specs].join(' ');
+  const fullCommand = [command, quote(unparse(restArgv)), specs.join(' ')].join(' ');
 
   log.info(printEnvironmentVariables(env) + fullCommand);
 

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -51,7 +51,7 @@ describe('CLI', () => {
       test('should pass --use-custom-logger true', () => expect(cliCall().command).toMatch(/--use-custom-logger true/));
       test('should not override process.env', () => expect(cliCall().env).toStrictEqual({}));
       test('should produce a default command (integration test)', () => {
-        const args = `--opts e2e/mocha.opts --grep :android: --invert --config-path ${detoxConfigPath} --use-custom-logger true`;
+        const args = `--opts e2e/mocha.opts --grep \\:android\\: --invert --config-path ${detoxConfigPath} --use-custom-logger true`;
         expect(cliCall().command).toBe(`mocha ${args} e2e`);
       });
     });
@@ -230,7 +230,7 @@ describe('CLI', () => {
       });
 
       test('should produce a default command (integration test, ios)', () => {
-        const args = `--config e2e/config.json --testNamePattern '^((?!:android:).)*$' --maxWorkers 1`;
+        const args = `--config e2e/config.json --testNamePattern \\^\\(\\(\\?\\!\\:android:\\).\\)\\*\\$ --maxWorkers 1`;
         expect(cliCall().command).toBe(`jest ${args} e2e`);
       });
 
@@ -251,7 +251,7 @@ describe('CLI', () => {
       });
 
       test('should produce a default command (integration test)', () => {
-        const args = `--config e2e/config.json --testNamePattern '^((?!:ios:).)*$' --maxWorkers 1`;
+        const args = `--config e2e/config.json --testNamePattern \\^\\(\\(\\?\\!\\:ios:\\).\\)\\*\\$ --maxWorkers 1`;
         expect(cliCall().command).toBe(`jest ${args} e2e`);
       });
 
@@ -276,11 +276,11 @@ describe('CLI', () => {
         detoxConfig.configurations.androidTest.type = 'android.emulator';
 
         await run(`${__configuration} androidTest`);
-        expect(cliCall(0).command).toContain(`--testNamePattern '^((?!:ios:).)*$'`);
+        expect(cliCall(0).command).toContain(`--testNamePattern \\^\\(\\(\\?\\!\\:ios:\\).\\)\\*\\$`);
         expect(cliCall(0).env.configuration).toBe('androidTest');
 
         await run(`${__configuration} iosTest`);
-        expect(cliCall(1).command).toContain(`--testNamePattern '^((?!:android:).)*$'`);
+        expect(cliCall(1).command).toContain(`--testNamePattern \\^\\(\\(\\?\\!\\:android:\\).\\)\\*\\$`);
         expect(cliCall(1).env.configuration).toBe('iosTest');
       }
     );

--- a/detox/package.json
+++ b/detox/package.json
@@ -55,6 +55,7 @@
     "proper-lockfile": "^3.0.2",
     "resolve-from": "^5.0.0",
     "sanitize-filename": "^1.6.1",
+    "shell-quote": "^1.7.2",
     "shell-utils": "^1.0.9",
     "signal-exit": "^3.0.3",
     "tail": "^2.0.0",


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Try running: `detox test -c ios.sim.release --testNamePattern="should tap"`, and instead of expected:

```bash
configuration="ios.sim.release" ... jest --config e2e/config.js --testNamePattern 'should tap' --maxWorkers 1 e2e
```

you actually get:

```bash
configuration="ios.sim.release" ... jest --config e2e/config.js --testNamePattern should tap --maxWorkers 1 e2e
```

All the other Detox native and forward arguments are prone to this very same issue.

This pull request aims to fix the incorrect behavior.