### PR TITLE
Introduce tap-time verification through ui-controller swizzling

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/Detox.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/Detox.java
@@ -9,6 +9,7 @@ import android.os.Looper;
 import android.util.Log;
 
 import com.wix.detox.config.DetoxConfig;
+import com.wix.detox.espresso.UiControllerSpy;
 
 import java.util.concurrent.TimeUnit;
 
@@ -190,9 +191,11 @@ public final class Detox {
      */
     public static void runTests(ActivityTestRule activityTestRule, @NonNull final Context context, DetoxConfig detoxConfig) {
         DetoxConfig.CONFIG = detoxConfig;
-        detoxConfig.apply();
+        DetoxConfig.CONFIG.apply();
 
         sActivityTestRule = activityTestRule;
+
+        UiControllerSpy.attachThroughProxy();
 
         Intent intent = extractInitialIntent();
         sActivityTestRule.launchActivity(intent);

--- a/detox/android/detox/src/main/java/com/wix/detox/common/DetoxErrors.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/common/DetoxErrors.java
@@ -20,4 +20,10 @@ public interface DetoxErrors {
             super(cause);
         }
     }
+
+    class DetoxIllegalStateException extends DetoxRuntimeException {
+        public DetoxIllegalStateException(String message) {
+            super(message);
+        }
+    }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/common/collect/PairsIterator.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/common/collect/PairsIterator.kt
@@ -1,0 +1,18 @@
+package com.wix.detox.common.collect
+
+import java.lang.IllegalStateException
+
+class PairsIterator<T>(private val delegate: Iterator<T>): Iterator<Pair<T, T>> {
+    constructor(iterable: Iterable<T>): this(iterable.iterator())
+
+    override fun hasNext(): Boolean = delegate.hasNext()
+    override fun next(): Pair<T, T> {
+        val next = delegate.next()
+        if (!delegate.hasNext()) {
+            throw IllegalStateException("Uneven iterator content!")
+        }
+
+        val nextNext = delegate.next()
+        return Pair(next, nextNext)
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/common/proxy/MethodsSpy.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/common/proxy/MethodsSpy.kt
@@ -1,0 +1,76 @@
+package com.wix.detox.common.proxy
+
+import android.util.Log
+import java.util.*
+
+data class CallInfo(var inTime: Long? = null, var outTime: Long? = null) {
+    fun open(inTime: Long = System.currentTimeMillis()): CallInfo {
+        this.inTime = inTime
+        this.outTime = null
+        return this
+    }
+
+    fun close(outTime: Long = System.currentTimeMillis()): CallInfo {
+        this.outTime = outTime
+        return this
+    }
+
+    operator fun minus(other: CallInfo): Long? {
+        val inTime = other.inTime
+        val outTime = this.outTime
+        if (outTime != null && inTime != null) {
+            return outTime - inTime
+        }
+        return null
+    }
+
+    override fun toString() = "$inTime -> $outTime"
+}
+
+open class MethodsSpy(private val entityName: String) {
+    private val methodHistories = mutableMapOf<String, LinkedList<CallInfo>>()
+    private var enabled = false
+
+    fun start() {
+        reset()
+        enabled = true
+    }
+
+    fun stop() {
+        enabled = false
+    }
+
+    fun onBeforeCall(methodName: String) {
+        if (enabled) {
+            historyOf(methodName).addFirst(CallInfo().open())
+        }
+    }
+
+    fun onAfterCall(methodName: String) {
+        if (enabled) {
+            historyOf(methodName).peekFirst()?.close()
+        }
+    }
+
+    fun getHistory(methodName: String): Queue<CallInfo>?
+        = methodHistories[methodName]
+
+    fun dumpToLog() {
+        for ((methodName, history) in methodHistories.entries) {
+            Log.d(LOG_TAG, "[$entityName] method $methodName: $history")
+        }
+    }
+
+    internal fun historyOf(key: String) =
+        methodHistories.getOrPut(key) {
+            LinkedList()
+        }
+
+    private fun reset() {
+        methodHistories.clear()
+    }
+
+    companion object {
+        private const val LOG_TAG = "MethodsSpy"
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/common/proxy/SpyingInvocationHandler.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/common/proxy/SpyingInvocationHandler.kt
@@ -1,0 +1,30 @@
+package com.wix.detox.common.proxy
+
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+class SpyingInvocationHandler(private val target: Any, private val spy: MethodsSpy) : InvocationHandler {
+    override fun invoke(proxy: Any, m: Method, args: Array<Any>): Any {
+        val result: Any
+        try {
+            spy.onBeforeCall(m.name)
+            result = m.invoke(target, *args)
+        } catch (e: InvocationTargetException) {
+            throw e.targetException
+        } finally {
+            spy.onAfterCall(m.name)
+        }
+        return result
+    }
+
+    companion object {
+        @JvmStatic
+        fun newInstance(obj: Any, journal: MethodsSpy) =
+            Proxy.newProxyInstance(
+                    obj.javaClass.classLoader,
+                    obj.javaClass.interfaces,
+                    SpyingInvocationHandler(obj, journal))
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/UiAutomatorHelper.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/UiAutomatorHelper.java
@@ -7,6 +7,8 @@ import android.util.Log;
 import android.view.Choreographer;
 import android.view.View;
 
+import com.wix.detox.espresso.common.utils.UiControllerUtils;
+
 import org.hamcrest.core.IsAnything;
 import org.joor.Reflect;
 import org.joor.ReflectException;
@@ -25,10 +27,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 public class UiAutomatorHelper {
     private static final String LOG_TAG = "detox";
 
-    private static final String FIELD_UI_CONTROLLER = "uiController";
-
     private static final String METHOD_LOOP_UNTIL_IDLE = "loopMainThreadUntilIdle";
-    private static final String METHOD_LOOP_AT_LEAST = "loopMainThreadForAtLeast";
 
     /**
      * This triggers a full Espresso sync. It's intended use is to sync UIAutomator calls.
@@ -37,12 +36,11 @@ public class UiAutomatorHelper {
         // I want to invoke Espresso's sync mechanism manually.
         // This turned out to be amazingly difficult. This below is the
         // nicest solution I could come up with.
-        final ViewInteraction interaction = Espresso.onView(new IsAnything<View>());
         InstrumentationRegistry.getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
                 try {
-                    Reflect.on(interaction).field(FIELD_UI_CONTROLLER).call(METHOD_LOOP_UNTIL_IDLE);
+                    Reflect.on(UiControllerUtils.getUiController()).call(METHOD_LOOP_UNTIL_IDLE);
                 } catch (ReflectException e) {
                     Log.e(LOG_TAG, "Failed to sync Espresso manually.", e.getCause());
                 }
@@ -59,12 +57,11 @@ public class UiAutomatorHelper {
         // I want to invoke Espresso's sync mechanism manually.
         // This turned out to be amazingly difficult. This below is the
         // nicest solution I could come up with.
-        final ViewInteraction interaction = Espresso.onView(new IsAnything<View>());
         InstrumentationRegistry.getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
                 try {
-                    Reflect.on(interaction).field(FIELD_UI_CONTROLLER).call(METHOD_LOOP_AT_LEAST, millis);
+                    Reflect.on(UiControllerUtils.getUiController()).call(METHOD_LOOP_UNTIL_IDLE, millis);
                 } catch (ReflectException e) {
                     Log.e(LOG_TAG, "Failed to sync Espresso manually.", e.getCause());
                 }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/UiControllerSpy.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/UiControllerSpy.kt
@@ -1,0 +1,38 @@
+package com.wix.detox.espresso
+
+import androidx.test.espresso.UiController
+import com.wix.detox.common.proxy.CallInfo
+import com.wix.detox.common.proxy.SpyingInvocationHandler
+import com.wix.detox.common.proxy.MethodsSpy
+import com.wix.detox.espresso.common.utils.getUiController
+import org.joor.Reflect
+
+class UiControllerSpy: MethodsSpy("uiController") {
+    fun eventInjectionsIterator(): Iterator<CallInfo?> = historyOf("injectMotionEvent").iterator()
+
+    companion object {
+        @JvmStatic
+        val instance = UiControllerSpy()
+
+        @JvmStatic
+        @JvmOverloads
+        fun attachThroughProxy(spy: UiControllerSpy = instance) {
+            val eventsInjectorReflected = EventsInjectorReflected(getUiController())
+
+            val eventsInjectionStrategy = eventsInjectorReflected.eventsInjectionStrategy!!
+            val eventsInjectionStrategyProxy = SpyingInvocationHandler.newInstance(eventsInjectionStrategy, spy)
+
+            eventsInjectorReflected.eventsInjectionStrategy = eventsInjectionStrategyProxy
+        }
+    }
+}
+
+private class EventsInjectorReflected constructor(uiController: UiController?) {
+    private /*EventInjector*/ val eventInjector: Any? = Reflect.on(uiController).get("eventInjector")
+
+    var eventsInjectionStrategy: Any? /*EventInjectionStrategy*/
+        get() = Reflect.on(eventInjector).get<Any>("injectionStrategy")
+        set(value) {
+            Reflect.on(eventInjector)["injectionStrategy"] = value
+        }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxMultiTap.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxMultiTap.kt
@@ -3,7 +3,12 @@ package com.wix.detox.espresso.action
 import android.view.MotionEvent
 import androidx.test.espresso.UiController
 import androidx.test.espresso.action.Tapper
+import com.wix.detox.common.DetoxErrors.DetoxIllegalStateException
+import com.wix.detox.common.collect.PairsIterator
+import com.wix.detox.common.proxy.CallInfo
+import com.wix.detox.espresso.UiControllerSpy
 import com.wix.detox.espresso.common.DetoxViewConfigurations.getDoubleTapMinTime
+import com.wix.detox.espresso.common.DetoxViewConfigurations.getLongTapMinTime
 import com.wix.detox.espresso.common.DetoxViewConfigurations.getPostTapCoolDownTime
 import com.wix.detox.espresso.common.TapEvents
 
@@ -27,8 +32,10 @@ open class DetoxMultiTap
     @JvmOverloads constructor(
             private val times: Int,
             private val interTapsDelayMs: Long = getDoubleTapMinTime(),
-            private val coolDownTime: Long = getPostTapCoolDownTime(),
-            private val tapEvents: TapEvents = TapEvents())
+            private val coolDownTimeMs: Long = getPostTapCoolDownTime(),
+            private val longTapMinTimeMs: Long = getLongTapMinTime(),
+            private val tapEvents: TapEvents = TapEvents(),
+            private val uiControllerCallSpy: UiControllerSpy = UiControllerSpy.instance)
     : Tapper {
 
     override fun sendTap(uiController: UiController?, coordinates: FloatArray?, precision: FloatArray?)
@@ -43,10 +50,12 @@ open class DetoxMultiTap
         try {
             eventSequence = generateEventSequences(coordinates, precision)
 
-            if (!uiController.injectMotionEventSequence(eventSequence)) {
+            if (!injectEvents(uiController, eventSequence)) {
                 return Tapper.Status.FAILURE
             }
-            uiController.loopMainThreadForAtLeast(coolDownTime)
+            verifyInjectionPeriods()
+
+            uiController.loopMainThreadForAtLeast(coolDownTimeMs)
             return Tapper.Status.SUCCESS
         } finally {
             eventSequence?.forEach { it.recycle() }
@@ -64,5 +73,37 @@ open class DetoxMultiTap
             downTimestamp = tapEvents.last().eventTime + interTapsDelayMs
         }
         return eventSequence
+    }
+
+    private fun injectEvents(uiController: UiController, eventSequence: List<MotionEvent>): Boolean {
+        try {
+            uiControllerCallSpy.start()
+            if (!uiController.injectMotionEventSequence(eventSequence)) {
+                return false
+            }
+        } finally {
+            uiControllerCallSpy.stop()
+        }
+        return true
+    }
+
+    /**
+     * Note: This renders the class non-extensible so as to not being able to handle other types of taps -- for example, a
+     * long-tap created by tapEvents.
+     * If extensibility is ever needed, this can, be solved by refactoring tapEvents onto a tap injection class
+     * that both creates tap events and validates the right constraints over them.
+     */
+    private fun verifyInjectionPeriods() {
+        val rawIterator = uiControllerCallSpy.eventInjectionsIterator()
+        PairsIterator(rawIterator).forEach {
+            verifyTapEventTimes(it.first!!, it.second!!)
+        }
+    }
+
+    private fun verifyTapEventTimes(upEvent: CallInfo, downEvent: CallInfo) {
+        val delta: Long = (upEvent - downEvent)!!
+        if (delta >= longTapMinTimeMs) {
+            throw DetoxIllegalStateException("Tap handled too slowly, and turned into a long-tap!")
+        }
     }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/common/DetoxViewConfiguration.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/common/DetoxViewConfiguration.kt
@@ -29,4 +29,6 @@ object DetoxViewConfigurations {
         }
         return 40 // Based on hard-coded value in raw implementation of ViewConfiguration
     }
+
+    fun getLongTapMinTime(): Long = ViewConfiguration.getLongPressTimeout().toLong()
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/common/utils/UiControllerUtils.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/common/utils/UiControllerUtils.kt
@@ -1,0 +1,13 @@
+@file:JvmName("UiControllerUtils")
+
+package com.wix.detox.espresso.common.utils
+
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.UiController
+import org.hamcrest.core.IsAnything
+import org.joor.Reflect
+
+fun getUiController(): UiController? {
+    val interaction = Espresso.onView(IsAnything())
+    return Reflect.on(interaction).get<UiController>("uiController")
+}

--- a/detox/android/detox/src/main/java/org/joor/Reflect.java
+++ b/detox/android/detox/src/main/java/org/joor/Reflect.java
@@ -233,7 +233,10 @@ public class Reflect {
         try {
             Field field = field0(name);
             if ((field.getModifiers() & Modifier.FINAL) == Modifier.FINAL) {
-                Field modifiersField = Field.class.getDeclaredField("modifiers");
+// Note (d4vidi): this is an important change, compared to the original implementation!!!
+// See here: https://stackoverflow.com/a/64378131/453052
+//                Field modifiersField = Field.class.getDeclaredField("modifiers");
+                Field modifiersField = Field.class.getDeclaredField("accessFlags");
                 modifiersField.setAccessible(true);
                 modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
             }

--- a/detox/android/detox/src/test/java/com/wix/detox/common/collect/PairsIteratorSpec.kt
+++ b/detox/android/detox/src/test/java/com/wix/detox/common/collect/PairsIteratorSpec.kt
@@ -1,0 +1,41 @@
+package com.wix.detox.common.collect
+
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.lang.Exception
+import kotlin.test.assertFailsWith
+
+object PairsIteratorSpec: Spek({
+    describe("Pairs iterator") {
+        it("should be sane about empty lists") {
+            val uut = PairsIterator(emptyList<Any>())
+            assertThat(uut.hasNext()).isFalse()
+
+            assertFailsWith(Exception::class) {
+                assertThat(uut.next())
+            }
+        }
+
+        it("should be sane about 2-item lists") {
+            val uut = PairsIterator(listOf("first", "second"))
+            assertThat(uut.hasNext()).isTrue()
+            assertThat(uut.next()).isEqualTo(Pair("first", "second"))
+        }
+
+        it("should throw if iterating onto an uneven size") {
+            val uut = PairsIterator(listOf("first", "second", "third"))
+            uut.next()
+
+            assertThat(uut.hasNext()).isTrue()
+            assertFailsWith(IllegalStateException::class) {
+                uut.next()
+            }
+        }
+
+        it("should init using an explicit iterator") {
+            val uut = PairsIterator(emptyList<Any>().iterator())
+            assertThat(uut.hasNext()).isFalse()
+        }
+    }
+})

--- a/detox/android/detox/src/test/java/com/wix/detox/common/proxy/MethodsSpySpec.kt
+++ b/detox/android/detox/src/test/java/com/wix/detox/common/proxy/MethodsSpySpec.kt
@@ -1,0 +1,154 @@
+package com.wix.detox.common.proxy
+
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.*
+
+class MethodsSpySpec: Spek({
+    describe("Method-calls spy") {
+
+        val defaultMethodName = "mockMethod"
+
+        lateinit var uut: MethodsSpy
+
+        beforeEachTest {
+            uut = MethodsSpy("uut")
+        }
+
+        fun assertHistory(methodName: String = defaultMethodName): Queue<CallInfo> {
+            val history = uut.getHistory(methodName)
+            assertThat(history).isNotNull
+            return history!!
+        }
+
+        fun triggerOpenMethodCall(methodName: String = defaultMethodName) {
+            uut.onBeforeCall(methodName)
+        }
+
+        fun triggerMethodCall(methodName: String = defaultMethodName) {
+            uut.onBeforeCall(methodName)
+            uut.onAfterCall(methodName)
+        }
+
+        fun assertMethodCall(callInfo: CallInfo?, expectedInTimeAbove: Long, expectedOutTimeAbove: Long) {
+            assertThat(callInfo).isNotNull
+            assertThat(callInfo!!.inTime).isGreaterThanOrEqualTo(expectedInTimeAbove)
+            assertThat(callInfo!!.outTime).isGreaterThanOrEqualTo(expectedOutTimeAbove)
+        }
+
+        fun assertMethodCallOpen(callInfo: CallInfo?, expectedInTimeAbove: Long) {
+            assertThat(callInfo).isNotNull
+            assertThat(callInfo!!.inTime).isGreaterThanOrEqualTo(expectedInTimeAbove)
+            assertThat(callInfo!!.outTime).isNull()
+        }
+
+        fun assertLastMethodCallOpen(methodName: String = defaultMethodName, expectedInTimeAbove: Long) {
+            val history = assertHistory(methodName)
+            assertMethodCallOpen(history.peek(), expectedInTimeAbove)
+        }
+
+        fun assertLastMethodCall(methodName: String = defaultMethodName, expectedInTimeAbove: Long, expectedOutTimeAbove: Long) {
+            val history = assertHistory(methodName)
+            assertMethodCall(history.peek(), expectedInTimeAbove, expectedOutTimeAbove)
+        }
+
+        fun assertCollectedCallCount(methodName: String = defaultMethodName, count: Int) {
+            val history = assertHistory(methodName)
+            assertThat(history.size).isEqualTo(count)
+        }
+
+        it("should handle an empty spy") {
+            assertThat(uut.getHistory("nonExistMethod")).isNull()
+        }
+
+        it("should spy on a method call, before calling it") {
+            val beforeTimeRef = System.currentTimeMillis()
+
+            uut.start()
+            triggerOpenMethodCall()
+
+            assertLastMethodCallOpen(expectedInTimeAbove = beforeTimeRef)
+        }
+
+        it("should spy on a method call, after call completes") {
+            val beforeTimeRef = System.currentTimeMillis()
+            val afterTimeRef = System.currentTimeMillis()
+
+            uut.start()
+            triggerMethodCall()
+
+            assertLastMethodCall(expectedInTimeAbove =  beforeTimeRef, expectedOutTimeAbove = afterTimeRef)
+        }
+
+        it("should spy on multiple calls, in order of: lower-index <=> newer-call") {
+            uut.start()
+
+            val timeRef1 = System.currentTimeMillis()
+            triggerMethodCall()
+
+            Thread.sleep(100)
+
+            val timeRef2 = System.currentTimeMillis()
+            triggerMethodCall()
+
+            val history = assertHistory()
+            assertCollectedCallCount(count = 2)
+            assertMethodCall(history.elementAt(0), timeRef2, timeRef2)
+            assertMethodCall(history.elementAt(1), timeRef1, timeRef1)
+        }
+
+        it("should not spy if stopped") {
+            uut.start()
+            triggerMethodCall()
+
+            uut.stop()
+            triggerMethodCall()
+
+            assertCollectedCallCount(count = 1)
+        }
+
+        it("should resume spying") {
+            triggerMethodCall()
+
+            uut.start()
+            triggerMethodCall()
+            assertCollectedCallCount(count = 1)
+        }
+
+        it("should reset calls when started") {
+            uut.start()
+            triggerMethodCall()
+            triggerMethodCall()
+            uut.stop()
+
+            uut.start()
+            triggerMethodCall()
+            assertCollectedCallCount(count = 1)
+        }
+
+        it("should spy methods distinctively") {
+            uut.start()
+            triggerMethodCall("method1")
+            triggerMethodCall("method2")
+            triggerMethodCall("method2")
+            uut.stop()
+
+            assertCollectedCallCount("method1", 1)
+            assertCollectedCallCount("method2", 2)
+        }
+
+        it("should allow for simple delta-time calculation") {
+            uut.start()
+            triggerMethodCall()
+            Thread.sleep(10)
+            triggerMethodCall()
+
+            val history = assertHistory()
+            val newerCall = history.elementAt(0)
+            val olderCall = history.elementAt(1)
+            val delta = newerCall - olderCall
+            assertThat(delta).isGreaterThanOrEqualTo(10)
+        }
+    }
+})

--- a/detox/android/detox/src/test/java/com/wix/detox/espresso/action/DetoxMultiTapSpec.kt
+++ b/detox/android/detox/src/test/java/com/wix/detox/espresso/action/DetoxMultiTapSpec.kt
@@ -4,25 +4,29 @@ import android.view.MotionEvent
 import androidx.test.espresso.UiController
 import androidx.test.espresso.action.Tapper
 import com.nhaarman.mockitokotlin2.*
+import com.wix.detox.common.DetoxErrors.DetoxIllegalStateException
+import com.wix.detox.common.proxy.CallInfo
+import com.wix.detox.espresso.UiControllerSpy
 import com.wix.detox.espresso.common.TapEvents
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.lang.RuntimeException
 import kotlin.test.assertFailsWith
 
 object DetoxMultiTapSpec: Spek({
     describe("Detox multi-tapper replacement for Espresso") {
 
-        val COOLDOWN_TIME = 111L
+        val coolDownTimeMs = 111L
+        val interTapsDelayMs = 667L
+        val longTapMinTimeMs = 333L
         val coordinates = FloatArray(2) { 1f }
         val precision = FloatArray(2) { 2f }
-        val interTapDelayMs = 667L
 
         lateinit var uiController: UiController
         lateinit var mock1stTapEventsSeq: List<MotionEvent>
         lateinit var mock2ndTapEventsSeq: List<MotionEvent>
         lateinit var tapEvents: TapEvents
+        lateinit var uiControllerCallSpy: UiControllerSpy
 
         beforeEachTest {
             uiController = mock()
@@ -38,22 +42,29 @@ object DetoxMultiTapSpec: Spek({
                 on { createEventsSeq(any(), any(), isNull()) }.doReturn(mock1stTapEventsSeq)
                 on { createEventsSeq(any(), any(), any()) }.doReturn(mock2ndTapEventsSeq)
             }
+
+            uiControllerCallSpy = mock() {
+                on { eventInjectionsIterator() }.doReturn(emptyList<CallInfo?>().iterator())
+            }
         }
 
         fun verify1stTapEventsSeqGenerated() = verify(tapEvents).createEventsSeq(coordinates, precision, null)
         fun verify2ndTapEventsSeqGenerated() = verify(tapEvents).createEventsSeq(eq(coordinates), eq(precision), any())
         fun verify2ndTapEventsGenerateWithTimestamp(downTimestamp: Long) = verify(tapEvents).createEventsSeq(any(), any(), eq(downTimestamp))
         fun verifyAllTapEventsInjected() = verify(uiController).injectMotionEventSequence(arrayListOf(mock1stTapEventsSeq, mock2ndTapEventsSeq).flatten())
-        fun verifyMainThreadSynced() = verify(uiController).loopMainThreadForAtLeast(eq(COOLDOWN_TIME))
+        fun verifyMainThreadSynced() = verify(uiController).loopMainThreadForAtLeast(eq(coolDownTimeMs))
         fun verifyMainThreadNeverSynced() = verify(uiController, never()).loopMainThreadForAtLeast(any())
 
         fun givenInjectionSuccess() = whenever(uiController.injectMotionEventSequence(any())).thenReturn(true)
         fun givenInjectionFailure() = whenever(uiController.injectMotionEventSequence(any())).thenReturn(false)
         fun givenInjectionError() = whenever(uiController.injectMotionEventSequence(any())).doThrow(RuntimeException("exceptionMock"))
 
-        fun uut(times: Int) = DetoxMultiTap(times, interTapDelayMs, COOLDOWN_TIME, tapEvents)
-        fun sendOneTap() = uut(1).sendTap(uiController, coordinates, precision, -1, -1)
-        fun sendTwoTaps() = uut(2).sendTap(uiController, coordinates, precision, -1, -1)
+        fun givenInjectionCallsHistory(injectionsHistory: List<CallInfo?>) =
+                whenever(uiControllerCallSpy.eventInjectionsIterator()).thenReturn(injectionsHistory.iterator())
+
+        fun uut(times: Int) = DetoxMultiTap(times, interTapsDelayMs, coolDownTimeMs, longTapMinTimeMs, tapEvents, uiControllerCallSpy)
+        fun sendOneTap(uut: DetoxMultiTap = uut(1)) = uut.sendTap(uiController, coordinates, precision, -1, -1)
+        fun sendTwoTaps(uut: DetoxMultiTap = uut(2)) = uut.sendTap(uiController, coordinates, precision, -1, -1)
 
         it("should generate a single-tap events sequence using tap-events helper") {
             sendOneTap()
@@ -67,7 +78,7 @@ object DetoxMultiTapSpec: Spek({
         }
 
         it("should generate 2nd event sequence with proper down-event timestamp") {
-            val expectedDownTimestamp = mock1stTapEventsSeq.last().eventTime + interTapDelayMs
+            val expectedDownTimestamp = mock1stTapEventsSeq.last().eventTime + interTapsDelayMs
             sendTwoTaps()
             verify2ndTapEventsGenerateWithTimestamp(expectedDownTimestamp)
         }
@@ -134,6 +145,69 @@ object DetoxMultiTapSpec: Spek({
 
             assertFailsWith(KotlinNullPointerException::class) {
                 uut(1).sendTap(uiController, coordinates, null, -1, -1)
+            }
+        }
+
+        it("should start ui-controller spy before injecting events") {
+            sendOneTap()
+
+            inOrder(uiControllerCallSpy, uiController) {
+                verify(uiControllerCallSpy).start()
+                verify(uiController).injectMotionEventSequence(any())
+            }
+        }
+
+        it("should stop ui-controller spy after injecting events") {
+            givenInjectionSuccess()
+
+            sendOneTap()
+            inOrder(uiControllerCallSpy, uiController) {
+                verify(uiController).injectMotionEventSequence(any())
+                verify(uiControllerCallSpy).stop()
+            }
+        }
+
+        it("should stop ui-controller spy after injecting events even if injection fails") {
+            givenInjectionFailure()
+
+            sendOneTap()
+            verify(uiControllerCallSpy).stop()
+        }
+
+        it("should stop ui-controller spy after injecting events even if injection crashes") {
+            givenInjectionError()
+
+            try {
+                sendOneTap()
+            } catch (e: Exception) {}
+            verify(uiControllerCallSpy).stop()
+        }
+
+        it("should throw if ui-controller spy indicates tap has turned into a long-tap") {
+            givenInjectionSuccess()
+
+            val injectionsHistory = listOf(
+                    CallInfo(longTapMinTimeMs - 1, longTapMinTimeMs),
+                    CallInfo(0, 1)
+            )
+            givenInjectionCallsHistory(injectionsHistory)
+
+            assertFailsWith(DetoxIllegalStateException::class, "Tap handled too slowly, and turned into a long-tap!") {
+                sendOneTap()
+            }
+        }
+
+        it("should throw if ui-controller spy indicates tap 1 of 2 has turned into a long-tap") {
+            givenInjectionSuccess()
+
+            val injectionsHistory = listOf(
+                    CallInfo(longTapMinTimeMs + 10, longTapMinTimeMs + 11), CallInfo(10, 11),
+                    CallInfo(6, 10), CallInfo(0, 5)
+            )
+            givenInjectionCallsHistory(injectionsHistory)
+
+            assertFailsWith(DetoxIllegalStateException::class) {
+                sendOneTap()
             }
         }
     }

--- a/detox/test/android/app/src/main/java/com/example/NativeModulePackage.java
+++ b/detox/test/android/app/src/main/java/com/example/NativeModulePackage.java
@@ -23,7 +23,8 @@ public class NativeModulePackage implements ReactPackage {
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.asList(
                 new AnimationViewManager(),
-                new DoubleTapsTextViewManager()
+                new DoubleTapsTextViewManager(),
+                new SluggishTextTextViewManager()
         );
     }
 

--- a/detox/test/android/app/src/main/java/com/example/SluggishTextTextViewManager.java
+++ b/detox/test/android/app/src/main/java/com/example/SluggishTextTextViewManager.java
@@ -1,0 +1,51 @@
+package com.example;
+
+import android.graphics.Color;
+import android.util.Log;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
+import android.view.ViewGroup.LayoutParams;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+public class SluggishTextTextViewManager extends SimpleViewManager<ViewGroup> {
+    @Override
+    public String getName() {
+        return "DetoxSluggishTapsTextView";
+    }
+
+    @Override
+    protected ViewGroup createViewInstance(ThemedReactContext reactContext) {
+        final FrameLayout layout = new FrameLayout(reactContext);
+        layout.setLayoutParams(new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+
+        final TextView textView = new TextView(reactContext);
+        textView.setTag("sluggishTappableText");
+        textView.setLayoutParams(new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, Gravity.CENTER));
+        textView.setTextAlignment(View.TEXT_ALIGNMENT_CENTER);
+        textView.setGravity(Gravity.CENTER);
+        textView.setText("Slow-Tap");
+        textView.setTextColor(Color.BLUE);
+
+        textView.setOnTouchListener((v, event) -> {
+            if (event.getAction() == MotionEvent.ACTION_DOWN) {
+                try {
+                    Thread.sleep(ViewConfiguration.getLongPressTimeout());
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return false;
+        });
+        textView.setOnClickListener(v -> {});
+
+        layout.addView(textView);
+        return layout;
+    }
+}

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -67,6 +67,17 @@ describe('Actions', () => {
     });
   });
 
+  it(':android: should throw if tap handling is too slow', async () => {
+    try {
+      await driver.sluggishTapElement.tap();
+    } catch (e) {
+      console.log('Got an expected error', e);
+      return;
+    }
+
+    throw new Error('Expected an error');
+  });
+
   it('should type in an element', async () => {
     const typedText = device.getPlatform() === 'ios' ? 'Type Working 123 אֱבּג абв!!!' : "Type Working!!!";
     await element(by.id('UniqueId937')).typeText(typedText);

--- a/detox/test/e2e/drivers/actions-driver.js
+++ b/detox/test/e2e/drivers/actions-driver.js
@@ -5,7 +5,7 @@ const driver = {
     testId: 'UniqueId819',
     get coordinates() {
       return {
-        x: (device.getPlatform() === 'ios' ? 180 : 125),
+        x: (device.getPlatform() === 'ios' ? 180 : 100),
         y: 107,
       };
     },
@@ -18,7 +18,7 @@ const driver = {
 
   doubleTapsElement: {
     testId: 'doubleTappableText',
-    coordinates: { x: 200, y: 160 },
+    coordinates: { x: 180, y: 160 },
     tapOnce: () => element(by.id(driver.doubleTapsElement.testId)).tap(),
     tapTwice: async () => {
       await driver.doubleTapsElement.tapOnce();
@@ -33,6 +33,11 @@ const driver = {
     },
     assertTapsCount: (count) => expect(element(by.id(driver.doubleTapsElement.testId))).toHaveText(`Double-Taps: ${count}`),
     assertNoTaps: () => driver.doubleTapsElement.assertTapsCount(0),
+  },
+
+  sluggishTapElement: {
+    testId: 'sluggishTappableText',
+    tap: () => element(by.id(driver.sluggishTapElement.testId)).tap()
   }
 };
 

--- a/detox/test/src/Screens/ActionsScreen.js
+++ b/detox/test/src/Screens/ActionsScreen.js
@@ -16,6 +16,7 @@ import {
 import TextInput from '../Views/TextInput';
 
 const DoubleTapsText = requireNativeComponent('DetoxDoubleTapsTextView');
+const SluggishTapsText = requireNativeComponent('DetoxSluggishTapsTextView');
 
 const { width } = Dimensions.get('window');
 
@@ -80,9 +81,13 @@ export default class ActionsScreen extends Component {
               testID='UniqueId819'>Taps: {this.state.numTaps}</Text>
           </TouchableOpacity>
 
-          {isAndroid && <Text style={{width: 10}}> | </Text>}
+          {isAndroid && this.renderInlineSeparator()}
           {isAndroid && <View style={{ width: 110 }}>
             <DoubleTapsText style={{ flex: 1 }}/>
+          </View>}
+          {isAndroid && this.renderInlineSeparator()}
+          {isAndroid && <View style={{ width: 75 }}>
+            <SluggishTapsText style={{ flex: 1 }}/>
           </View>}
         </View>
 
@@ -166,6 +171,10 @@ export default class ActionsScreen extends Component {
         </View>
       </SafeAreaView>
     );
+  }
+
+  renderInlineSeparator() {
+    return <Text style={{width: 10}}> | </Text>;
   }
 
   renderAfterButton() {


### PR DESCRIPTION
- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Fixes #2207 by spying over Espresso's `UiController` (or actually over the internals of `UiControllerImpl: `UiControllerImpl>EventInjector>EventInjectionStrategy`), and monitoring the inject-method call timestamps.

This time-stamps are utilized (in order to be able to fail the tap if it turns "long" - see #2207), by recording them in the taps handler and then post-processing there in order to calculate down/up event deltas, comparing to Android's long-tap time threshold.

The reason this works is because `UiController` always injects the last event syncrhonously - waiting for the injection to complete, and thus the global beginning and ending timestamps truly depict what happened in between.