### PR TITLE
Remove 'iOS only's from CLI associated with workers arg

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -73,7 +73,7 @@ module.exports.middlewares = [
 function choosePrepareArgs({ cliConfig, detoxArgs, runner }) {
   if (runner === 'mocha') {
     if (hasMultipleWorkers(cliConfig)) {
-      log.warn('Cannot use -w, --workers. Parallel test execution is only supported with iOS and Jest');
+      log.warn('Cannot use -w, --workers. Parallel test execution is only supported with Jest');
     }
 
     if (detoxArgs.retries > 0) {

--- a/detox/local-cli/utils/testCommandArgs.js
+++ b/detox/local-cli/utils/testCommandArgs.js
@@ -104,8 +104,7 @@ module.exports = {
   w: {
     alias: 'workers',
     group: 'Execution:',
-    describe:
-      '[iOS Only] Specifies the number of workers the test runner should spawn, requires a test runner with parallel execution support (Detox CLI currently supports Jest)',
+    describe: 'Specifies the number of workers the test runner should spawn. Requires a test runner with parallel execution support (e.g. Jest)',
     number: true,
     default: 1,
   },


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request fixes #2729 

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have updated the messages produced by the CLI with respect to usage of `--workers` such that it would not show an iOS-only constraint.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
