### PR TITLE
Warn about Genycloud instances leakage in case of abrupt terminations

### DIFF
--- a/detox/src/DetoxExportWrapper.js
+++ b/detox/src/DetoxExportWrapper.js
@@ -109,6 +109,16 @@ class DetoxExportWrapper {
   }
 }
 
+DetoxExportWrapper.prototype.globalInit = async function() {
+  try {
+    // TODO For the next consumer, need to come up with some kind of infra-code to allow for dynamic registration of init-callbacks.
+    const GenyCloudDriver = require('./devices/drivers/android/genycloud/GenyCloudDriver');
+    await GenyCloudDriver.globalInit();
+  } catch (error) {
+    log.warn({ event: 'GLOBAL_INIT' }, 'An error occurred trying to globally-init Genymotion-cloud emulator instances!', error);
+  }
+}
+
 DetoxExportWrapper.prototype.globalCleanup = async function() {
   try {
     // TODO For the next consumer, need to come up with some kind of infra-code to allow for dynamic registration of cleanup-callbacks.

--- a/detox/src/devices/DeviceRegistry.js
+++ b/detox/src/devices/DeviceRegistry.js
@@ -1,19 +1,30 @@
 const _ = require('lodash');
 const environment = require('../utils/environment');
+const fs = require('fs-extra');
 const ExclusiveLockfile = require('../utils/ExclusiveLockfile');
 const safeAsync = require('../utils/safeAsync');
 
 const getDeviceEqualsFn = (deviceHandle) => (otherDeviceHandle) => _.isEqual(otherDeviceHandle, deviceHandle);
 const getDeviceDifferFn = (deviceHandle) => (otherDeviceHandle) => !_.isEqual(otherDeviceHandle, deviceHandle);
+const readOptions = {
+  encoding: 'utf8',
+};
 
 class DeviceRegistry {
   constructor({ lockfilePath }) {
+    /***
+     * @private
+     * @type {string}
+     */
+    this._lockfilePath = lockfilePath;
+
     /***
      * @protected
      * @type {ExclusiveLockfile}
      */
     this._lockfile = new ExclusiveLockfile(lockfilePath, {
       getInitialState: this._getInitialLockFileState.bind(this),
+      readOptions,
     });
   }
 
@@ -62,6 +73,11 @@ class DeviceRegistry {
       result = this.getRegisteredDevices();
     })
     return result;
+  }
+
+  readRegisteredDevicesUNSAFE() {
+    const contents = fs.readFileSync(this._lockfilePath, readOptions);
+    return JSON.parse(contents);
   }
 
   /***

--- a/detox/src/devices/DeviceRegistry.test.js
+++ b/detox/src/devices/DeviceRegistry.test.js
@@ -110,6 +110,14 @@ describe('DeviceRegistry', () => {
       assertForbiddenOutOfContextDeviceListQuery();
     });
 
+    it('should allow UNSAFE-getting of registered devices list, even outside of allocation/disposal context', async () => {
+      const deviceHandle = 'emulator-5554';
+
+      await allocateDevice(deviceHandle);
+      const result = registry.readRegisteredDevicesUNSAFE();
+      expect(result).toEqual([ deviceHandle ]);
+    });
+
     it('should be able to read a valid list of registered devices', async () => {
       const deviceHandle = 'emulator-5554';
       const anotherDeviceHandle = 'emulator-5556';

--- a/detox/src/index.test.js
+++ b/detox/src/index.test.js
@@ -169,12 +169,29 @@ describe('index (regular)', () => {
         GenyCloudDriver = require('./devices/drivers/android/genycloud/GenyCloudDriver');
       });
 
+      it('should invoke genymotion-cloud\'s global init API', async () => {
+        await detox.globalInit();
+        expect(GenyCloudDriver.globalInit).toHaveBeenCalled();
+      });
+
+      it('should catch and warn errors from genymotion-cloud driver in global init', async () => {
+        const error = new Error('mocked-error');
+        GenyCloudDriver.globalInit.mockRejectedValue(error);
+
+        await detox.globalInit();
+        expect(logger.warn).toHaveBeenCalledWith(
+          { event: 'GLOBAL_INIT' },
+          'An error occurred trying to globally-init Genymotion-cloud emulator instances!',
+          error,
+        );
+      });
+
       it('should invoke genymotion-cloud\'s global cleanup API', async () => {
         await detox.globalCleanup();
         expect(GenyCloudDriver.globalCleanup).toHaveBeenCalled();
       });
 
-      it('should catch and warn errors from genymotion-cloud driver', async () => {
+      it('should catch and warn errors from genymotion-cloud driver int global cleanup', async () => {
         const error = new Error('mocked-error');
         GenyCloudDriver.globalCleanup.mockRejectedValue(error);
 

--- a/detox/test/e2e/global-setup.js
+++ b/detox/test/e2e/global-setup.js
@@ -22,11 +22,14 @@ function downloadTestButlerAPKIfNeeded() {
   }
 }
 
-function globalSetup() {
+async function globalSetup() {
   const config = resolveSelectedConfiguration();
   if (config && config.type.includes('android')) {
     downloadTestButlerAPKIfNeeded();
   }
+
+  const detox = require('detox');
+  await detox.globalInit();
 }
 
 module.exports = globalSetup;


### PR DESCRIPTION
## Description

Part of the ongoing work on Genymotion-cloud support (#2429).

Warn about Genycloud instances leakage in case test suite execution is terminated prematurely (e.g. due to the user hitting a CTRL+C, or a kill signal). That is to take place on top of the standard (controlled) cleanup performed by Detox following a proper execution of the test suites down to the very end.

- This relates mostly to users cancelling their jobs manually while running test locally.
- It is not related to whether the tests in the suite have failed: A test suite failure still undergoes a proper cleanup.
- It will _not_ run in case of a CI agent's sudden shutdown.