### PR TITLE
fix: move device.typeText() to internals

### DIFF
--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -5,6 +5,7 @@ const logger = require('./utils/logger');
 const Deferred = require('./utils/Deferred');
 const Device = require('./devices/Device');
 const DetoxRuntimeErrorComposer = require('./errors/DetoxRuntimeErrorComposer');
+const InternalDeviceAPI = require('./devices/InternalDeviceAPI');
 const AsyncEmitter = require('./utils/AsyncEmitter');
 const MissingDetox = require('./utils/MissingDetox');
 const Client = require('./client/Client');
@@ -164,6 +165,11 @@ class Detox {
       sessionConfig,
     });
 
+    const internalDeviceAPI = new InternalDeviceAPI({
+      deviceDriver,
+      getDeviceId: () => this.device && this.device.id,
+    });
+
     this._artifactsManager = new ArtifactsManager(this._artifactsConfig);
     this._artifactsManager.subscribeToDeviceEvents(this._eventEmitter);
     this._artifactsManager.registerArtifactPlugins(deviceDriver.declareArtifactPlugins());
@@ -172,7 +178,7 @@ class Detox {
 
     const matchers = matchersRegistry.resolve(this.device, {
       invocationManager,
-      device: this.device,
+      internalDeviceAPI,
       emitter: this._eventEmitter,
     });
     Object.assign(this, matchers);

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -25,6 +25,7 @@ describe('Detox', () => {
   let DetoxServer;
   let matchersRegistry;
   let ArtifactsManager;
+  let InternalDeviceAPI;
   let invoke;
   let Detox;
   let detox;
@@ -59,6 +60,7 @@ describe('Detox', () => {
     matchersRegistry = require('./matchersRegistry');
     Detox = require('./Detox');
     lifecycleSymbols = require('../runners/integration').lifecycle;
+    InternalDeviceAPI = require('./devices/InternalDeviceAPI');
   });
 
   describe('when detox.init() is called', () => {
@@ -120,7 +122,7 @@ describe('Detox', () => {
         const { emitter } = Device.mock.calls[0][0];
         expect(matchersRegistry.resolve).toHaveBeenCalledWith(device(), {
           invocationManager: invocationManager(),
-          device: device(),
+          internalDeviceAPI: expect.any(InternalDeviceAPI),
           emitter,
         });
       });

--- a/detox/src/android/AndroidExpect.js
+++ b/detox/src/android/AndroidExpect.js
@@ -7,8 +7,8 @@ const { WebExpectElement } = require('./core/WebExpect');
 const matchers = require('./matchers');
 
 class AndroidExpect {
-  constructor({ invocationManager, device, emitter }) {
-    this._device = device;
+  constructor({ invocationManager, internalDeviceAPI, emitter }) {
+    this._internalDeviceAPI = internalDeviceAPI;
     this._emitter = emitter;
     this._invocationManager = invocationManager;
 
@@ -31,7 +31,7 @@ class AndroidExpect {
   // Matcher can be null only if there is only one webview on the hierarchy tree.
   web(matcher) {
     if (matcher == null || matcher instanceof NativeMatcher) {
-      return new WebViewElement(this._invocationManager, this._device, this._emitter, matcher);
+      return new WebViewElement(this._invocationManager, this._internalDeviceAPI, this._emitter, matcher);
     }
 
     throw new Error(`web() argument is invalid, expected a native matcher, but got ${typeof element}`);

--- a/detox/src/android/AndroidExpect.test.js
+++ b/detox/src/android/AndroidExpect.test.js
@@ -3,25 +3,25 @@ describe('AndroidExpect', () => {
 
   let mockExecutor;
   let emitter;
-  let device;
+  let internalDeviceAPI;
 
   beforeEach(() => {
     jest.mock('tempfile');
     jest.mock('fs-extra');
+    jest.mock('../devices/InternalDeviceAPI');
 
     mockExecutor = new MockExecutor();
 
     const Emitter = jest.genMockFromModule('../utils/AsyncEmitter');
     emitter = new Emitter();
 
-    device = {
-      typeText: jest.fn(),
-    };
+    const InternalDeviceAPI = require('../devices/InternalDeviceAPI');
+    internalDeviceAPI = new InternalDeviceAPI();
 
     const AndroidExpect = require('./AndroidExpect');
     e = new AndroidExpect({
       invocationManager: mockExecutor,
-      device,
+      internalDeviceAPI,
       emitter,
     });
   });
@@ -345,17 +345,17 @@ describe('AndroidExpect', () => {
 
       it('typeText with isContentEditable=false', async () => {
         await e.web.element(e.by.html.id('id')).typeText('text', false);
-        global.expect(device.typeText).not.toHaveBeenCalled();
+        global.expect(internalDeviceAPI.typeText).not.toHaveBeenCalled();
       });
 
       it('typeText with isContentEditable=true', async () => {
         await e.web.element(e.by.html.id('id')).typeText('text', true);
-        global.expect(device.typeText).toHaveBeenCalled();
+        global.expect(internalDeviceAPI.typeText).toHaveBeenCalled();
       });
 
       it('typeText default isContentEditable is false', async () => {
         await e.web.element(e.by.html.id('id')).typeText('text');
-        global.expect(device.typeText).not.toHaveBeenCalled();
+        global.expect(internalDeviceAPI.typeText).not.toHaveBeenCalled();
       });
 
       it('replaceText', async () => {

--- a/detox/src/android/core/WebElement.js
+++ b/detox/src/android/core/WebElement.js
@@ -6,9 +6,9 @@ const { ActionInteraction } = require('../interactions/web');
 const { WebMatcher } = require('./WebMatcher');
 
 class WebElement {
-  constructor(invocationManager, device, webViewElement, matcher, index) {
+  constructor(invocationManager, internalDeviceAPI, webViewElement, matcher, index) {
     this._invocationManager = invocationManager;
-    this._device = device;
+    this._internalDeviceAPI = internalDeviceAPI;
     this._call = invoke.callDirectly(WebViewElementApi.element(webViewElement._call, matcher._call.value, index));
   }
 
@@ -19,7 +19,7 @@ class WebElement {
 
   async typeText(text, isContentEditable = false) {
     if (isContentEditable) {
-      return await this._device.typeText(text);
+      return await this._internalDeviceAPI.typeText(text);
     }
     return await new ActionInteraction(this._invocationManager,  new actions.WebTypeTextAction(this, text)).execute();
   }
@@ -72,9 +72,9 @@ class WebElement {
 }
 
 class WebViewElement {
-  constructor(invocationManager, device, emitter, matcher) {
+  constructor(invocationManager, internalDeviceAPI, emitter, matcher) {
     this._invocationManager = invocationManager;
-    this._device = device;
+    this._internalDeviceAPI = internalDeviceAPI;
     this._emitter = emitter;
     this._matcher = matcher;
 
@@ -89,7 +89,7 @@ class WebViewElement {
 
   element(webMatcher, index = 0) {
     if (webMatcher instanceof WebMatcher) {
-      return new WebElement(this._invocationManager, this._device, this, webMatcher, index);
+      return new WebElement(this._invocationManager, this._internalDeviceAPI, this, webMatcher, index);
     }
 
     throw new Error(`element() argument is invalid, expected a web matcher, but got ${typeof element}`);

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -266,10 +266,6 @@ class Device {
     await this.deviceDriver.resetStatusBar(this._deviceId);
   }
 
-  async typeText(text) {
-    await this.deviceDriver.typeText(this._deviceId, text);
-  }
-
   get _bundleId() {
     return this._getCurrentApp().bundleId;
   }

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -772,14 +772,6 @@ describe('Device', () => {
     expect(driverMock.driver.resetStatusBar).toHaveBeenCalledWith(device.id);
   });
 
-  it(`typeText() should pass to device driver`, async () => {
-    const device = await aValidDevice();
-    const params = {};
-    await device.typeText('Text');
-
-    expect(driverMock.driver.typeText).toHaveBeenCalledWith(device.id, 'Text');
-  });
-
   it(`shake() should pass to device driver`, async () => {
     const device = await aValidDevice();
     await device.shake();

--- a/detox/src/devices/InternalDeviceAPI.js
+++ b/detox/src/devices/InternalDeviceAPI.js
@@ -1,0 +1,15 @@
+class InternalDeviceAPI {
+  constructor({
+    deviceDriver,
+    getDeviceId,
+  }) {
+    this._deviceDriver = deviceDriver;
+    this._getDeviceId = getDeviceId;
+  }
+
+  async typeText(text) {
+    await this._deviceDriver.typeText(this._getDeviceId(), text);
+  }
+}
+
+module.exports = InternalDeviceAPI;

--- a/detox/src/devices/InternalDeviceAPI.test.js
+++ b/detox/src/devices/InternalDeviceAPI.test.js
@@ -1,0 +1,26 @@
+describe('InternalDeviceAPI', () => {
+  let deviceDriver;
+  let getDeviceId;
+  let api;
+
+  beforeEach(async () => {
+    getDeviceId = jest.fn();
+
+    jest.mock('./drivers/DeviceDriverBase');
+    const DeviceDriverMock = require('./drivers/DeviceDriverBase');
+    deviceDriver = new DeviceDriverMock();
+
+    const InternalDeviceAPI = require('./InternalDeviceAPI');
+    api = new InternalDeviceAPI({
+      deviceDriver,
+      getDeviceId,
+    });
+  });
+
+  it(`typeText() should pass to device driver`, async () => {
+    getDeviceId.mockReturnValue('fakeId');
+    await api.typeText('Text');
+
+    expect(deviceDriver.typeText).toHaveBeenCalledWith('fakeId', 'Text');
+  });
+});


### PR DESCRIPTION
- [x] This is a small change 
- [ ] This change has been discussed in issue #<?> and the solution has been agreed upon with maintainers.

---

**Description:**

Address the concern of publicly available half-baked semi-private API.
