### PR TITLE
feat(artifacts): always loglevel=trace for log artifacts

### DIFF
--- a/detox/src/utils/logger.js
+++ b/detox/src/utils/logger.js
@@ -83,7 +83,7 @@ function init() {
       jsonFileStreamPath = temporaryPath.for.log();
       fs.ensureFileSync(jsonFileStreamPath);
       bunyanStreams.push({
-        level,
+        level: 'trace',
         path: jsonFileStreamPath,
       });
     }
@@ -91,7 +91,7 @@ function init() {
       plainFileStreamPath = temporaryPath.for.log();
       fs.ensureFileSync(plainFileStreamPath);
       bunyanStreams.push(createPlainBunyanStream({
-        level,
+        level: 'trace',
         logPath: plainFileStreamPath,
       }));
     }


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

When something wrong happens, we usually go to the logs.
When things mostly go alright, we don't turn on verbose logging mode.
At the moment, verbosity in log artifacts is tightly coupled to the verbosity of CLI output.

This PR suggests using always `loglevel=trace` for log artifacts, presuming that a user will stick to `--record-logs failing` in the majority of cases. If it is `--record-logs all` — better to take care of CI storage. ;) 