### PR TITLE
Run non-Spek Android unit tests

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -113,7 +113,11 @@ dependencies {
     // noinspection GradleDynamicVersion
     testImplementation 'com.facebook.react:react-native:+'
     testImplementation 'org.json:json:20140107'
-    testImplementation 'junit:junit:4.13'
+
+// https://github.com/spekframework/spek/issues/232#issuecomment-610732158
+//    testImplementation 'junit:junit:4.13.2'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.6.0'
+
     testImplementation 'org.assertj:assertj-core:3.16.1'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$_kotlinVersion"
     testImplementation 'org.apache.commons:commons-io:1.3.2'
@@ -131,7 +135,7 @@ if (rootProject.hasProperty('isOfficialDetoxLib') ||
             junitPlatform {
                 filters {
                     engines {
-                        include 'spek2'
+                        include 'spek2', 'junit-vintage'
                     }
                 }
             }
@@ -139,8 +143,8 @@ if (rootProject.hasProperty('isOfficialDetoxLib') ||
     }
 
     dependencies {
-        testImplementation 'org.spekframework.spek2:spek-dsl-jvm:2.0.12'
-        testImplementation 'org.spekframework.spek2:spek-runner-junit5:2.0.12'
+        testImplementation 'org.spekframework.spek2:spek-dsl-jvm:2.0.15'
+        testImplementation 'org.spekframework.spek2:spek-runner-junit5:2.0.15'
         testImplementation "org.jetbrains.kotlin:kotlin-reflect:$_kotlinVersion"
     }
 }

--- a/detox/android/detox/src/testFull/java/com/wix/detox/common/proxy/MethodsSpySpec.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/common/proxy/MethodsSpySpec.kt
@@ -5,7 +5,7 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.util.*
 
-class MethodsSpySpec: Spek({
+object MethodsSpySpec: Spek({
     describe("Method-calls spy") {
 
         val defaultMethodName = "mockMethod"


### PR DESCRIPTION
## Description

Apparently, non-Spek unit tests (Android) were not executed by gradle (e.g. in commands such as `./gradle testFullReleaseUnitTest`).

See https://github.com/spekframework/spek/issues/232#issuecomment-610732158
