### PR TITLE
Add note about fbsimctl deprecation

### DIFF
--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -319,7 +319,7 @@ Check out Detox's [own test suite.](../detox/test/e2e/06.device-orientation.test
 
 ### `device.setLocation(lat, lon)` **iOS Only**
 
-> Note: `setLocation` is dependent on [fbsimctl](https://github.com/facebook/idb/tree/master/fbsimctl) which is now deprecated. If `fbsimctl` is not installed, the command will fail, asking for it to be installed.
+> Note: `setLocation` is dependent on [fbsimctl](https://github.com/facebook/idb/tree/4b7929480c3c0f158f33f78a5b802c1d0e7030d2/fbsimctl) which [is now deprecated](https://github.com/wix/Detox/issues/1371). If `fbsimctl` is not installed, the command will fail, asking for it to be installed.
 
 Sets the simulator location to the given latitude and longitude.
 

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -319,7 +319,7 @@ Check out Detox's [own test suite.](../detox/test/e2e/06.device-orientation.test
 
 ### `device.setLocation(lat, lon)` **iOS Only**
 
-> Note: `setLocation` is dependent on [fbsimctl](https://github.com/facebook/idb/tree/master/fbsimctl). If `fbsimctl` is not installed, the command will fail, asking for it to be installed.
+> Note: `setLocation` is dependent on [fbsimctl](https://github.com/facebook/idb/tree/master/fbsimctl) which is now deprecated. If `fbsimctl` is not installed, the command will fail, asking for it to be installed.
 
 Sets the simulator location to the given latitude and longitude.
 


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 

---

**Description:** Adding this note will make it clearer for future readers of the documentation that this external library is no longer working.
I saw that some people are already working on a proper solution in #1371, so I am wondering if it is appropriate to reference this issue in the documentation?
