### PR TITLE
fix(config): throw err on invalid device type

### DIFF
--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -217,8 +217,7 @@ describe('CLI', () => {
     });
 
     test('should omit --grep --invert for custom platforms', async () => {
-      const customDriver = `module.exports = class CustomDriver {};`
-      singleConfig().type = tempfile('.js', customDriver);
+      singleConfig().type = tempfile('.js', aCustomDriverModule());
 
       await run();
       expect(cliCall().command).not.toContain(' --invert ');
@@ -494,8 +493,7 @@ describe('CLI', () => {
     });
 
     test('should omit --testNamePattern for custom platforms', async () => {
-      const customDriver = `module.exports = class CustomDriver {};`
-      singleConfig().type = tempfile('.js', customDriver);
+      singleConfig().type = tempfile('.js', aCustomDriverModule());
 
       await run();
       expect(cliCall().command).not.toContain('--testNamePattern');
@@ -780,5 +778,9 @@ describe('CLI', () => {
 
   function quote(s, q = isInCMD() ? `"` : `'`) {
     return q + s + q;
+  }
+
+  function aCustomDriverModule() {
+    return `class DriverClass {}; module.exports = { DriverClass }`;
   }
 });

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -148,7 +148,8 @@ class Detox {
     await this._client.connect();
 
     const invocationManager = new InvocationManager(this._client);
-    const deviceDriver = driverRegistry.resolve(this._deviceConfig.type, {
+    const DeviceDriverImpl = driverRegistry.resolve(this._deviceConfig.type);
+    const deviceDriver = new DeviceDriverImpl({
       client: this._client,
       invocationManager,
       emitter: this._eventEmitter,

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -107,14 +107,7 @@ describe('Detox', () => {
         expect(client().connect).toHaveBeenCalled());
 
       it('should resolve a device driver from the registry', () =>
-        expect(FakeDriverRegistry.default.resolve).toHaveBeenCalledWith(
-          detoxConfig.deviceConfig.type,
-          {
-            client: client(),
-            invocationManager: invocationManager(),
-            emitter: expect.anything(),
-          }
-        ));
+        expect(FakeDriverRegistry.default.resolve).toHaveBeenCalledWith(detoxConfig.deviceConfig.type));
 
       it('should resolve matchers implementation', () => {
         const { emitter } = Device.mock.calls[0][0];

--- a/detox/src/configuration/composeDeviceConfig.js
+++ b/detox/src/configuration/composeDeviceConfig.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const driverRegistry = require('../devices/DriverRegistry').default;
 
 /**
  * @param {DetoxConfigErrorComposer} opts.errorComposer
@@ -92,6 +93,11 @@ function composeDeviceConfigFromAliased(opts) {
 function validateDeviceConfig({ deviceConfig, errorComposer, deviceAlias }) {
   if (!deviceConfig.type) {
     throw errorComposer.missingDeviceType(deviceAlias);
+  }
+
+  const DriverClass = _.attempt(() => driverRegistry.resolve(deviceConfig.type));
+  if (_.isError(DriverClass)) {
+    throw errorComposer.invalidDeviceType(deviceAlias, deviceConfig, DriverClass);
   }
 
   if (deviceConfig.utilBinaryPaths) {

--- a/detox/src/devices/DriverRegistry.js
+++ b/detox/src/devices/DriverRegistry.js
@@ -5,22 +5,18 @@ class DriverRegistry {
     this.deviceClasses = deviceClasses;
   }
 
-  resolve(deviceType, opts) {
+  resolve(deviceType) {
     let DeviceDriverClass = this.deviceClasses[deviceType];
 
     if (!DeviceDriverClass) {
-      try {
-        DeviceDriverClass = resolveModuleFromPath(deviceType).DriverClass;
-      } catch (e) {
-        // noop, if we don't find a module to require, we'll hit the unsupported error below
+      DeviceDriverClass = resolveModuleFromPath(deviceType).DriverClass;
+
+      if (!DeviceDriverClass) {
+        throw new Error(`The custom driver '${deviceType}' does not export DriverClass property`);
       }
     }
 
-    if (!DeviceDriverClass) {
-      throw new Error(`'${deviceType}' is not supported`);
-    }
-
-    return new DeviceDriverClass(opts);
+    return DeviceDriverClass;
   }
 }
 

--- a/detox/src/errors/DetoxConfigErrorComposer.js
+++ b/detox/src/errors/DetoxConfigErrorComposer.js
@@ -253,6 +253,22 @@ Examine your Detox config${this._atPath()}`,
     });
   }
 
+  invalidDeviceType(deviceAlias, deviceConfig, innerError) {
+    return new DetoxConfigError({
+      message: `Invalid device type ${J(deviceConfig.type)} inside your configuration.`,
+      hint: `Did you mean to use one of these?
+${hintConfigurations(deviceAppTypes)}
+
+P.S. If you intended to use a third-party driver, please resolve this error:
+
+${innerError.message}
+
+Please check your Detox config${this._atPath()}`,
+      debugInfo: this._focusOnDeviceConfig(deviceAlias, this._ensureProperty('type')),
+      inspectOptions: { depth: 3 },
+    });
+  }
+
   malformedUtilBinaryPaths(deviceAlias) {
     return new DetoxConfigError({
       message: `Invalid type of "utilBinaryPaths" inside the device configuration.`

--- a/detox/src/errors/DetoxConfigErrorComposer.test.js
+++ b/detox/src/errors/DetoxConfigErrorComposer.test.js
@@ -222,6 +222,30 @@ describe('DetoxConfigErrorComposer', () => {
       });
     });
 
+    describe('.invalidDeviceType', () => {
+      beforeEach(() => {
+        build = (deviceConfig, alias) => {
+          // eslint-disable-next-line node/no-missing-require
+          const err = _.attempt(() => require('android.apk'));
+          return builder.invalidDeviceType(alias, deviceConfig, err);
+        };
+      });
+
+      it('should create an error for inlined configuration', () => {
+        const deviceConfig = config.configurations.inlined.device;
+        deviceConfig.type = 'android.apk';
+        builder.setConfigurationName('inlined');
+        expect(build(deviceConfig)).toMatchSnapshot();
+      });
+
+      it('should create an error for aliased configuration', () => {
+        const deviceConfig = config.devices.aDevice;
+        deviceConfig.type = 'android.apk';
+        builder.setConfigurationName('aliased');
+        expect(build(deviceConfig, 'aDevice')).toMatchSnapshot();
+      });
+    });
+
     describe('.missingDeviceMatcherProperties', () => {
       beforeEach(() => {
         build = (alias) => builder.missingDeviceMatcherProperties(alias, ['foo', 'bar']);

--- a/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
+++ b/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
@@ -557,6 +557,64 @@ Examine your Detox config at path:
 /home/detox/myproject/.detoxrc.json]
 `;
 
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .invalidDeviceType should create an error for aliased configuration 1`] = `
+[DetoxConfigError: Invalid device type "android.apk" inside your configuration.
+
+HINT: Did you mean to use one of these?
+* ios.simulator
+* ios.none
+* android.attached
+* android.emulator
+* android.genycloud
+
+P.S. If you intended to use a third-party driver, please resolve this error:
+
+Cannot find module 'android.apk' from 'src/errors/DetoxConfigErrorComposer.test.js'
+
+Please check your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'android.apk',
+      device: {
+        type: 'iPhone 12'
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .invalidDeviceType should create an error for inlined configuration 1`] = `
+[DetoxConfigError: Invalid device type "android.apk" inside your configuration.
+
+HINT: Did you mean to use one of these?
+* ios.simulator
+* ios.none
+* android.attached
+* android.emulator
+* android.genycloud
+
+P.S. If you intended to use a third-party driver, please resolve this error:
+
+Cannot find module 'android.apk' from 'src/errors/DetoxConfigErrorComposer.test.js'
+
+Please check your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'android.apk',
+        device: [Object]
+      }
+    }
+  }
+}]
+`;
+
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedUtilBinaryPaths should create an error for aliased configuration 1`] = `
 [DetoxConfigError: Invalid type of "utilBinaryPaths" inside the device configuration. Expected an array of strings.
 


### PR DESCRIPTION
- [x] This change has been discussed in issue #2675 and the solution has been agreed upon with maintainers.

---

**Description:**

```
DetoxConfigError: Invalid device type "android.apk" inside your configuration.

HINT: Did you mean to use one of these?
* ios.simulator
* ios.none
* android.attached
* android.emulator
* android.genycloud

P.S. If you intended to use a third-party driver, please resolve this error:

Cannot find module 'android.apk'

Please check your Detox config at path:
/Users/yaroslavs/Projects/wix/Detox/detox/test/.detoxrc.json

{
  configurations: {
    debug: {
      binaryPath: 'C:/Users/adema/Desktop/myMoney/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk',
      build: 'cd android && ./gradlew build assembleDebug ' +
        'assembleAndroidTest -DtestBuildType=debug',
      type: 'android.apk',
      devices: {
        emulator: [Object]
      }
    }
  }
}
```

P. S. @Ademar-SJ, this is the error message you should have been seeing in the perfect world with unicorns and rainbows.