### PR TITLE
fix(ios): disable artifacts plugins with incomplete support

### DIFF
--- a/detox/src/devices/drivers/ios/IosDriver.js
+++ b/detox/src/devices/drivers/ios/IosDriver.js
@@ -1,32 +1,16 @@
 const path = require('path');
 const fs = require('fs');
 const DeviceDriverBase = require('../DeviceDriverBase');
-const AppleSimUtils = require('./tools/AppleSimUtils');
 
-const SimulatorLogPlugin = require('../../../artifacts/log/ios/SimulatorLogPlugin');
-const SimulatorScreenshotPlugin = require('../../../artifacts/screenshot/SimulatorScreenshotPlugin');
-const SimulatorRecordVideoPlugin = require('../../../artifacts/video/SimulatorRecordVideoPlugin');
-const SimulatorInstrumentsPlugin = require('../../../artifacts/instruments/ios/SimulatorInstrumentsPlugin');
 const TimelineArtifactPlugin = require('../../../artifacts/timeline/TimelineArtifactPlugin');
 const IosUIHierarchyPlugin = require('../../../artifacts/uiHierarchy/IosUIHierarchyPlugin');
 
 class IosDriver extends DeviceDriverBase {
-  constructor(config) {
-    super(config);
-
-    this.applesimutils = new AppleSimUtils();
-  }
-
   declareArtifactPlugins() {
-    const appleSimUtils = this.applesimutils;
     const client = this.client;
 
     return {
-      instruments: (api) => new SimulatorInstrumentsPlugin({ api, client }),
-      log: (api) => new SimulatorLogPlugin({ api, appleSimUtils }),
-      screenshot: (api) => new SimulatorScreenshotPlugin({ api, appleSimUtils }),
-      video: (api) => new SimulatorRecordVideoPlugin({ api, appleSimUtils }),
-      timeline: (api) => new TimelineArtifactPlugin({api, appleSimUtils}),
+      timeline: (api) => new TimelineArtifactPlugin({ api }),
       uiHierarchy: (api) => new IosUIHierarchyPlugin({ api, client }),
     };
   }

--- a/detox/src/devices/drivers/ios/SimulatorDriver.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.js
@@ -4,6 +4,11 @@ const path = require('path');
 const exec = require('child-process-promise').exec;
 const DeviceRegistry = require('../../DeviceRegistry');
 const IosDriver = require('./IosDriver');
+const AppleSimUtils = require('./tools/AppleSimUtils');
+const SimulatorInstrumentsPlugin = require('../../../artifacts/instruments/ios/SimulatorInstrumentsPlugin');
+const SimulatorLogPlugin = require('../../../artifacts/log/ios/SimulatorLogPlugin');
+const SimulatorRecordVideoPlugin = require('../../../artifacts/video/SimulatorRecordVideoPlugin');
+const SimulatorScreenshotPlugin = require('../../../artifacts/screenshot/SimulatorScreenshotPlugin');
 const temporaryPath = require('../../../artifacts/utils/temporaryPath');
 const DetoxConfigError = require('../../../errors/DetoxConfigError');
 const DetoxRuntimeError = require('../../../errors/DetoxRuntimeError');
@@ -16,12 +21,27 @@ class SimulatorDriver extends IosDriver {
   constructor(config) {
     super(config);
 
+    this.applesimutils = new AppleSimUtils();
     this.deviceRegistry = DeviceRegistry.forIOS();
     this._name = 'Unspecified Simulator';
   }
 
   get name() {
     return this._name;
+  }
+
+  declareArtifactPlugins() {
+    const appleSimUtils = this.applesimutils;
+    const client = this.client;
+
+    return {
+      ...super.declareArtifactPlugins(),
+
+      log: (api) => new SimulatorLogPlugin({ api, appleSimUtils }),
+      screenshot: (api) => new SimulatorScreenshotPlugin({ api, appleSimUtils }),
+      video: (api) => new SimulatorRecordVideoPlugin({ api, appleSimUtils }),
+      instruments: (api) => new SimulatorInstrumentsPlugin({ api, client }),
+    };
   }
 
   async prepare() {


### PR DESCRIPTION
- [x] This change has been discussed in issue #2162 and the solution has been agreed upon with maintainers.

---

Resolves #2162 for `ios.none` configuration.
