### PR TITLE
Improve mocking guide instructions

### DIFF
--- a/docs/Guide.Mocking.md
+++ b/docs/Guide.Mocking.md
@@ -23,7 +23,11 @@ This replacement mechanism provides a lot of flexibility to change implementatio
 
 #### Configuration
 0. For RN < 0.55, setup `react-native-repackager` in your library.
-1. For case 0.55 <= RN < 0.59 create a file called `rn-cli.config.js` in the root folder. If you use RN >= 0.59 (which in turn uses Metro with breaking changes introduced in 0.43 - https://github.com/facebook/metro/releases/tag/v0.43.0) file should have name `metro.config.js` or `metro.config.json` (or define metro field in `package.json`) to root dir. Then set up `resolver.sourceExts` to prioritize any given source extension over the default one:
+1. Configure the metro bundler to use the extensions defined by `RN_SRC_EXT`:
+   - If you use 0.55 <= RN < 0.59, create a file called `rn-cli.config.js` in the root folder. 
+   - If you use RN >= 0.59 (which in turn uses Metro with breaking changes introduced in [0.43](https://github.com/facebook/metro/releases/tag/v0.43.0)) the file should be named `metro.config.js` or `metro.config.json` (or define metro field in `package.json`) to root dir. 
+   
+   Then set up `resolver.sourceExts` to prioritize any given source extension over the default one:
 
     ```js
     const defaultSourceExts = require('metro-config/src/defaults/defaults').sourceExts


### PR DESCRIPTION
## Description

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have improved the mocking guide slightly. Due to the way it was previously worded, I completely skipped step 1 as I assumed it was not relevant for me as I am using a modern version of RN. Had I read step 1 in more detail, I would have seen that I needed to follow this step. This change makes the instructions easier to consume to prevent confusion over the RN versions.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
