### PR TITLE
Fixed crash in Google Maps SDK, caused by exposing a `text` property on every object

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,8 @@ detox/test/ios/* @LeoNatan
 *.m @LeoNatan
 *.mm @LeoNatan
 *.cpp @LeoNatan
+*.swift @LeoNatan
+*.pch @LeoNatan
+*.plist @LeoNatan
+
 *.sh @rotemmiz

--- a/detox/ios/Detox/Invocation/Element.swift
+++ b/detox/ios/Detox/Invocation/Element.swift
@@ -216,7 +216,7 @@ class Element : NSObject {
 	
 	@objc
 	var text: String? {
-		return view.value(forKey: "text") as? String
+		return view.value(forKey: "dtx_text") as? String
 	}
 	
 	@objc

--- a/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
@@ -193,7 +193,7 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 
 - (NSString *)dtx_text
 {
-	id rv = [self text];
+	id rv = [self _dtx_text];
 	if(rv == nil || [rv isKindOfClass:NSString.class])
 	{
 		return rv;

--- a/detox/ios/Detox/Utilities/NSObject+DontCrash.h
+++ b/detox/ios/Detox/Utilities/NSObject+DontCrash.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSObject (DontCrash)
 
-- (id)text;
+- (id)_dtx_text;
 
 @end
 

--- a/detox/ios/Detox/Utilities/NSObject+DontCrash.m
+++ b/detox/ios/Detox/Utilities/NSObject+DontCrash.m
@@ -9,10 +9,19 @@
 
 @implementation NSObject (DontCrash)
 
-- (id)text
+- (id)_dtx_text
 {
-	Class cls = NSClassFromString(@"RCTTextView");
-	if(cls != nil && [self isKindOfClass:cls])
+	if([self respondsToSelector:@selector(text)])
+	{
+		return [(UITextView*)self text];
+	}
+	
+	static Class RCTTextView;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		RCTTextView = NSClassFromString(@"RCTTextView");
+	});
+	if(RCTTextView != nil && [self isKindOfClass:RCTTextView])
 	{
 		return [(NSTextStorage*)[self valueForKey:@"textStorage"] string];
 	}


### PR DESCRIPTION
Closes #2516