### PR TITLE
docs: note about testNamePattern on detox test

### DIFF
--- a/detox/local-cli/utils/testCommandArgs.js
+++ b/detox/local-cli/utils/testCommandArgs.js
@@ -109,6 +109,12 @@ module.exports = {
     number: true,
     default: 1,
   },
+  t: {
+    alias: 'testNamePattern',
+    group: 'Execution:',
+    describe:
+      '[Jest Only] Run only tests with a name that matches the regex.',
+  },
   'jest-report-specs': {
     group: 'Execution:',
     describe: '[Jest Only] Whether to output logs per each running spec, in real-time. By default, disabled with multiple workers.',

--- a/docs/APIRef.DetoxCLI.md
+++ b/docs/APIRef.DetoxCLI.md
@@ -86,6 +86,7 @@ Initiating your test suite. <sup>[[1]](#notice-passthrough)</sup>
 | -r, --reuse                                   | Reuse existing installed app (do not delete + reinstall) for a faster run. |
 | -u, --cleanup                                 | Shutdown simulator when test is over, useful for CI scripts, to make sure detox exists cleanly with no residue |
 | -w, --workers                                 | Specifies number of workers the test runner should spawn, requires a test runner with parallel execution support (Detox CLI currently supports Jest). *Note: For workers > 1, Jest's spec-level reporting is disabled, by default (can be overridden using --jest-report-specs).* |
+| -t, --testNamePattern                         | [Jest Only] Run only tests with a name that matches the regex. |
 | --jest-report-specs | [Jest Only] Whether to output logs per each running spec, in real-time. By default, disabled with multiple workers. |
 | -H, --headless                                | [Android Only] Launch Emulator in headless mode. Useful when running on CI. |
 | --gpu                                         | [Android Only] Launch Emulator with the specific -gpu [gpu mode] parameter. |


### PR DESCRIPTION
- [x] This is a small change 
---

**Description:**

I came across the fact that the DetoxCLI documentation does not indicate that you can pass the --testNamePattern flag directly. I decided to fix this point in the documentation