### PR TITLE
fix(logger): consider also -l, the alias for --loglevel

### DIFF
--- a/detox/src/utils/argparse.js
+++ b/detox/src/utils/argparse.js
@@ -2,12 +2,10 @@ const _ = require('lodash');
 const argv = require('minimist')(process.argv.slice(2));
 const {escape} = require('./pipeCommands');
 
-function getArgValue(key) {
-  let value;
+function getArgValue(key, alias) {
+  let value = _getArgvValue(key, alias);
 
-  if (argv && argv[key]) {
-    value = argv[key];
-  } else {
+  if (value === undefined) {
     const envKey = _.findKey(process.env, matchesKey(
       `DETOX_${_.snakeCase(key)}`.toUpperCase()
     ));
@@ -19,6 +17,18 @@ function getArgValue(key) {
   }
 
   return value;
+}
+
+function _getArgvValue(...aliases) {
+  if (!argv) {
+    return;
+  }
+
+  for (const alias of aliases) {
+    if (alias && argv[alias]) {
+      return argv[alias];
+    }
+  }
 }
 
 function matchesKey(key) {

--- a/detox/src/utils/argparse.test.js
+++ b/detox/src/utils/argparse.test.js
@@ -1,6 +1,13 @@
 jest.unmock('process');
 
 describe('argparse', () => {
+  let minimist;
+
+  beforeEach(() => {
+    jest.mock('minimist');
+    minimist = require('minimist');
+  });
+
   describe('getArgValue()', () => {
     describe('using env variables', () => {
       let _env;
@@ -14,6 +21,7 @@ describe('argparse', () => {
           DETOX_FOO_BAR: 'value',
         };
 
+        minimist.mockReturnValue(undefined);
         argparse = require('./argparse');
       });
 
@@ -43,14 +51,16 @@ describe('argparse', () => {
       let argparse;
 
       beforeEach(() => {
-        jest.mock('minimist');
-        const minimist = require('minimist');
-        minimist.mockReturnValue({'kebab-case-key': 'a value'});
+        minimist.mockReturnValue({'kebab-case-key': 'a value', 'b': 'shortened'});
         argparse = require('./argparse');
       });
 
       it(`nonexistent key should return undefined result`, () => {
         expect(argparse.getArgValue('blah')).not.toBeDefined();
+      });
+
+      it(`alias alternative should fiind the result`, () => {
+        expect(argparse.getArgValue('blah', 'b')).toBe('shortened');
       });
 
       it(`existing key should return a result`, () => {
@@ -63,8 +73,6 @@ describe('argparse', () => {
     let argparse;
 
     beforeEach(() => {
-      jest.mock('minimist');
-      const minimist = require('minimist');
       minimist.mockReturnValue({'flag-true': 1, 'flag-false': 0});
       argparse = require('./argparse');
     });

--- a/detox/src/utils/logger.js
+++ b/detox/src/utils/logger.js
@@ -73,7 +73,7 @@ function createPlainBunyanStream({ logPath, level }) {
 }
 
 function init() {
-  const levelFromArg = argparse.getArgValue('loglevel');
+  const levelFromArg = argparse.getArgValue('loglevel', 'l');
   const level = adaptLogLevelName(levelFromArg);
   const bunyanStreams = [createPlainBunyanStream({ level })];
 


### PR DESCRIPTION
- [x] This is a small change 

---

**Description:**

It appears that non-`detox test` commands do not really react to `-l` shorthand alias for `--loglevel`.

For example, `detox run-server` – it is confusing that you cannot start it in a standalone mode with `--loglevel trace` when required.

It is easy to show that on the example with INFO/WARN levels.

Before (incorrect, because WARN level is higher than INFO):

![image](https://user-images.githubusercontent.com/1962469/110597266-fae85e80-8188-11eb-9e9f-fca01019dc1a.png)

After (correct, the log level now allows only ERROR and WARN messages):

![image](https://user-images.githubusercontent.com/1962469/110597153-da200900-8188-11eb-9cbd-223af2136180.png)