### PR TITLE
dx: fix stack traces for device.*() calls

### DIFF
--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -10,6 +10,7 @@ jest.mock('./client/Client');
 jest.mock('./devices/Device');
 jest.mock('./matchersRegistry');
 jest.mock('./invoke');
+jest.mock('./utils/cutStackTraces');
 
 jest.mock('./server/DetoxServer', () => {
   const FakeServer = jest.genMockFromModule('./server/DetoxServer');

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 
 const DetoxRuntimeError = require('../errors/DetoxRuntimeError');
+const cutStackTraces = require('../utils/cutStackTraces');
 const debug = require('../utils/debug'); // debug utils, leave here even if unused
 const { traceCall } = require('../utils/trace');
 
@@ -16,6 +17,41 @@ class Device {
     sessionConfig,
     runtimeErrorComposer,
   }) {
+    cutStackTraces(this, [
+      'captureViewHierarchy',
+      'clearKeychain',
+      'disableSynchronization',
+      'enableSynchronization',
+      'installApp',
+      'launchApp',
+      'matchFace',
+      'matchFinger',
+      'openURL',
+      'pressBack',
+      'relaunchApp',
+      'reloadReactNative',
+      'resetContentAndSettings',
+      'resetStatusBar',
+      'reverseTcpPort',
+      'selectApp',
+      'sendToHome',
+      'sendUserActivity',
+      'sendUserNotification',
+      'setBiometricEnrollment',
+      'setLocation',
+      'setOrientation',
+      'setStatusBar',
+      'setURLBlacklist',
+      'shake',
+      'shutdown',
+      'takeScreenshot',
+      'terminateApp',
+      'uninstallApp',
+      'unmatchFace',
+      'unmatchFinger',
+      'unreverseTcpPort',
+    ]);
+
     this._appsConfig = appsConfig;
     this._behaviorConfig = behaviorConfig;
     this._deviceConfig = deviceConfig;

--- a/detox/src/errors/index.js
+++ b/detox/src/errors/index.js
@@ -1,0 +1,13 @@
+const DetoxConfigError = require('./DetoxConfigError');
+const DetoxError = require('./DetoxError');
+const DetoxInternalError = require('./DetoxInternalError');
+const DetoxRuntimeError = require('./DetoxRuntimeError');
+const DetoxRuntimeErrorComposer = require('./DetoxRuntimeErrorComposer');
+
+module.exports = {
+  DetoxError,
+  DetoxConfigError,
+  DetoxInternalError,
+  DetoxRuntimeError,
+  DetoxRuntimeErrorComposer,
+};

--- a/detox/src/utils/cutStackTraces.js
+++ b/detox/src/utils/cutStackTraces.js
@@ -1,0 +1,24 @@
+const DetoxError = require('../errors/DetoxError');
+const { asError, createErrorWithUserStack, replaceErrorStack } = require('../utils/errorUtils');
+
+function cutStackTraces(obj, methodNames) {
+  for (const methodName of methodNames) {
+    const originalMethod = obj[methodName];
+
+    obj[methodName] = async function stackTraceWrapper() {
+      const errorWithUserStack = createErrorWithUserStack();
+
+      try {
+        return await originalMethod.apply(obj, arguments);
+      } catch (err) {
+        if (err instanceof DetoxError) {
+          throw replaceErrorStack(errorWithUserStack, asError(err));
+        } else {
+          throw err;
+        }
+      }
+    };
+  }
+}
+
+module.exports = cutStackTraces;

--- a/detox/src/utils/cutStackTraces.test.js
+++ b/detox/src/utils/cutStackTraces.test.js
@@ -1,0 +1,48 @@
+const errors = require('../errors');
+
+const cutStackTraces = require('./cutStackTraces');
+
+describe('cutStackTraces', () => {
+  it.each([
+    ['DetoxError'],
+    ['DetoxConfigError'],
+    ['DetoxInternalError'],
+    ['DetoxRuntimeError'],
+  ])('should post-process known errors (e.g., %s)', async (errName) => {
+    const AnError = errors[errName];
+    const obj = createThrowingObject(AnError);
+
+    /** @type {Error} */
+    const anError = await obj.willThrow().catch(e => e);
+    expect(anError).toBeInstanceOf(AnError);
+    expect(anError.stack).not.toBe(obj.originalErrorStack);
+    expect(anError.stack).not.toContain('detox/src');
+  });
+
+  it.each([
+    [Error],
+  ])('should not post-process non-Detox errors (e.g., %s)', async (AnError) => {
+    const obj = createThrowingObject(AnError);
+
+    /** @type {Error} */
+    const anError = await obj.willThrow().catch(e => e);
+    expect(anError).toBeInstanceOf(AnError);
+    expect(anError.stack).toBe(obj.originalErrorStack);
+    expect(anError.stack).toContain('detox/src');
+  });
+
+  it('should not much affect the original logic of wrapped methods', async () => {
+    const obj = createThrowingObject(Error);
+    await expect(obj.returns42()).resolves.toBe(42);
+  });
+
+  function createThrowingObject(AnError) {
+    const originalError = new AnError('test error');
+    const willThrow = () => { throw originalError; };
+    const returns42 = () => 42;
+    const result = { originalErrorStack: originalError.stack, willThrow, returns42 };
+    cutStackTraces(result, ['willThrow', 'returns42']);
+
+    return result;
+  }
+});

--- a/detox/test/e2e-unhappy/failing-device-method.test.js
+++ b/detox/test/e2e-unhappy/failing-device-method.test.js
@@ -1,0 +1,5 @@
+describe('Failing device method', () => {
+  it('should fail with a correct stack trace', async () => {
+    await device.selectApp('non-existing');
+  });
+});

--- a/detox/test/scripts/ci_unhappy.sh
+++ b/detox/test/scripts/ci_unhappy.sh
@@ -14,19 +14,32 @@ echo "Running e2e test for jest-jasmine timeout handling..."
 node scripts/assert_timeout.js npm run "e2e:$platform" -- -H -o e2e-unhappy/detox-init-timeout/jest-jasmine/config.js e2e-unhappy 
 cp coverage/lcov.info "../../coverage/e2e-legacy-jasmine-$platform-timeout-ci.lcov"
 
-echo "Running e2e stack trace mangling test..."
-runnerOutput="$(npm run "e2e:$platform" -- -H e2e-unhappy/failing-matcher.test.js 2>&1 | tee /dev/stdout)"
-
 echo "Running early syntax error test..."
 node scripts/assert_timeout.js npm run "e2e:$platform" -- -H e2e-unhappy/early-syntax-error.test.js
 cp coverage/lcov.info "../../coverage/e2e-early-syntax-error-$platform-ci.lcov"
 
+echo "Running e2e stack trace mangling test (Client.js)..."
+runnerOutput="$(npm run "e2e:$platform" -- -H e2e-unhappy/failing-matcher.test.js 2>&1 | tee /dev/stdout)"
+
 if grep -q "await.*element.*supercalifragilisticexpialidocious" <<< "$runnerOutput" ;
 then
-    echo "Stack trace mangling has passed OK."
-    cp coverage/lcov.info "../../coverage/e2e-$platform-error-stack-mangling.lcov"
+    echo "Stack trace mangling for Client.js passed OK."
+    cp coverage/lcov.info "../../coverage/e2e-$platform-error-stack-client-js.lcov"
 else
-    echo "Stack trace mangling test has failed"
+    echo "Stack trace mangling for Client.js test has failed"
+    echo "$runnerOutput"
+    exit 1
+fi
+
+echo "Running e2e stack trace mangling test (Device.js.js)..."
+runnerOutput="$(npm run "e2e:$platform" -- -H e2e-unhappy/failing-device-method.test.js 2>&1 | tee /dev/stdout)"
+
+if grep -q "await.*device.*selectApp" <<< "$runnerOutput" ;
+then
+    echo "Stack trace mangling for Device.js has passed OK."
+    cp coverage/lcov.info "../../coverage/e2e-$platform-error-stack-device-js.lcov"
+else
+    echo "Stack trace mangling for Device.js test has failed"
     echo "$runnerOutput"
     exit 1
 fi


### PR DESCRIPTION
## Description

This is a developer experience improvement.

It improves stack traces for known errors (derived from Detox) occurring inside asynchronous `device.***()` public methods, e.g.:

#### Before the fix

![device.launchApp() stack trace before fix](https://user-images.githubusercontent.com/1962469/121189711-0411c600-c873-11eb-8cbc-630d6846a0a9.png)

#### After the fix

![device.launchApp() stack trace after fix](https://user-images.githubusercontent.com/1962469/121189759-112eb500-c873-11eb-9d30-dc3901b60b85.png)

As you can see, the improved error stack points exactly to the user code, and not to the misleading lines in Detox internals.

## Test strategy

Added an `e2e-unhappy` suite for this case. Regression tests on CI should pass as well before this can be merged. 