### PR TITLE
hotfix(detox-cli): do not check -g on win32

### DIFF
--- a/detox-cli/cli.js
+++ b/detox-cli/cli.js
@@ -15,7 +15,7 @@ function log(msg) {
 function main([_$0, _detox, ...cliArgs]) {
   const [command] = cliArgs;
 
-  if (!isInstalledGlobally) {
+  if (process.platform !== 'win32' && !isInstalledGlobally) {
     log('Error: "detox-cli" package is not meant to be installed locally, exiting...');
     log('HINT: Remove the local installation and reinstall it globally:');
     log('  npm uninstall detox-cli');


### PR DESCRIPTION
## Description

Resolves #2789 in a hotfix fashion (to unblock people).

Ultimately requires a fix inside [global-dirs](https://github.com/sindresorhus/global-dirs) packages for Windows 10 and modern Node.js 14. @sindresorhus, we are coming to you with an issue.