### PR TITLE
Rename device log artifact from process.log to device.log

### DIFF
--- a/detox/src/artifacts/log/LogArtifactPlugin.js
+++ b/detox/src/artifacts/log/LogArtifactPlugin.js
@@ -45,7 +45,7 @@ class LogArtifactPlugin extends StartupAndTestRecorderPlugin {
   }
 
   async preparePathForTestArtifact(testSummary) {
-    return this.api.preparePathForArtifact('process.log', testSummary);
+    return this.api.preparePathForArtifact('device.log', testSummary);
   }
 
   /** @param {string} config */


### PR DESCRIPTION
## Description

In this pull request, I have change the `process.log` artifact's name to `device.log`.
For all those times we've requested the artifacts under the artifacts folder, and didn't get the device logs, as requested ([example](https://github.com/wix/Detox/issues/2787#issuecomment-851295525)) 😄 

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
