### PR TITLE
Longer native timeouts for Android

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/config/DetoxIdlePolicyConfig.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/config/DetoxIdlePolicyConfig.kt
@@ -11,10 +11,10 @@ import java.util.concurrent.TimeUnit
  */
 class DetoxIdlePolicyConfig {
     /** Directly binds to [IdlingPolicies.setMasterPolicyTimeout]. Applied in seconds.  */
-    @JvmField var masterTimeoutSec = 120
+    @JvmField var masterTimeoutSec = 240
 
     /** Directly binds to [IdlingPolicies.setIdlingResourceTimeout]. Applied in seconds.  */
-    @JvmField var idleResourceTimeoutSec = 60
+    @JvmField var idleResourceTimeoutSec = 180
 
     fun apply() {
         IdlingPolicies.setMasterPolicyTimeout(masterTimeoutSec.toLong(), TimeUnit.SECONDS)


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Significantly increase the default (yet customizable) _native_ timeouts on Android: master timeout, idling resource timeout.