### PR TITLE
Omit toggle-off of bridge sync for storage stress e2e, which is needed

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/reactnative/ReactNativeExtension.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/reactnative/ReactNativeExtension.kt
@@ -99,13 +99,6 @@ object ReactNativeExtension {
         }
     }
 
-    @JvmStatic
-    fun toggleJSBridgeSynchronization(enable: Boolean) {
-        rnIdlingResources?.let {
-            if (enable) it.resumeJSBridgeIdlingResource() else it.pauseJSBridgeIdlingResource()
-        }
-    }
-
     private fun reloadReactNativeInBackground(reactApplication: ReactApplication) {
         val rnReloader = ReactNativeReLoader(InstrumentationRegistry.getInstrumentation(), reactApplication)
         rnReloader.reloadInBackground()

--- a/detox/test/android/app/src/main/java/com/example/NativeModule.java
+++ b/detox/test/android/app/src/main/java/com/example/NativeModule.java
@@ -118,7 +118,6 @@ public class NativeModule extends ReactContextBaseJavaModule {
     public void toggleNonStorageSynchronization(Boolean enable) {
         ReactNativeExtensionReflected rnExtension = ReactNativeExtensionReflected.getInstance();
         rnExtension.toggleUISynchronization(enable);
-        rnExtension.toggleJSBridgeSynchronization(enable);
         rnExtension.toggleTimersSynchronization(enable);
         rnExtension.toggleNetworkSynchronization(enable);
     }

--- a/detox/test/android/app/src/main/java/com/example/utils/ReactNativeExtensionReflected.java
+++ b/detox/test/android/app/src/main/java/com/example/utils/ReactNativeExtensionReflected.java
@@ -4,7 +4,6 @@ import java.lang.reflect.Method;
 
 public class ReactNativeExtensionReflected {
     private final Method toggleUISynchronization;
-    private final Method toggleJSBridgeSynchronization;
     private final Method toggleTimersSynchronization;
     private final Method toggleNetworkSynchronization;
 
@@ -20,7 +19,6 @@ public class ReactNativeExtensionReflected {
         try {
             Class<?> clazz = Class.forName("com.wix.detox.reactnative.ReactNativeExtension");
             toggleUISynchronization = clazz.getDeclaredMethod("toggleUISynchronization", boolean.class);
-            toggleJSBridgeSynchronization = clazz.getDeclaredMethod("toggleJSBridgeSynchronization", boolean.class);
             toggleTimersSynchronization = clazz.getDeclaredMethod("toggleTimersSynchronization", boolean.class);
             toggleNetworkSynchronization = clazz.getDeclaredMethod("toggleNetworkSynchronization", boolean.class);
         } catch (Exception e) {
@@ -30,10 +28,6 @@ public class ReactNativeExtensionReflected {
 
     public void toggleUISynchronization(boolean enable) {
         invokeToggleMethod(toggleUISynchronization, enable);
-    }
-
-    public void toggleJSBridgeSynchronization(boolean enable) {
-        invokeToggleMethod(toggleJSBridgeSynchronization, enable);
     }
 
     public void toggleTimersSynchronization(boolean enable) {

--- a/detox/test/src/helpers/storage.js
+++ b/detox/test/src/helpers/storage.js
@@ -1,11 +1,12 @@
 import AsyncStorage from '@react-native-community/async-storage';
 
-const SET_AND_GET_ITERATIONS = 100;
-const GLOBAL_ITERATIONS = 3;
+const SET_AND_GET_ITERATIONS = 50;
+const GLOBAL_ITERATIONS = 4;
 
 export async function runStressTest() {
-  let keyCount = 0;
-  for (let globalCount = 0; globalCount < GLOBAL_ITERATIONS; globalCount++, keyCount += 10) {
+  for (let globalCount = 1, keyCount = 10;
+        globalCount <= GLOBAL_ITERATIONS;
+        globalCount++, keyCount += 10) {
     console.log(`Storage@Stress Global iteration #${globalCount}`);
     await AsyncStorage.clear();
 


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Fix flakiness of recently introduced async-storage IR in Detox' test-app-based stress-test (not affecting "production").

~_Note: I ran this repeatedly on a separate branch on CI, just to be sure._~ Now working on making the e2e even more robust

cc @noomorph (thanks!)