### PR TITLE
Add device.setLaunchArgs(), clearAllLaunchArgs()

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -312,11 +312,35 @@ declare global {
              */
             setLaunchArg(name: string, value: any): void;
             /**
+             * Set multiple launch-arguments in one go. See {@link setLaunchArg}.
+             * @param launchArgs A **plain** object containing the argument to set. Specifying `undefined` will result
+             * in the clearing of the associated launch-argument.
+             *
+             * @example
+             * device.setLaunchArgs({
+             *   mockServerPort: 1234,
+             *   mockServerCredentials: 'user@test.com:12345678',
+             * });
+             * await device.launchApp();
+             * @example
+             * // Set one arg (mockServerPort) and clear another (mockServerToken) in one go:
+             * device.setLaunchArgs({
+             *   mockServerPort: 1234,
+             *   mockServerToken: undefined,
+             * });
+             * await device.launchApp();
+             */
+            setLaunchArgs(launchArgs: object): void;
+            /**
              * Clear a launch-argument previously set using {@link setLaunchArg};
              *
              * @param name Name of the argument to clear.
              */
             clearLaunchArg(name: string): void;
+            /**
+             * Completely reset any previously set launch-arguments.
+             */
+            clearAllLaunchArgs(): void;
             /**
              * Launch the app
              *

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -105,16 +105,27 @@ class Device {
     }
   }
 
-  setLaunchArg(key, value) {
+  setLaunchArg(name, value) {
     if (value === undefined) {
-      this.clearLaunchArg(key);
+      this.clearLaunchArg(name);
     } else {
-      this._launchArgs[key] = value;
+      this._launchArgs[name] = value;
     }
   }
 
-  clearLaunchArg(key) {
-    delete this._launchArgs[key];
+  setLaunchArgs(launchArgs) {
+    Object
+      .keys(launchArgs)
+      .forEach((name) =>
+        this.setLaunchArg(name, launchArgs[name]));
+  }
+
+  clearLaunchArg(name) {
+    delete this._launchArgs[name];
+  }
+
+  clearAllLaunchArgs() {
+    this._launchArgs = {};
   }
 
   get id() {

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -446,14 +446,14 @@ describe('Device', () => {
     describe('with user launchArgs', () => {
       it('should pass on-site launch-args to device via driver', async () => {
         const launchArgs = {
-          arg1: "1",
+          arg1: '1',
           arg2: 2,
         };
         const expectedArgs = {
-          "detoxServer": "ws://localhost:8099",
-          "detoxSessionId": "test",
-          "arg1": "1",
-          "arg2": 2,
+          detoxServer: 'ws://localhost:8099',
+          detoxSessionId: 'test',
+          arg1: '1',
+          arg2: 2,
         };
 
         const device = validDevice();
@@ -462,7 +462,7 @@ describe('Device', () => {
         driverMock.expectLaunchCalled(device, expectedArgs);
       });
 
-      it('should keep args unmodified', async () => {
+      it('should keep on-site args unmodified', async () => {
         const params = {
           url: 'some.url',
           launchArgs: {
@@ -501,6 +501,29 @@ describe('Device', () => {
         driverMock.expectLaunchCalledContainingArgs(device, expectedArgs);
       });
 
+      it('should allow for setting up multiple pre-bake args in one go', async () => {
+        const prebakedArgs = {
+          argX: 'valX',
+          argY: { value: 'Y' },
+        };
+        const prebakedArg = {
+          key: 'argZ',
+          value: 'valZ',
+        };
+        const expectedArgs = {
+          argX: 'valX',
+          argY: { value: 'Y' },
+          argZ: 'valZ',
+        }
+
+        const device = validDevice();
+        device.setLaunchArg(prebakedArg.key, prebakedArg.value);
+        device.setLaunchArgs(prebakedArgs);
+        await device.launchApp();
+
+        driverMock.expectLaunchCalledContainingArgs(device, expectedArgs);
+      });
+
       it('should give priority to on-site launch-args over pre-baked launch-args', async () => {
         const params = {
           launchArgs: {
@@ -523,12 +546,12 @@ describe('Device', () => {
 
     it('should allow for explicit clearing of prebaked launch-args', async () => {
       const prebakedArg1 = {
-        key: 'arg1',
-        value: 'value1',
+        key: 'argX',
+        value: 'valX',
       };
       const prebakedArg2 = {
-        key: 'arg2',
-        value: 'value2',
+        key: 'argY',
+        value: 'valY',
       };
 
       const device = validDevice();
@@ -541,7 +564,7 @@ describe('Device', () => {
       driverMock.expectLaunchCalledWithoutLaunchArg(prebakedArg1.key);
     });
 
-    it('should allow for implicit clearing of prebaked launch-args', async () => {
+    it('should allow for implicit clearing of pre-baked launch-args', async () => {
       const prebakedArg1 = {
         key: 'arg1',
         value: 'value1',
@@ -560,6 +583,38 @@ describe('Device', () => {
       driverMock.expectLaunchCalledWithLaunchArg(prebakedArg2.key, prebakedArg2.value);
       driverMock.expectLaunchCalledWithoutLaunchArg(prebakedArg1.key);
     });
+  });
+
+  it('should allow for implicit clearing of multiple pre-baked launch-args', async () => {
+    const device = validDevice();
+    device.setLaunchArgs({
+      argX: 'valX',
+      argY: 'valY',
+      argZ: 'valZ',
+    });
+    device.setLaunchArgs({
+      argY: undefined,
+      argZ: undefined,
+    });
+
+    await device.launchApp();
+
+    driverMock.expectLaunchCalledWithLaunchArg('argX', 'valX');
+    driverMock.expectLaunchCalledWithoutLaunchArg('argY');
+    driverMock.expectLaunchCalledWithoutLaunchArg('argZ');
+  });
+
+  it('should allow for the complete resetting of all pre-baked launch-args', async () => {
+    const device = validDevice();
+
+    device.setLaunchArgs({
+      argX: 'valX',
+      argY: 'valY',
+    });
+    device.clearAllLaunchArgs();
+    await device.launchApp();
+    driverMock.expectLaunchCalledWithoutLaunchArg('argX');
+    driverMock.expectLaunchCalledWithoutLaunchArg('argY');
   });
 
   describe('installApp()', () => {

--- a/detox/test/e2e/22.launch-args.test.js
+++ b/detox/test/e2e/22.launch-args.test.js
@@ -46,22 +46,22 @@ describe(':android: Launch arguments', () => {
 
   it('should allow for pre-baked arguments setup', async () => {
     const launchArgs = {
-      userArg: 'value',
+      onsiteArg: 'on-site',
     };
 
-    device.setLaunchArg('prebakedArg1', 'pie');
-    device.setLaunchArg('prebakedArg2', {
-      tofu: 'with gravy',
+    device.setLaunchArgs({
+      prebakedIngredient: 'spoiled milk',
+      prebakedDesert: 'pie',
     });
-    device.setLaunchArg('prebakedArg3', 'spoiled milk');
-    device.clearLaunchArg('prebakedArg3');
-    await device.launchApp({newInstance: true, launchArgs});
+    device.setLaunchArg('prebakedDish', { tofu: 'with gravy' });
+    device.clearLaunchArg('prebakedIngredient');
+    await device.launchApp({ newInstance: true, launchArgs });
     await element(by.text('Launch Args')).tap();
 
-    await assertLaunchArg('userArg', 'value');
-    await assertLaunchArg('prebakedArg1', 'pie');
-    await assertLaunchArg('prebakedArg2', JSON.stringify({ tofu: 'with gravy' }));
-    await assertNoLaunchArg('prebakedArg3');
+    await assertLaunchArg('onsiteArg', 'on-site');
+    await assertLaunchArg('prebakedDesert', 'pie');
+    await assertLaunchArg('prebakedDish', JSON.stringify({ tofu: 'with gravy' }));
+    await assertNoLaunchArg('prebakedIngredient');
   });
 
   // Ref: https://developer.android.com/studio/test/command-line#AMOptionsSyntax

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -23,6 +23,7 @@ The value will be `undefined` until the device is properly _prepared_ (i.e. in `
 
 - [`device.launchApp()`](#devicelaunchappparams)
 - [`device.setLaunchArg(name, value)`](#devicesetlaunchargname-value)
+- [`device.setLaunchArgs(args)`](#devicesetlaunchargsargs)
 - [`device.clearLaunchArg(name)`](#deviceclearlaunchargname)
 - [`device.terminateApp()`](#deviceterminateapp)
 - [`device.sendToHome()`](#devicesendtohome)
@@ -222,9 +223,19 @@ Set a launch-argument (name & value) to bundle alongside launch-arguments specif
 
 Equivalent to specifying on-site `launchArgs` to `device.launchApp()`, but is set ahead-of-time rather than on-site - thus allowing for a gradual, multi-phased setup of a test environment, typically suitable for complex apps.
 
+> Note: Setting `value` to `undefined` will result in the clearing of the associated launch-argument.
+
+### `device.setLaunchArgs(args)`
+
+Same as `setLaunchArg(name, value)`, but allows for the setting (or clearing) of multiple arguments (names & values) in one go.
+
 ### `device.clearLaunchArg(name)`
 
-Clear a launch-argument previous set using `device.setLaunchArg()`.
+Clear a launch-argument previously set using `device.setLaunchArg()`, `device.setLaunchArgs()`.
+
+### `device.clearAllLaunchArgs()`
+
+Clear **all** launch-arguments previously set using `device.setLaunchArg()`, `device.setLaunchArgs()`.
 
 ### `device.terminateApp()`
 By default, `terminateApp()` with no params will terminate the app file defined in the current [`configuration`](APIRef.Configuration.md).


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

Add `device.setLaunchArgs()` - a flavour of `device.setLaunchArg()` that accepts multiple launch-arguments. A follow-up on #2613.