### PR TITLE
broken link changed `expect.js` to `expectTwo.js`

### DIFF
--- a/docs/Introduction.HowDetoxWorks.md
+++ b/docs/Introduction.HowDetoxWorks.md
@@ -39,7 +39,7 @@ To understand this topic more thoroughly we need to have a look at an example ac
 ### Action (`element.tap`)
 
 1. `element.tap()` in your test case is invoked.
-2. `TapAction` in [`expect.js`](https://github.com/wix/detox/blob/master/detox/src/ios/expect.js) gets invoked
+2. `TapAction` in [`expect.js`](https://github.com/wix/detox/blob/master/detox/src/ios/expectTwo.js) gets invoked
 3.  `TapAction` instance gets passed to [`invoke.js`](https://github.com/wix/detox/blob/master/detox/src/invoke.js), where it gets transformed to JSON. The resulting JSON correlates more with the native code than with the JS code for better extensibility.
 4. JSON gets send to detox server by [`Client.js`](https://github.com/wix/detox/blob/master/detox/src/client/Client.js)
 6. detox server forwards it to the testee in [`DetoxServer.js`](https://github.com/wix/detox/blob/master/detox/src/server/DetoxServer.js)


### PR DESCRIPTION
The following js link is dead: https://github.com/wix/detox/blob/master/detox/src/ios/expect.js
so i change it to another expectTwo.js file

changes for **docs/Introduction.HowDetoxWorks.md** 