### PR TITLE
fix(artifacts): suppress some stderr logs from iOS video recordings

### DIFF
--- a/detox/src/devices/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/drivers/ios/tools/AppleSimUtils.js
@@ -273,7 +273,15 @@ class AppleSimUtils {
       args.push('--codec');
       args.push(options.codec);
     }
-    return exec.spawnAndLog('/usr/bin/xcrun', args);
+
+    return exec.spawnAndLog('/usr/bin/xcrun', args, {
+      logLevelPatterns: {
+        trace: [
+          /^Recording started/,
+          /^Wrote video to/,
+        ],
+      },
+    });
   }
 
   async _execAppleSimUtils(options) {

--- a/detox/src/utils/exec.test.js
+++ b/detox/src/utils/exec.test.js
@@ -265,6 +265,21 @@ describe('spawn', () => {
     expect(log.error).toHaveBeenCalledWith(expect.objectContaining({ event: 'SPAWN_STDERR' }), 'world');
   });
 
+  it('should override log levels if configured', async () => {
+    jest.spyOn(log, 'child');
+    await exec.spawnAndLog('command', [], {
+      logLevelPatterns: {
+        debug: [/hello/],
+        warn: [/world/],
+      },
+    });
+
+    await nextCycle();
+
+    expect(log.debug).toHaveBeenCalledWith(expect.objectContaining({ event: 'SPAWN_STDOUT' }), 'hello');
+    expect(log.warn).toHaveBeenCalledWith(expect.objectContaining({ event: 'SPAWN_STDERR' }), 'world');
+  });
+
   it('should not log output if silent: true', async () => {
     await exec.spawnAndLog('command', [], { silent: true });
     await nextCycle();


### PR DESCRIPTION
## Description

Suppresses redundant messages from **stderr** of `xcrun ... recordVideo` command (used by `--record-videos all` on iOS), that started appearing since Xcode 12.4 (or even earlier).

```diff
 detox[10505] INFO:  [test.js] DETOX_CONFIGURATION="ios.sim.release" DETOX_RECORD_VIDEOS="all" DETOX_REPORT_SPECS=true DETOX_START_TIMESTAMP=1623313422454 DETOX_USE_CUSTOM_LOGGER=true nyc jest --config e2e/config.js --testNamePattern '^((?!:android:).)*$' --maxWorkers 1 e2e/01.sanity.test.js
 detox[10507] INFO:  [AppleSimUtils.js] com.wix.detox-example launched. To watch simulator logs, run:
         /usr/bin/xcrun simctl spawn 6371830E-8B44-422B-A52C-DB0B62E6B6E3 log stream --level debug --style compact --predicate 'process == "example"'
 detox[10507] INFO:  Sanity is assigned to 6371830E-8B44-422B-A52C-DB0B62E6B6E3 {"type":"iPhone 12 Pro Max"}
 detox[10507] INFO:  Sanity: should have welcome screen
-detox[10507] ERROR: [SPAWN_STDERR, #10617] Recording started
-
-detox[10507] ERROR: [SPAWN_STDERR, #10617] Wrote video to: /private/var/folders/lm/thz8hdxs4v3fppjh0fjc2twhfl_3x2/T/1a19c7de-8be9-4a6b-af36-fe4f32749755.detox.mp4
 
 detox[10507] INFO:  Sanity: should have welcome screen [OK]
 detox[10507] INFO:  Sanity: should show hello screen after tap
-detox[10507] ERROR: [SPAWN_STDERR, #10631] Recording started
-
-detox[10507] ERROR: [SPAWN_STDERR, #10631] Wrote video to: /private/var/folders/lm/thz8hdxs4v3fppjh0fjc2twhfl_3x2/T/71ac0573-9d1a-4ede-8935-4a6024e109dc.detox.mp4
 
 detox[10507] INFO:  Sanity: should show hello screen after tap [OK]
 detox[10507] INFO:  Sanity: should show world screen after tap
-detox[10507] ERROR: [SPAWN_STDERR, #10644] Recording started
-
-detox[10507] ERROR: [SPAWN_STDERR, #10644] Wrote video to: /private/var/folders/lm/thz8hdxs4v3fppjh0fjc2twhfl_3x2/T/17ffa532-edb7-4620-b58e-9e78a1532a4a.detox.mp4
 
 detox[10507] INFO:  Sanity: should show world screen after tap [OK]
 
  PASS  e2e/01.sanity.test.js (9.555 s)
   Sanity
     ✓ should have welcome screen (1026 ms)
     ✓ should show hello screen after tap (1334 ms)
     ✓ should show world screen after tap (1458 ms)
```