### PR TITLE
fix(config): better detection of app/apps errors

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -190,6 +190,8 @@ declare global {
             build?: string;
             testBinaryPath?: string;
             launchArgs?: Record<string, any>;
+            app?: never;
+            apps?: never;
         }
 
         type DetoxBuiltInDeviceConfig =

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -190,8 +190,6 @@ declare global {
             build?: string;
             testBinaryPath?: string;
             launchArgs?: Record<string, any>;
-            app?: never;
-            apps?: never;
         }
 
         type DetoxBuiltInDeviceConfig =

--- a/detox/src/configuration/composeAppsConfig.js
+++ b/detox/src/configuration/composeAppsConfig.js
@@ -39,6 +39,10 @@ function composeAppsConfig(opts) {
 function composeAppsConfigFromPlain(opts) {
   const { errorComposer, localConfig } = opts;
 
+  if (localConfig.app || localConfig.apps) {
+    throw errorComposer.oldSchemaHasAppAndApps();
+  }
+
   /** @type {Detox.DetoxAppConfig} */
   let appConfig;
 

--- a/detox/src/configuration/composeAppsConfig.test.js
+++ b/detox/src/configuration/composeAppsConfig.test.js
@@ -237,6 +237,31 @@ describe('composeAppsConfig', () => {
   });
 
   describe('unhappy scenarios:', () => {
+    describe('plain configuration:', () => {
+      beforeEach(() => {
+        localConfig = {
+          type: 'ios.simulator',
+          device: 'Phone',
+          binaryPath: 'path/to/app',
+          bundleId: 'com.example.app',
+          build: 'echo OK',
+          launchArgs: {
+            hello: 'world',
+          }
+        };
+      });
+
+      it('should throw if the config has .app property defined', () => {
+        localConfig.app = 'myapp';
+        expect(compose).toThrowError(errorComposer.oldSchemaHasAppAndApps());
+      });
+
+      it('should throw if the config has .apps property defined', () => {
+        localConfig.apps = ['myapp'];
+        expect(compose).toThrowError(errorComposer.oldSchemaHasAppAndApps());
+      });
+    });
+
     describe('aliased configuration:', () => {
       beforeEach(() => {
         globalConfig.apps = {

--- a/detox/src/errors/DetoxConfigErrorComposer.js
+++ b/detox/src/errors/DetoxConfigErrorComposer.js
@@ -23,6 +23,15 @@ class DetoxConfigErrorComposer {
     return this.filepath ? ` at path:\n${this.filepath}` : '.';
   }
 
+  _inTheAppConfig() {
+    const { type } = this._getSelectedConfiguration();
+    if (type) {
+      return `in configuration ${J(this.configurationName)}`;
+    }
+
+    return `in the app config`;
+  }
+
   _getSelectedConfiguration() {
     return _.get(this.contents, ['configurations', this.configurationName]);
   }
@@ -380,7 +389,7 @@ Examine your Detox config${this._atPath()}`,
 
   malformedAppLaunchArgs(appPath) {
     return new DetoxConfigError({
-      message: `Invalid type of "launchArgs" property in the app config.\nExpected an object:`,
+      message: `Invalid type of "launchArgs" property ${this._inTheAppConfig()}.\nExpected an object:`,
       debugInfo: this._focusOnAppConfig(appPath),
       inspectOptions: { depth: 4 },
     });
@@ -388,7 +397,7 @@ Examine your Detox config${this._atPath()}`,
 
   missingAppBinaryPath(appPath) {
     return new DetoxConfigError({
-      message: `Missing "binaryPath" property in the app config.\nExpected a string:`,
+      message: `Missing "binaryPath" property ${this._inTheAppConfig()}.\nExpected a string:`,
       debugInfo: this._focusOnAppConfig(appPath, this._ensureProperty('binaryPath')),
       inspectOptions: { depth: 4 },
     });
@@ -459,6 +468,18 @@ Examine your Detox config${this._atPath()}`,
 Examine your Detox config${this._atPath()}`,
       debugInfo: this._focusOnConfiguration(),
       inspectOptions: { depth: 0 }
+    });
+  }
+
+  oldSchemaHasAppAndApps() {
+    return new DetoxConfigError({
+      message: `Your configuration ${J(this.configurationName)} appears to be in a legacy format, which can’t contain "app" or "apps".`,
+      hint: `Remove "type" property from configuration and use "device" property instead:\n` +
+        `a) "device": { "type": ${J(this._getSelectedConfiguration().type)}, ... }\n` +
+        `b) "device": "<alias-to-device>" // you should add that device configuration to "devices" with the same key` +
+        `\n\nCheck your Detox config${this._atPath()}`,
+      debugInfo: this._focusOnConfiguration(this._ensureProperty('type', 'device')),
+      inspectOptions: { depth: 2 },
     });
   }
 

--- a/detox/src/errors/DetoxConfigErrorComposer.test.js
+++ b/detox/src/errors/DetoxConfigErrorComposer.test.js
@@ -478,6 +478,19 @@ describe('DetoxConfigErrorComposer', () => {
       });
     });
 
+    describe('.oldSchemaHasAppAndApps', () => {
+      beforeEach(() => {
+        build = () => builder.oldSchemaHasAppAndApps();
+      });
+
+      it('should create an error for ambigous old/new configuration if it has .apps', () => {
+        builder.setConfigurationName('plain');
+        config.configurations.plain.app = 'my-app';
+
+        expect(build()).toMatchSnapshot();
+      });
+    });
+
     describe('.ambiguousAppAndApps', () => {
       beforeEach(() => {
         build = () => builder.ambiguousAppAndApps();

--- a/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
+++ b/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
@@ -268,7 +268,7 @@ Expected an object:
 `;
 
 exports[`DetoxConfigErrorComposer (from composeAppsConfig) .malformedAppLaunchArgs should work with plain configurations 1`] = `
-[DetoxConfigError: Invalid type of "launchArgs" property in the app config.
+[DetoxConfigError: Invalid type of "launchArgs" property in configuration "plain".
 Expected an object:
 
 {
@@ -329,7 +329,7 @@ Expected a string:
 `;
 
 exports[`DetoxConfigErrorComposer (from composeAppsConfig) .missingAppBinaryPath should create an error for plain configuration 1`] = `
-[DetoxConfigError: Missing "binaryPath" property in the app config.
+[DetoxConfigError: Missing "binaryPath" property in configuration "plain".
 Expected a string:
 
 {
@@ -493,6 +493,28 @@ HINT: There should be an inlined object or an alias to the app config, e.g.:
 
 Examine your Detox config at path:
 /home/detox/myproject/.detoxrc.json]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeAppsConfig) .oldSchemaHasAppAndApps should create an error for ambigous old/new configuration if it has .apps 1`] = `
+[DetoxConfigError: Your configuration "plain" appears to be in a legacy format, which can’t contain "app" or "apps".
+
+HINT: Remove "type" property from configuration and use "device" property instead:
+a) "device": { "type": "android.emulator", ... }
+b) "device": "<alias-to-device>" // you should add that device configuration to "devices" with the same key
+
+Check your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    plain: {
+      type: 'android.emulator',
+      device: 'Pixel_3a_API_30_x86',
+      binaryPath: 'path/to/apk',
+      app: 'my-app'
+    }
+  }
+}]
 `;
 
 exports[`DetoxConfigErrorComposer (from composeAppsConfig) .thereAreNoAppConfigs should create an error for aliased configuration 1`] = `


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #2757

In this pull request, I have improved error handling for the next cases:

1. Someone is using a legacy (plain) config yet wants to adds `app` or `apps` property:

```
DetoxConfigError: Your configuration "plain" appears to be in a legacy format, which can’t contain "app" or "apps".

HINT: Remove "type" property from configuration and use "device" property instead:
a) "device": { "type": "android.emulator", ... }
b) "device": "<alias-to-device>" // you should add that device configuration to "devices" with the same key

Check your Detox config at path:
/home/detox/myproject/.detoxrc.json

{
  configurations: {
    plain: {
      type: 'android.emulator',
      device: 'Pixel_3a_API_30_x86',
      binaryPath: 'path/to/apk',
      app: 'my-app'
    }
  }
}
```

2. Someone is using a legacy (plain) config and has app configuration error, e.g. missing binaryPath:

```diff
-DetoxConfigError: Missing "binaryPath" property in the app config.
+DetoxConfigError: Missing "binaryPath" property in configuration "plain".
```

In other words, I fix here the phrasing from `in the app config` to `configuration <name>` to avoid confusion.

3. Same as 2, but for another property, `launchArgs`:

```diff
-DetoxConfigError: Invalid type of "launchArgs" property in the app config.
+DetoxConfigError: Invalid type of "launchArgs" property in configuration "plain".
```

That should improve UX when transitioning between old and new format, and overall.