### PR TITLE
Disable tap2longtap err

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/common/DetoxLog.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/common/DetoxLog.kt
@@ -1,0 +1,25 @@
+package com.wix.detox.common
+
+import android.util.Log
+
+class DetoxLog {
+    fun verbose(tag: String, log: String) = Log.v(tag, log)
+    fun verbose(tag: String, log: String, error: Throwable) = Log.v(tag, log, error)
+
+    fun debug(tag: String, log: String) = Log.d(tag, log)
+    fun debug(tag: String, log: String, error: Throwable) = Log.d(tag, log, error)
+
+    fun info(tag: String, log: String) = Log.i(tag, log)
+    fun info(tag: String, log: String, error: Throwable) = Log.i(tag, log, error)
+
+    fun warn(tag: String, log: String) = Log.w(tag, log)
+    fun warn(tag: String, log: String, error: Throwable) = Log.w(tag, log, error)
+    fun warn(tag: String, error: Throwable) = Log.w(tag, error)
+
+    fun error(tag: String, log: String) = Log.e(tag, log)
+    fun error(tag: String, log: String, error: Throwable) = Log.e(tag, log, error)
+
+    companion object {
+        val instance = DetoxLog()
+    }
+}

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxAction.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxAction.java
@@ -41,15 +41,17 @@ import static org.hamcrest.Matchers.allOf;
  */
 
 public class DetoxAction {
+    private static final String LOG_TAG = "detox";
+
     private DetoxAction() {
         // static class
     }
 
-    public static ViewAction multiClick(int times, boolean strictMode) {
-        return actionWithAssertions(new GeneralClickAction(new DetoxMultiTap(strictMode, times), GeneralLocation.CENTER, Press.FINGER, 0, 0));
+    public static ViewAction multiClick(int times) {
+        return actionWithAssertions(new GeneralClickAction(new DetoxMultiTap(times), GeneralLocation.CENTER, Press.FINGER, 0, 0));
     }
 
-    public static ViewAction tapAtLocation(final int x, final int y, boolean strictMode) {
+    public static ViewAction tapAtLocation(final int x, final int y) {
         final int px = UiAutomatorHelper.convertDiptoPix(x);
         final int py = UiAutomatorHelper.convertDiptoPix(y);
         CoordinatesProvider c = new CoordinatesProvider() {
@@ -62,7 +64,7 @@ public class DetoxAction {
                 return new float[] {fx, fy};
             }
         };
-        return actionWithAssertions(new RNClickAction(c, strictMode));
+        return actionWithAssertions(new RNClickAction(c));
     }
 
     /**

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxViewActions.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DetoxViewActions.java
@@ -12,8 +12,8 @@ import static androidx.test.espresso.action.ViewActions.actionWithAssertions;
  * An alternative to {@link ViewActions} - providing alternative implementations, where needed.
  */
 public class DetoxViewActions {
-    public static ViewAction click(boolean strictMode) {
-        return actionWithAssertions(new RNClickAction(strictMode));
+    public static ViewAction click() {
+        return actionWithAssertions(new RNClickAction());
     }
 
     public static ViewAction typeText(String text) {

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxMultiTap.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxMultiTap.kt
@@ -3,7 +3,8 @@ package com.wix.detox.espresso.action
 import android.view.MotionEvent
 import androidx.test.espresso.UiController
 import androidx.test.espresso.action.Tapper
-import com.wix.detox.common.DetoxErrors.DetoxIllegalStateException
+import com.wix.detox.Detox
+import com.wix.detox.common.DetoxLog
 import com.wix.detox.common.collect.PairsIterator
 import com.wix.detox.common.proxy.CallInfo
 import com.wix.detox.espresso.UiControllerSpy
@@ -35,7 +36,8 @@ open class DetoxMultiTap
             private val coolDownTimeMs: Long = getPostTapCoolDownTime(),
             private val longTapMinTimeMs: Long = getLongTapMinTime(),
             private val tapEvents: TapEvents = TapEvents(),
-            private val uiControllerCallSpy: UiControllerSpy = UiControllerSpy.instance)
+            private val uiControllerCallSpy: UiControllerSpy = UiControllerSpy.instance,
+            private val log: DetoxLog = DetoxLog.instance)
     : Tapper {
 
     override fun sendTap(uiController: UiController?, coordinates: FloatArray?, precision: FloatArray?)
@@ -103,7 +105,7 @@ open class DetoxMultiTap
     private fun verifyTapEventTimes(upEvent: CallInfo, downEvent: CallInfo) {
         val delta: Long = (upEvent - downEvent)!!
         if (delta >= longTapMinTimeMs) {
-            throw DetoxIllegalStateException("Tap handled too slowly, and turned into a long-tap!")
+            log.warn(Detox.LOG_TAG, "Tap handled too slowly, and turned into a long-tap!") // TODO conditionally turn into an error, based on a global strict-mode detox config
         }
     }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxMultiTap.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxMultiTap.kt
@@ -1,10 +1,8 @@
 package com.wix.detox.espresso.action
 
-import android.util.Log
 import android.view.MotionEvent
 import androidx.test.espresso.UiController
 import androidx.test.espresso.action.Tapper
-import com.wix.detox.Detox
 import com.wix.detox.common.DetoxErrors.DetoxIllegalStateException
 import com.wix.detox.common.collect.PairsIterator
 import com.wix.detox.common.proxy.CallInfo
@@ -37,11 +35,8 @@ open class DetoxMultiTap
             private val coolDownTimeMs: Long = getPostTapCoolDownTime(),
             private val longTapMinTimeMs: Long = getLongTapMinTime(),
             private val tapEvents: TapEvents = TapEvents(),
-            private val uiControllerCallSpy: UiControllerSpy = UiControllerSpy.instance,
-            private val strictMode: Boolean = true)
+            private val uiControllerCallSpy: UiControllerSpy = UiControllerSpy.instance)
     : Tapper {
-
-    constructor(strictMode: Boolean, times: Int): this(times, strictMode = strictMode)
 
     override fun sendTap(uiController: UiController?, coordinates: FloatArray?, precision: FloatArray?)
             = sendTap(uiController, coordinates, precision, 0, 0)
@@ -108,11 +103,7 @@ open class DetoxMultiTap
     private fun verifyTapEventTimes(upEvent: CallInfo, downEvent: CallInfo) {
         val delta: Long = (upEvent - downEvent)!!
         if (delta >= longTapMinTimeMs) {
-            val message = "Tap handled too slowly, and has turned into a long-tap, instead!!!";
-            if (strictMode) {
-                throw DetoxIllegalStateException(message)
-            }
-            Log.w(Detox.LOG_TAG, message)
+            throw DetoxIllegalStateException("Tap handled too slowly, and turned into a long-tap!")
         }
     }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxSingleTap.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxSingleTap.kt
@@ -1,3 +1,3 @@
 package com.wix.detox.espresso.action
 
-open class DetoxSingleTap(strictMode: Boolean) : DetoxMultiTap(1, strictMode = strictMode)
+open class DetoxSingleTap : DetoxMultiTap(1)

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxTypeTextAction.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/DetoxTypeTextAction.java
@@ -17,7 +17,7 @@ public class DetoxTypeTextAction implements ViewAction {
 
     public DetoxTypeTextAction(String text) {
         this.text = text;
-        clickAction = new RNClickAction(false);
+        clickAction = new RNClickAction();
         typeTextAction = new TypeTextAction(text, false);
     }
 

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/RNClickAction.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/RNClickAction.java
@@ -20,13 +20,18 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
 public class RNClickAction implements ViewAction {
     private final GeneralClickAction clickAction;
 
-    public RNClickAction(boolean strictMode) {
-        this(GeneralLocation.VISIBLE_CENTER, strictMode);
+    public RNClickAction() {
+        clickAction = new GeneralClickAction(
+                        new DetoxSingleTap(),
+                        GeneralLocation.VISIBLE_CENTER,
+                        Press.FINGER,
+                        InputDevice.SOURCE_UNKNOWN,
+                        MotionEvent.BUTTON_PRIMARY);
     }
 
-    public RNClickAction(CoordinatesProvider coordinatesProvider, boolean strictMode) {
+    public RNClickAction(CoordinatesProvider coordinatesProvider) {
         clickAction = new GeneralClickAction(
-                        new DetoxSingleTap(strictMode),
+                        new DetoxSingleTap(),
                         coordinatesProvider,
                         Press.FINGER,
                         InputDevice.SOURCE_UNKNOWN,

--- a/detox/android/detox/src/test/java/com/wix/detox/espresso/action/DetoxMultiTapSpec.kt
+++ b/detox/android/detox/src/test/java/com/wix/detox/espresso/action/DetoxMultiTapSpec.kt
@@ -63,7 +63,6 @@ object DetoxMultiTapSpec: Spek({
                 whenever(uiControllerCallSpy.eventInjectionsIterator()).thenReturn(injectionsHistory.iterator())
 
         fun uut(times: Int) = DetoxMultiTap(times, interTapsDelayMs, coolDownTimeMs, longTapMinTimeMs, tapEvents, uiControllerCallSpy)
-        fun uutNonStrict(times: Int) = DetoxMultiTap(times, interTapsDelayMs, coolDownTimeMs, longTapMinTimeMs, tapEvents, uiControllerCallSpy, false)
         fun sendOneTap(uut: DetoxMultiTap = uut(1)) = uut.sendTap(uiController, coordinates, precision, -1, -1)
         fun sendTwoTaps(uut: DetoxMultiTap = uut(2)) = uut.sendTap(uiController, coordinates, precision, -1, -1)
 
@@ -211,17 +210,5 @@ object DetoxMultiTapSpec: Spek({
                 sendOneTap()
             }
         }
-
-        it("should NOT throw even though ui-controller spy indicates tap has turned into a long-tap, in non-strict mode") {
-            givenInjectionSuccess()
-
-            val injectionsHistory = listOf(
-                    CallInfo(longTapMinTimeMs - 1, longTapMinTimeMs),
-                    CallInfo(0, 1)
-            )
-            givenInjectionCallsHistory(injectionsHistory)
-            uutNonStrict(1).sendTap(uiController, coordinates, precision, -1, -1)
-        }
-
     }
 })

--- a/detox/src/android/espressoapi/DetoxAction.js
+++ b/detox/src/android/espressoapi/DetoxAction.js
@@ -34,9 +34,8 @@ function sanitize_android_direction(direction) {
   }
 } 
 class DetoxAction {
-  static multiClick(times, strictMode) {
+  static multiClick(times) {
     if (typeof times !== "number") throw new Error("times should be a number, but got " + (times + (" (" + (typeof times + ")"))));
-    if (typeof strictMode !== "boolean") throw new Error("strictMode should be a boolean, but got " + (strictMode + (" (" + (typeof strictMode + ")"))));
     return {
       target: {
         type: "Class",
@@ -46,17 +45,13 @@ class DetoxAction {
       args: [{
         type: "Integer",
         value: times
-      }, {
-        type: "boolean",
-        value: strictMode
       }]
     };
   }
 
-  static tapAtLocation(x, y, strictMode) {
+  static tapAtLocation(x, y) {
     if (typeof x !== "number") throw new Error("x should be a number, but got " + (x + (" (" + (typeof x + ")"))));
     if (typeof y !== "number") throw new Error("y should be a number, but got " + (y + (" (" + (typeof y + ")"))));
-    if (typeof strictMode !== "boolean") throw new Error("strictMode should be a boolean, but got " + (strictMode + (" (" + (typeof strictMode + ")"))));
     return {
       target: {
         type: "Class",
@@ -69,9 +64,6 @@ class DetoxAction {
       }, {
         type: "Integer",
         value: y
-      }, {
-        type: "boolean",
-        value: strictMode
       }]
     };
   }

--- a/detox/src/android/espressoapi/DetoxViewActions.js
+++ b/detox/src/android/espressoapi/DetoxViewActions.js
@@ -7,18 +7,14 @@
 
 
 class DetoxViewActions {
-  static click(strictMode) {
-    if (typeof strictMode !== "boolean") throw new Error("strictMode should be a boolean, but got " + (strictMode + (" (" + (typeof strictMode + ")"))));
+  static click() {
     return {
       target: {
         type: "Class",
         value: "com.wix.detox.espresso.DetoxViewActions"
       },
       method: "click",
-      args: [{
-        type: "boolean",
-        value: strictMode
-      }]
+      args: []
     };
   }
 

--- a/detox/src/android/expect.js
+++ b/detox/src/android/expect.js
@@ -29,20 +29,16 @@ class Action {
 }
 
 class TapAction extends Action {
-  constructor(value = {}) {
+  constructor(value) {
     super();
-
-    const { strict = true } = value;
-    this._call = invoke.callDirectly((value.x && value.y) ? DetoxActionApi.tapAtLocation(value.x, value.y, strict) : DetoxViewActionsApi.click(strict));
+    this._call = invoke.callDirectly(value ? DetoxActionApi.tapAtLocation(value.x, value.y) : DetoxViewActionsApi.click());
   }
 }
 
 class TapAtPointAction extends Action {
   constructor(value) {
     super();
-
-    const { strict = true } = value;
-    this._call = invoke.callDirectly(DetoxActionApi.tapAtLocation(value.x, value.y, strict));
+    this._call = invoke.callDirectly(DetoxActionApi.tapAtLocation(value.x, value.y));
   }
 }
 
@@ -54,11 +50,9 @@ class LongPressAction extends Action {
 }
 
 class MultiClickAction extends Action {
-  constructor(times, value = {}) {
+  constructor(times) {
     super();
-
-    const { strict = true } = value;
-    this._call = invoke.callDirectly(DetoxActionApi.multiClick(times, strict));
+    this._call = invoke.callDirectly(DetoxActionApi.multiClick(times));
   }
 }
 
@@ -247,8 +241,8 @@ class Element {
     return await new ActionInteraction(this._invocationManager, this, new LongPressAction()).execute();
   }
 
-  async multiTap(times, value) {
-    return await new ActionInteraction(this._invocationManager, this, new MultiClickAction(times, value)).execute();
+  async multiTap(times) {
+    return await new ActionInteraction(this._invocationManager, this, new MultiClickAction(times)).execute();
   }
 
   async tapBackspaceKey() {

--- a/detox/src/android/expect.test.js
+++ b/detox/src/android/expect.test.js
@@ -142,13 +142,10 @@ describe('expect', () => {
   describe('element interactions', () => {
     it('should tap and long-press', async () => {
       await e.element(e.by.label('Tap Me')).tap();
-      await e.element(e.by.label('Tap Me')).tap({ strict: false });
       await e.element(e.by.label('Tap Me')).tap({ x: 10, y: 10 });
       await e.element(e.by.label('Tap Me')).tapAtPoint({x: 100, y: 200});
-      await e.element(e.by.label('Tap Me')).tapAtPoint({x: 100, y: 200, strict: false});
       await e.element(e.by.label('Tap Me')).longPress();
       await e.element(e.by.id('UniqueId819')).multiTap(3);
-      await e.element(e.by.id('UniqueId819')).multiTap(3, { strict: false });
     });
 
     it('should not tap and long-press given bad args', async () => {

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -67,7 +67,7 @@ describe('Actions', () => {
     });
   });
 
-  it(':android: should throw if tap handling is too slow', async () => {
+  it.skip(':android: should throw if tap handling is too slow', async () => {
     try {
       await driver.sluggishTapElement.tap();
     } catch (e) {

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -72,16 +72,13 @@ describe('Actions', () => {
       await driver.sluggishTapElement.tap();
     } catch (e) {
       console.log('Got an expected error', e);
-      if (!e.toString().includes('Tap handled too slowly, and has turned into a long-tap, instead!!!')) {
+      if (!e.toString().includes('Tap handled too slowly, and turned into a long-tap!')) {
         throw new Error('Error content isn\'t as expected!');
       }
       return;
     }
-    throw new Error('Expected an error');
-  });
 
-  it(':android: should NOT throw if tap handling is too slow, if strict-mode is disabled', async () => {
-    await driver.sluggishTapElement.tap({ strict: false });
+    throw new Error('Expected an error');
   });
 
   it('should type in an element', async () => {

--- a/detox/test/e2e/drivers/actions-driver.js
+++ b/detox/test/e2e/drivers/actions-driver.js
@@ -37,7 +37,7 @@ const driver = {
 
   sluggishTapElement: {
     testId: 'sluggishTappableText',
-    tap: (value) => element(by.id(driver.sluggishTapElement.testId)).tap(value)
+    tap: () => element(by.id(driver.sluggishTapElement.testId)).tap()
   }
 };
 


### PR DESCRIPTION
- [ ] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**
Revert #2438 - kill 'strict mode' for now, and make tap2long-tap validation a soft one (i.e. warning instead of error).