### PR TITLE
fix: use Node.js resolution for Detox config paths

### DIFF
--- a/detox/src/configuration/__mocks__/configuration/badconfig/detox.config.js
+++ b/detox/src/configuration/__mocks__/configuration/badconfig/detox.config.js
@@ -1,0 +1,2 @@
+/* eslint-disable */
+module.exports = require('something-that-does-not-exist');

--- a/detox/src/configuration/index.js
+++ b/detox/src/configuration/index.js
@@ -11,7 +11,7 @@ const composeSessionConfig = require('./composeSessionConfig');
 const selectConfiguration = require('./selectConfiguration');
 
 async function composeDetoxConfig({
-  cwd,
+  cwd = process.cwd(),
   argv,
   override,
   userParams,


### PR DESCRIPTION
- [x] This change has been discussed in issue #2550 and the solution has been agreed upon with maintainers.

---

**Description:**

This is a preparation towards extendable presets - now resolving Detox config paths via Node.js resolution mechanism.
Legacy configuration paths will be getting a warning:

```
Cannot resolve Detox config path by using Node.js require() mechanism:
require("node_modules/my-preset/index.js")

Detox now will resort to legacy filesystem-based path resolution.
Please fix your config path, so it conforms to `require(modulePath)` resolution.
```

Also, here we've got a fix.

Now Detox will be reporting correct errors when trying to evaluate something erroneous in a user-created JS (not JSON) Detox config. Previously, we incorrectly handled `Cannot find module` error. Why? So, if there was an inner `require` that failed, we were handling it like the user had provided an incorrect Detox config path, which is not always a true presumption.

Before:

![image](https://user-images.githubusercontent.com/1962469/111499465-a7a77a80-874b-11eb-9ffd-c58197a2f1c2.png)

After:

![image](https://user-images.githubusercontent.com/1962469/111499498-ad9d5b80-874b-11eb-8e56-06c81ff51683.png)
