### PR TITLE
fix: stabilize stuck cleanup

### DIFF
--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -23,6 +23,7 @@ class Client {
     this._onBeforeAppCrash = this._onBeforeAppCrash.bind(this);
     this._onAppDisconnected = this._onAppDisconnected.bind(this);
     this._onUnhandledServerError = this._onUnhandledServerError.bind(this);
+    this._logError = this._logError.bind(this);
 
     this._sessionId = sessionId;
     this._slowInvocationTimeout = debugSynchronization;
@@ -73,23 +74,16 @@ class Client {
 
     try {
       if (this.isConnected) {
-        this._scheduleAppTermination();
-
-        try {
-          await this.sendAction(new actions.Cleanup(this._successfulTestRun));
-        } catch (e) {
-          log.error({ event: 'ERROR' }, DetoxRuntimeError.format(e));
-        }
+        await this.sendAction(new actions.Cleanup(this._successfulTestRun)).catch(this._logError);
 
         this._whenAppIsConnected = this._invalidState('while cleaning up')
         this._whenAppIsReady = this._whenAppIsConnected;
       }
     } finally {
-      this._unscheduleAppTermination();
-      delete this.terminateApp; // property injection
-
-      await this._asyncWebSocket.close();
+      await this._asyncWebSocket.close().catch(this._logError);
     }
+
+    delete this.terminateApp; // property injection
   }
 
   setEventCallback(event, callback) {
@@ -134,11 +128,11 @@ class Client {
   }
 
   async sendAction(action) {
-    const options = this._inferSendOptions(action);
+    const { queryStatus, ...options } = this._inferSendOptions(action);
 
-    return await ((options.queryStatus)
-      ? this._sendMonitoredAction(action)
-      : this._doSendAction(action))
+    return await (queryStatus
+      ? this._sendMonitoredAction(action, options)
+      : this._doSendAction(action, options))
   }
 
   _inferSendOptions(action) {
@@ -146,26 +140,26 @@ class Client {
       || action instanceof actions.Login
       || action instanceof actions.Cleanup
     ) {
-      return { queryStatus: false };
+      return { queryStatus: false, timeout: 5000 };
     }
 
-    return { queryStatus: true };
+    return { queryStatus: true, timeout: 0 };
   }
 
-  async _sendMonitoredAction(action) {
+  async _sendMonitoredAction(action, options) {
     try {
       this._scheduleSlowInvocationQuery();
-      return await this._doSendAction(action);
+      return await this._doSendAction(action, options);
     } finally {
       this._unscheduleSlowInvocationQuery();
     }
   }
 
-  async _doSendAction(action) {
+  async _doSendAction(action, options) {
     const errorWithUserStack = createErrorWithUserStack();
 
     try {
-      const parsedResponse = await this._asyncWebSocket.send(action);
+      const parsedResponse = await this._asyncWebSocket.send(action, options);
       if (parsedResponse && parsedResponse.type === 'serverError') {
         throw deserializeError(parsedResponse.params.error);
       }
@@ -334,8 +328,6 @@ class Client {
   }
 
   _onAppDisconnected() {
-    const wasAppTerminatedByUs = !!this._appTerminationHandle;
-
     this._unscheduleSlowInvocationQuery();
     this._unscheduleAppTermination();
     this._whenAppIsConnected = this._invalidState('after the app has disconnected')
@@ -345,9 +337,7 @@ class Client {
       this._asyncWebSocket.rejectAll(this._pendingAppCrash);
       this._pendingAppCrash = null;
     } else if (this._asyncWebSocket.hasPendingActions()) {
-      this._asyncWebSocket.rejectAll(wasAppTerminatedByUs
-        ? new DetoxRuntimeError('The app has been unresponsive and Detox had to terminate it forcibly.')
-        : new DetoxRuntimeError('The app has unexpectedly disconnected from Detox server.'));
+      this._asyncWebSocket.rejectAll(new DetoxRuntimeError('The app has unexpectedly disconnected from Detox server.'));
     }
   }
 
@@ -365,6 +355,10 @@ class Client {
     return Deferred.rejected(
       new DetoxInternalError(`Detected an attempt to interact with Detox Client ${state}.`)
     );
+  }
+
+  _logError(e) {
+    log.error({ event: 'ERROR' }, DetoxRuntimeError.format(e));
   }
 }
 

--- a/detox/src/client/InflightRequest.js
+++ b/detox/src/client/InflightRequest.js
@@ -1,0 +1,50 @@
+const DetoxRuntimeError = require('../errors/DetoxRuntimeError');
+const Deferred = require('../utils/Deferred');
+
+class InflightRequest extends Deferred {
+  constructor(message) {
+    super();
+
+    this._timeoutHandle = null;
+    this.message = message;
+  }
+
+  resolve(value) {
+    this.clearTimeout();
+    return super.resolve(value);
+  }
+
+  reject(reason) {
+    this.clearTimeout();
+
+    const { messageId, type } = this.message;
+    return super.reject(new DetoxRuntimeError({
+      message: `The pending request #${messageId} ("${type}") has been rejected due to the following error:`,
+      debugInfo: reason,
+    }));
+  }
+
+  withTimeout(ms) {
+    if (ms > 0) {
+      this._timeoutHandle = setTimeout(() => {
+        this.reject(new DetoxRuntimeError({
+          message: `The tester has not received a response within ${ms}ms timeout to the message:`,
+          debugInfo: this.message,
+        }));
+      }, ms);
+    }
+
+    return this;
+  }
+
+  clearTimeout() {
+    if (this._timeoutHandle) {
+      clearTimeout(this._timeoutHandle);
+      this._timeoutHandle = null;
+    }
+
+    return this;
+  }
+}
+
+module.exports = InflightRequest;

--- a/detox/src/client/__snapshots__/AsyncWebSocket.test.js.snap
+++ b/detox/src/client/__snapshots__/AsyncWebSocket.test.js.snap
@@ -53,13 +53,26 @@ HINT: Please report this issue on our GitHub tracker:
 https://github.com/wix/Detox/issues
 
 {
+  type: 'invoke',
   message: 'a message',
   messageId: undefined
 }"
 `;
 
+exports[`AsyncWebSocket .send() when opened should fail if the message timeout has expired 1`] = `
+"The pending request #0 (\\"invoke\\") has been rejected due to the following error:
+
+The tester has not received a response within 5000ms timeout to the message:
+
+{
+  type: 'invoke',
+  message: 'a message',
+  messageId: 0
+}"
+`;
+
 exports[`AsyncWebSocket .send() when opened should log an error if the incoming message was completely unexpected 1`] = `
-"Unexpected error on an attempt to handle a message over the web socket.
+"Unexpected error on an attempt to handle the response received over the web socket.
 
 HINT: Examine the inner error:
 
@@ -71,19 +84,25 @@ The payload was:
 `;
 
 exports[`AsyncWebSocket .send() when opened should reject all messages in the flight if there's an error 1`] = `
-"Failed to deliver the message to the Detox server:
+"The pending request #0 (\\"invoke\\") has been rejected due to the following error:
+
+Failed to deliver the message to the Detox server:
 
 Error: TestError"
 `;
 
 exports[`AsyncWebSocket .send() when opened should reject all messages in the flight if there's an error 2`] = `
-"Failed to deliver the message to the Detox server:
+"The pending request #1 (\\"invoke\\") has been rejected due to the following error:
+
+Failed to deliver the message to the Detox server:
 
 Error: TestError"
 `;
 
 exports[`AsyncWebSocket edge cases should elaborate about null-like messages 1`] = `
-[DetoxRuntimeError: Unexpected error on an attempt to handle a message over the web socket.
+[DetoxRuntimeError: The pending request #0 ("invoke") has been rejected due to the following error:
+
+Unexpected error on an attempt to handle the response received over the web socket.
 
 HINT: Examine the inner error:
 

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -328,20 +328,18 @@ class Device {
       await this.deviceDriver.deliverPayload({...params, delayPayload: true});
     }
 
-    let processId;
     if (this._behaviorConfig.launchApp === 'manual') {
-      processId = await this.deviceDriver.waitForAppLaunch(deviceId, bundleId, this._prepareLaunchArgs(baseLaunchArgs), params.languageAndLocale);
+      this._processes[bundleId] = await this.deviceDriver.waitForAppLaunch(deviceId, bundleId, this._prepareLaunchArgs(baseLaunchArgs), params.languageAndLocale);
     } else {
-      processId = await this.deviceDriver.launchApp(deviceId, bundleId, this._prepareLaunchArgs(baseLaunchArgs), params.languageAndLocale);
+      this._processes[bundleId] = await this.deviceDriver.launchApp(deviceId, bundleId, this._prepareLaunchArgs(baseLaunchArgs), params.languageAndLocale);
       await this.deviceDriver.waitUntilReady();
       await this.deviceDriver.waitForActive();
     }
-    this._processes[bundleId] = processId;
 
     await this._emitter.emit('appReady', {
       deviceId,
       bundleId,
-      pid: processId,
+      pid: this._processes[bundleId],
     });
 
     if(params.detoxUserNotificationDataURL) {


### PR DESCRIPTION
## Description

1. Resolves the edge case, when the app does not respond to `cleanup` action at all, hence it breaks the entire Jest + Detox cleanup phase. Technically, I am adding a 5s graceful period before we reject the pending `cleanup` request and go further in our `detox.cleanup()` routine.

2. `client.cleanup()` now theoretically cannot throw an error now. That's important if we want to finish properly the outer  `detox.cleanup()`.

3. Also, here I fix an incorrect app PID saving (it is prescribed to run too late, only after the app responds to "isReady"). After the fix, I am able to verify the existing PID (=> app is running) even in cases when the app is not eager to respond it is ready. Not entirely related to this PR (although it was relevant in the first commit with the first implementation, then I changed my mind and we have a no-app-terminate-just-reject-inflightpromise solution), but it is certainly worth fixing.