### PR TITLE
Get test-butler from maven-central, upgrade to v2.2.1

### DIFF
--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -97,8 +97,8 @@ dependencies {
     implementation project(':react-native-webview')
 
     androidTestImplementation(project(path: ':detox'))
-    androidTestImplementation 'com.linkedin.testbutler:test-butler-library:2.1.0'
-    androidTestUtil 'com.linkedin.testbutler:test-butler-app:2.1.0'
+    androidTestImplementation 'com.linkedin.testbutler:test-butler-library:2.2.1'
+    androidTestUtil 'com.linkedin.testbutler:test-butler-app:2.2.1'
 }
 
 if (rnInfo.isRN60OrHigher) {

--- a/detox/test/e2e/global-setup.js
+++ b/detox/test/e2e/global-setup.js
@@ -8,12 +8,12 @@ function resolveSelectedConfiguration() {
 }
 
 function downloadTestButlerAPKIfNeeded() {
-  const version = '2.1.0';
-  const artifactUrl = `https://linkedin.bintray.com/maven/com/linkedin/testbutler/test-butler-app/${version}/test-butler-app-${version}.apk`;
-  const filePath = './cache/test-butler-app.apk';
+  const version = '2.2.1';
+  const artifactUrl = `https://repo1.maven.org/maven2/com/linkedin/testbutler/test-butler-app/${version}/test-butler-app-${version}.apk`;
+  const filePath = `./cache/test-butler-app.apk`;
   fs.ensureDirSync('./cache');
   if (!fs.existsSync(filePath)) {
-    console.log('\nDownloading Test-Butler APK...');
+    console.log(`\nDownloading Test-Butler APK v${version}...`);
     execSync(`curl -f -o ${filePath} ${artifactUrl}`);
   }
 }


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #2734

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have made the test-butler util-APK dynamic downloading take place from maven-central instead of bintray.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
