### PR TITLE
Passthrough or set user-agent to gmsaas

### DIFF
--- a/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.js
+++ b/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.js
@@ -3,6 +3,7 @@ const exec = require('../../../../../utils/exec').execWithRetriesAndLogs;
 class GenyCloudExec {
   constructor(binaryPath) {
     this.binaryExec = `"${binaryPath}" --format compactjson`;
+    process.env.GMSAAS_USER_AGENT_EXTRA_DATA = process.env.GMSAAS_USER_AGENT_EXTRA_DATA || 'detox';
   }
 
   getVersion() {

--- a/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.test.js
+++ b/detox/src/devices/drivers/android/genycloud/exec/GenyCloudExec.test.js
@@ -38,6 +38,10 @@ describe('Genymotion-cloud executable', () => {
     uut = new GenyCloudExec('mock/path/to/gmsaas');
   });
 
+  afterEach(() => {
+    delete process.env.GMSAAS_USER_AGENT_EXTRA_DATA;
+  });
+
   [
     {
       commandName: 'version',
@@ -116,6 +120,27 @@ describe('Genymotion-cloud executable', () => {
           expect(e.message).toEqual(JSON.stringify(failResponse));
         }
       });
+    });
+  });
+
+  describe('User-agent bundling into gmsaas requests', () => {
+    it('should set up \'detox\' as the default user-agent', () => {
+      delete process.env.GMSAAS_USER_AGENT_EXTRA_DATA;
+
+      const GenyCloudExec = require('./GenyCloudExec');
+      new GenyCloudExec('mock/path/to/gmsaas');
+
+      expect(process.env.GMSAAS_USER_AGENT_EXTRA_DATA).toEqual('detox');
+    });
+
+    it('should retain any value prespecified for user-agent', () => {
+      delete process.env.GMSAAS_USER_AGENT_EXTRA_DATA;
+      process.env.GMSAAS_USER_AGENT_EXTRA_DATA = 'mockUserAgent';
+
+      const GenyCloudExec = require('./GenyCloudExec');
+      new GenyCloudExec('mock/path/to/gmsaas');
+
+      expect(process.env.GMSAAS_USER_AGENT_EXTRA_DATA).toEqual('mockUserAgent');
     });
   });
 });

--- a/detox/src/utils/exec.test.js
+++ b/detox/src/utils/exec.test.js
@@ -24,12 +24,6 @@ describe('exec', () => {
     expect(cpp.exec).toHaveBeenCalledWith(`bin`, { timeout: 0 });
   });
 
-  it(`exec command with no arguments successfully`, async () => {
-    mockCppSuccessful(cpp);
-    await exec.execWithRetriesAndLogs('bin');
-    expect(cpp.exec).toHaveBeenCalledWith(`bin`, { timeout: 0 });
-  });
-
   it(`exec command with arguments successfully`, async () => {
     mockCppSuccessful(cpp);
 
@@ -37,6 +31,14 @@ describe('exec', () => {
     await exec.execWithRetriesAndLogs('bin', options);
 
     expect(cpp.exec).toHaveBeenCalledWith(`bin --argument 123`, { timeout: 0 });
+  });
+
+  it(`exec command with env-vars pass-through (i.e. no custom env-vars specification`, async () => {
+    mockCppSuccessful(cpp);
+    await exec.execWithRetriesAndLogs('bin');
+    const usedOptions = cpp.exec.mock.calls[0][1];
+    expect(usedOptions).not.toHaveProperty('env');
+    expect(cpp.exec).toHaveBeenCalledTimes(1);
   });
 
   it(`exec command with arguments and prefix successfully`, async () => {


### PR DESCRIPTION
## Description

As per request from Genymobile, adding `detox` as the (default) user-agent extra-data for requests sent out via Detox.
The actual value can be overridden by a user by setting `GMSAAS_USER_AGENT_EXTRA_DATA` themselves, before invoking detox.

Relates to #2655.