### PR TITLE
Fix currentStatus logging on Android

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/DetoxActionHandlers.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/DetoxActionHandlers.kt
@@ -99,35 +99,22 @@ class QueryStatusActionHandler(
     : DetoxActionHandler {
 
     override fun handle(params: String, messageId: Long) {
-        val busyResources = testEngineFacade.getBusyIdlingResources()
         val data = mutableMapOf<String, Any>()
+        val busyResources = testEngineFacade.getBusyIdlingResources()
+        var status = ""
 
         if (busyResources.isEmpty()) {
-            data["state"] = "idle"
+            status = "The app is idle."
         } else {
-            val resources = JSONArray()
-            busyResources.forEach {
-                try {
-                    resources.put(getIdleResourceInfo(it))
-                } catch (je: JSONException) {
-                    Log.d(LOG_TAG, "Couldn't collect busy resource '${it.name}'", je)
-                }
+            status = "Busy idling resources:\n"
+            for (res in busyResources) {
+                status += "\t- ${res.name}\n"
             }
-
-            data["resources"] = resources
-            data["state"] = "busy"
         }
 
+        data["status"] = status
         wsClient.sendAction("currentStatusResult", data, messageId)
     }
-
-    private fun getIdleResourceInfo(resource: IdlingResource) =
-        JSONObject().apply {
-            put("name", resource.javaClass.simpleName)
-            put("info", JSONObject().apply {
-                put("prettyPrint", resource.name)
-            })
-        }
 }
 
 class InstrumentsRecordingStateActionHandler(


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

It seems that there was a quick'n'dirty reimplementation, and by accident nobody remembered that Android native implementation sends legacy format of `currentStatusResult`.

Hereby I return the historical justice, although, of course, the best solution is to eventually align the JSON formats for `currentStatusResult` for both iOS and Android.

Before:

![Screenshot 2021-02-20 at 12 15 06](https://user-images.githubusercontent.com/1962469/108592449-951d6980-7376-11eb-9386-c8d82aab73df.png)


After:

![image](https://user-images.githubusercontent.com/1962469/109541856-f4911d00-7acc-11eb-8769-4c63fd0a349b.png)
