### PR TITLE
Added back --args to xcrun simctl launch, was wrongly removed in #2540

### DIFF
--- a/detox/src/devices/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/drivers/ios/tools/AppleSimUtils.js
@@ -331,7 +331,7 @@ class AppleSimUtils {
 
     const cmdArgs = this._mergeLaunchArgs(launchArgs, languageAndLocale).join(' ');
     let launchBin = `SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="${dylibs}" ` +
-      `/usr/bin/xcrun simctl launch ${udid} ${bundleId} ${cmdArgs}`;
+      `/usr/bin/xcrun simctl launch ${udid} ${bundleId} --args ${cmdArgs}`;
 
     const result = await exec.execWithRetriesAndLogs(launchBin, {
       retries: 1,


### PR DESCRIPTION
**Description:**
Fix an issue introduced in #2540, where `--args` was dropped from `xcrun simctl launch`.
Missing: some sort of testing for this, to make sure args are being passed correctly.