### PR TITLE
Clean up default log printing to prevent clutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img alt="Detox" width=380 src="https://raw.githubusercontent.com/wix/Detox/master/docs/img/DetoxLogo.png"/>
+	<img alt="Detox" width=380 src="docs/img/DetoxLogo.png"/>
 </p>
 <h1 align="center">
   Detox
@@ -8,8 +8,9 @@
 <b>Gray box end-to-end testing and automation library for mobile apps.</b>
 </p>
 <p align="center">
-<img alt="Demo" src="http://i.imgur.com/eoaDEYp.gif"/>
+<img alt="Demo" src="docs/img/Detox.gif"/>
 </p>
+
 
 
 ---

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -217,7 +217,7 @@ function launchTestRunner({ argv, env, specs }) {
     specs.join(' ')
   ].join(' ');
 
-  log.trace(printEnvironmentVariables(env) + fullCommand);
+  log.debug(printEnvironmentVariables(env) + fullCommand);
 
   cp.execSync(fullCommand, {
     stdio: 'inherit',

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -217,7 +217,7 @@ function launchTestRunner({ argv, env, specs }) {
     specs.join(' ')
   ].join(' ');
 
-  log.info(printEnvironmentVariables(env) + fullCommand);
+  log.trace(printEnvironmentVariables(env) + fullCommand);
 
   cp.execSync(fullCommand, {
     stdio: 'inherit',

--- a/detox/runners/jest/SpecReporterImpl.js
+++ b/detox/runners/jest/SpecReporterImpl.js
@@ -1,6 +1,7 @@
 const chalk = require('chalk').default;
 const { traceln } = require('./utils/stdout');
-const log = require('../../src/utils/logger').child();
+const logger = require('../../src/utils/logger');
+const log = logger.child();
 
 const RESULT_SKIPPED = chalk.yellow('SKIPPED');
 const RESULT_FAILED = chalk.red('FAIL');
@@ -29,7 +30,9 @@ class SpecReporter {
   }
 
   onTestStart({description, invocations = 1}) {
-    this._traceTest({description, invocations});
+    if(/^(debug|trace)$/.test(logger.getDetoxLevel())) {
+      this._traceTest({description, invocations});
+    }
   }
 
   onTestEnd({description, invocations = 1}, result) {
@@ -58,11 +61,17 @@ class SpecReporter {
   }
 
   _traceTest({description, invocations}, _status = undefined) {
+    if(_status === RESULT_SKIPPED && !/^(debug|trace)$/.test(logger.getDetoxLevel())) {
+      return;
+    }
+    
     const testDescription = chalk.gray(description);
     const retriesDescription = (invocations > 1) ? chalk.gray(` [Retry #${invocations - 1}]`) : '';
     const status = chalk.gray(_status ? ` [${_status}]` : '');
     const desc = this._suitesDesc + testDescription + retriesDescription + status;
-    log.info({event: 'SPEC_STATE_CHANGE'}, desc);
+    
+    const loggingFunc = _status === RESULT_FAILED ? log.error.bind(log) : log.info.bind(log);
+    loggingFunc({event: 'SPEC_STATE_CHANGE'}, desc);
   }
 }
 

--- a/detox/runners/jest/WorkerAssignReporterImpl.js
+++ b/detox/runners/jest/WorkerAssignReporterImpl.js
@@ -13,7 +13,7 @@ class WorkerAssignReporterImpl {
       ? chalk.redBright('undefined')
       : chalk.blueBright(deviceName);
 
-    log.info({event: 'WORKER_ASSIGN'}, `${chalk.whiteBright(workerName)} is assigned to ${formattedDeviceName}`);
+    log.trace({event: 'WORKER_ASSIGN'}, `${chalk.whiteBright(workerName)} is assigned to ${formattedDeviceName}`);
   }
 }
 

--- a/detox/src/devices/drivers/ios/SimulatorDriver.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.js
@@ -126,7 +126,7 @@ class SimulatorDriver extends IosDriver {
               `xcrun simctl spawn ${deviceId} launchctl list | grep -F '${bundleId}'\n`,
       });
     } else {
-      log.info({}, `Found the app (${bundleId}) with process ID = ${pid}. Proceeding...`);
+      log.debug({}, `Found the app (${bundleId}) with process ID = ${pid}. Proceeding...`);
     }
 
     await this.emitter.emit('launchApp', {bundleId, deviceId, launchArgs, pid});

--- a/detox/src/devices/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/drivers/ios/tools/AppleSimUtils.js
@@ -351,7 +351,7 @@ class AppleSimUtils {
     const predicate = `process == "${CFBundleExecutable}"`;
     const command = `/usr/bin/xcrun simctl spawn ${udid} log stream --level debug --style compact --predicate '${predicate}'`;
 
-    log.info(`${bundleId} launched. To watch simulator logs, run:\n        ${command}`);
+    log.debug(`${bundleId} launched. To watch simulator logs, run:\n        ${command}`);
   }
 
   _parseLaunchId(result) {

--- a/detox/src/server/DetoxServer.js
+++ b/detox/src/server/DetoxServer.js
@@ -16,7 +16,7 @@ class DetoxServer {
     });
     this.sessions = {};
     this.standalone = standalone;
-    logger.info(`server listening on localhost:${this.wss.options.port}...`);
+    logger.debug(`server listening on localhost:${this.wss.options.port}...`);
     this._setup();
   }
 

--- a/detox/src/utils/customConsoleLogger.js
+++ b/detox/src/utils/customConsoleLogger.js
@@ -46,9 +46,9 @@ function overrideConsoleMethods(console, bunyanLogger) {
   if (!console.__detox_log__) {
     const log = bunyanLogger;
 
-    override(console, 'log', log.info.bind(log));
+    override(console, 'log', log.debug.bind(log));
     override(console, 'warn', log.warn.bind(log));
-    override(console, 'trace', log.info.bind(log));
+    override(console, 'trace', log.trace.bind(log));
     override(console, 'error', log.error.bind(log));
     override(console, 'debug', log.debug.bind(log));
     override(console, 'assert', log.error.bind(log));

--- a/detox/src/utils/customConsoleLogger.js
+++ b/detox/src/utils/customConsoleLogger.js
@@ -46,7 +46,7 @@ function overrideConsoleMethods(console, bunyanLogger) {
   if (!console.__detox_log__) {
     const log = bunyanLogger;
 
-    override(console, 'log', log.debug.bind(log));
+    override(console, 'log', log.info.bind(log));
     override(console, 'warn', log.warn.bind(log));
     override(console, 'trace', log.trace.bind(log));
     override(console, 'error', log.error.bind(log));

--- a/detox/src/utils/customConsoleLogger.test.js
+++ b/detox/src/utils/customConsoleLogger.test.js
@@ -47,9 +47,9 @@ describe('customConsoleLogger.overrideConsoleMethods(console, bunyanLogger)', ()
       overrideConsoleMethods(fakeConsole, bunyanLogger);
     });
 
-    it('should connect: console.log -> logger.info', () => {
+    it('should connect: console.log -> logger.debug', () => {
       fakeConsole.log('OK %d', 200);
-      expect(bunyanLogger.info).toHaveBeenCalledWith(USER_LOG_EVENT, expectedOrigin, '\n', 'OK 200');
+      expect(bunyanLogger.debug).toHaveBeenCalledWith(USER_LOG_EVENT, expectedOrigin, '\n', 'OK 200');
     });
 
     it('should connect: console.warn -> logger.warn', () => {
@@ -57,9 +57,9 @@ describe('customConsoleLogger.overrideConsoleMethods(console, bunyanLogger)', ()
       expect(bunyanLogger.warn).toHaveBeenCalledWith(USER_LOG_EVENT, expectedOrigin, '\n', 'Warning 301');
     });
 
-    it('should connect: console.trace -> logger.info', () => {
+    it('should connect: console.trace -> logger.trace', () => {
       fakeConsole.trace('TraceMe %d', 100500);
-      expect(bunyanLogger.info).toHaveBeenCalledWith(USER_LOG_EVENT, expectedOrigin, '\n  Trace:', 'TraceMe 100500', expectedStackDump);
+      expect(bunyanLogger.trace).toHaveBeenCalledWith(USER_LOG_EVENT, expectedOrigin, '\n  Trace:', 'TraceMe 100500', expectedStackDump);
     });
 
     it('should connect: console.error -> logger.error', () => {

--- a/detox/src/utils/customConsoleLogger.test.js
+++ b/detox/src/utils/customConsoleLogger.test.js
@@ -47,9 +47,9 @@ describe('customConsoleLogger.overrideConsoleMethods(console, bunyanLogger)', ()
       overrideConsoleMethods(fakeConsole, bunyanLogger);
     });
 
-    it('should connect: console.log -> logger.debug', () => {
+    it('should connect: console.log -> logger.info', () => {
       fakeConsole.log('OK %d', 200);
-      expect(bunyanLogger.debug).toHaveBeenCalledWith(USER_LOG_EVENT, expectedOrigin, '\n', 'OK 200');
+      expect(bunyanLogger.info).toHaveBeenCalledWith(USER_LOG_EVENT, expectedOrigin, '\n', 'OK 200');
     });
 
     it('should connect: console.warn -> logger.warn', () => {

--- a/detox/src/utils/customConsoleLogger.test.js
+++ b/detox/src/utils/customConsoleLogger.test.js
@@ -17,10 +17,11 @@ describe('customConsoleLogger.overrideConsoleMethods(console, bunyanLogger)', ()
     };
 
     bunyanLogger = {
-      debug: jest.fn(),
+      error: jest.fn(),
       warn: jest.fn(),
       info: jest.fn(),
-      error: jest.fn(),
+      debug: jest.fn(),
+      trace: jest.fn(),
     };
   });
 

--- a/detox/src/utils/logger.js
+++ b/detox/src/utils/logger.js
@@ -6,6 +6,7 @@ const bunyanDebugStream = require('bunyan-debug-stream');
 const argparse = require('./argparse');
 const temporaryPath = require('../artifacts/utils/temporaryPath');
 const customConsoleLogger = require('./customConsoleLogger');
+const isRunningInBand = !!global.DETOX_CLI || argparse.getArgValue('maxWorkers') == '1';
 
 function adaptLogLevelName(level) {
   switch (level) {
@@ -35,8 +36,8 @@ function tryOverrideConsole(logger, global) {
 function createPlainBunyanStream({ logPath, level }) {
   const options = {
     showDate: false,
-    showLoggerName: true,
-    showPid: true,
+    showLoggerName: !isRunningInBand,
+    showPid: !isRunningInBand,
     showMetadata: false,
     basepath: __dirname,
     out: process.stderr,


### PR DESCRIPTION
This will be the default output:
<img width="1202" alt="Good" src="https://user-images.githubusercontent.com/2270433/107978479-81b07e00-6fc5-11eb-992e-0018e0f54307.png">

Instead of:
<img width="1228" alt="Bad" src="https://user-images.githubusercontent.com/2270433/107977511-e8cd3300-6fc3-11eb-8291-56519fa655fe.png">
