### PR TITLE
Fix Detox' proguard rules-set to support obfuscating apps, with docs

### DIFF
--- a/detox/android/detox/proguard-rules-app.pro
+++ b/detox/android/detox/proguard-rules-app.pro
@@ -1,1 +1,9 @@
+-keepattributes InnerClasses, Exceptions
+-keep class com.facebook.react.modules.** { *; }
+-keep class com.facebook.react.uimanager.** { *; }
+-keep class com.facebook.react.animated.** { *; }
+-keep class com.facebook.react.ReactApplication { *; }
+-keep class com.facebook.react.ReactNativeHost { *; }
 -keep class com.facebook.react.ReactInstanceManager { *; }
+-keep class com.facebook.react.ReactInstanceManager** { *; }
+-keep class com.reactnativecommunity.asyncstorage.** { *; }

--- a/detox/android/detox/proguard-rules.pro
+++ b/detox/android/detox/proguard-rules.pro
@@ -13,12 +13,6 @@
 -dontnote org.hamcrest.**
 -dontnote com.facebook.**
 
-# Detox dynamic access to declared methods of RN's timing module
-
--keep class com.facebook.react.modules.core.TimingModule { *; } # RN >= .63
--keep class com.facebook.react.modules.core.Timing { *; } # RN <= .62
--dontnote com.wix.detox.reactnative.idlingresources.timers.**
-
 # Detox profiler (optional)
 
 -keep class com.wix.detoxprofiler.** { *; }

--- a/detox/android/detox/src/main/java/com/wix/detox/reactnative/helpers/RNHelpers.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/reactnative/helpers/RNHelpers.kt
@@ -12,9 +12,9 @@ object RNHelpers {
             val moduleClass = Class.forName(className) as Class<NativeModule>
 
             if (reactContext.hasNativeModule(moduleClass)) {
-                Log.d(LOG_TAG, "Native module not resolved: no registered module")
                 reactContext.getNativeModule(moduleClass)
             } else {
+                Log.d(LOG_TAG, "Native module not resolved: no registered module")
                 null
             }
         } catch (ex: Exception) {

--- a/detox/android/detox/src/main/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResource.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResource.kt
@@ -30,6 +30,9 @@ open class AsyncStorageIdlingResource
         sexecutorReflectedGenFn: SExecutorReflectedGenFnType = defaultSExecutorReflectedGenFn)
     : IdlingResource {
 
+    open val logTag: String
+        get() = LOG_TAG
+
     private val moduleReflected = ModuleReflected(module, sexecutorReflectedGenFn)
     private var callback: IdlingResource.ResourceCallback? = null
     private var idleCheckTask: Runnable? = null
@@ -50,7 +53,7 @@ open class AsyncStorageIdlingResource
     override fun isIdleNow(): Boolean =
         checkIdle().also { idle ->
             if (!idle) {
-                Log.d(LOG_TAG, "Async-storage is busy!")
+                Log.d(logTag, "Async-storage is busy!")
                 enqueueIdleCheckTask()
             }
         }
@@ -106,4 +109,7 @@ open class AsyncStorageIdlingResource
     }
 }
 
-class AsyncStorageIdlingResourceLegacy(module: NativeModule): AsyncStorageIdlingResource(module)
+class AsyncStorageIdlingResourceLegacy(module: NativeModule): AsyncStorageIdlingResource(module) {
+    override val logTag: String
+        get() = super.logTag + "Legacy"
+}

--- a/detox/test/android/app/proguard-rules.pro
+++ b/detox/test/android/app/proguard-rules.pro
@@ -16,6 +16,7 @@
 -dontnote okio.**
 
 # Do not strip any method/class that is annotated with @DoNotStrip
+# This should really come from React Native itself. See here: https://github.com/react-native-community/upgrade-support/issues/31
 -keep @com.facebook.jni.annotations.DoNotStrip class *
 -keep class * {
     @com.facebook.proguard.annotations.DoNotStrip *;

--- a/examples/demo-react-native/android/app/build.gradle
+++ b/examples/demo-react-native/android/app/build.gradle
@@ -69,6 +69,8 @@ dependencies {
 
     // noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
+    // noinspection GradleDynamicVersion
+    implementation(project(path: ':AsyncStorage')) // Note: not required unless effectively used by your app
 
     androidTestImplementation('com.wix:detox:+')
 }

--- a/examples/demo-react-native/android/app/proguard-rules.pro
+++ b/examples/demo-react-native/android/app/proguard-rules.pro
@@ -3,8 +3,6 @@
 # the lean configuration file.
 ###
 
--dontobfuscate
-
 -dontnote android.net.**
 -dontnote org.apache.**
 
@@ -16,6 +14,7 @@
 -dontnote okio.**
 
 # Do not strip any method/class that is annotated with @DoNotStrip
+# This should really come from React Native itself. See here: https://github.com/react-native-community/upgrade-support/issues/31
 -keep @com.facebook.jni.annotations.DoNotStrip class *
 -keep class * {
     @com.facebook.proguard.annotations.DoNotStrip *;

--- a/examples/demo-react-native/android/app/src/main/java/com/example/MainApplication.java
+++ b/examples/demo-react-native/android/app/src/main/java/com/example/MainApplication.java
@@ -7,6 +7,7 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
+import com.reactnativecommunity.asyncstorage.AsyncStoragePackage;
 
 import java.util.Arrays;
 import java.util.List;
@@ -21,7 +22,8 @@ public class MainApplication extends Application implements ReactApplication {
         @Override
         protected List<ReactPackage> getPackages() {
             return Arrays.<ReactPackage>asList(
-                    new MainReactPackage()
+                    new MainReactPackage(),
+                    new AsyncStoragePackage() // Note: Not required unless effectively used by your app
             );
         }
     };

--- a/examples/demo-react-native/android/build.gradle
+++ b/examples/demo-react-native/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     println "[$project] Resorted to Android Gradle-plugin version $androidGradlePluginVersion"
 
     ext {
-        kotlinVersion = '1.3.41'
+        kotlinVersion = '1.4.21'
         buildToolsVersion = '29.0.3'
         compileSdkVersion = 29
         targetSdkVersion = 29

--- a/examples/demo-react-native/android/gradle.properties
+++ b/examples/demo-react-native/android/gradle.properties
@@ -16,3 +16,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.useAndroidX=true
+android.enableJetifier=true
+

--- a/examples/demo-react-native/android/settings.gradle
+++ b/examples/demo-react-native/android/settings.gradle
@@ -1,3 +1,6 @@
 rootProject.name = 'DetoxRNExample'
 
 include ':app'
+
+include ':AsyncStorage'
+project(':AsyncStorage').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/async-storage/android')

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "react": "16.11.x",
-    "react-native": "0.62.x"
+    "react-native": "0.62.x",
+    "@react-native-community/async-storage": "^1.12.0"
   },
   "devDependencies": {
     "detox": "^17.14.3",


### PR DESCRIPTION
## Description

Resolves #2431.

1. Adds ProGuard/R8 rules to Detox' app-associated rules-set (aka `proguard-rules-app.pro`) so as to retain interrogated React-Native code.
2. Turns on obfuscation in the example app, to consistently prove that the rules-set is sufficient.
3. Elaborates on ProGuard+Detox in the Android setup doc.

cc @GEllickson-Hover - you've been credited in the docs.