### PR TITLE
test: add <ActivityIndicator> sync test

### DIFF
--- a/detox/test/e2e/28.sync.test.js
+++ b/detox/test/e2e/28.sync.test.js
@@ -1,0 +1,11 @@
+describe('Sync', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+    await element(by.text('Sync')).tap();
+  });
+
+  it('should show activity indicator without stucking', async () => {
+    await element(by.id('showIndicator')).tap();
+    await expect(element(by.id('indicator'))).toBeVisible();
+  });
+});

--- a/detox/test/src/Screens/SyncScreen.js
+++ b/detox/test/src/Screens/SyncScreen.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react';
+import {
+  Text,
+  TouchableOpacity,
+  ActivityIndicator,
+  Platform,
+  StyleSheet,
+  SafeAreaView,
+  View,
+} from 'react-native';
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+
+  container: {
+    justifyContent: 'flex-start',
+    paddingTop: Platform.OS === 'ios' ? 30 : 0,
+  },
+
+  textButton: {
+    color: 'blue',
+    marginVertical: 10,
+    textAlign: 'center',
+  },
+});
+
+export default class SyncScreen extends Component {
+  state = {
+    showIndicator: false,
+  }
+
+  render() {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View testID="SyncScreenContainer" style={styles.container}>
+          <TouchableOpacity testID="showIndicator" onPress={() => this.setState({ showIndicator: true })}>
+            <Text style={styles.textButton}>Show Activity Indicator</Text>
+          </TouchableOpacity>
+
+          { this.state.showIndicator && <ActivityIndicator testID="indicator" key="indicator" size="large" color="black" /> }
+        </View>
+      </SafeAreaView>
+    );
+  }
+}

--- a/detox/test/src/Screens/index.js
+++ b/detox/test/src/Screens/index.js
@@ -22,6 +22,7 @@ import LaunchNotificationScreen from './LaunchNotificationScreen';
 import PickerViewScreen from './PickerViewScreen';
 import DeviceScreen from './DeviceScreen';
 import ElementScreenshotScreen from './ElementScreenshotScreen';
+import SyncScreen from './SyncScreen';
 
 export {
   SanityScreen,
@@ -48,4 +49,5 @@ export {
   LaunchNotificationScreen,
   DeviceScreen,
   ElementScreenshotScreen,
+  SyncScreen,
 };

--- a/detox/test/src/app.js
+++ b/detox/test/src/app.js
@@ -105,6 +105,7 @@ class example extends Component {
         {this.renderAnimationScreenButtons()}
         {this.renderScreenButton('Device', Screens.DeviceScreen)}
         {this.renderScreenButton('Location', Screens.LocationScreen)}
+        {this.renderScreenButton('Sync', Screens.SyncScreen)}
         {!isAndroid && this.renderScreenButton('DatePicker', Screens.DatePickerScreen)}
         {!isAndroid && this.renderScreenButton('Picker', Screens.PickerViewScreen)}
 


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Detox is stuck forever when React Native's built-in `<ActivityIndicator />` is being rendered.

The issue can be reproduced on iOS since Detox 18.0.0 (the latest version is 18.0.3, at the moment, and it is affected as well).

```js
it('should show activity indicator without stucking', async () => {
  await element(by.id('showIndicator')).tap(); // here the test is stuck
  await expect(element(by.id('indicator'))).toBeVisible();
});

```

<img src="https://user-images.githubusercontent.com/1962469/103661856-dfd65400-4f77-11eb-8179-84296dac1ed9.png" width=360 alt="iOS simulator stuck" />
