### PR TITLE
Adding UserTracking permission

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1161,6 +1161,7 @@ declare global {
             siri?: SiriPermission;
             speech?: SpeechPermission;
             faceid?: FaceIDPermission;
+            userTracking?: UserTrackingPermission;
         }
 
         type LocationPermission = 'always' | 'inuse' | 'never' | 'unset';
@@ -1179,6 +1180,7 @@ declare global {
         type SpeechPermission = PermissionState;
         type NotificationsPermission = PermissionState;
         type FaceIDPermission = PermissionState;
+        type UserTrackingPermission = PermissionState;
 
         interface DeviceLaunchAppConfig {
             /**


### PR DESCRIPTION
## Description
iOS 14 introduced a new user tracking permission. 
AppleSimulatorUtils added support for this permission on [v0.9](https://github.com/wix/AppleSimulatorUtils/releases/tag/0.9).
I've added the missing definition to enable the use of this permission to `DevicePermissions` and the related `type`


