### PR TITLE
Reorganize roles in Emu delegates to match cleanup vs. shutdown

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -105,7 +105,7 @@
       "src/devices/drivers/DeviceDriverBase.js",
       "src/devices/drivers/android/AndroidDriver.js",
       "src/devices/drivers/android/emulator/EmulatorDriver.js",
-      "src/devices/drivers/android/emulator/EmulatorLauncher.js",
+      "src/devices/drivers/android/emulator/helpers/EmulatorLauncher.js",
       "src/devices/drivers/android/exec/AAPT.js",
       "src/devices/drivers/android/exec/ADB.js",
       "src/devices/drivers/android/exec/EmulatorExec.js",

--- a/detox/src/devices/drivers/android/AndroidDeviceAllocation.js
+++ b/detox/src/devices/drivers/android/AndroidDeviceAllocation.js
@@ -18,14 +18,6 @@ class AndroidDeviceAllocation {
   async _notifyAllocation(deviceId, type, isNew) {
     return this._eventEmitter.emit('bootDevice', { coldBoot: isNew, deviceId, type, });
   }
-
-  async _notifyPreDeallocation(deviceId) {
-    return this._eventEmitter.emit('beforeShutdownDevice', { deviceId });
-  }
-
-  async _notifyDeallocationCompleted(deviceId) {
-    return this._eventEmitter.emit('shutdownDevice', { deviceId });
-  }
 }
 
 AndroidDeviceAllocation.ALLOCATE_DEVICE_LOG_EVT = ALLOCATE_DEVICE_LOG_EVT;

--- a/detox/src/devices/drivers/android/AndroidDeviceLauncher.js
+++ b/detox/src/devices/drivers/android/AndroidDeviceLauncher.js
@@ -1,0 +1,15 @@
+class AndroidDeviceLauncher {
+  constructor(eventEmitter) {
+    this._eventEmitter = eventEmitter;
+  }
+
+  async _notifyPreShutdown(deviceId) {
+    return this._eventEmitter.emit('beforeShutdownDevice', { deviceId });
+  }
+
+  async _notifyShutdownCompleted(deviceId) {
+    return this._eventEmitter.emit('shutdownDevice', { deviceId });
+  }
+}
+
+module.exports = AndroidDeviceLauncher;

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorDeviceAllocation.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorDeviceAllocation.js
@@ -1,7 +1,5 @@
-const _ = require('lodash');
 const AndroidDeviceAllocation  = require('../../AndroidDeviceAllocation');
 const DetoxRuntimeError = require('../../../../../errors/DetoxRuntimeError');
-const EmulatorTelnet = require('../../tools/EmulatorTelnet');
 const logger = require('../../../../../utils/logger').child({ __filename });
 const retry = require('../../../../../utils/retry');
 const { traceCall } = require('../../../../../utils/trace');
@@ -12,13 +10,13 @@ const DetoxEmulatorsPortRange = {
 };
 
 class EmulatorDeviceAllocation extends AndroidDeviceAllocation {
-  constructor(deviceRegistry, freeDeviceFinder, emulatorLauncher, adb, eventEmitter, telnetGeneratorFn = () => new EmulatorTelnet(), rand = Math.random) {
+
+  constructor(deviceRegistry, freeDeviceFinder, emulatorLauncher, adb, eventEmitter, rand = Math.random) {
     super(deviceRegistry, eventEmitter, logger);
     this._freeDeviceFinder = freeDeviceFinder;
     this._emulatorLauncher = emulatorLauncher;
     this._adb = adb;
     this._rand = rand;
-    this._telnetGeneratorFn = telnetGeneratorFn;
   }
 
   async allocateDevice(avdName) {
@@ -39,12 +37,7 @@ class EmulatorDeviceAllocation extends AndroidDeviceAllocation {
   }
 
   async deallocateDevice(adbName) {
-    await this._notifyPreDeallocation(adbName);
-    const port = _.split(adbName, '-')[1];
-    const telnet = this._telnetGeneratorFn();
-    await telnet.connect(port);
-    await telnet.kill();
-    await this._notifyDeallocationCompleted(adbName);
+    await this._deviceRegistry.disposeDevice(adbName);
   }
 
   async _doSynchronizedAllocation(avdName) {

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.js
@@ -1,15 +1,18 @@
 const _ = require('lodash');
 const fs = require('fs');
 const Tail = require('tail').Tail;
-const { LaunchCommand } = require('../exec/EmulatorExec');
-const unitLogger = require('../../../../utils/logger').child({ __filename });
-const retry = require('../../../../utils/retry');
+const EmulatorTelnet = require('../../tools/EmulatorTelnet');
+const { LaunchCommand } = require('../../exec/EmulatorExec');
+const unitLogger = require('../../../../../utils/logger').child({ __filename });
+const retry = require('../../../../../utils/retry');
 
 const isUnknownEmulatorError = (err) => (err.message || '').includes('failed with code null');
 
 class EmulatorLauncher {
-  constructor(emulatorExec) {
+  constructor(emulatorExec, eventEmitter, telnetGeneratorFn = () => new EmulatorTelnet()) {
     this._emulatorExec = emulatorExec;
+    this._eventEmitter = eventEmitter;
+    this._telnetGeneratorFn = telnetGeneratorFn;
   }
 
   async launch(emulatorName, options = {port: undefined}) {
@@ -20,6 +23,15 @@ class EmulatorLauncher {
       interval: 100,
       conditionFn: isUnknownEmulatorError,
     }, () => this._launchEmulator(emulatorName, launchCommand));
+  }
+
+  async shutdown(adbName) {
+    await this._notifyPreShutdown(adbName);
+    const port = _.split(adbName, '-')[1];
+    const telnet = this._telnetGeneratorFn();
+    await telnet.connect(port);
+    await telnet.kill();
+    await this._notifyShutdownCompleted(adbName);
   }
 
   _launchEmulator(emulatorName, launchCommand) {
@@ -75,6 +87,14 @@ class EmulatorLauncher {
       log.debug({ event: 'SPAWN_SUCCESS', stdout: true }, childProcessOutput);
       return coldBoot;
     });
+  }
+
+  async _notifyPreShutdown(deviceId) {
+    return this._eventEmitter.emit('beforeShutdownDevice', { deviceId });
+  }
+
+  async _notifyShutdownCompleted(deviceId) {
+    return this._eventEmitter.emit('shutdownDevice', { deviceId });
   }
 }
 

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const fs = require('fs');
 const Tail = require('tail').Tail;
+const AndroidDeviceLauncher = require('../../AndroidDeviceLauncher');
 const EmulatorTelnet = require('../../tools/EmulatorTelnet');
 const { LaunchCommand } = require('../../exec/EmulatorExec');
 const unitLogger = require('../../../../../utils/logger').child({ __filename });
@@ -8,10 +9,10 @@ const retry = require('../../../../../utils/retry');
 
 const isUnknownEmulatorError = (err) => (err.message || '').includes('failed with code null');
 
-class EmulatorLauncher {
+class EmulatorLauncher extends AndroidDeviceLauncher {
   constructor(emulatorExec, eventEmitter, telnetGeneratorFn = () => new EmulatorTelnet()) {
+    super(eventEmitter);
     this._emulatorExec = emulatorExec;
-    this._eventEmitter = eventEmitter;
     this._telnetGeneratorFn = telnetGeneratorFn;
   }
 
@@ -87,14 +88,6 @@ class EmulatorLauncher {
       log.debug({ event: 'SPAWN_SUCCESS', stdout: true }, childProcessOutput);
       return coldBoot;
     });
-  }
-
-  async _notifyPreShutdown(deviceId) {
-    return this._eventEmitter.emit('beforeShutdownDevice', { deviceId });
-  }
-
-  async _notifyShutdownCompleted(deviceId) {
-    return this._eventEmitter.emit('shutdownDevice', { deviceId });
   }
 }
 

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
@@ -39,7 +39,7 @@ describe('Emulator launcher', () => {
     // TODO
   });
 
-  describe('teardown', () => {
+  describe('shutdown', () => {
     it('should kill device via telnet', async () => {
       await uut.shutdown(adbName);
 

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
@@ -1,0 +1,77 @@
+const adbName = 'mock_adb_name-1117';
+const avdName = 'mock-AVD-name';
+
+describe('Emulator launcher', () => {
+
+  let logger;
+  let retry;
+  let eventEmitter;
+  let emulatorTelnet;
+  let emulatorExec;
+  let uut;
+  beforeEach(() => {
+    jest.mock('../../../../../utils/logger');
+    logger = require('../../../../../utils/logger');
+
+    jest.mock('../../../../../utils/retry');
+    retry = require('../../../../../utils/retry');
+    retry.mockImplementation((options, func) => func());
+
+    jest.mock('../../../../../utils/trace', () => ({
+      traceCall: jest.fn().mockImplementation((__, func) => func()),
+    }));
+
+    const AsyncEmitter = jest.genMockFromModule('../../../../..//utils/AsyncEmitter');
+    eventEmitter = new AsyncEmitter();
+
+    const EmulatorTelnet = jest.genMockFromModule('../../tools/EmulatorTelnet');
+    emulatorTelnet = new EmulatorTelnet();
+    jest.mock('../../tools/EmulatorTelnet');
+
+    const { EmulatorExec } = jest.genMockFromModule('../../exec/EmulatorExec');
+    emulatorExec = new EmulatorExec();
+
+    const EmulatorLauncher = require('./EmulatorLauncher');
+    uut = new EmulatorLauncher(emulatorExec, eventEmitter, () => emulatorTelnet);
+  });
+
+  describe('launch', () => {
+    // TODO
+  });
+
+  describe('teardown', () => {
+    it('should kill device via telnet', async () => {
+      await uut.shutdown(adbName);
+
+      expect(emulatorTelnet.connect).toHaveBeenCalledWith('1117');
+      expect(emulatorTelnet.kill).toHaveBeenCalled();
+    });
+
+    it('should emit associated events', async () => {
+      await uut.shutdown(adbName);
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith('beforeShutdownDevice', { deviceId: adbName });
+      expect(eventEmitter.emit).toHaveBeenCalledWith('shutdownDevice', { deviceId: adbName });
+    });
+
+    it('should not emit shutdownDevice prematurely', async () => {
+      emulatorTelnet.kill.mockRejectedValue(new Error());
+
+      try {
+        await uut.shutdown(adbName);
+      } catch (e) {
+        expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+        expect(eventEmitter.emit).not.toHaveBeenCalledWith('shutdownDevice', expect.any(Object));
+        return;
+      }
+      throw new Error('Expected an error');
+    });
+
+    it('should resort to a default telnet generator func', async () => {
+      const EmulatorLauncher = require('./EmulatorLauncher');
+      uut = new EmulatorLauncher(emulatorExec, eventEmitter);
+
+      await uut.shutdown(adbName);
+    });
+  });
+});

--- a/detox/src/devices/drivers/android/genycloud/helpers/GenyCloudInstanceLauncher.js
+++ b/detox/src/devices/drivers/android/genycloud/helpers/GenyCloudInstanceLauncher.js
@@ -1,0 +1,36 @@
+const AndroidDeviceLauncher = require('../../AndroidDeviceLauncher');
+const GenyCloudInstanceHandle = require('../GenyCloudInstanceHandle');
+
+class GenyCloudInstanceLauncher extends AndroidDeviceLauncher {
+  constructor(instanceLifecycleService, deviceCleanupRegistry, eventEmitter) {
+    super(eventEmitter);
+    this._instanceLifecycleService = instanceLifecycleService;
+    this._deviceCleanupRegistry = deviceCleanupRegistry;
+  }
+
+  /**
+   * Note:
+   * In the context of Genymotion-cloud (as opposed to local emulators), the "launching"
+   * effectively only boils down to book-keeping associated with it, rather than the
+   * launch itself. That it because the actual launching (creation) of it is done in a synchronized,
+   * isolated means beforehand.
+   *
+   * @param instance {GenyInstance} The freshly allocated cloud-instance.
+   * @returns {Promise<void>}
+   */
+  async launch(instance) {
+    const instanceHandle = new GenyCloudInstanceHandle(instance);
+    await this._deviceCleanupRegistry.allocateDevice(instanceHandle);
+  }
+
+  async shutdown(instance) {
+    const instanceHandle = new GenyCloudInstanceHandle(instance);
+
+    await this._notifyPreShutdown(instance.adbName);
+    await this._instanceLifecycleService.deleteInstance(instance.uuid);
+    await this._deviceCleanupRegistry.disposeDevice(instanceHandle);
+    await this._notifyShutdownCompleted(instance.adbName);
+  }
+}
+
+module.exports = GenyCloudInstanceLauncher;

--- a/detox/src/devices/drivers/android/genycloud/helpers/GenyCloudInstanceLauncher.test.js
+++ b/detox/src/devices/drivers/android/genycloud/helpers/GenyCloudInstanceLauncher.test.js
@@ -1,0 +1,90 @@
+describe('Genymotion-Cloud instance launcher', () => {
+  const anInstance = () => {
+    const instance = new GenyInstance();
+    instance.uuid = 'mock-instance-uuid';
+    instance.name = 'mock-instance-name';
+    return instance;
+  }
+
+  const givenAnInstanceDeletionError = () => instanceLifecycleService.deleteInstance.mockRejectedValue(new Error());
+
+  let eventEmitter;
+  let deviceCleanupRegistry;
+  let instanceLifecycleService;
+  let GenyInstance;
+  let uut;
+  beforeEach(() => {
+    const AsyncEmitter = jest.genMockFromModule('../../../../../utils/AsyncEmitter');
+    eventEmitter = new AsyncEmitter();
+
+    const InstanceLifecycleService = jest.genMockFromModule('../services/GenyInstanceLifecycleService');
+    instanceLifecycleService = new InstanceLifecycleService();
+
+    const DeviceRegistry = jest.genMockFromModule('../../../../../devices/DeviceRegistry');
+    deviceCleanupRegistry = new DeviceRegistry();
+
+    GenyInstance = jest.genMockFromModule('../services/dto/GenyInstance');
+
+    const GenyCloudInstanceLauncher = require('./GenyCloudInstanceLauncher');
+    uut = new GenyCloudInstanceLauncher(instanceLifecycleService, deviceCleanupRegistry, eventEmitter);
+  });
+
+  describe('Launch', () => {
+    it('should register device in cleanup registry', async () => {
+      const instance = anInstance();
+
+      await uut.launch(instance);
+      expect(deviceCleanupRegistry.allocateDevice).toHaveBeenCalledWith({
+        uuid: instance.uuid,
+        name: instance.name,
+      })
+    });
+  });
+
+  describe('Shutdown', () => {
+    it('should delete the associated instance', async () => {
+      const instance = anInstance();
+      await uut.shutdown(instance);
+      expect(instanceLifecycleService.deleteInstance).toHaveBeenCalledWith(instance.uuid);
+    });
+
+    it('should fail if deletion fails', async () => {
+      givenAnInstanceDeletionError();
+
+      try {
+        const instance = anInstance();
+        await uut.shutdown(instance);
+        fail('Expected an error');
+      } catch (e) {}
+    });
+
+    it('should remove the instance from the cleanup registry', async () => {
+      const instance = anInstance();
+      await uut.shutdown(instance);
+      expect(deviceCleanupRegistry.disposeDevice).toHaveBeenCalledWith(expect.objectContaining({
+        uuid: instance.uuid,
+      }));
+    });
+
+    it('should emit associated events', async () => {
+      const instance = anInstance();
+      await uut.shutdown(instance);
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith('beforeShutdownDevice', { deviceId: instance.adbName });
+      expect(eventEmitter.emit).toHaveBeenCalledWith('shutdownDevice', { deviceId: instance.adbName });
+    });
+
+    it('should not emit shutdownDevice prematurely', async () => {
+      givenAnInstanceDeletionError();
+
+      try {
+        const instance = anInstance();
+        await uut.shutdown(instance);
+        fail('Expected an error');
+      } catch (e) {}
+
+      expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+      expect(eventEmitter.emit).not.toHaveBeenCalledWith('shutdownDevice', expect.any(Object));
+    });
+  });
+});


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

I've found this while working on redefining the concept of a `DeviceId` throughout our JS framework, as a tech debt left from the work on Genymotion (see #2655):

In the context of Android drivers, the terms 'cleanup' and 'shutdown' were (semantically) wrongly interpreted inside the related delegate (i.e. `EmulatorDeviceAllocation` class). While the implementation was correct, the associated code was simply misplaced inside it.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have reorganized `EmulatorDeviceAllocation` such that the code inside `deallocateDevice()` would in fact simply have it removed from the device registry, instead of shutting it down altogether. The latter was relocated onto a new method in an existing class: `EmulatorLauncher.shutdown()`.

UPDATE: I've done the same for Genymotion.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
