### PR TITLE
Make usage of new gmsaas getInstance 'endpoint' of 1.6.0

### DIFF
--- a/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.test.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.test.js
@@ -2,6 +2,24 @@ const _ = require('lodash');
 
 const latestInstanceOf = (clazz) => _.last(clazz.mock.instances);
 
+const MOCK_GMSAAS_PATH = '/path/to/gmsaas';
+
+const aRecipe = () => ({
+  uuid: 'mock-recipe-uuid',
+  name: 'mock-recipe-name',
+  toString: () => 'mock-recipe-toString()-result',
+});
+
+const anInstance = () => ({
+  uuid: 'mock-instance-uuid',
+  name: 'mock-instance-name',
+  adbName: 'mock-instance-adb-name',
+});
+
+const aDeviceQuery = () => ({
+  query: 'mock',
+});
+
 describe('Genymotion-cloud driver', () => {
   class MockInstanceLifecycleService {
     constructor(...args) {
@@ -9,24 +27,6 @@ describe('Genymotion-cloud driver', () => {
       this.ctor(...args);
     }
   }
-
-  const MOCK_GMSAAS_PATH = '/path/to/gmsaas';
-
-  const aRecipe = () => ({
-    uuid: 'mock-recipe-uuid',
-    name: 'mock-recipe-name',
-    toString: () => 'mock-recipe-toString()-result',
-  });
-
-  const anInstance = () => ({
-    uuid: 'mock-instance-uuid',
-    name: 'mock-instance-name',
-    adbName: 'mock-instance-adb-name',
-  });
-
-  const aDeviceQuery = () => ({
-    query: 'mock',
-  });
 
   beforeEach(mockBaseClassesDependencies);
   beforeEach(mockDirectDependencies);
@@ -37,6 +37,7 @@ describe('Genymotion-cloud driver', () => {
   let environment;
   let adbObj;
   let Exec;
+  let execObj;
   let deviceQueryHelper;
   let deviceRegistry;
   let deviceCleanupRegistry;
@@ -58,6 +59,7 @@ describe('Genymotion-cloud driver', () => {
     adbObj = () => latestInstanceOf(ADB);
 
     Exec = require('./exec/GenyCloudExec');
+    execObj = () => latestInstanceOf(Exec);
 
     const GenyDeviceRegistryFactory = require('./GenyDeviceRegistryFactory');
     const DeviceRegistry = jest.genMockFromModule('../../../DeviceRegistry');
@@ -109,21 +111,67 @@ describe('Genymotion-cloud driver', () => {
     });
 
     describe('preparation', () => {
-      it('should throw error if not logged-in to gmsaas', async () => {
-        authServiceObj().getLoginEmail.mockResolvedValue(null);
+      const givenProperGmsaasLogin = () => authServiceObj().getLoginEmail.mockResolvedValue('detox@wix.com');
+      const givenGmsaasLoggedOut = () => authServiceObj().getLoginEmail.mockResolvedValue(null);
+      const givenGmsaasExecVersion = (version) => execObj().getVersion.mockResolvedValue({ version });
+      const givenProperGmsaasExecVersion = () => givenGmsaasExecVersion('1.6.0');
+
+      it('should throw an error if gmsaas exec is too old (minor version < 6)', async () => {
+        givenProperGmsaasLogin();
+        givenGmsaasExecVersion('1.5.9');
 
         try {
           await uut.prepare();
           fail('Expected an error');
         } catch (e) {
           expect(e.constructor.name).toEqual('DetoxRuntimeError');
-          expect(e.toString()).toContain('Cannot run tests using a Genymotion-cloud emulator, because Genymotion was not logged-in to!');
+          expect(e.toString()).toContain(`Your Genymotion-Cloud executable (found in ${MOCK_GMSAAS_PATH}) is too old! (version 1.5.9)`);
+          expect(e.toString()).toContain(`HINT: Detox requires version 1.6.0, or newer. To use 'android.genycloud' type devices, you must upgrade it, first.`);
+        }
+      });
+
+      it('should accept the gmsaas exec if version is sufficiently new', async () => {
+        givenProperGmsaasLogin();
+        givenGmsaasExecVersion('1.6.0');
+        await uut.prepare();
+      });
+
+      it('should accept the gmsaas exec if version is more than sufficiently new', async () => {
+        givenProperGmsaasLogin();
+        givenGmsaasExecVersion('1.7.2');
+        await uut.prepare();
+      });
+
+      it('should throw an error if gmsaas exec is too old (major version < 1)', async () => {
+        givenProperGmsaasLogin();
+        givenGmsaasExecVersion('0.6.0');
+
+        try {
+          await uut.prepare();
+          fail('Expected an error');
+        } catch (e) {
+          expect(e.toString()).toContain(`Your Genymotion-Cloud executable (found in ${MOCK_GMSAAS_PATH}) is too old! (version 0.6.0)`);
+        }
+      });
+
+      it('should throw an error if not logged-in to gmsaas', async () => {
+        givenProperGmsaasExecVersion();
+        givenGmsaasLoggedOut();
+
+        try {
+          await uut.prepare();
+          fail('Expected an error');
+        } catch (e) {
+          expect(e.constructor.name).toEqual('DetoxRuntimeError');
+          expect(e.toString()).toContain(`Cannot run tests using 'android.genycloud' type devices, because Genymotion was not logged-in to!`);
           expect(e.toString()).toContain(`HINT: Log-in to Genymotion-cloud by running this command (and following instructions):\n${MOCK_GMSAAS_PATH} auth login --help`);
         }
       });
 
       it('should not throw an error if properly logged in to gmsaas', async () => {
-        authServiceObj().getLoginEmail.mockResolvedValue('detox@wix.com');
+        givenProperGmsaasExecVersion();
+        givenProperGmsaasLogin();
+
         await uut.prepare();
       });
     });

--- a/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.js
+++ b/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.js
@@ -5,16 +5,24 @@ class GenyCloudExec {
     this.binaryExec = `"${binaryPath}" --format compactjson`;
   }
 
+  getVersion() {
+    return this._exec('--version');
+  }
+
   whoAmI() {
-    return this._exec(`auth whoami`);
+    return this._exec('auth whoami');
   }
 
   getRecipe(name) {
     return this._exec(`recipes list --name "${name}"`);
   }
 
+  getInstance(instanceUUID) {
+    return this._exec(`instances get ${instanceUUID}`);
+  }
+
   getInstances() {
-    return this._exec(`instances list -q`);
+    return this._exec('instances list -q');
   }
 
   startInstance(recipeUUID, instanceName) {

--- a/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.test.js
+++ b/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.test.js
@@ -1,18 +1,23 @@
-describe('Genymotion-cloud executable', () => {
-  const aResponse = (exit_code = 0, exit_code_desc = 'NO_ERROR') => ({
-    exit_code,
-    exit_code_desc,
-  });
-  const anErrorResponse = (exit_code, exit_code_desc, error_desc) => ({
-    ...aResponse(exit_code, exit_code_desc),
-    error: {
-      message: `API return unexpected code: ${exit_code}. Error: {"code":"${error_desc}","message":"Oh no, mocked error has occurred!"}`,
-      details: '',
-    }
-  });
 
+const aResponse = (exit_code = 0, exit_code_desc = 'NO_ERROR') => ({
+  exit_code,
+  exit_code_desc,
+});
+const anErrorResponse = (exit_code, exit_code_desc, error_desc) => ({
+  ...aResponse(exit_code, exit_code_desc),
+  error: {
+    message: `API return unexpected code: ${exit_code}. Error: {"code":"${error_desc}","message":"Oh no, mocked error has occurred!"}`,
+    details: '',
+  }
+});
+
+describe('Genymotion-cloud executable', () => {
   const successResponse = aResponse();
   const failResponse = anErrorResponse(4, 'API_ERROR', 'TOO_MANY_RUNNING_VDS');
+  const recipeName = 'mock-recipe-name';
+  const recipeUUID = 'mock-recipe-uuid';
+  const instanceUUID = 'mock-uuid';
+  const instanceName = 'detox-instance1';
 
   const givenSuccessResult = () => exec.mockResolvedValue({
     stdout: JSON.stringify(successResponse),
@@ -33,12 +38,12 @@ describe('Genymotion-cloud executable', () => {
     uut = new GenyCloudExec('mock/path/to/gmsaas');
   });
 
-  const recipeName = 'mock-recipe-name';
-  const recipeUUID = 'mock-recipe-uuid';
-  const instanceUUID = 'mock-uuid';
-  const instanceName = 'detox-instance1';
-
   [
+    {
+      commandName: 'version',
+      commandExecFn: () => uut.getVersion(),
+      expectedExec: `"mock/path/to/gmsaas" --format compactjson --version`,
+    },
     {
       commandName: 'whoami',
       commandExecFn: () => uut.whoAmI(),
@@ -48,6 +53,11 @@ describe('Genymotion-cloud executable', () => {
       commandName: 'Get Recipe',
       commandExecFn: () => uut.getRecipe(recipeName),
       expectedExec: `"mock/path/to/gmsaas" --format compactjson recipes list --name "${recipeName}"`,
+    },
+    {
+      commandName: 'Get Instance',
+      commandExecFn: () => uut.getInstance(instanceUUID),
+      expectedExec: `"mock/path/to/gmsaas" --format compactjson instances get ${instanceUUID}`,
     },
     {
       commandName: 'Get Instances',

--- a/detox/src/devices/drivers/android/genycloud/services/GenyInstanceLookupService.js
+++ b/detox/src/devices/drivers/android/genycloud/services/GenyInstanceLookupService.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const Instance = require('./dto/GenyInstance');
 
 class GenyInstanceLookupService {
@@ -14,8 +13,8 @@ class GenyInstanceLookupService {
   }
 
   async getInstance(instanceUUID) {
-    const instances = await this._getAllInstances();
-    return _.find(instances, (instance) => instance.uuid === instanceUUID);
+    const { instance } = await this.genyCloudExec.getInstance(instanceUUID);
+    return new Instance(instance);
   }
 
   async _getRelevantInstances() {

--- a/detox/src/devices/drivers/android/genycloud/services/GenyInstanceLookupService.test.js
+++ b/detox/src/devices/drivers/android/genycloud/services/GenyInstanceLookupService.test.js
@@ -43,6 +43,7 @@ describe('Genymotion-Cloud instances lookup service', () => {
   const givenNoRegisteredInstances = () => deviceRegistry.getRegisteredDevices.mockReturnValue([]);
   const givenInstances = (...instances) => exec.getInstances.mockResolvedValue({ instances });
   const givenNoInstances = () => exec.getInstances.mockResolvedValue({ instances: [] });
+  const givenAnInstance = (instance) => exec.getInstance.mockResolvedValue({ instance });
   const givenAllDevicesFamilial = () => instanceNaming.isFamilial.mockReturnValue(true);
   const givenNoDevicesFamilial = () => instanceNaming.isFamilial.mockReturnValue(false);
 
@@ -123,12 +124,13 @@ describe('Genymotion-Cloud instances lookup service', () => {
 
   describe('finding a specific instance', () => {
     it('should return an instance matching a UUID', async () => {
-      const instance1 = anInstance();
-      const instance2 = anotherInstance();
-      givenInstances(instance1, instance2);
+      const instance = anInstance();
+      givenAnInstance(instance);
 
-      const result = await uut.getInstance(instance2.uuid);
-      expect(result.uuid).toEqual(instance2.uuid);
+      const result = await uut.getInstance(instance.uuid);
+      expect(result.uuid).toEqual(instance.uuid);
+      expect(result.constructor.name).toContain('Instance');
+      expect(exec.getInstance).toHaveBeenCalledWith(instance.uuid);
     });
   });
 });


### PR DESCRIPTION
## Description

In `gmsaas` version `1.6.0`, as per Wix' request, a reach onto the `getInstance` endpoint via `gmsaas` was introduced through the `gmsaas instances get <uuid>` command. This PR plugs that in into the driver by reimplementing lookup-service' `getInstance()`, which previously fetched _all_ instances and manually filtered them (which wasn't scalable - hence the point in all this).

This comes alongside a preliminary check in the driver's `prepare()` of that the `gmsaas` executable is sufficiently new on the host machine.