### PR TITLE
Prevalidate gmsaas: binary and auth

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -13,10 +13,10 @@ class Device {
   }
 
   async prepare() {
+    await this.deviceDriver.prepare();
+
     this._deviceId = await this.deviceDriver.acquireFreeDevice(this._deviceConfig.device || this._deviceConfig.name);
     this._bundleId = await this.deviceDriver.getBundleIdFromBinary(this._deviceConfig.binaryPath);
-
-    await this.deviceDriver.prepare();
   }
 
   async launchApp(params = {newInstance: false}, bundleId) {

--- a/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.js
+++ b/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.js
@@ -1,6 +1,14 @@
 const exec = require('../../../../../utils/exec').execWithRetriesAndLogs;
 
 class GenyCloudExec {
+  constructor(binaryPath) {
+    this.binaryExec = `"${binaryPath}" --format compactjson`;
+  }
+
+  whoAmI() {
+    return this._exec(`auth whoami`);
+  }
+
   getRecipe(name) {
     return this._exec(`recipes list --name "${name}"`);
   }
@@ -40,7 +48,7 @@ class GenyCloudExec {
         retrying: true,
       },
     };
-    return (await exec(`"gmsaas" --format compactjson ${args}`, options )).stdout;
+    return (await exec(`${this.binaryExec} ${args}`, options )).stdout;
   }
 }
 

--- a/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.test.js
+++ b/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.test.js
@@ -30,38 +30,44 @@ describe('Genymotion-cloud executable', () => {
     exec = require('../../../../../utils/exec').execWithRetriesAndLogs;
 
     const GenyCloudExec = require('./GenyCloudExec');
-    uut = new GenyCloudExec;
+    uut = new GenyCloudExec('mock/path/to/gmsaas');
   });
 
   const recipeName = 'mock-recipe-name';
   const recipeUUID = 'mock-recipe-uuid';
   const instanceUUID = 'mock-uuid';
   const instanceName = 'detox-instance1';
+
   [
+    {
+      commandName: 'whoami',
+      commandExecFn: () => uut.whoAmI(),
+      expectedExec: `"mock/path/to/gmsaas" --format compactjson auth whoami`,
+    },
     {
       commandName: 'Get Recipe',
       commandExecFn: () => uut.getRecipe(recipeName),
-      expectedExec: `"gmsaas" --format compactjson recipes list --name "${recipeName}"`,
+      expectedExec: `"mock/path/to/gmsaas" --format compactjson recipes list --name "${recipeName}"`,
     },
     {
       commandName: 'Get Instances',
       commandExecFn: () => uut.getInstances(),
-      expectedExec: `"gmsaas" --format compactjson instances list -q`,
+      expectedExec: `"mock/path/to/gmsaas" --format compactjson instances list -q`,
     },
     {
       commandName: 'Start Instance',
       commandExecFn: () => uut.startInstance(recipeUUID, instanceName),
-      expectedExec: `"gmsaas" --format compactjson instances start --stop-when-inactive --no-wait ${recipeUUID} "${instanceName}"`,
+      expectedExec: `"mock/path/to/gmsaas" --format compactjson instances start --stop-when-inactive --no-wait ${recipeUUID} "${instanceName}"`,
     },
     {
       commandName: 'ADB Connect',
       commandExecFn: () => uut.adbConnect(instanceUUID),
-      expectedExec: `"gmsaas" --format compactjson instances adbconnect ${instanceUUID}`,
+      expectedExec: `"mock/path/to/gmsaas" --format compactjson instances adbconnect ${instanceUUID}`,
     },
     {
       commandName: 'Stop Instance',
       commandExecFn: () => uut.stopInstance(instanceUUID),
-      expectedExec: `"gmsaas" --format compactjson instances stop ${instanceUUID}`,
+      expectedExec: `"mock/path/to/gmsaas" --format compactjson instances stop ${instanceUUID}`,
       expectedExecOptions: { retries: 3 },
     },
   ].forEach((testCase) => {

--- a/detox/src/devices/drivers/android/genycloud/services/GenyAuthService.js
+++ b/detox/src/devices/drivers/android/genycloud/services/GenyAuthService.js
@@ -1,0 +1,12 @@
+class GenyAuthService {
+  constructor(genyCloudExec) {
+    this.genyCloudExec = genyCloudExec;
+  }
+
+  async getLoginEmail() {
+    const whoAmI = await this.genyCloudExec.whoAmI();
+    return whoAmI.auth.email;
+  }
+}
+
+module.exports = GenyAuthService;

--- a/detox/src/devices/drivers/android/genycloud/services/GenyAuthService.test.js
+++ b/detox/src/devices/drivers/android/genycloud/services/GenyAuthService.test.js
@@ -1,0 +1,32 @@
+describe('Genymotion-cloud authentication service', () => {
+  let exec;
+  let uut;
+  beforeEach(() => {
+    const GenyCloudExec = jest.genMockFromModule('../exec/GenyCloudExec');
+    exec = new GenyCloudExec();
+
+    const GenyAuthService = require('./GenyAuthService');
+    uut = new GenyAuthService(exec);
+  });
+
+  const givenLoginEmail = (email) => exec.whoAmI.mockResolvedValue({
+    auth: {
+      email,
+    },
+  });
+  const givenLoggedOut = () => givenLoginEmail(null);
+
+  it('should return logged-in user email', async () => {
+    givenLoginEmail('mock@wix.com');
+
+    const result = await uut.getLoginEmail();
+    expect(result).toEqual('mock@wix.com');
+  });
+
+  it('should return null if logged-out', async () => {
+    givenLoggedOut();
+
+    const result = await uut.getLoginEmail();
+    expect(result).toEqual(null);
+  });
+});

--- a/detox/src/utils/environment.js
+++ b/detox/src/utils/environment.js
@@ -119,6 +119,10 @@ function getAdbPath() {
   throwSdkIntegrityError(sdkRoot, 'platform-tools/adb');
 }
 
+function getGmsaasPath() {
+  return which('gmsaas') || throwMissingGmsaasError();
+}
+
 function throwMissingSdkError() {
   throw new Error(MISSING_SDK_ERROR);
 }
@@ -143,6 +147,10 @@ function throwSdkIntegrityError(sdkRoot, relativeExecutablePath) {
     `There was no "${name}" executable file in directory: ${dir}.\n` +
     `Check integrity of your Android SDK.`
   );
+}
+
+function throwMissingGmsaasError() {
+  throw new Error(`Failed to locate Genymotion\'s gmsaas executable. Please add it to your $PATH variable!\nPATH is currently set to: ${process.env.PATH}`)
 }
 
 function getDetoxVersion() {
@@ -187,6 +195,7 @@ module.exports = {
   getAvdDir,
   getAvdManagerPath,
   getAndroidSdkManagerPath,
+  getGmsaasPath,
   getDetoxVersion,
   getFrameworkPath,
   getAndroidSDKPath,

--- a/detox/src/utils/environment.test.js
+++ b/detox/src/utils/environment.test.js
@@ -262,5 +262,20 @@ describe('Environment', () => {
         await expect(asyncGetter()).rejects.toThrow(/\$ANDROID_SDK_ROOT is not defined/);
       });
     }
+
+    describe('Genymotion SaaS executable - getGmsaasPath', () => {
+      it('should resolve based on $PATH', async () => {
+        const executable = 'gmsaas';
+        process.env.PATH = path.join(tempSdkPath, 'somewhere');
+        await genExec(`somewhere/${executable}`);
+        expect(Environment.getGmsaasPath()).toMatch(new RegExp(`${tempSdkPath}.+somewhere.${executable}`));
+      });
+
+      it('should throw error if gmsaas is not in $PATH', async () => {
+        const pathToNowhere = path.join('one', 'mock', 'directory');
+        process.env.PATH = pathToNowhere;
+        await expect(async () => Environment.getGmsaasPath()).rejects.toThrow(`Failed to locate Genymotion\'s gmsaas executable. Please add it to your $PATH variable!\nPATH is currently set to: ${pathToNowhere}`);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description

As per insightful notes by @noomorph - added a validation of that `gmsaas` is in path (so as to avoid pointless retires to take place in trying to execute initial setup command, resulting in obscure, unfriendly errors).

Actually, with genymotion's SaaS, there are two things to handle before enabling access to the cloud:
1. Setting up `gmsaas` in path
2. Logging in

This PR effectively handles both aspects.