### PR TITLE
Remove duplicate commands from docs

### DIFF
--- a/docs/APIRef.DetoxCLI.md
+++ b/docs/APIRef.DetoxCLI.md
@@ -28,8 +28,6 @@ detox <command> [options]
 | [clean-framework-cache](#cache) | Cleans the Detox cache |
 | [rebuild-framework-cache](#cache) | Rebuilds the Detox cache |
 | [recorder](#recorder) | Starts a [Detox Recorder](https://github.com/wix/DetoxRecorder) recording |
-| clean-framework-cache      | **MacOS only.** Delete all compiled framework binaries from ~/Library/Detox, they will be rebuilt on 'npm install' or when running 'build-framework-cache'
-| build-framework-cache      | **MacOS only.** Build Detox.framework to ~/Library/Detox. The framework cache is specific for each combination of Xcode and Detox versions
 
 ### Options:
 


### PR DESCRIPTION
[`aeae983`](https://github.com/wix/Detox/commit/aeae9839f316d0619688b185b71fb10df00cafab#diff-584dcadc8b8133a55d24fce70dbb6cce5993624a4ce30765f0b66fc1f00393eb) added the `{build,clean,rebuild}-framework-cache` commands to the docs. However, `{build,clean}-framework-cache` were already documented and are now listed twice. This pull request removes the older duplicates.