### PR TITLE
fix(win32): environment vars handling

### DIFF
--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -663,7 +663,9 @@ describe('CLI', () => {
       process.env.DETOX_ARGV_OVERRIDE = '--inspect-brk --testNamePattern "[$PLATFORM] tap" e2e/sanity/*.test.js';
       await run();
 
-      expect(cliCall().command).toMatch(/^node --inspect-brk.* --testNamePattern '\[ios\] tap'.* e2e\/sanity\/\*\.test.js$/);
+      const pattern = new RegExp(`^node --inspect-brk.* --testNamePattern ${quote('\\[ios\\] tap')}.* e2e/sanity/\\*\\.test.js$`);
+
+      expect(cliCall().command).toMatch(pattern);
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('$DETOX_ARGV_OVERRIDE is detected'));
     });
   });

--- a/detox/src/utils/argparse.js
+++ b/detox/src/utils/argparse.js
@@ -21,21 +21,27 @@ function getArgValue(key) {
   return value;
 }
 
+function getEnvVar(aliases) {
+  const env = getNormalizedEnv();
+
+  for (const key of getNormalizedAliases(aliases)) {
+    if (env[key] !== undefined) {
+      return env[key];
+    }
+  }
+}
+
 const getNormalizedEnv = _.once(() => {
   return /* istanbul ignore next */ process.platform === 'win32'
     ? _.mapKeys(process.env, (value, key) => key.toUpperCase())
     : { ...process.env };
 });
 
-function getEnvVar(aliases) {
-  const env = getNormalizedEnv();
-
-  for (const key of aliases) {
-    if (env[key] !== undefined) {
-      return env[key];
-    }
-  }
-}
+const getNormalizedAliases = (aliases) => {
+  return /* istanbul ignore next */ process.platform === 'win32'
+    ? aliases.map(key => key.toUpperCase())
+    : aliases;
+};
 
 function getFlag(key) {
   if (argv && argv[key]) {

--- a/detox/src/utils/argparse.js
+++ b/detox/src/utils/argparse.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const argv = require('minimist')(process.argv.slice(2));
 const {escape} = require('./pipeCommands');
-const toUpper = (s) => s.toUpperCase();
 
 function getArgValue(key) {
   let value;
@@ -9,14 +8,10 @@ function getArgValue(key) {
   if (argv && argv[key]) {
     value = argv[key];
   } else {
-    const resolvedKey = resolveProcessEnvKey([
-      toUpper(`DETOX_${_.snakeCase(key)}`),
+    value = getEnvVar([
+      `DETOX_${_.snakeCase(key)}`.toUpperCase(),
       _.camelCase(key),
     ]);
-
-    if (resolvedKey !== undefined) {
-      value = process.env[resolvedKey];
-    }
 
     if (value === 'undefined') {
       value = undefined;
@@ -26,17 +21,20 @@ function getArgValue(key) {
   return value;
 }
 
-function resolveProcessEnvKey(searchedKeys) {
-  let envKeys = _.keys(process.env);
+const getNormalizedEnv = _.once(() => {
+  return /* istanbul ignore next */ process.platform === 'win32'
+    ? _.mapKeys(process.env, (value, key) => key.toUpperCase())
+    : { ...process.env };
+});
 
-  /* istanbul ignore next */
-  if (process.platform === 'win32') {
-    searchedKeys = searchedKeys.map(toUpper);
-    envKeys = envKeys.map(toUpper);
+function getEnvVar(aliases) {
+  const env = getNormalizedEnv();
+
+  for (const key of aliases) {
+    if (env[key] !== undefined) {
+      return env[key];
+    }
   }
-
-  const keySet = new Set(envKeys);
-  return searchedKeys.find(key => keySet.has(key));
 }
 
 function getFlag(key) {


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

The latest PR #2399 had issues on Windows, which slipped unnoticed, fortunately before the release. The `argparse` utils have been slightly reimplemented to correctly extract camelCased env vars along with DETOX_SNAKE_CASE ones on both Win32 and POSIX.

