### PR TITLE
Introduce device.setLaunchArg()

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -283,10 +283,34 @@ declare global {
              */
             id: string;
             /**
-             * Holds a descriptive name of the device. Example: emulator-5554 (Pixel_API_26)
+             * Holds a descriptive name of the device. Example: emulator-5554 (Pixel_API_29)
              * The value will be undefined until the device is properly prepared (i.e. in detox.init()).
              */
             name: string;
+            /***
+             * Set a launch-argument (name & value) to bundle alongside launch-arguments specified in any future call to {@link launchApp}.
+             *
+             * Equivalent to {@link DeviceLaunchAppConfig#launchArgs}, but is set ahead-of-time rather than on-site - thus allowing for
+             * a gradual, multi-phased setup of a test environment, typically suitable for complex apps.
+             *
+             * @example
+             * // Even without launchArgs specified in call to launchApp() --
+             * // launch it with the value 'world' associated with 'hello':
+             * device.setLaunchArg('hello', 'world');
+             * await device.launchApp();
+             * @example
+             * // On-site arguments (specified in call to launchApp()) take precedence over arguments set using this method.
+             * // For example, here the tested app will be launched with the value of '222' associated with argument 'arg1',
+             * // rather than '111'.
+             * device.setLaunchArg('arg1', '111');
+             * await device.launchApp({ launchArgs: {'arg1': '222'} }};
+             *
+             * @param name Name of argument to provide.
+             * @param value Argument's value.
+             *
+             * @see DeviceLaunchAppConfig#launchArgs
+             */
+            setLaunchArg(name: string, value: any): void;
             /**
              * Launch the app
              *
@@ -300,6 +324,11 @@ declare global {
              * @example
              * // Mock opening the app from URL to test your app's deep link handling mechanism.
              * await device.launchApp({url: url});
+             * @example
+             * // Start the app with some custom arguments.
+             * await device.launchApp({
+             *   launchArgs: {arg1: 1, arg2: "2"},
+             * });
              */
             launchApp(config?: DeviceLaunchAppConfig): Promise<void>;
             /**
@@ -780,7 +809,11 @@ declare global {
             delete?: boolean;
             /**
              * Detox can start the app with additional launch arguments
-             * The added launchArgs will be passed through the launch command to the device and be accessible via [[NSProcessInfo processInfo] arguments]
+             *
+             * On iOS, the specified launchArgs will be passed through the launch command to the device and be accessible via `[[NSProcessInfo processInfo] arguments]`.
+             *
+             * On Android, they will be set as bundle-extra's into the activity's intent. They will therefore be accessible on the current activity using:
+             * `currentActivity.getIntent().getBundleExtra("launchArgs")`.
              */
             launchArgs?: any;
             /**

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -287,7 +287,7 @@ declare global {
              * The value will be undefined until the device is properly prepared (i.e. in detox.init()).
              */
             name: string;
-            /***
+            /**
              * Set a launch-argument (name & value) to bundle alongside launch-arguments specified in any future call to {@link launchApp}.
              *
              * Equivalent to {@link DeviceLaunchAppConfig#launchArgs}, but is set ahead-of-time rather than on-site - thus allowing for
@@ -306,11 +306,17 @@ declare global {
              * await device.launchApp({ launchArgs: {'arg1': '222'} }};
              *
              * @param name Name of argument to provide.
-             * @param value Argument's value.
+             * @param value Argument's value. `Undefined` can be used for clearing the argument completely.
              *
              * @see DeviceLaunchAppConfig#launchArgs
              */
             setLaunchArg(name: string, value: any): void;
+            /**
+             * Clear a launch-argument previously set using {@link setLaunchArg};
+             *
+             * @param name Name of the argument to clear.
+             */
+            clearLaunchArg(name: string): void;
             /**
              * Launch the app
              *

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -19,6 +19,7 @@ class Device {
     this.deviceDriver = deviceDriver;
     this.deviceDriver.validateDeviceConfig(deviceConfig);
     this.debug = debug;
+    this._launchArgs = {};
   }
 
   async prepare() {
@@ -50,6 +51,7 @@ class Device {
 
     const baseLaunchArgs = {
       ...this._deviceConfig.launchArgs,
+      ...this._launchArgs,
       ...params.launchArgs,
     };
 
@@ -101,6 +103,10 @@ class Device {
     if(params.detoxUserActivityDataURL) {
       await this.deviceDriver.cleanupRandomDirectory(params.detoxUserActivityDataURL);
     }
+  }
+
+  setLaunchArg(key, value) {
+    this._launchArgs[key] = value;
   }
 
   get id() {

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -106,7 +106,15 @@ class Device {
   }
 
   setLaunchArg(key, value) {
-    this._launchArgs[key] = value;
+    if (value === undefined) {
+      this.clearLaunchArg(key);
+    } else {
+      this._launchArgs[key] = value;
+    }
+  }
+
+  clearLaunchArg(key) {
+    delete this._launchArgs[key];
   }
 
   get id() {

--- a/detox/test/e2e/22.launch-args.test.js
+++ b/detox/test/e2e/22.launch-args.test.js
@@ -53,12 +53,15 @@ describe(':android: Launch arguments', () => {
     device.setLaunchArg('prebakedArg2', {
       tofu: 'with gravy',
     });
+    device.setLaunchArg('prebakedArg3', 'spoiled milk');
+    device.clearLaunchArg('prebakedArg3');
     await device.launchApp({newInstance: true, launchArgs});
     await element(by.text('Launch Args')).tap();
 
     await assertLaunchArg('userArg', 'value');
     await assertLaunchArg('prebakedArg1', 'pie');
     await assertLaunchArg('prebakedArg2', JSON.stringify({ tofu: 'with gravy' }));
+    await assertNoLaunchArg('prebakedArg3');
   });
 
   // Ref: https://developer.android.com/studio/test/command-line#AMOptionsSyntax

--- a/detox/test/e2e/22.launch-args.test.js
+++ b/detox/test/e2e/22.launch-args.test.js
@@ -34,15 +34,31 @@ describe(':android: Launch arguments', () => {
           then: 'so, me',
         }
       },
-      complexlist: ['arguments', 'https://haxorhost:666'],
+      complexlist: ['arguments', 'https://haxorhost:1337'],
     };
 
     await device.launchApp({newInstance: true, launchArgs});
-
     await element(by.text('Launch Args')).tap();
 
     await assertLaunchArg('complex', JSON.stringify(launchArgs.complex));
     await assertLaunchArg('complexlist', JSON.stringify(launchArgs.complexlist));
+  });
+
+  it('should allow for pre-baked arguments setup', async () => {
+    const launchArgs = {
+      userArg: 'value',
+    };
+
+    device.setLaunchArg('prebakedArg1', 'pie');
+    device.setLaunchArg('prebakedArg2', {
+      tofu: 'with gravy',
+    });
+    await device.launchApp({newInstance: true, launchArgs});
+    await element(by.text('Launch Args')).tap();
+
+    await assertLaunchArg('userArg', 'value');
+    await assertLaunchArg('prebakedArg1', 'pie');
+    await assertLaunchArg('prebakedArg2', JSON.stringify({ tofu: 'with gravy' }));
   });
 
   // Ref: https://developer.android.com/studio/test/command-line#AMOptionsSyntax

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -22,6 +22,7 @@ The value will be `undefined` until the device is properly _prepared_ (i.e. in `
 ## Methods
 
 - [`device.launchApp()`](#devicelaunchappparams)
+- [`device.setLaunchArg(name, value)`](#devicesetlaunchargname-value)
 - [`device.terminateApp()`](#deviceterminateapp)
 - [`device.sendToHome()`](#devicesendtohome)
 - [`device.reloadReactNative()`](#devicereloadreactnative)
@@ -213,6 +214,12 @@ await device.launchApp({
 ### `device.relaunchApp(params)`
 
 **Deprecated:** Use `device.launchApp(params)` instead. The method calls `launchApp({newInstance: true})` for backwards compatibility.
+
+### `device.setLaunchArg(name, value)`
+
+Set a launch-argument (name & value) to bundle alongside launch-arguments specified in any future call to `device.launchApp()`. 
+
+Equivalent to specifying on-site `launchArgs` to `device.launchApp()`, but is set ahead-of-time rather than on-site - thus allowing for a gradual, multi-phased setup of a test environment, typically suitable for complex apps.
 
 ### `device.terminateApp()`
 By default, `terminateApp()` with no params will terminate the app file defined in the current [`configuration`](APIRef.Configuration.md).

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -23,6 +23,7 @@ The value will be `undefined` until the device is properly _prepared_ (i.e. in `
 
 - [`device.launchApp()`](#devicelaunchappparams)
 - [`device.setLaunchArg(name, value)`](#devicesetlaunchargname-value)
+- [`device.clearLaunchArg(name, value)`](#deviceclearlaunchargname)
 - [`device.terminateApp()`](#deviceterminateapp)
 - [`device.sendToHome()`](#devicesendtohome)
 - [`device.reloadReactNative()`](#devicereloadreactnative)
@@ -220,6 +221,10 @@ await device.launchApp({
 Set a launch-argument (name & value) to bundle alongside launch-arguments specified in any future call to `device.launchApp()`. 
 
 Equivalent to specifying on-site `launchArgs` to `device.launchApp()`, but is set ahead-of-time rather than on-site - thus allowing for a gradual, multi-phased setup of a test environment, typically suitable for complex apps.
+
+### `device.clearLaunchArg(name)`
+
+Clear a launch-argument previous set using `device.setLaunchArg()`.
 
 ### `device.terminateApp()`
 By default, `terminateApp()` with no params will terminate the app file defined in the current [`configuration`](APIRef.Configuration.md).


### PR DESCRIPTION
## Description

I've decided to take a step forward and reduce the added complexity in e2e's of large-scale apps (as Wix' internal ones) in trying to prepare and set up suitable app launch arguments.

The typical use case is of modules settings up mock servers, in particular.
Some mock servers are provided by frameworks, while some by modules/apps, which are separate - yet all must be aggregated into the same call to `launchApp({ launchArgs: { ... } })`. This API allows the separation to be properly retained, and eliminate hacks such as `launchApp` swizzling, currently used to overcome this.

_This is in a way both a PR and a discussion, BTW. I've went ahead and implemented this ahead of time because there's very little production code involved._