### PR TITLE
dx: prettier error message on app binary not found

### DIFF
--- a/detox/src/utils/getAbsoluteBinaryPath.js
+++ b/detox/src/utils/getAbsoluteBinaryPath.js
@@ -12,7 +12,13 @@ function getAbsoluteBinaryPath(appPath) {
   if (fs.existsSync(absPath)) {
     return absPath;
   } else {
-    throw new DetoxRuntimeError(`app binary not found at '${absPath}', did you build it?`);
+    throw new DetoxRuntimeError({
+      message: `Failed to find the app binary at:\n${absPath}`,
+      hint: `Make sure that:
+1. You built the app before running tests:
+  detox build -c <your-configuration-name>
+2. The app binary can be found at the given path.`,
+    });
   }
 }
 


### PR DESCRIPTION
## Description

Before:

```
detox[24148] ERROR: app binary not found at '/Users/yaroslavs/Projects/1/SPECIFY_PATH_TO_YOUR_APP_BINARY', did you build it?
```

After:

```
detox[24868] ERROR: Failed to find the app binary at:
/Users/yaroslavs/Projects/wix/Detox/detox/test/ios/build/Build/Products/Debug-iphonesimulator/example2789.app
HINT: Make sure that:
1. You built the app before running tests:
  detox build -c <your-configuration-name>
2. The app binary can be found at the given path.
```