### PR TITLE
Improve Genymotion leakage warning by including instance names

### DIFF
--- a/detox/src/devices/DeviceRegistry.js
+++ b/detox/src/devices/DeviceRegistry.js
@@ -45,7 +45,7 @@ class DeviceRegistry {
   }
 
   includes(deviceId) {
-    return this._lockfile.read().includes(deviceId);
+    return !!_.find(this._lockfile.read(), (item) => _.isEqual(item, deviceId));
   }
 
   getRegisteredDevices() {
@@ -74,7 +74,7 @@ class DeviceRegistry {
     const state = this._lockfile.read();
     const newState = busy
       ? _.concat(state, deviceId)
-      : _.without(state, deviceId);
+      : _.filter(state, (item) => !_.isEqual(item, deviceId));
     this._lockfile.write(newState);
   }
 

--- a/detox/src/devices/DeviceRegistry.test.js
+++ b/detox/src/devices/DeviceRegistry.test.js
@@ -41,7 +41,7 @@ describe('DeviceRegistry', () => {
       return registry.disposeDevice(() => deviceId);
     }
 
-    async function checkDeviceNotRegistered(deviceId) {
+    async function checkDeviceIsNotRegistered(deviceId) {
       return registry.allocateDevice(async () => {
         expect(registry.includes(deviceId)).toBe(false);
         throw new Error('ignored'); // So it wouldn't really allocate anything
@@ -62,7 +62,22 @@ describe('DeviceRegistry', () => {
       const deviceId = 'emulator-5554';
       await allocateDevice(deviceId);
       await checkDeviceRegisteredAndDispose(deviceId);
-      await checkDeviceNotRegistered(deviceId);
+      await checkDeviceIsNotRegistered(deviceId);
+    });
+
+    it('should be able to tell whether a device is registered, given object-like IDs', async () => {
+      const rawDeviceId = {
+        type: 'mocked-device-type',
+        adbName: 'localhost:11111',
+      };
+      const deviceId = {
+        ...rawDeviceId,
+        mockFunc: () => 'mocked-func-result',
+      };
+
+      await allocateDevice(deviceId);
+      await checkDeviceRegisteredAndDispose(rawDeviceId);
+      await checkDeviceIsNotRegistered(deviceId);
     });
 
     it('should throw on attempt of checking whether a device is registered outside of allocation/disposal context', async () => {
@@ -104,6 +119,18 @@ describe('DeviceRegistry', () => {
       await checkRegisteredDevicesEqual(deviceId, anotherDeviceId);
       await disposeDevice(deviceId);
       await checkRegisteredDevicesEqual(anotherDeviceId);
+    });
+
+    it('should be able to dispose devices with object-like ID\'s', async () => {
+      const deviceId = {
+        type: 'mocked-device-type',
+        adbName: 'emulator-5554',
+      };
+
+      await allocateDevice(deviceId);
+      await checkRegisteredDevicesEqual(deviceId);
+      await disposeDevice(deviceId);
+      await checkRegisteredDevicesEqual();
     });
 
     describe('.reset() method', () => {

--- a/detox/src/devices/DeviceRegistry.test.js
+++ b/detox/src/devices/DeviceRegistry.test.js
@@ -19,37 +19,37 @@ describe('DeviceRegistry', () => {
       await fs.remove(lockfilePath);
     });
 
-    async function allocateDevice(deviceId) {
-      return registry.allocateDevice(() => deviceId);
+    async function allocateDevice(deviceHandle) {
+      return registry.allocateDevice(() => deviceHandle);
     }
 
-    function expectRegisteredDevices(...deviceIds) {
+    function expectRegisteredDevices(...deviceHandles) {
       return registry.allocateDevice(() => {
-        expect(registry.getRegisteredDevices()).toEqual([ ...deviceIds ]);
+        expect(registry.getRegisteredDevices()).toEqual([ ...deviceHandles ]);
         throw new Error('ignored'); // So it wouldn't really allocate anything
       }).catch((e) => { if (e.message !== 'ignored') throw e });
     }
 
-    async function checkDeviceRegisteredAndDispose(deviceId) {
+    async function checkDeviceRegisteredAndDispose(deviceHandle) {
       return registry.disposeDevice(async () => {
-        expect(registry.includes(deviceId)).toBe(true);
-        return deviceId;
+        expect(registry.includes(deviceHandle)).toBe(true);
+        return deviceHandle;
       });
     }
 
-    async function disposeDevice(deviceId) {
-      return registry.disposeDevice(() => deviceId);
+    async function disposeDevice(deviceHandle) {
+      return registry.disposeDevice(() => deviceHandle);
     }
 
-    async function checkDeviceIsNotRegistered(deviceId) {
+    async function checkDeviceIsNotRegistered(deviceHandle) {
       return registry.allocateDevice(async () => {
-        expect(registry.includes(deviceId)).toBe(false);
+        expect(registry.includes(deviceHandle)).toBe(false);
         throw new Error('ignored'); // So it wouldn't really allocate anything
       }).catch((e) => { if (e.message !== 'ignored') throw e });
     }
 
-    async function checkRegisteredDevicesEqual(...deviceIds) {
-      expect(await registry.readRegisteredDevices()).toEqual([ ...deviceIds ]);
+    async function checkRegisteredDevicesEqual(...deviceHandles) {
+      expect(await registry.readRegisteredDevices()).toEqual([ ...deviceHandles ]);
     }
 
     const assertForbiddenOutOfContextRegistryQuery = () =>
@@ -59,69 +59,69 @@ describe('DeviceRegistry', () => {
       expect(() => registry.getRegisteredDevices()).toThrowError();
 
     it('should be able to tell whether a device is registered', async () => {
-      const deviceId = 'emulator-5554';
-      await allocateDevice(deviceId);
-      await checkDeviceRegisteredAndDispose(deviceId);
-      await checkDeviceIsNotRegistered(deviceId);
+      const deviceHandle = 'emulator-5554';
+      await allocateDevice(deviceHandle);
+      await checkDeviceRegisteredAndDispose(deviceHandle);
+      await checkDeviceIsNotRegistered(deviceHandle);
     });
 
-    it('should be able to tell whether a device is registered, given object-like IDs', async () => {
-      const rawDeviceId = {
+    it('should be able to tell whether a device is registered, given objects for handles', async () => {
+      const rawDeviceHandle = {
         type: 'mocked-device-type',
         adbName: 'localhost:11111',
       };
-      const deviceId = {
-        ...rawDeviceId,
+      const deviceHandle = {
+        ...rawDeviceHandle,
         mockFunc: () => 'mocked-func-result',
       };
 
-      await allocateDevice(deviceId);
-      await checkDeviceRegisteredAndDispose(rawDeviceId);
-      await checkDeviceIsNotRegistered(deviceId);
+      await allocateDevice(deviceHandle);
+      await checkDeviceRegisteredAndDispose(rawDeviceHandle);
+      await checkDeviceIsNotRegistered(deviceHandle);
     });
 
     it('should throw on attempt of checking whether a device is registered outside of allocation/disposal context', async () => {
-      const deviceId = 'emulator-5554';
+      const deviceHandle = 'emulator-5554';
 
       assertForbiddenOutOfContextRegistryQuery();
 
-      await allocateDevice(deviceId);
+      await allocateDevice(deviceHandle);
       assertForbiddenOutOfContextRegistryQuery();
     });
 
     it('should be able to fast-get a valid list of registered devices', async () => {
-      const deviceId = 'emulator-5554';
-      const anotherDeviceId = {
+      const deviceHandle = 'emulator-5554';
+      const anotherDeviceHandle = {
         type: 'mocked-device-type',
         adbName: 'emulator-5556',
       };
 
-      await allocateDevice(deviceId);
-      await allocateDevice(anotherDeviceId);
-      await expectRegisteredDevices(deviceId, anotherDeviceId);
+      await allocateDevice(deviceHandle);
+      await allocateDevice(anotherDeviceHandle);
+      await expectRegisteredDevices(deviceHandle, anotherDeviceHandle);
     });
 
     it('should throw on attempt of fast-getting registered devices list outside of allocation/disposal context', async () => {
-      const deviceId = 'emulator-5554';
+      const deviceHandle = 'emulator-5554';
 
       assertForbiddenOutOfContextDeviceListQuery();
 
-      await allocateDevice(deviceId);
+      await allocateDevice(deviceHandle);
       assertForbiddenOutOfContextDeviceListQuery();
     });
 
     it('should be able to read a valid list of registered devices', async () => {
-      const deviceId = 'emulator-5554';
-      const anotherDeviceId = 'emulator-5556';
+      const deviceHandle = 'emulator-5554';
+      const anotherDeviceHandle = 'emulator-5556';
 
-      await allocateDevice(deviceId);
-      await allocateDevice(anotherDeviceId);
-      await checkRegisteredDevicesEqual(deviceId, anotherDeviceId);
-      await disposeDevice(deviceId);
-      await checkRegisteredDevicesEqual(anotherDeviceId);
+      await allocateDevice(deviceHandle);
+      await allocateDevice(anotherDeviceHandle);
+      await checkRegisteredDevicesEqual(deviceHandle, anotherDeviceHandle);
+      await disposeDevice(deviceHandle);
+      await checkRegisteredDevicesEqual(anotherDeviceHandle);
     });
 
-    it('should be able to dispose devices with object-like ID\'s', async () => {
+    it('should be able to dispose devices with object-like handles', async () => {
       const deviceId = {
         type: 'mocked-device-type',
         adbName: 'emulator-5554',

--- a/detox/src/devices/drivers/android/genycloud/GenyCloudDeviceAllocator.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudDeviceAllocator.js
@@ -13,8 +13,10 @@ class GenyCloudDeviceAllocator extends AndroidDeviceAllocator {
 
   async _doAllocateDevice(recipe) {
     let { instance, isNew } = await this._doSynchronizedAllocation(recipe);
+    const { uuid, name } = instance;
+
     if (isNew) {
-      await this.deviceCleanupRegistry.allocateDevice(instance.uuid);
+      await this.deviceCleanupRegistry.allocateDevice({ uuid, name });
     }
 
     instance = await this._waitForInstanceBoot(instance);
@@ -22,7 +24,7 @@ class GenyCloudDeviceAllocator extends AndroidDeviceAllocator {
     return {
       instance,
       isNew,
-      toString: () => `GenyCloud:${instance.name} (${instance.uuid})`,
+      toString: () => `GenyCloud:${name} (${uuid})`,
     }
   }
 

--- a/detox/src/devices/drivers/android/genycloud/GenyCloudDeviceAllocator.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudDeviceAllocator.js
@@ -1,4 +1,5 @@
 const AndroidDeviceAllocator = require('../AndroidDeviceAllocator');
+const GenyCloudInstanceHandle = require('./GenyCloudInstanceHandle');
 const retry = require('../../../../utils/retry');
 const logger = require('../../../../utils/logger').child({ __filename });
 
@@ -13,10 +14,10 @@ class GenyCloudDeviceAllocator extends AndroidDeviceAllocator {
 
   async _doAllocateDevice(recipe) {
     let { instance, isNew } = await this._doSynchronizedAllocation(recipe);
-    const { uuid, name } = instance;
+    const instanceHandle = new GenyCloudInstanceHandle(instance);
 
     if (isNew) {
-      await this.deviceCleanupRegistry.allocateDevice({ uuid, name });
+      await this.deviceCleanupRegistry.allocateDevice(instanceHandle);
     }
 
     instance = await this._waitForInstanceBoot(instance);
@@ -24,7 +25,7 @@ class GenyCloudDeviceAllocator extends AndroidDeviceAllocator {
     return {
       instance,
       isNew,
-      toString: () => `GenyCloud:${name} (${uuid})`,
+      toString: () => instanceHandle.toString(),
     }
   }
 

--- a/detox/src/devices/drivers/android/genycloud/GenyCloudDeviceAllocator.test.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudDeviceAllocator.test.js
@@ -220,6 +220,26 @@ describe('Genymotion-Cloud device allocator', () => {
     expect(deviceRegistry.allocateDevice).toHaveBeenCalled();
   });
 
+  it('should register a new device for cleanup', async () => {
+    const instance = aFullyConnectedInstance();
+    givenNoFreeInstances();
+    givenCreatedInstance(instance);
+
+    await uut.allocateDevice(aRecipe());
+    expect(deviceCleanupRegistry.allocateDevice).toHaveBeenCalledWith({
+      uuid: instance.uuid,
+      name: instance.name,
+    });
+  });
+
+  it('should not register an existing device for cleanup', async () => {
+    const instance = aFullyConnectedInstance();
+    givenFreeInstance(instance);
+
+    await uut.allocateDevice(aRecipe());
+    expect(deviceCleanupRegistry.allocateDevice).not.toHaveBeenCalled();
+  });
+
   it('should log pre-allocate event', async () => {
     givenFreeInstance(aFullyConnectedInstance());
     await uut.allocateDevice(aRecipe());

--- a/detox/src/devices/drivers/android/genycloud/GenyCloudInstanceHandle.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudInstanceHandle.js
@@ -1,0 +1,12 @@
+class GenyCloudInstanceHandle {
+  constructor(instance) {
+    this.uuid = instance.uuid;
+    this.name = instance.name;
+  }
+
+  toString() {
+    return `GenyCloud:${this.name} (${this.uuid})`;
+  }
+}
+
+module.exports = GenyCloudInstanceHandle;

--- a/detox/src/devices/drivers/android/genycloud/services/dto/GenyInstance.js
+++ b/detox/src/devices/drivers/android/genycloud/services/dto/GenyInstance.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const Recipe = require('./GenyRecipe');
 
 const STATE_ONLINE = 'ONLINE';
@@ -13,7 +12,9 @@ const initStates = [
 
 class GenyInstance {
   constructor(rawInstance) {
-    Object.assign(this, _.pick(rawInstance, 'uuid', 'name', 'state'));
+    this.uuid = rawInstance.uuid;
+    this.name = rawInstance.name;
+    this.state = rawInstance.state;
     this.adb = {
       name: rawInstance.adb_serial,
       port: rawInstance.adb_serial_port,

--- a/detox/src/devices/drivers/android/genycloud/services/dto/GenyRecipe.js
+++ b/detox/src/devices/drivers/android/genycloud/services/dto/GenyRecipe.js
@@ -1,8 +1,7 @@
-const _ = require('lodash');
-
-class Recipe {
+class GenyRecipe {
   constructor(rawRecipe) {
-    Object.assign(this, _.pick(rawRecipe, 'uuid', 'name'));
+    this.uuid = rawRecipe.uuid;
+    this.name = rawRecipe.name;
   }
 
   toString() {
@@ -10,4 +9,4 @@ class Recipe {
   }
 }
 
-module.exports = Recipe;
+module.exports = GenyRecipe;


### PR DESCRIPTION
## Description

Improve Genymotion leakage warnings by including instance names, in addition to meaningless UUID's.
This incorporates 2 main things:
1. Enhancing the device registry such that it would allow for managing object, and not just strings (!)
2. Managing the device cleanup registry using objects, containing both instance `uuid`'s _and_ names (thus allowing for the instance names to be logged, eventually, in global-cleanup).

Related to #2429.