### PR TITLE
fix(detox-cli): infinite loop if locally installed

### DIFF
--- a/detox-cli/cli.js
+++ b/detox-cli/cli.js
@@ -2,9 +2,27 @@
 const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const chalk = require('chalk');
+const isInstalledGlobally = require('is-installed-globally');
+
+/**
+ * @param {string} msg
+ */
+function log(msg) {
+  console.error(chalk.red(msg));
+}
 
 function main([_$0, _detox, ...cliArgs]) {
   const [command] = cliArgs;
+
+  if (!isInstalledGlobally) {
+    log('Error: "detox-cli" package is not meant to be installed locally, exiting...');
+    log('HINT: Remove the local installation and reinstall it globally:');
+    log('  npm uninstall detox-cli');
+    log('  npm install -g detox-cli\n');
+
+    return 1;
+  }
 
   if (command === 'recorder' && process.platform === 'darwin') {
     return spawnRecorder(cliArgs);
@@ -19,11 +37,11 @@ function spawnDetoxBinary(cliArgs) {
   const binaryPath = path.join(nodeBinariesPath, `detox${isWin32 ? '.cmd' : ''}`);
 
   if (!fs.existsSync(binaryPath)) {
-    console.log(`Failed to find Detox executable at path: ${binaryPath}`);
-    console.log(`\nPossible solutions:`);
-    console.log(`1. Make sure your current working directory is correct.`);
-    console.log(`2. Run "npm install" to ensure your "node_modules" directory is up-to-date.`);
-    console.log(`3. Run "npm install detox --save-dev" for the fresh Detox installation in your project.\n`);
+    log(`Failed to find Detox executable at path: ${binaryPath}`);
+    log(`\nPossible solutions:`);
+    log(`1. Make sure your current working directory is correct.`);
+    log(`2. Run "npm install" to ensure your "node_modules" directory is up-to-date.`);
+    log(`3. Run "npm install detox --save-dev" for the fresh Detox installation in your project.\n`);
 
     return 1;
   }
@@ -49,13 +67,13 @@ function spawnRecorder([_recorder, ...recorderArgs]) {
   const detoxRecorderPath = path.join(process.cwd(), 'node_modules/detox-recorder');
   const detoxRecorderCLIPath = path.join(detoxRecorderPath, 'DetoxRecorderCLI');
 
-  if (fs.existsSync(detoxRecorderCLIPath)) {
-    const result = cp.spawnSync(detoxRecorderCLIPath, recorderArgs, { stdio: 'inherit' });
-    return result.status;
-  } else {
-    console.log(`Detox Recorder is not installed in this directory: ${detoxRecorderPath}`);
+  if (!fs.existsSync(detoxRecorderCLIPath)) {
+    log(`Detox Recorder is not installed in this directory: ${detoxRecorderPath}`);
     return 1;
   }
+
+  const result = cp.spawnSync(detoxRecorderCLIPath, recorderArgs, { stdio: 'inherit' });
+  return result.status;
 }
 
 function findPathKey() {

--- a/detox-cli/package.json
+++ b/detox-cli/package.json
@@ -1,8 +1,8 @@
 {
   "name": "detox-cli",
   "version": "18.0.0",
-  "description": "detox CLI tool wrapper",
-  "main": "index.js",
+  "description": "Optional wrapper for Detox CLI, meant to be installed globally",
+  "main": "cli.js",
   "scripts": {
     "test": ":"
   },
@@ -17,20 +17,14 @@
     "detox",
     "cli"
   ],
-  "author": "Rotem Mizrachi Meidan <rotemm@wix.com>",
+  "author": "Yaroslav Serhieiev <yaroslavs@wix.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/wix/detox/issues"
+    "url": "https://github.com/wix/Detox/issues"
   },
   "dependencies": {
-    "commander": "^2.9.0",
-    "minimist": "^1.2.0"
+    "chalk": "^4.0.0",
+    "is-installed-globally": "^0.4.0"
   },
-  "devDependencies": {
-    "jest": "*"
-  },
-  "homepage": "https://github.com/wix/detox#readme",
-  "jest": {
-    "verbose": true
-  }
+  "homepage": "https://github.com/wix/Detox"
 }

--- a/detox/package.json
+++ b/detox/package.json
@@ -58,6 +58,7 @@
     "proper-lockfile": "^3.0.2",
     "resolve-from": "^5.0.0",
     "sanitize-filename": "^1.6.1",
+    "semver": "^7.0.0",
     "serialize-error": "^8.0.1",
     "shell-quote": "^1.7.2",
     "signal-exit": "^3.0.3",

--- a/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.js
@@ -1,4 +1,4 @@
-const semver = require('semver'); // eslint-disable-line node/no-extraneous-require
+const semver = require('semver');
 const onSignalExit = require('signal-exit');
 const AndroidDriver = require('../AndroidDriver');
 const InstanceLauncher = require('./helpers/GenyCloudInstanceLauncher');


### PR DESCRIPTION
## Description

- This pull request resolves the issue described here: https://github.com/wix/Detox/issues/2750

In this pull request, I have:

* added an emergency exit when `detox-cli` detects itself running in a non-global mode:
  ![image](https://user-images.githubusercontent.com/1962469/117266463-f628e980-ae5d-11eb-8bce-b1c2144c762b.png)

* made all the error messages red (with `chalk`):
  ![image](https://user-images.githubusercontent.com/1962469/117266610-1789d580-ae5e-11eb-8d19-498f99a454bd.png)
  ![image](https://user-images.githubusercontent.com/1962469/117266681-2e302c80-ae5e-11eb-8ad4-36d12e512e49.png)

* fixed `semver` npm resolution issue on a bare project with Detox installed
  ![image](https://user-images.githubusercontent.com/1962469/117266772-430cc000-ae5e-11eb-9da0-21debd9d6b42.png)

* updated `detox-cli/package.json` with the up-to-date information and purged unused dependencies (`commander`, `minimist`, etc...)
