### PR TITLE
Fix “UISrollView” typo

### DIFF
--- a/detox/ios/Detox/Invocation/Element.swift
+++ b/detox/ios/Detox/Invocation/Element.swift
@@ -83,7 +83,7 @@ class Element : NSObject {
 			return (view.value(forKey: "scrollView") as! UIScrollView)
 		}
 		
-		dtx_fatalError("View “\(self.view.dtx_shortDescription)” is not an instance of “UISrollView”", viewDescription: debugAttributes)
+		dtx_fatalError("View “\(self.view.dtx_shortDescription)” is not an instance of “UIScrollView”", viewDescription: debugAttributes)
 	}
 	
 	override var description: String {


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

Fixes a small typo in the UIScrollView visibility error message.

“UISrollView” -> “UIScrollView”