### PR TITLE
fix: better error stacks for unhandled errors

### DIFF
--- a/detox/local-cli/cli.js
+++ b/detox/local-cli/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 global.DETOX_CLI = true;
 const yargs = require('yargs');
+const DetoxRuntimeError = require('../src/errors/DetoxRuntimeError');
 const logger = require('../src/utils/logger').child({ __filename });
 
 yargs
@@ -24,7 +25,7 @@ yargs
   .wrap(yargs.terminalWidth() * 0.9)
   .fail(function(msg, err, program) {
     if (err) {
-      const lines = err.toString().split("\n");
+      const lines = DetoxRuntimeError.format(err).split("\n");
       for (const line of lines) {
         logger.error(line);
       }

--- a/detox/runners/jest-circus/environment.js
+++ b/detox/runners/jest-circus/environment.js
@@ -5,6 +5,7 @@ const DetoxInitErrorListener = require('./listeners/DetoxInitErrorListener');
 const assertJestCircus26 = require('./utils/assertJestCircus26');
 const assertExistingContext = require('./utils/assertExistingContext');
 const wrapErrorWithNoopLifecycle = require('./utils/wrapErrorWithNoopLifecycle');
+const DetoxRuntimeError = require('../../src/errors/DetoxRuntimeError');
 const Timer = require('../../src/utils/Timer');
 
 const SYNC_CIRCUS_EVENTS = new Set([
@@ -71,7 +72,7 @@ class DetoxCircusEnvironment extends NodeEnvironment {
           try {
             await this._timer.run(() => listener[name](event, state));
           } catch (listenerError) {
-            this._logger.error(`${listenerError}`);
+            this._logError(listenerError);
           }
         }
       }
@@ -104,7 +105,7 @@ class DetoxCircusEnvironment extends NodeEnvironment {
           return await this.initDetox();
         } catch (actualError) {
           state.unhandledErrors.push(actualError);
-          this._logger.error(`${actualError}`);
+          this._logError(actualError);
           throw actualError;
         }
       });
@@ -112,7 +113,7 @@ class DetoxCircusEnvironment extends NodeEnvironment {
       if (!state.unhandledErrors.includes(maybeActualError)) {
         const timeoutError = maybeActualError;
         state.unhandledErrors.push(timeoutError);
-        this._logger.error(`${timeoutError}`);
+        this._logError(timeoutError);
       }
 
       detox = wrapErrorWithNoopLifecycle(maybeActualError);
@@ -137,13 +138,18 @@ class DetoxCircusEnvironment extends NodeEnvironment {
       await this._timer.run(() => this.cleanupDetox());
     } catch (cleanupError) {
       state.unhandledErrors.push(cleanupError);
-      this._logger.error(`${cleanupError}`);
+      this._logError(cleanupError);
     }
   }
 
   /** @private */
   get _logger() {
     return require('../../src/utils/logger');
+  }
+
+  /** @private */
+  _logError(e) {
+    this._logger.error(DetoxRuntimeError.format(e));
   }
 
   /** @protected */

--- a/detox/src/errors/DetoxRuntimeError.js
+++ b/detox/src/errors/DetoxRuntimeError.js
@@ -6,7 +6,7 @@ class DetoxRuntimeError extends Error {
     message = '',
     hint = '',
     debugInfo = '',
-    inspectOptions,
+    inspectOptions = null,
   } = {}) {
     const formattedMessage = _.compact([
       message,
@@ -29,6 +29,25 @@ class DetoxRuntimeError extends Error {
 
       ...options,
     });
+  }
+
+  /**
+   * @param {*} err
+   */
+  static format(err) {
+    if (err instanceof DetoxRuntimeError) {
+      return err.message;
+    }
+
+    if (_.isError(err) && /^Command failed:/.test(err.message)) {
+      return err.message;
+    }
+
+    if (_.isError(err) && (err.stack || err.message)) {
+      return String(err.stack || err.message);
+    }
+
+    return this.inspectObj(err, { depth: 1 })
   }
 }
 

--- a/detox/src/errors/DetoxRuntimeError.test.js
+++ b/detox/src/errors/DetoxRuntimeError.test.js
@@ -9,6 +9,29 @@ describe(DetoxRuntimeError, () => {
     });
   });
 
+  it('should format any object to an error message', () => {
+    expect(DetoxRuntimeError.format({})).toBe("{}");
+
+    const err = new Error('Command failed: echo Hello world');
+    expect(DetoxRuntimeError.format(err)).toBe(err.message);
+
+    err.message = 'Other error message';
+    expect(DetoxRuntimeError.format(err)).toBe(err.stack);
+
+    delete err.stack;
+    expect(DetoxRuntimeError.format(err)).toBe(err.message);
+
+    delete err.message;
+    expect(DetoxRuntimeError.format(err)).toBe('[Error]');
+
+    const runtimeError = new DetoxRuntimeError({
+      message: 'msg',
+      hint: 'hint',
+    });
+
+    expect(DetoxRuntimeError.format(runtimeError)).toBe(runtimeError.message);
+  });
+
   function varietiesOfInstantiation() {
     return {
       'no args': new DetoxRuntimeError(),


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

* For thrown `DetoxRuntimeError` errors we'll be printing `err.message`.
* For other errors (except `child_process.execSync()` "Command failed" errors) we'll be printing `err.stack`, so that any unhandled errors contain more details and we can fix them.
* For unhandled non-error values, we'll be using `util.inspect()`.

**Examples:**

Before:
![image](https://user-images.githubusercontent.com/1962469/110596123-98429300-8187-11eb-9750-17e134d4c3a7.png)

After:
![image](https://user-images.githubusercontent.com/1962469/110596076-88c34a00-8187-11eb-8349-0f263b2cc873.png)

Regression testing (there should be no error stacks for known messages):
![image](https://user-images.githubusercontent.com/1962469/110596211-b27c7100-8187-11eb-99ec-df3cbcd85145.png)

