### PR TITLE
code: rename by.html to by.web

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -693,15 +693,15 @@ declare global {
             /**
              * Collection of web matchers
              */
-            readonly html: ByHtmlFacade;
+            readonly web: ByWebFacade;
         }
 
-        interface ByHtmlFacade {
+        interface ByWebFacade {
             /**
              * Find an element on the DOM tree by its id
              * @param id
              * @example
-             * web.element(by.html.id('testingh1'))
+             * web.element(by.web.id('testingh1'))
              */
             id(id: string): WebMatcher;
 
@@ -709,7 +709,7 @@ declare global {
              * Find an element on the DOM tree by its CSS class
              * @param className
              * @example
-             * web.element(by.html.className('a'))
+             * web.element(by.web.className('a'))
              */
             className(className: string): WebMatcher;
 
@@ -717,15 +717,15 @@ declare global {
              * Find an element on the DOM tree matching the given CSS selector
              * @param cssSelector
              * @example
-             * web.element(by.html.selector('#cssSelector'))
+             * web.element(by.web.cssSelector('#cssSelector'))
              */
-            selector(cssSelector: string): WebMatcher;
+            cssSelector(cssSelector: string): WebMatcher;
 
             /**
              * Find an element on the DOM tree by its "name" attribute
              * @param name
              * @example
-             * web.element(by.html.name('sec_input'))
+             * web.element(by.web.name('sec_input'))
              */
             name(name: string): WebMatcher;
 
@@ -733,7 +733,7 @@ declare global {
              * Find an element on the DOM tree by its XPath
              * @param xpath
              * @example
-             * web.element(by.html.xpath('//*[@id="testingh1-1"]'))
+             * web.element(by.web.xpath('//*[@id="testingh1-1"]'))
              */
             xpath(xpath: string): WebMatcher;
 
@@ -741,7 +741,7 @@ declare global {
              * Find an <a> element on the DOM tree by its link text (href content)
              * @param linkText
              * @example
-             * web.element(by.html.href('disney.com'))
+             * web.element(by.web.href('disney.com'))
              */
             href(linkText: string): WebMatcher;
 
@@ -749,7 +749,7 @@ declare global {
              * Find an <a> element on the DOM tree by its partial link text (href content)
              * @param linkTextFragment
              * @example
-             * web.element(by.html.hrefContains('disney'))
+             * web.element(by.web.hrefContains('disney'))
              */
             hrefContains(linkTextFragment: string): WebMatcher;
 
@@ -757,7 +757,7 @@ declare global {
              * Find an element on the DOM tree by its tag name
              * @param tag
              * @example
-             * web.element(by.html.tag('mark'))
+             * web.element(by.web.tag('mark'))
              */
             tag(tagName: string): WebMatcher;
         }
@@ -1030,7 +1030,7 @@ declare global {
         interface WebExpect<R = Promise<void>> {
             /**
              * Negate the expectation.
-             * @example await expect(webview.element(by.htmlId('UniqueId205'))).not.toExist();
+             * @example await expect(webview.element(by.web.id('UniqueId205'))).not.toExist();
              */
             not: this;
 
@@ -1038,13 +1038,13 @@ declare global {
              * Expect the element content to have the `text` supplied
              * @param text expected to be on the element content
              * @example
-             * await expect(webview.element(by.htmlId('UniqueId205'))).toHaveText('ExactText');
+             * await expect(webview.element(by.web.id('UniqueId205'))).toHaveText('ExactText');
              */
             toHaveText(text: string): R
 
             /**
              * Expect the view to exist in the webview DOM tree.
-             * @example await expect(webview.element(by.htmlId('UniqueId205'))).toExist();
+             * @example await expect(webview.element(by.web.id('UniqueId205'))).toExist();
              */
             toExist(): R;
         }
@@ -1052,7 +1052,7 @@ declare global {
         interface IndexableWebElement extends WebElement {
             /**
              * Choose from multiple elements matching the same matcher using index
-             * @example await web.element(by.text('Product')).atIndex(2).tap();
+             * @example await web.element(by.web.hrefContains('Details')).atIndex(2).tap();
              */
             atIndex(index: number): WebElement;
         }

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1030,7 +1030,7 @@ declare global {
         interface WebExpect<R = Promise<void>> {
             /**
              * Negate the expectation.
-             * @example await expect(webview.element(by.web.id('UniqueId205'))).not.toExist();
+             * @example await expect(web.element(by.web.id('UniqueId205'))).not.toExist();
              */
             not: this;
 
@@ -1038,13 +1038,13 @@ declare global {
              * Expect the element content to have the `text` supplied
              * @param text expected to be on the element content
              * @example
-             * await expect(webview.element(by.web.id('UniqueId205'))).toHaveText('ExactText');
+             * await expect(web.element(by.web.id('UniqueId205'))).toHaveText('ExactText');
              */
             toHaveText(text: string): R
 
             /**
              * Expect the view to exist in the webview DOM tree.
-             * @example await expect(webview.element(by.web.id('UniqueId205'))).toExist();
+             * @example await expect(web.element(by.web.id('UniqueId205'))).toExist();
              */
             toExist(): R;
         }

--- a/detox/src/android/AndroidExpect.test.js
+++ b/detox/src/android/AndroidExpect.test.js
@@ -281,33 +281,33 @@ describe('AndroidExpect', () => {
     describe('General', () => {
       it('should return undefined', async () => {
         mockExecutor.executeResult = Promise.resolve(undefined);
-        await e.web(e.by.id('webview_id')).element(e.by.html.id('any')).tap();
+        await e.web(e.by.id('webview_id')).element(e.by.web.id('any')).tap();
       });
     })
 
     describe('web', () => {
 
       it('default', async () => {
-        await e.web.element(e.by.html.id('id')).tap();
+        await e.web.element(e.by.web.id('id')).tap();
       });
 
       it('default explicit', async () => {
-        await e.web().element(e.by.html.id('id')).tap();
+        await e.web().element(e.by.web.id('id')).tap();
       });
 
       it('with webview matcher', async () => {
-        await e.web(e.by.id('webview_id')).element(e.by.html.id('id')).tap();
+        await e.web(e.by.id('webview_id')).element(e.by.web.id('id')).tap();
       });
 
       it(`with wrong matcher should throw`, async () => {
-        await expectToThrow(() => e.web(e.by.html.className('webMatcher')));
-        await expectToThrow(() => e.web(e.by.html.selector('webMatcher')));
-        await expectToThrow(() => e.web(e.by.html.id('webMatcher')));
-        await expectToThrow(() => e.web(e.by.html.href('webMatcher')));
-        await expectToThrow(() => e.web(e.by.html.name('webMatcher')));
-        await expectToThrow(() => e.web(e.by.html.hrefContains('webMatcher')));
-        await expectToThrow(() => e.web(e.by.html.tag('webMatcher')));
-        await expectToThrow(() => e.web(e.by.html.xpath('webMatcher')));
+        await expectToThrow(() => e.web(e.by.web.className('webMatcher')));
+        await expectToThrow(() => e.web(e.by.web.cssSelector('webMatcher')));
+        await expectToThrow(() => e.web(e.by.web.id('webMatcher')));
+        await expectToThrow(() => e.web(e.by.web.href('webMatcher')));
+        await expectToThrow(() => e.web(e.by.web.name('webMatcher')));
+        await expectToThrow(() => e.web(e.by.web.hrefContains('webMatcher')));
+        await expectToThrow(() => e.web(e.by.web.tag('webMatcher')));
+        await expectToThrow(() => e.web(e.by.web.xpath('webMatcher')));
       });
 
       it(`inner element with wrong matcher should throw`, async () => {
@@ -322,232 +322,232 @@ describe('AndroidExpect', () => {
 
     describe('WebElement Actions', () => {
       it('tap', async () => {
-        await e.web.element(e.by.html.id('id')).tap();
-        await e.web.element(e.by.html.className('className')).tap();
-        await e.web.element(e.by.html.selector('cssSelector')).tap();
-        await e.web.element(e.by.html.name('name')).tap();
-        await e.web.element(e.by.html.xpath('xpath')).tap();
-        await e.web.element(e.by.html.href('linkText')).tap();
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).tap();
-        await e.web.element(e.by.html.tag('tag')).tap();
+        await e.web.element(e.by.web.id('id')).tap();
+        await e.web.element(e.by.web.className('className')).tap();
+        await e.web.element(e.by.web.cssSelector('cssSelector')).tap();
+        await e.web.element(e.by.web.name('name')).tap();
+        await e.web.element(e.by.web.xpath('xpath')).tap();
+        await e.web.element(e.by.web.href('linkText')).tap();
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).tap();
+        await e.web.element(e.by.web.tag('tag')).tap();
       });
 
       it('typeText', async () => {
-        await e.web.element(e.by.html.id('id')).typeText('text');
-        await e.web.element(e.by.html.className('className')).typeText('text');
-        await e.web.element(e.by.html.selector('cssSelector')).typeText('text');
-        await e.web.element(e.by.html.name('name')).typeText('text');
-        await e.web.element(e.by.html.xpath('xpath')).typeText('text');
-        await e.web.element(e.by.html.href('linkText')).typeText('text');
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).typeText('text');
-        await e.web.element(e.by.html.tag('tag')).typeText('text');
+        await e.web.element(e.by.web.id('id')).typeText('text');
+        await e.web.element(e.by.web.className('className')).typeText('text');
+        await e.web.element(e.by.web.cssSelector('cssSelector')).typeText('text');
+        await e.web.element(e.by.web.name('name')).typeText('text');
+        await e.web.element(e.by.web.xpath('xpath')).typeText('text');
+        await e.web.element(e.by.web.href('linkText')).typeText('text');
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).typeText('text');
+        await e.web.element(e.by.web.tag('tag')).typeText('text');
       });
 
       it('typeText with isContentEditable=false', async () => {
-        await e.web.element(e.by.html.id('id')).typeText('text', false);
+        await e.web.element(e.by.web.id('id')).typeText('text', false);
         global.expect(device._typeText).not.toHaveBeenCalled();
       });
 
       it('typeText with isContentEditable=true', async () => {
-        await e.web.element(e.by.html.id('id')).typeText('text', true);
+        await e.web.element(e.by.web.id('id')).typeText('text', true);
         global.expect(device._typeText).toHaveBeenCalled();
       });
 
       it('typeText default isContentEditable is false', async () => {
-        await e.web.element(e.by.html.id('id')).typeText('text');
+        await e.web.element(e.by.web.id('id')).typeText('text');
         global.expect(device._typeText).not.toHaveBeenCalled();
       });
 
       it('replaceText', async () => {
-        await e.web.element(e.by.html.id('id')).replaceText('text');
-        await e.web.element(e.by.html.className('className')).replaceText('text');
-        await e.web.element(e.by.html.selector('cssSelector')).replaceText('text');
-        await e.web.element(e.by.html.name('name')).replaceText('text');
-        await e.web.element(e.by.html.xpath('xpath')).replaceText('text');
-        await e.web.element(e.by.html.href('linkText')).replaceText('text');
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).replaceText('text');
-        await e.web.element(e.by.html.tag('tag')).replaceText('text');
+        await e.web.element(e.by.web.id('id')).replaceText('text');
+        await e.web.element(e.by.web.className('className')).replaceText('text');
+        await e.web.element(e.by.web.cssSelector('cssSelector')).replaceText('text');
+        await e.web.element(e.by.web.name('name')).replaceText('text');
+        await e.web.element(e.by.web.xpath('xpath')).replaceText('text');
+        await e.web.element(e.by.web.href('linkText')).replaceText('text');
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).replaceText('text');
+        await e.web.element(e.by.web.tag('tag')).replaceText('text');
       });
 
       it('clearText', async () => {
-        await e.web.element(e.by.html.id('id')).clearText();
-        await e.web.element(e.by.html.className('className')).clearText();
-        await e.web.element(e.by.html.selector('cssSelector')).clearText();
-        await e.web.element(e.by.html.name('name')).clearText();
-        await e.web.element(e.by.html.xpath('xpath')).clearText();
-        await e.web.element(e.by.html.href('linkText')).clearText();
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).clearText();
-        await e.web.element(e.by.html.tag('tag')).clearText();
+        await e.web.element(e.by.web.id('id')).clearText();
+        await e.web.element(e.by.web.className('className')).clearText();
+        await e.web.element(e.by.web.cssSelector('cssSelector')).clearText();
+        await e.web.element(e.by.web.name('name')).clearText();
+        await e.web.element(e.by.web.xpath('xpath')).clearText();
+        await e.web.element(e.by.web.href('linkText')).clearText();
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).clearText();
+        await e.web.element(e.by.web.tag('tag')).clearText();
       });
 
       it('scrollToView', async () => {
-        await e.web.element(e.by.html.id('id')).scrollToView();
-        await e.web.element(e.by.html.className('className')).scrollToView();
-        await e.web.element(e.by.html.selector('cssSelector')).scrollToView();
-        await e.web.element(e.by.html.name('name')).scrollToView();
-        await e.web.element(e.by.html.xpath('xpath')).scrollToView();
-        await e.web.element(e.by.html.href('linkText')).scrollToView();
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).scrollToView();
-        await e.web.element(e.by.html.tag('tag')).scrollToView();
+        await e.web.element(e.by.web.id('id')).scrollToView();
+        await e.web.element(e.by.web.className('className')).scrollToView();
+        await e.web.element(e.by.web.cssSelector('cssSelector')).scrollToView();
+        await e.web.element(e.by.web.name('name')).scrollToView();
+        await e.web.element(e.by.web.xpath('xpath')).scrollToView();
+        await e.web.element(e.by.web.href('linkText')).scrollToView();
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).scrollToView();
+        await e.web.element(e.by.web.tag('tag')).scrollToView();
       });
 
       it('getText', async () => {
-        await e.web.element(e.by.html.id('id')).getText();
-        await e.web.element(e.by.html.className('className')).getText();
-        await e.web.element(e.by.html.selector('cssSelector')).getText();
-        await e.web.element(e.by.html.name('name')).getText();
-        await e.web.element(e.by.html.xpath('xpath')).getText();
-        await e.web.element(e.by.html.href('linkText')).getText();
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).getText();
-        await e.web.element(e.by.html.tag('tag')).getText();
+        await e.web.element(e.by.web.id('id')).getText();
+        await e.web.element(e.by.web.className('className')).getText();
+        await e.web.element(e.by.web.cssSelector('cssSelector')).getText();
+        await e.web.element(e.by.web.name('name')).getText();
+        await e.web.element(e.by.web.xpath('xpath')).getText();
+        await e.web.element(e.by.web.href('linkText')).getText();
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).getText();
+        await e.web.element(e.by.web.tag('tag')).getText();
       });
 
       it('focus', async () => {
-        await e.web.element(e.by.html.id('id')).focus();
-        await e.web.element(e.by.html.className('className')).focus();
-        await e.web.element(e.by.html.selector('cssSelector')).focus();
-        await e.web.element(e.by.html.name('name')).focus();
-        await e.web.element(e.by.html.xpath('xpath')).focus();
-        await e.web.element(e.by.html.href('linkText')).focus();
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).focus();
-        await e.web.element(e.by.html.tag('tag')).focus();
+        await e.web.element(e.by.web.id('id')).focus();
+        await e.web.element(e.by.web.className('className')).focus();
+        await e.web.element(e.by.web.cssSelector('cssSelector')).focus();
+        await e.web.element(e.by.web.name('name')).focus();
+        await e.web.element(e.by.web.xpath('xpath')).focus();
+        await e.web.element(e.by.web.href('linkText')).focus();
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).focus();
+        await e.web.element(e.by.web.tag('tag')).focus();
       });
 
       it('selectAllText', async () => {
-        await e.web.element(e.by.html.id('id')).selectAllText();
-        await e.web.element(e.by.html.className('className')).selectAllText();
-        await e.web.element(e.by.html.selector('cssSelector')).selectAllText();
-        await e.web.element(e.by.html.name('name')).selectAllText();
-        await e.web.element(e.by.html.xpath('xpath')).selectAllText();
-        await e.web.element(e.by.html.href('linkText')).selectAllText();
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).selectAllText();
-        await e.web.element(e.by.html.tag('tag')).selectAllText();
+        await e.web.element(e.by.web.id('id')).selectAllText();
+        await e.web.element(e.by.web.className('className')).selectAllText();
+        await e.web.element(e.by.web.cssSelector('cssSelector')).selectAllText();
+        await e.web.element(e.by.web.name('name')).selectAllText();
+        await e.web.element(e.by.web.xpath('xpath')).selectAllText();
+        await e.web.element(e.by.web.href('linkText')).selectAllText();
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).selectAllText();
+        await e.web.element(e.by.web.tag('tag')).selectAllText();
       });
 
       it('moveCursorToEnd', async () => {
-        await e.web.element(e.by.html.id('id')).moveCursorToEnd();
-        await e.web.element(e.by.html.className('className')).moveCursorToEnd();
-        await e.web.element(e.by.html.selector('cssSelector')).moveCursorToEnd();
-        await e.web.element(e.by.html.name('name')).moveCursorToEnd();
-        await e.web.element(e.by.html.xpath('xpath')).moveCursorToEnd();
-        await e.web.element(e.by.html.href('linkText')).moveCursorToEnd();
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).moveCursorToEnd();
-        await e.web.element(e.by.html.tag('tag')).moveCursorToEnd();
+        await e.web.element(e.by.web.id('id')).moveCursorToEnd();
+        await e.web.element(e.by.web.className('className')).moveCursorToEnd();
+        await e.web.element(e.by.web.cssSelector('cssSelector')).moveCursorToEnd();
+        await e.web.element(e.by.web.name('name')).moveCursorToEnd();
+        await e.web.element(e.by.web.xpath('xpath')).moveCursorToEnd();
+        await e.web.element(e.by.web.href('linkText')).moveCursorToEnd();
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).moveCursorToEnd();
+        await e.web.element(e.by.web.tag('tag')).moveCursorToEnd();
       });
 
       it('runScript', async () => {
         const script = 'function foo(el) {}';
-        await e.web.element(e.by.html.id('id')).runScript(script);
-        await e.web.element(e.by.html.className('className')).runScript(script);
-        await e.web.element(e.by.html.selector('cssSelector')).runScript(script);
-        await e.web.element(e.by.html.name('name')).runScript(script);
-        await e.web.element(e.by.html.xpath('xpath')).runScript(script);
-        await e.web.element(e.by.html.href('linkText')).runScript(script);
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).runScript(script);
-        await e.web.element(e.by.html.tag('tag')).runScript(script);
+        await e.web.element(e.by.web.id('id')).runScript(script);
+        await e.web.element(e.by.web.className('className')).runScript(script);
+        await e.web.element(e.by.web.cssSelector('cssSelector')).runScript(script);
+        await e.web.element(e.by.web.name('name')).runScript(script);
+        await e.web.element(e.by.web.xpath('xpath')).runScript(script);
+        await e.web.element(e.by.web.href('linkText')).runScript(script);
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).runScript(script);
+        await e.web.element(e.by.web.tag('tag')).runScript(script);
       });
 
       it('runScriptWithArgs', async () => {
         const script = 'function bar(a,b) {}';
         const argsArr = ['fooA','barB'];
-        await e.web.element(e.by.html.id('id')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.html.className('className')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.html.selector('cssSelector')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.html.name('name')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.html.xpath('xpath')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.html.href('linkText')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.html.tag('tag')).runScriptWithArgs(script, argsArr);
+        await e.web.element(e.by.web.id('id')).runScriptWithArgs(script, argsArr);
+        await e.web.element(e.by.web.className('className')).runScriptWithArgs(script, argsArr);
+        await e.web.element(e.by.web.cssSelector('cssSelector')).runScriptWithArgs(script, argsArr);
+        await e.web.element(e.by.web.name('name')).runScriptWithArgs(script, argsArr);
+        await e.web.element(e.by.web.xpath('xpath')).runScriptWithArgs(script, argsArr);
+        await e.web.element(e.by.web.href('linkText')).runScriptWithArgs(script, argsArr);
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).runScriptWithArgs(script, argsArr);
+        await e.web.element(e.by.web.tag('tag')).runScriptWithArgs(script, argsArr);
       });
 
       it('getCurrentUrl', async () => {
-        await e.web.element(e.by.html.id('id')).getCurrentUrl();
-        await e.web.element(e.by.html.className('className')).getCurrentUrl();
-        await e.web.element(e.by.html.selector('cssSelector')).getCurrentUrl();
-        await e.web.element(e.by.html.name('name')).getCurrentUrl();
-        await e.web.element(e.by.html.xpath('xpath')).getCurrentUrl();
-        await e.web.element(e.by.html.href('linkText')).getCurrentUrl();
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).getCurrentUrl();
-        await e.web.element(e.by.html.tag('tag')).getCurrentUrl();
+        await e.web.element(e.by.web.id('id')).getCurrentUrl();
+        await e.web.element(e.by.web.className('className')).getCurrentUrl();
+        await e.web.element(e.by.web.cssSelector('cssSelector')).getCurrentUrl();
+        await e.web.element(e.by.web.name('name')).getCurrentUrl();
+        await e.web.element(e.by.web.xpath('xpath')).getCurrentUrl();
+        await e.web.element(e.by.web.href('linkText')).getCurrentUrl();
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).getCurrentUrl();
+        await e.web.element(e.by.web.tag('tag')).getCurrentUrl();
       });
 
       it('getTitle', async () => {
-        await e.web.element(e.by.html.id('id')).getTitle();
-        await e.web.element(e.by.html.className('className')).getTitle();
-        await e.web.element(e.by.html.selector('cssSelector')).getTitle();
-        await e.web.element(e.by.html.name('name')).getTitle();
-        await e.web.element(e.by.html.xpath('xpath')).getTitle();
-        await e.web.element(e.by.html.href('linkText')).getTitle();
-        await e.web.element(e.by.html.hrefContains('partialLinkText')).getTitle();
-        await e.web.element(e.by.html.tag('tag')).getTitle();
+        await e.web.element(e.by.web.id('id')).getTitle();
+        await e.web.element(e.by.web.className('className')).getTitle();
+        await e.web.element(e.by.web.cssSelector('cssSelector')).getTitle();
+        await e.web.element(e.by.web.name('name')).getTitle();
+        await e.web.element(e.by.web.xpath('xpath')).getTitle();
+        await e.web.element(e.by.web.href('linkText')).getTitle();
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).getTitle();
+        await e.web.element(e.by.web.tag('tag')).getTitle();
       });
 
       it('should allow for access to by via element', async () => {
         const webview = await e.web;
-        await webview.element(e.by.html.id('id')).tap();
+        await webview.element(e.by.web.id('id')).tap();
       });
     })
 
     describe('Web Matchers',() => {
-      it('by.html.id', async () => {
-        await e.expect(e.web.element(e.by.html.id('id'))).toExist();
-        await e.expect(e.web.element(e.by.html.id('id'))).not.toExist();
-        await e.expect(e.web.element(e.by.html.id('id'))).toHaveText('text');
-        await e.expect(e.web.element(e.by.html.id('id'))).not.toHaveText('text');
+      it('by.web.id', async () => {
+        await e.expect(e.web.element(e.by.web.id('id'))).toExist();
+        await e.expect(e.web.element(e.by.web.id('id'))).not.toExist();
+        await e.expect(e.web.element(e.by.web.id('id'))).toHaveText('text');
+        await e.expect(e.web.element(e.by.web.id('id'))).not.toHaveText('text');
       });
 
-      it('by.html.className', async () => {
-        await e.expect(e.web.element(e.by.html.className('className'))).toExist();
-        await e.expect(e.web.element(e.by.html.className('className'))).not.toExist();
-        await e.expect(e.web.element(e.by.html.className('className'))).toHaveText('text');
-        await e.expect(e.web.element(e.by.html.className('className'))).not.toHaveText('text');
+      it('by.web.className', async () => {
+        await e.expect(e.web.element(e.by.web.className('className'))).toExist();
+        await e.expect(e.web.element(e.by.web.className('className'))).not.toExist();
+        await e.expect(e.web.element(e.by.web.className('className'))).toHaveText('text');
+        await e.expect(e.web.element(e.by.web.className('className'))).not.toHaveText('text');
       });
 
-      it('by.html.selector', async () => {
-        await e.expect(e.web.element(e.by.html.selector('cssSelector'))).toExist();
-        await e.expect(e.web.element(e.by.html.selector('cssSelector'))).not.toExist();
-        await e.expect(e.web.element(e.by.html.selector('cssSelector'))).toHaveText('text');
-        await e.expect(e.web.element(e.by.html.selector('cssSelector'))).not.toHaveText('text');
+      it('by.web.cssSelector', async () => {
+        await e.expect(e.web.element(e.by.web.cssSelector('cssSelector'))).toExist();
+        await e.expect(e.web.element(e.by.web.cssSelector('cssSelector'))).not.toExist();
+        await e.expect(e.web.element(e.by.web.cssSelector('cssSelector'))).toHaveText('text');
+        await e.expect(e.web.element(e.by.web.cssSelector('cssSelector'))).not.toHaveText('text');
       });
 
-      it('by.html.name', async () => {
-        await e.expect(e.web.element(e.by.html.name('name'))).toExist();
-        await e.expect(e.web.element(e.by.html.name('name'))).not.toExist();
-        await e.expect(e.web.element(e.by.html.name('name'))).toHaveText('text');
-        await e.expect(e.web.element(e.by.html.name('name'))).not.toHaveText('text');
+      it('by.web.name', async () => {
+        await e.expect(e.web.element(e.by.web.name('name'))).toExist();
+        await e.expect(e.web.element(e.by.web.name('name'))).not.toExist();
+        await e.expect(e.web.element(e.by.web.name('name'))).toHaveText('text');
+        await e.expect(e.web.element(e.by.web.name('name'))).not.toHaveText('text');
       });
 
-      it('by.html.xpath', async () => {
-        await e.expect(e.web.element(e.by.html.xpath('xpath'))).toExist();
-        await e.expect(e.web.element(e.by.html.xpath('xpath'))).not.toExist();
-        await e.expect(e.web.element(e.by.html.xpath('xpath'))).toHaveText('text');
-        await e.expect(e.web.element(e.by.html.xpath('xpath'))).not.toHaveText('text');
+      it('by.web.xpath', async () => {
+        await e.expect(e.web.element(e.by.web.xpath('xpath'))).toExist();
+        await e.expect(e.web.element(e.by.web.xpath('xpath'))).not.toExist();
+        await e.expect(e.web.element(e.by.web.xpath('xpath'))).toHaveText('text');
+        await e.expect(e.web.element(e.by.web.xpath('xpath'))).not.toHaveText('text');
       });
 
-      it('by.html.href', async () => {
-        await e.expect(e.web.element(e.by.html.href('link'))).toExist();
-        await e.expect(e.web.element(e.by.html.href('link'))).not.toExist();
-        await e.expect(e.web.element(e.by.html.href('link'))).toHaveText('text');
-        await e.expect(e.web.element(e.by.html.href('link'))).not.toHaveText('text');
+      it('by.web.href', async () => {
+        await e.expect(e.web.element(e.by.web.href('link'))).toExist();
+        await e.expect(e.web.element(e.by.web.href('link'))).not.toExist();
+        await e.expect(e.web.element(e.by.web.href('link'))).toHaveText('text');
+        await e.expect(e.web.element(e.by.web.href('link'))).not.toHaveText('text');
       });
 
-      it('by.html.hrefContains', async () => {
-        await e.expect(e.web.element(e.by.html.hrefContains('lin'))).toExist();
-        await e.expect(e.web.element(e.by.html.hrefContains('lin'))).not.toExist();
-        await e.expect(e.web.element(e.by.html.hrefContains('lin'))).toHaveText('text');
-        await e.expect(e.web.element(e.by.html.hrefContains('lin'))).not.toHaveText('text');
+      it('by.web.hrefContains', async () => {
+        await e.expect(e.web.element(e.by.web.hrefContains('lin'))).toExist();
+        await e.expect(e.web.element(e.by.web.hrefContains('lin'))).not.toExist();
+        await e.expect(e.web.element(e.by.web.hrefContains('lin'))).toHaveText('text');
+        await e.expect(e.web.element(e.by.web.hrefContains('lin'))).not.toHaveText('text');
       });
 
-      it('by.html.tag', async () => {
-        await e.expect(e.web.element(e.by.html.tag('tag'))).toExist();
-        await e.expect(e.web.element(e.by.html.tag('tag'))).not.toExist();
-        await e.expect(e.web.element(e.by.html.tag('tag'))).toHaveText('text');
-        await e.expect(e.web.element(e.by.html.tag('tag'))).not.toHaveText('text');
+      it('by.web.tag', async () => {
+        await e.expect(e.web.element(e.by.web.tag('tag'))).toExist();
+        await e.expect(e.web.element(e.by.web.tag('tag'))).not.toExist();
+        await e.expect(e.web.element(e.by.web.tag('tag'))).toHaveText('text');
+        await e.expect(e.web.element(e.by.web.tag('tag'))).not.toHaveText('text');
       });
 
       it('should allow for access to except via element', async () => {
         const webview = e.web();
-        await e.expect(webview.element(e.by.html.id('id'))).toExist();
+        await e.expect(webview.element(e.by.web.id('id'))).toExist();
       });
     });
   });

--- a/detox/src/android/matchers/index.js
+++ b/detox/src/android/matchers/index.js
@@ -10,10 +10,10 @@ module.exports = {
   type: (value) => new native.TypeMatcher(value),
   value: (value) => new native.ValueMatcher(value),
 
-  html: {
+  web: {
     id: (value) => new web.IdMatcher(value),
     className: (value) => new web.ClassNameMatcher(value),
-    selector: (value) => new web.CssSelectorMatcher(value),
+    cssSelector: (value) => new web.CssSelectorMatcher(value),
     name: (value) => new web.NameMatcher(value),
     tag: (value) => new web.TagNameMatcher(value),
     xpath: (value) => new web.XPathMatcher(value),

--- a/detox/src/ios/expectTwo.js
+++ b/detox/src/ios/expectTwo.js
@@ -301,8 +301,8 @@ class By {
     return new Matcher().value(value);
   }
 
-  get html() {
-    throw new Error('Detox does not support by.html matchers on iOS.');
+  get web() {
+    throw new Error('Detox does not support by.web matchers on iOS.');
   }
 }
 

--- a/detox/src/ios/expectTwo.test.js
+++ b/detox/src/ios/expectTwo.test.js
@@ -427,8 +427,8 @@ describe('expectTwo', () => {
     }
   });
 
-  it('by.html should throw', () => {
-    expect(() => e.by.html).toThrowError(/not support/);
+  it('by.web should throw', () => {
+    expect(() => e.by.web).toThrowError(/not support/);
   });
 
   it('web() should throw', () => {

--- a/detox/test/e2e/28.webview.test.js
+++ b/detox/test/e2e/28.webview.test.js
@@ -11,60 +11,60 @@ describe(':android: WebView', () => {
 
   describe('Expectations',() => {
     it('expect element to exists', async () => {
-      await expect(webview_1.element(by.html.id('testingPar'))).toExist();
+      await expect(webview_1.element(by.web.id('testingPar'))).toExist();
     });
 
     it('expect element to NOT exists', async () => {
-      await expect(webview_1.element(by.html.id('not_found'))).not.toExist();
+      await expect(webview_1.element(by.web.id('not_found'))).not.toExist();
     });
 
     it('expect element to have text', async () => {
-      await expect(webview_1.element(by.html.id('testingPar'))).toHaveText('Message');
+      await expect(webview_1.element(by.web.id('testingPar'))).toHaveText('Message');
     });
 
     it('expect element to NOT have text', async () => {
-      await expect(webview_1.element(by.html.id('testingPar'))).not.toHaveText(MOCK_TEXT);
+      await expect(webview_1.element(by.web.id('testingPar'))).not.toHaveText(MOCK_TEXT);
     });
   });
 
   describe('Element Matchers',() => {
     it('expect to find element by id', async () => {
-      await expect(webview_1.element(by.html.id('testingh1'))).toExist();
+      await expect(webview_1.element(by.web.id('testingh1'))).toExist();
     });
 
     it('expect to find element by class name', async () => {
-      await expect(webview_1.element(by.html.className('a'))).toExist();
+      await expect(webview_1.element(by.web.className('a'))).toExist();
     });
 
     it('expect to find element by css selector', async () => {
-      await expect(webview_1.element(by.html.selector('#cssSelector'))).toExist();
+      await expect(webview_1.element(by.web.cssSelector('#cssSelector'))).toExist();
     });
 
     it('expect to find element by name', async () => {
-      await expect(webview_1.element(by.html.name('sec_input'))).toExist();
+      await expect(webview_1.element(by.web.name('sec_input'))).toExist();
     });
 
     it('expect to find element by xpath', async () => {
-      await expect(webview_1.element(by.html.xpath('//*[@id="testingh1-1"]'))).toExist();
+      await expect(webview_1.element(by.web.xpath('//*[@id="testingh1-1"]'))).toExist();
     });
 
     it('expect to find element by href', async () => {
-      await expect(webview_1.element(by.html.href('disney.com'))).toExist();
+      await expect(webview_1.element(by.web.href('disney.com'))).toExist();
     });
 
     it('expect to find element by hrefContains', async () => {
-      await expect(webview_1.element(by.html.hrefContains('disney'))).toExist();
+      await expect(webview_1.element(by.web.hrefContains('disney'))).toExist();
     });
 
     it('expect to find element by tag name', async () => {
-      await expect(webview_1.element(by.html.tag('mark'))).toExist();
+      await expect(webview_1.element(by.web.tag('mark'))).toExist();
     });
   });
 
   describe('ContentEditable', () => {
 
     it('should replace text by selecting all text', async () => {
-        const editable = await webview_1.element(by.html.className('public-DraftEditor-content'));
+        const editable = await webview_1.element(by.web.className('public-DraftEditor-content'));
         const text = await editable.getText();
 
         await editable.scrollToView();
@@ -81,7 +81,7 @@ describe(':android: WebView', () => {
     });
 
     it('move cursor to end and add text', async () => {
-      const editable = await webview_1.element(by.html.className('public-DraftEditor-content'));
+      const editable = await webview_1.element(by.web.className('public-DraftEditor-content'));
       await editable.scrollToView();
 
       //tapping, (at the moment not working on content-editable)
@@ -103,53 +103,53 @@ describe(':android: WebView', () => {
 
   it('should set input and change text', async () => {
     // Verify initial value
-    const para = webview_1.element(by.html.id('testingPar'));
+    const para = webview_1.element(by.web.id('testingPar'));
     await expect(para).toHaveText('Message');
 
-    const textInput = await webview_1.element(by.html.id('textInput'));
+    const textInput = await webview_1.element(by.web.id('textInput'));
     await textInput.scrollToView();
     await textInput.tap();
     await textInput.typeText(MOCK_TEXT);
 
-    await webview_1.element(by.html.id('changeTextBtn')).tap();
+    await webview_1.element(by.web.id('changeTextBtn')).tap();
     // Verify text updated
     await expect(para).toHaveText(MOCK_TEXT);
   });
 
   it('should header get text and verify its value', async () => {
-    const text = await webview_1.element(by.html.id('testingh1')).getText();
+    const text = await webview_1.element(by.web.id('testingh1')).getText();
 
-    const textInput = await webview_1.element(by.html.id('textInput'));
+    const textInput = await webview_1.element(by.web.id('textInput'));
     await textInput.scrollToView();
     await textInput.tap();
     await textInput.typeText(text);
 
-    await webview_1.element(by.html.id('changeTextBtn')).tap();
+    await webview_1.element(by.web.id('changeTextBtn')).tap();
 
     // Verify text is the title text
-    await expect(webview_1.element(by.html.id('testingPar'))).toHaveText(text);
+    await expect(webview_1.element(by.web.id('testingPar'))).toHaveText(text);
 
   });
 
   it('should replace text', async () => {
-    const textInput = await webview_1.element(by.html.id('textInput'));
+    const textInput = await webview_1.element(by.web.id('textInput'));
     await textInput.scrollToView();
     await textInput.tap();
     await textInput.typeText('first text');
 
-    await webview_1.element(by.html.id('changeTextBtn')).tap();
-    await expect(webview_1.element(by.html.id('testingPar'))).toHaveText('first text');
+    await webview_1.element(by.web.id('changeTextBtn')).tap();
+    await expect(webview_1.element(by.web.id('testingPar'))).toHaveText('first text');
 
     await textInput.replaceText(MOCK_TEXT);
-    await webview_1.element(by.html.id('changeTextBtn')).tap();
+    await webview_1.element(by.web.id('changeTextBtn')).tap();
 
     // Verify param value is the latest changed text
-    await expect(webview_1.element(by.html.id('testingPar'))).toHaveText(MOCK_TEXT);
+    await expect(webview_1.element(by.web.id('testingPar'))).toHaveText(MOCK_TEXT);
   });
 
   it('getWebView with matcher id', async () => {
     const webview_2 = await web(by.id('webview_2'));
-    await expect(webview_2.element(by.html.tag('p'))).toHaveText('Second Webview');
+    await expect(webview_2.element(by.web.tag('p'))).toHaveText('Second Webview');
   });
 
 });

--- a/detox/test/types/detox-global-tests.ts
+++ b/detox/test/types/detox-global-tests.ts
@@ -38,11 +38,11 @@ describe("Test", () => {
             .whileElement(by.id("ScrollView630"))
             .scroll(50, "down");
 
-        await web.element(by.html.id("btnSave")).tap();
-        await web.element(by.html.className("scroll-end")).atIndex(0).scrollToView();
+        await web.element(by.web.id("btnSave")).tap();
+        await web.element(by.web.className("scroll-end")).atIndex(0).scrollToView();
 
         const webview = web(by.id("webview"));
-        await expect(webview.element(by.html.selector(".button"))).toExist();
-        await expect(webview.element(by.html.selector(".button")).atIndex(1)).toExist();
+        await expect(webview.element(by.web.cssSelector(".button"))).toExist();
+        await expect(webview.element(by.web.cssSelector(".button")).atIndex(1)).toExist();
     });
 });


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

Per request of @OrenZak, I've renamed `by.html` matchers to `by.web`, and `by.html.selector` now is `by.web.cssSelector`.
