### PR TITLE
Fix regression caused by 9dd9635f

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/UiAutomatorHelper.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/UiAutomatorHelper.java
@@ -28,6 +28,7 @@ public class UiAutomatorHelper {
     private static final String LOG_TAG = "detox";
 
     private static final String METHOD_LOOP_UNTIL_IDLE = "loopMainThreadUntilIdle";
+    private static final String METHOD_LOOP_AT_LEAST = "loopMainThreadForAtLeast";
 
     /**
      * This triggers a full Espresso sync. It's intended use is to sync UIAutomator calls.
@@ -61,7 +62,7 @@ public class UiAutomatorHelper {
             @Override
             public void run() {
                 try {
-                    Reflect.on(UiControllerUtils.getUiController()).call(METHOD_LOOP_UNTIL_IDLE, millis);
+                    Reflect.on(UiControllerUtils.getUiController()).call(METHOD_LOOP_AT_LEAST, millis);
                 } catch (ReflectException e) {
                     Log.e(LOG_TAG, "Failed to sync Espresso manually.", e.getCause());
                 }


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
A tiny fix for a regression caused by 9dd9635f. Error - coming from one-app, looks something like this:
```
10-26 03:26:58.112  4153  4153 E detox   : java.lang.NoSuchMethodException: No similar method loopMainThreadUntilIdle with params [class java.lang.Long] could be found on type class androidx.test.espresso.base.UiControllerImpl.
10-26 03:26:58.112  4153  4153 E detox   : 	at org.joor.Reflect.similarMethod(Reflect.java:491)
10-26 03:26:58.112  4153  4153 E detox   : 	at org.joor.Reflect.call(Reflect.java:421)
10-26 03:26:58.112  4153  4153 E detox   : 	at com.wix.detox.espresso.UiAutomatorHelper$2.run(UiAutomatorHelper.java:64)
10-26 03:26:58.112  4153  4153 E detox   : 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:462)
10-26 03:26:58.112  4153  4153 E detox   : 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
10-26 03:26:58.112  4153  4153 E detox   : 	at android.app.Instrumentation$SyncRunnable.run(Instrumentation.java:2207)
10-26 03:26:58.112  4153  4153 E detox   : 	at android.os.Handler.handleCallback(Handler.java:883)
10-26 03:26:58.112  4153  4153 E detox   : 	at android.os.Handler.dispatchMessage(Handler.java:100)
10-26 03:26:58.112  4153  4153 E detox   : 	at android.os.Looper.loop(Looper.java:214)
10-26 03:26:58.112  4153  4153 E detox   : 	at android.app.ActivityThread.main(ActivityThread.java:7356)
10-26 03:26:58.112  4153  4153 E detox   : 	at java.lang.reflect.Method.invoke(Native Method)
10-26 03:26:58.112  4153  4153 E detox   : 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
10-26 03:26:58.112  4153  4153 E detox   : 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: Test exception
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: java.lang.reflect.InvocationTargetException
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at java.lang.reflect.Method.invoke(Native Method)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at org.apache.commons.lang3.reflect.MethodUtils.invokeStaticMethod(MethodUtils.java:443)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at org.apache.commons.lang3.reflect.MethodUtils.invokeStaticMethod(MethodUtils.java:405)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at com.wix.invoke.types.ClassTarget.execute(ClassTarget.java:23)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at com.wix.invoke.types.Target.invoke(Target.java:59)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at com.wix.invoke.MethodInvocation.invoke(MethodInvocation.java:35)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at com.wix.invoke.MethodInvocation.invoke(MethodInvocation.java:26)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at com.wix.invoke.MethodInvocation.invoke(MethodInvocation.java:20)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at com.wix.detox.InvokeActionHandler.handle(DetoxActionHandlers.kt:55)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at com.wix.detox.DetoxManager$4.run(DetoxManager.java:120)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at android.os.Handler.handleCallback(Handler.java:883)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at android.os.Handler.dispatchMessage(Handler.java:100)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at android.os.Looper.loop(Looper.java:214)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at com.wix.detox.Detox$1.run(Detox.java:214)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at java.lang.Thread.run(Thread.java:919)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: Caused by: com.wix.detox.common.DetoxErrors$DetoxRuntimeException: 10.0sec timeout expired without matching of given matcher: not null
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	at com.wix.detox.espresso.DetoxAssertion.waitForAssertMatcher(DetoxAssertion.java:58)
10-26 03:26:58.113  4153  4266 I DetoxActionHandlers: 	... 15 more
```
The first part (`java.lang.NoSuchMethodException`, etc.) is logged in an endless loop.