### PR TITLE
Improving Android's onboarding

### DIFF
--- a/detox/local-cli/androidExperimental/DetoxTest.java
+++ b/detox/local-cli/androidExperimental/DetoxTest.java
@@ -1,0 +1,31 @@
+package com.example;
+
+import com.wix.detox.Detox;
+import com.wix.detox.config.DetoxConfig;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class DetoxTest {
+    @Rule
+    // Replace 'MainActivity' with the value of android:name entry in 
+    // <activity> in AndroidManifest.xml
+    public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
+
+    @Test
+    public void runDetoxTests() {
+        DetoxConfig detoxConfig = new DetoxConfig();
+        detoxConfig.idlePolicyConfig.masterTimeoutSec = 90;
+        detoxConfig.idlePolicyConfig.idleResourceTimeoutSec = 60;
+        detoxConfig.rnContextLoadTimeoutSec = (com.example.BuildConfig.DEBUG ? 180 : 60);
+
+        Detox.runTests(mActivityRule, detoxConfig);
+    }
+}

--- a/detox/local-cli/androidExperimental/detox.android.build.gradle
+++ b/detox/local-cli/androidExperimental/detox.android.build.gradle
@@ -1,0 +1,22 @@
+buildscript {
+    ext {
+        minSdkVersion = 18
+        kotlinVersion = '1.3.10'
+    }
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    }
+}
+
+allprojects {
+    repositories {
+        maven {
+            // All of Detox' artifacts are provided via the npm module
+            url "$rootDir/../node_modules/detox/Detox-android"
+        }
+    }
+}

--- a/detox/local-cli/androidExperimental/detox.app.build.gradle
+++ b/detox/local-cli/androidExperimental/detox.app.build.gradle
@@ -1,0 +1,10 @@
+android {
+    defaultConfig {
+        testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+    }
+}
+
+dependencies {
+    androidTestImplementation('com.wix:detox:+')
+}

--- a/detox/local-cli/androidExperimental/init-experimental.js
+++ b/detox/local-cli/androidExperimental/init-experimental.js
@@ -1,0 +1,67 @@
+const {execSync} = require('child_process');
+const log = require('../../src/utils/logger').child({ __filename });
+const fs = require('fs');
+const {createFile} = require('../utils/misc');
+let packageName, minSdkVersion;
+
+function build(androidDir) {
+    log.info('Building android');
+    // TODO: should we do something different for release?
+    execSync(`cd ${androidDir} && ./gradlew clean app:assembleDebug`);
+}
+
+function findInfo(androidDir) {
+    log.info('Finding information');
+    const mergedJsonLocation = `${androidDir}/app/build/intermediates/merged_manifests/debug/output.json`;
+    const mergedJson = JSON.parse(fs.readFileSync(mergedJsonLocation, 'utf-8'));
+    packageName = mergedJson[0].properties.packageId;
+    minSdkVersion = mergedJson[0].properties.minSdkVersion;
+}
+
+function createDetoxTest(androidDir) {
+    log.info('Creating DetoxTest');
+    let DetoxTest = fs.readFileSync('node_modules/detox/local-cli/androidExperimental/DetoxTest.java', 'utf-8');
+    DetoxTest = DetoxTest.replace(/com.example/g, packageName);
+    const detoxTestFolder = `${androidDir}/app/src/androidTest/java/${packageName.split('.').join('/')}`;
+    fs.mkdirSync(detoxTestFolder, {recursive: true});
+    createFile(`${detoxTestFolder}/DetoxTest.java`, DetoxTest);
+}
+
+function applyBuildGradle(androidDir, extraDir, detoxBuildGradle) {
+    createFile(`${androidDir}${extraDir}/detox.build.gradle`, detoxBuildGradle);
+    let buildGradle = fs.readFileSync(`${androidDir}${extraDir}/build.gradle`, 'utf-8');
+    buildGradle += `apply from: 'detox.build.gradle'\n\n`;
+    fs.writeFileSync(`${androidDir}${extraDir}/build.gradle`, buildGradle); // just modifying, do not call createFile
+}
+
+function modifyBuildGradle(androidDir) {
+    // TODO: We currently do not support projects which already have kotlin (larger than our 1.3.10)
+    log.info('Modifying build.gradle');
+    let detoxAndroidBuildGradle = fs.readFileSync('node_modules/detox/local-cli/androidExperimental/detox.android.build.gradle', 'utf-8');
+    const detoxAppBuildGradle = fs.readFileSync('node_modules/detox/local-cli/androidExperimental/detox.app.build.gradle', 'utf-8');
+    if (minSdkVersion < 18) {
+        log.warn(`Please be aware that the minSdkVersion needs to be at least 18 (you have it set to ${minSdkVersion}, it will be modified).`);
+    } else {
+        detoxAndroidBuildGradle = detoxAndroidBuildGradle.split('\n').filter(function(line){ 
+            return line.indexOf('minSdkVersion') == -1;
+        }).join('\n')
+    }
+
+    applyBuildGradle(androidDir, '', detoxAndroidBuildGradle);
+    applyBuildGradle(androidDir, '/app', detoxAppBuildGradle);
+}
+
+function experimentalAndroidInit(androidDir) {
+    try {
+        build(androidDir);
+        findInfo(androidDir);
+        createDetoxTest(androidDir);
+        modifyBuildGradle(androidDir);
+    } catch (e) {
+        log.error(`experimentalAndroidInit: ${e}`);
+    }
+}
+
+module.exports = {
+    experimentalAndroidInit
+};

--- a/detox/local-cli/utils/misc.js
+++ b/detox/local-cli/utils/misc.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const fs = require('fs');
+const log = require('../../src/utils/logger').child({ __filename });
 
 function getPlatformSpecificString(platform) {
   switch (platform) {
@@ -30,7 +32,30 @@ function prependNodeModulesBinToPATH(env) {
   }
 }
 
+function reportError(...args) {
+  log.error(...args);
+  exitCode = 1;
+}
+
+function createFile(filename, content) {
+  if (fs.existsSync(filename)) {
+    return reportError(
+      `Failed to create ${filename} file, ` +
+      `because it already exists at path: ${path.resolve(filename)}`
+    );
+  }
+
+  try {
+    fs.writeFileSync(filename, content);
+    log.info(`Created a file at path: ${filename}`);
+  } catch (err) {
+    reportError({ err }, `Failed to create a file at path: ${filename}`);
+  }
+}
+
 module.exports = {
+  reportError,
+  createFile,
   getPlatformSpecificString,
   printEnvironmentVariables,
   prependNodeModulesBinToPATH,


### PR DESCRIPTION
This has been partially discussed with @rotemmiz 

**Description:**
Adding an experimental stage to the `init` command that should remove or at least decrease substantially the amount of configuration on an Android project.
Tested on a new RN project (react-native init) in debug mode --> was not tested on:
1. More elaborate project.
2. Release APK.

This may break (without a manual fix) a project with `Kotlin` version greater than `1.3.10`.
I could not reproduce a failure on [unencrypted traffic](https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md#6-enable-clear-text-unencrypted-traffic-for-detox), either on an emulator or a real device even though I did not patch it.

I've added this as an experimental feature because it was not tested on enough variations of Android projects.