### PR TITLE
Lock react-native-webview's verison in test-proj, temporarily

### DIFF
--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -32,7 +32,7 @@
     "moment": "^2.24.0",
     "react": "16.11.x",
     "react-native": "0.62.x",
-    "react-native-webview": "^11.2.3"
+    "react-native-webview": "11.4.4"
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",


### PR DESCRIPTION
## Description

In this pull request, I have temporarily changed the demo-app's `react-native-webview` dependency specs to use version `11.4.4` specifically, due to recent build-breaking changes introduced in one of the [newer version](https://github.com/react-native-webview/react-native-webview/releases) (Versions `11.4.5`, and then `11.4.6` through `11.6.1` seemed to have been released in approximately the same recent time frame, and they are all broken. `11.4.6` Seems to be the particular culprit, at a glance, comparing with the error details).

The build error is as follows:
```
14:44:14 > Task :react-native-webview:compileReleaseJavaWithJavac FAILED
14:44:14 /home/jenkins/.jenkins/workspace/detox-android-63-x-master/detox/test/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java:119: error: RNCWebViewManager is not abstract and does not override abstract method createViewInstance(ThemedReactContext) in ViewManager
14:44:14 public class RNCWebViewManager extends SimpleViewManager<WebView> {
14:44:14        ^
14:44:14 /home/jenkins/.jenkins/workspace/detox-android-63-x-master/detox/test/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java:172: error: method does not override or implement a method from a supertype
14:44:14   @Override
14:44:14   ^
14:44:14 /home/jenkins/.jenkins/workspace/detox-android-63-x-master/detox/test/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java:590: error: method does not override or implement a method from a supertype
14:44:14   @Override
14:44:14   ^
14:44:14 Note: Some input files use or override a deprecated API.
14:44:14 Note: Recompile with -Xlint:deprecation for details.
14:44:14 Note: /home/jenkins/.jenkins/workspace/detox-android-63-x-master/detox/test/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java uses unchecked or unsafe operations.
14:44:14 Note: Recompile with -Xlint:unchecked for details.
14:44:14 3 errors
14:44:14 
14:44:14 > Task :detox:bundleLibCompileFullRelease
14:44:14 > Task :app:processFromBinReleaseAndroidTestResources
14:44:14 > Task :detox:bundleLibRuntimeFullRelease
14:44:14 
14:44:14 FAILURE: Build failed with an exception.
```

Hopefully, the recent mass version releasing in `react-native-webview` suggest that they aware that something could be wrong. We will revisit this soon in #2791, or either find this is fixable indirectly during our upcoming upgrade to RN 64.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
