### PR TITLE
Increase concurrent simulators count on CI

### DIFF
--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -12,7 +12,7 @@
     "packager": "react-native start",
     "detox-server": "detox run-server",
     "e2e:ios": "detox test -c ios.sim.release",
-    "e2e:ios-ci": "npm run e2e:ios -- --workers 3 --retries 1",
+    "e2e:ios-ci": "npm run e2e:ios -- --workers 4 --retries 1 -l verbose",
     "e2e:android": "detox test -c android.emu.release",
     "e2e:android-ci-genycloud": "detox test -c android.genycloud.release --workers 5 --retries 1 --jest-report-specs --loglevel verbose",
     "e2e:android-ci-google": "detox test -c android.emu.release --workers 3 --retries 1 --jest-report-specs --loglevel verbose --headless",


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request closes #2749.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have increased the number of concurrent simulators running on our internal CI (Detox' self-test app) from 3 to 4.

This comes after some research, which has empirically showed the following:
- With 3 workers, total tests exec time is 7-7.5min
- With 4 workers, total tests exec time decreases to ~6:40
- With more than 4 workers (even just 5), the total tests exec time increases back up.

The original intent was to try to elevate the new tech introduced in DetoxSync, which should allow for this kind of an improvement.

The intermediate conclusion from this, I therefore believe, is that the benefits of DetoxSync's asynchronousity only shine when the executing machine is powerful enough. Of course, this is premature - we will have to revisit when more powerful agents are available internally at Wix.

Regardless, we could perhaps consider whether we could reorganize our e2e suites such that they would more efficiently run in a highly parallel env.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
