### PR TITLE
no-unused-vars lint set as error, plus total cleanup

### DIFF
--- a/detox/.eslintrc
+++ b/detox/.eslintrc
@@ -55,7 +55,7 @@
     "no-only-tests/no-only-tests": "error",
     "no-undef": "warn",
     "no-unused-vars": [
-      "warn",
+      "error",
       {
         "argsIgnorePattern": "^_"
       }

--- a/detox/runners/jest-circus/environment.js
+++ b/detox/runners/jest-circus/environment.js
@@ -1,5 +1,4 @@
 const NodeEnvironment = require('jest-environment-node');
-const _ = require('lodash');
 
 const DetoxError = require('../../src/errors/DetoxError');
 const Timer = require('../../src/utils/Timer');

--- a/detox/runners/jest/DetoxAdapterCircus.js
+++ b/detox/runners/jest/DetoxAdapterCircus.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const DetoxAdapter = require('./DetoxAdapterImpl');
 const { getFullTestName, hasTimedOut } = require('./utils');
 
@@ -25,11 +23,11 @@ class DetoxAdapterCircus {
     await this._adapter.afterAll();
   }
 
-  async run_describe_start({ describeBlock: { name, children } }, state) {
+  async run_describe_start({ describeBlock: { name, children } }, state) { // eslint-disable-line no-unused-vars
     if (children.length) await this._adapter.suiteStart({ name });
   }
 
-  async run_describe_finish({ describeBlock: { name, children } }, state) {
+  async run_describe_finish({ describeBlock: { name, children } }, state) { // eslint-disable-line no-unused-vars
     if (children.length) await this._adapter.suiteEnd({ name });
   }
 
@@ -54,7 +52,7 @@ class DetoxAdapterCircus {
     });
   }
 
-  test_skip(event) {
+  test_skip(event) { // eslint-disable-line no-unused-vars
     // Ignored (for clarity)
   }
 }

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -1,5 +1,4 @@
 const { URL } = require('url');
-const util = require('util');
 
 const _ = require('lodash');
 

--- a/detox/src/artifacts/ArtifactsManager.test.js
+++ b/detox/src/artifacts/ArtifactsManager.test.js
@@ -42,9 +42,10 @@ describe('ArtifactsManager', () => {
     let artifactsManager, factory, plugin;
 
     beforeEach(() => {
-      factory = jest.fn().mockReturnValue(plugin = {
+      plugin = {
         onBeforeLaunchApp: jest.fn(),
-      });
+      };
+      factory = jest.fn().mockReturnValue(plugin);
 
       artifactsManager = new proxy.ArtifactsManager({
         pathBuilder: new proxy.ArtifactPathBuilder({
@@ -121,10 +122,9 @@ describe('ArtifactsManager', () => {
     });
 
     describe('.preparePathForArtifact()', () => {
-      let argparse, fs;
+      let fs;
 
       beforeEach(() => {
-        argparse = require('../utils/argparse');
         fs = require('fs-extra');
       });
 

--- a/detox/src/artifacts/instruments/InstrumentsArtifactRecording.test.js
+++ b/detox/src/artifacts/instruments/InstrumentsArtifactRecording.test.js
@@ -1,13 +1,9 @@
 const InstrumentsArtifactRecording = require('./InstrumentsArtifactRecording');
 
 describe('InstrumentsArtifactRecording', () => {
-  let mockedApi, mockedClient, mockedPluginContext;
+  let mockedClient, mockedPluginContext;
 
   beforeEach(() => {
-    mockedApi = {
-      trackArtifact: jest.fn(),
-      untrackArtifact: jest.fn()
-    };
     mockedClient = {
       startInstrumentsRecording: jest.fn(),
       stopInstrumentsRecording: jest.fn()

--- a/detox/src/artifacts/instruments/android/AndroidInstrumentsRecording.js
+++ b/detox/src/artifacts/instruments/android/AndroidInstrumentsRecording.js
@@ -1,4 +1,3 @@
-const log = require('../../../utils/logger').child({ __filename });
 const InstrumentsArtifactRecording = require('../InstrumentsArtifactRecording');
 
 class AndroidInstrumentsRecording extends InstrumentsArtifactRecording {

--- a/detox/src/artifacts/log/android/ADBLogcatPlugin.js
+++ b/detox/src/artifacts/log/android/ADBLogcatPlugin.js
@@ -30,7 +30,7 @@ class ADBLogcatPlugin extends LogArtifactPlugin {
   }
 
   createTestRecording() {
-    const { deviceId, bundleId, pid } = this.context;
+    const { deviceId, bundleId } = this.context;
 
     return new ADBLogcatRecording({
       adb: this._adb,

--- a/detox/src/artifacts/log/ios/SimulatorLogPlugin.js
+++ b/detox/src/artifacts/log/ios/SimulatorLogPlugin.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const temporaryPath = require('../../utils/temporaryPath');
 const LogArtifactPlugin = require('../LogArtifactPlugin');
 

--- a/detox/src/artifacts/log/ios/SimulatorLogPlugin.test.js
+++ b/detox/src/artifacts/log/ios/SimulatorLogPlugin.test.js
@@ -39,7 +39,7 @@ describe('SimulatorLogPlugin', () => {
       };
 
       fakeAppleSimUtils = {
-        logStream({ udid, processImagePath, level, stdout, stderr }) {
+        logStream({ udid, processImagePath, level, stdout, stderr }) { // eslint-disable-line no-unused-vars
           // fs.writeFileSync(fakeSources.stdin, '');
 
           const handle = fs.openSync(fakeSources.stdin, 'r');

--- a/detox/src/artifacts/screenshot/SimulatorScreenshotPlugin.js
+++ b/detox/src/artifacts/screenshot/SimulatorScreenshotPlugin.js
@@ -1,6 +1,3 @@
-const fs = require('fs-extra');
-const _ = require('lodash');
-
 const log = require('../../utils/logger').child({ __filename });
 const FileArtifact = require('../templates/artifact/FileArtifact');
 const temporaryPath = require('../utils/temporaryPath');

--- a/detox/src/artifacts/templates/artifact/Artifact.js
+++ b/detox/src/artifacts/templates/artifact/Artifact.js
@@ -106,7 +106,7 @@ class Artifact {
 
   async doStop() {}
 
-  async doSave(artifactPath) {}
+  async doSave(artifactPath) {} // eslint-disable-line no-unused-vars
 
   async doDiscard() {}
 }

--- a/detox/src/artifacts/templates/artifact/Artifact.test.js
+++ b/detox/src/artifacts/templates/artifact/Artifact.test.js
@@ -1,5 +1,3 @@
-jest.mock('../../../utils/logger');
-
 const util = require('util');
 
 const _ = require('lodash');
@@ -7,10 +5,8 @@ const _ = require('lodash');
 const Artifact = require('./Artifact');
 
 describe('Artifact', () => {
-  let logger;
-
   beforeEach(() => {
-    logger = require('../../../utils/logger');
+    jest.mock('../../../utils/logger');
   });
 
   describe('extends Artifact', () => {

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+
 const _ = require('lodash');
 
 const log = require('../../../utils/logger').child({ __filename });

--- a/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.js
+++ b/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.js
@@ -84,7 +84,7 @@ class TwoSnapshotsPerTestPlugin extends ArtifactPlugin {
    * @protected
    * @abstract
    */
-  async preparePathForSnapshot(testSummary, snapshotName) {}
+  async preparePathForSnapshot(testSummary, snapshotName) {} // eslint-disable-line no-unused-vars
 
   /***
    * Creates a handle for a test artifact (video recording, log, etc.)

--- a/detox/src/artifacts/templates/plugin/WholeTestRecorderPlugin.js
+++ b/detox/src/artifacts/templates/plugin/WholeTestRecorderPlugin.js
@@ -55,7 +55,7 @@ class WholeTestRecorderPlugin extends ArtifactPlugin {
   /***
    * @abstract
    */
-  async preparePathForTestArtifact(testSummary) {}
+  async preparePathForTestArtifact(testSummary) {} // eslint-disable-line no-unused-vars
 
   _startSavingTestRecording(testRecording, testSummary) {
     this.api.requestIdleCallback(async () => {

--- a/detox/src/artifacts/timeline/TimelineArtifactPlugin.test.js
+++ b/detox/src/artifacts/timeline/TimelineArtifactPlugin.test.js
@@ -16,7 +16,6 @@ describe('TimelineArtifactPlugin', () => {
   let chromeTracingExporterObj;
   let FileArtifact;
   let fileArtifactObj;
-  let Trace;
   let trace;
   let TimelineArtifactPlugin;
   let uutEnabled;
@@ -40,7 +39,6 @@ describe('TimelineArtifactPlugin', () => {
     jest.mock('../../utils/trace', () => ({
       trace: mockTrace,
     }));
-    Trace = MockTrace;
     trace = mockTrace;
 
     TimelineArtifactPlugin = require('./TimelineArtifactPlugin');

--- a/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.js
+++ b/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.js
@@ -38,8 +38,7 @@ class IosUIHierarchyPlugin extends ArtifactPlugin {
     this._registerSnapshot(e.name, e.artifact);
   }
 
-  // TODO revisit why the event includes all of this unused information
-  _onInvokeFailure({ params: { viewHierarchyURL, visibilityFailingScreenshotsURL, visibilityFailingRectsURL } }) { // eslint-disable-line no-unused-vars
+  _onInvokeFailure({ params: { viewHierarchyURL } }) {
     if (viewHierarchyURL) {
       this._registerSnapshot('ui', new FileArtifact({
         temporaryPath: viewHierarchyURL,

--- a/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.js
+++ b/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 
-const Client = require('../../client/Client');
 const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
 const setUniqueProperty = require('../../utils/setUniqueProperty');
 const FileArtifact = require('../templates/artifact/FileArtifact');
@@ -39,7 +38,8 @@ class IosUIHierarchyPlugin extends ArtifactPlugin {
     this._registerSnapshot(e.name, e.artifact);
   }
 
-  _onInvokeFailure({ params: { viewHierarchyURL, visibilityFailingScreenshotsURL, visibilityFailingRectsURL } }) {
+  // TODO revisit why the event includes all of this unused information
+  _onInvokeFailure({ params: { viewHierarchyURL, visibilityFailingScreenshotsURL, visibilityFailingRectsURL } }) { // eslint-disable-line no-unused-vars
     if (viewHierarchyURL) {
       this._registerSnapshot('ui', new FileArtifact({
         temporaryPath: viewHierarchyURL,

--- a/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.test.js
+++ b/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.test.js
@@ -65,8 +65,6 @@ describe('IosUIHierarchyPlugin', () => {
 
   describe('behavior for externally created artifacts', () => {
     it('should validate event.artifact', async () => {
-      const artifacts = [0, 1, 2, 3].map(() => new FileArtifact());
-
       await expect(plugin.onCreateExternalArtifact({ name: 'invalid' }))
         .rejects
         .toThrowError(/Internal error/);

--- a/detox/src/artifacts/utils/ArtifactPathBuilder.test.js
+++ b/detox/src/artifacts/utils/ArtifactPathBuilder.test.js
@@ -1,7 +1,5 @@
 const path = require('path');
 
-const _ = require('lodash');
-
 const ArtifactPathBuilder = require('./ArtifactPathBuilder');
 
 describe(ArtifactPathBuilder, () => {

--- a/detox/src/client/AsyncWebSocket.js
+++ b/detox/src/client/AsyncWebSocket.js
@@ -159,7 +159,7 @@ class AsyncWebSocket {
    * @param {WebSocket.OpenEvent} event
    * @private
    */
-  _onOpen(event) {
+  _onOpen(event) { // eslint-disable-line no-unused-vars
     this._log.trace(EVENTS.OPEN, `opened web socket to: ${this._url}`);
     this._opening.resolve();
     this._opening = null;
@@ -251,7 +251,7 @@ class AsyncWebSocket {
    * @param {WebSocket.CloseEvent | null} event
    * @private
    */
-  _onClose(event) {
+  _onClose(event) { // eslint-disable-line no-unused-vars
     if (this._closing) {
       this._closing.resolve();
     }

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const DetoxInternalError = require('../../errors/DetoxInternalError');
 const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
 const { getDetoxLevel } = require('../../utils/logger');

--- a/detox/src/configuration/composeAppsConfig.test.js
+++ b/detox/src/configuration/composeAppsConfig.test.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const DetoxConfigErrorComposer = require('../errors/DetoxConfigErrorComposer');
 
 const {

--- a/detox/src/configuration/composeBehaviorConfig.test.js
+++ b/detox/src/configuration/composeBehaviorConfig.test.js
@@ -41,7 +41,6 @@ describe('composeBehaviorConfig', () => {
     });
 
     it('should implicitly override behavior.init.reinstallApp = false', () => {
-      const expected = _.cloneDeep(globalConfig.behavior);
       const actual = composed();
 
       expect(actual.init.reinstallApp).toBe(false);

--- a/detox/src/configuration/index.test.js
+++ b/detox/src/configuration/index.test.js
@@ -3,16 +3,11 @@ jest.mock('../utils/argparse');
 const os = require('os');
 const path = require('path');
 
-const _ = require('lodash');
-
 const DetoxConfigErrorComposer = require('../errors/DetoxConfigErrorComposer');
 
 describe('composeDetoxConfig', () => {
   let args;
   let configuration;
-  let detoxConfig;
-  let deviceConfig;
-  let userParams;
 
   /** @type {DetoxConfigErrorComposer} */
   let errorComposer;
@@ -21,9 +16,6 @@ describe('composeDetoxConfig', () => {
     errorComposer = new DetoxConfigErrorComposer();
 
     args = {};
-    detoxConfig = {};
-    deviceConfig = {};
-    userParams = undefined;
 
     require('../utils/argparse').getArgValue.mockImplementation(key => args[key]);
     configuration = require('./index');

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -5,7 +5,6 @@ const configurationsMock = require('../configuration/configurations.mock');
 describe('Device', () => {
   let fs;
   let DeviceDriverBase;
-  let SimulatorDriver;
   let DetoxRuntimeErrorComposer;
   let errorComposer;
   let emitter;
@@ -27,8 +26,6 @@ describe('Device', () => {
 
     jest.mock('./drivers/DeviceDriverBase');
     DeviceDriverBase = require('./drivers/DeviceDriverBase');
-
-    SimulatorDriver = require('./drivers/ios/SimulatorDriver');
 
     jest.mock('../client/Client');
     Client = require('../client/Client');

--- a/detox/src/devices/DeviceRegistry.test.js
+++ b/detox/src/devices/DeviceRegistry.test.js
@@ -69,11 +69,6 @@ describe('DeviceRegistry', () => {
       expect(registeredDevices.includes(deviceId)).toEqual(true);
     }
 
-    async function expectNotIncludedInReadDevicesList(deviceHandle) {
-      const registeredDevices = await registry.readRegisteredDevices();
-      expect(registeredDevices.includes(deviceHandle)).not.toEqual(true);
-    }
-
     async function expectReadDevicesListEquals(rawDeviceHandles) {
       const registeredDevices = await registry.readRegisteredDevices();
       expect(registeredDevices.rawDevices).toEqual(rawDeviceHandles);

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 const os = require('os');
 const path = require('path');
 
@@ -21,7 +19,7 @@ class DeviceDriverBase {
     return {};
   }
 
-  async acquireFreeDevice(deviceQuery) {
+  async acquireFreeDevice(_deviceQuery) {
     return await Promise.resolve('');
   }
 
@@ -37,7 +35,7 @@ class DeviceDriverBase {
     return await Promise.resolve(NaN);
   }
 
-  async takeScreenshot(deviceId, screenshotName) {
+  async takeScreenshot(_deviceId, _screenshotName) {
     return await Promise.resolve('');
   }
 
@@ -69,7 +67,7 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
-  async installApp(deviceId, binaryPath, testBinaryPath) {
+  async installApp(_deviceId, _binaryPath, _testBinaryPath) {
     return await Promise.resolve('');
   }
 
@@ -85,7 +83,7 @@ class DeviceDriverBase {
     return await this.client.deliverPayload(params);
   }
 
-  async setLocation(lat, lon) {
+  async setLocation(_lat, _lon) {
     return await Promise.resolve('');
   }
 
@@ -123,11 +121,11 @@ class DeviceDriverBase {
     return notificationFilePath;
   }
 
-  async setPermissions(deviceId, bundleId, permissions) {
+  async setPermissions(_deviceId, _bundleId, _permissions) {
     return await Promise.resolve('');
   }
 
-  async terminate(deviceId, bundleId) {
+  async terminate(_deviceId, _bundleId) {
     return await Promise.resolve('');
   }
 
@@ -135,11 +133,11 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
-  async setOrientation(deviceId, orientation) {
+  async setOrientation(_deviceId, _orientation) {
     return await Promise.resolve('');
   }
 
-  async setURLBlacklist(urlList) {
+  async setURLBlacklist(_urlList) {
     return await Promise.resolve('');
   }
 
@@ -167,10 +165,10 @@ class DeviceDriverBase {
     }
   }
 
-  getBundleIdFromBinary(appPath) {
+  getBundleIdFromBinary(_appPath) {
   }
 
-  validateDeviceConfig(deviceConfig) {
+  validateDeviceConfig(_deviceConfig) {
   }
 
   getPlatform() {
@@ -181,11 +179,11 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
-  async cleanup(deviceId, bundleId) {
+  async cleanup(_deviceId, _bundleId) {
     this.emitter.off(); // clean all listeners
   }
 
-  getLogsPaths(deviceId) {
+  getLogsPaths(_deviceId) {
     return {
       stdout: undefined,
       stderr: undefined
@@ -197,14 +195,14 @@ class DeviceDriverBase {
     return await Promise.resolve('');
   }
 
-  async typeText(deviceId, text) {
+  async typeText(_deviceId, _text) {
     return await Promise.resolve('');
   }
 
-  async setStatusBar(deviceId, flags) {
+  async setStatusBar(_deviceId, _flags) {
   }
 
-  async resetStatusBar(deviceId) {
+  async resetStatusBar(_deviceId) {
   }
 
   async captureViewHierarchy() {

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -1,8 +1,9 @@
+/* eslint-disable no-unused-vars */
+
 const os = require('os');
 const path = require('path');
 
 const fs = require('fs-extra');
-const _ = require('lodash');
 
 const log = require('../../utils/logger').child({ __filename });
 
@@ -167,15 +168,12 @@ class DeviceDriverBase {
   }
 
   getBundleIdFromBinary(appPath) {
-
   }
 
   validateDeviceConfig(deviceConfig) {
-
   }
 
   getPlatform() {
-
   }
 
   async getUiDevice() {

--- a/detox/src/devices/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.js
@@ -112,7 +112,7 @@ class AndroidDriver extends DeviceDriverBase {
     });
   }
 
-  async _handleLaunchApp({ manually, deviceId, bundleId, launchArgs, languageAndLocale }) {
+  async _handleLaunchApp({ manually, deviceId, bundleId, launchArgs }) {
     const adbName = this._getAdbName(deviceId);
 
     await this.emitter.emit('beforeLaunchApp', { deviceId: adbName, bundleId, launchArgs });
@@ -157,11 +157,11 @@ class AndroidDriver extends DeviceDriverBase {
       }
   }
 
-  async pressBack(deviceId) {
+  async pressBack(deviceId) { // eslint-disable-line no-unused-vars
     await this.uiDevice.pressBack();
   }
 
-  async sendToHome(deviceId, params) {
+  async sendToHome(deviceId, params) { // eslint-disable-line no-unused-vars
     await this.uiDevice.pressHome();
   }
 

--- a/detox/src/devices/drivers/android/AndroidDriver.test.js
+++ b/detox/src/devices/drivers/android/AndroidDriver.test.js
@@ -14,7 +14,6 @@ describe('Android driver', () => {
   let client;
   let getAbsoluteBinaryPath;
   let fs;
-  let exec;
   let emitter;
   let detoxApi;
   let invocationManager;
@@ -511,7 +510,6 @@ describe('Android driver', () => {
     jest.mock('../../../utils/exec', () => ({
       interruptProcess: jest.fn(),
     }));
-    exec = require('../../../utils/exec');
 
     client = {
       serverUrl: `ws://localhost:${detoxServerPort}`,

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
@@ -1,9 +1,6 @@
 const adbName = 'mock_adb_name-1117';
-const avdName = 'mock-AVD-name';
 
 describe('Emulator launcher', () => {
-
-  let logger;
   let retry;
   let eventEmitter;
   let emulatorTelnet;
@@ -11,7 +8,6 @@ describe('Emulator launcher', () => {
   let uut;
   beforeEach(() => {
     jest.mock('../../../../../utils/logger');
-    logger = require('../../../../../utils/logger');
 
     jest.mock('../../../../../utils/retry');
     retry = require('../../../../../utils/retry');

--- a/detox/src/devices/drivers/android/tools/EmulatorTelnet.js
+++ b/detox/src/devices/drivers/android/tools/EmulatorTelnet.js
@@ -38,7 +38,7 @@ class EmulatorTelnet {
   }
 
   async shell(command) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this.connection.shell((error, stream) => {
         stream.write(`${command}\n`);
         stream.on('data', (data) => {

--- a/detox/src/devices/drivers/ios/IosDriver.js
+++ b/detox/src/devices/drivers/ios/IosDriver.js
@@ -34,7 +34,7 @@ class IosDriver extends DeviceDriverBase {
     return await this.client.setSyncSettings({ enabled: false });
   }
 
-  async shake(deviceId) {
+  async shake(deviceId) { // eslint-disable-line no-unused-vars
     return await this.client.shake();
   }
 

--- a/detox/src/devices/drivers/ios/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.test.js
@@ -19,15 +19,14 @@ describe('IOS simulator driver', () => {
   });
 
   describe('launch args', () => {
-    let launchArgs, languageAndLocale;
+    const languageAndLocale = '';
+    let launchArgs;
 
     beforeEach(() => {
       launchArgs = {
         'dog1': 'dharma',
         'dog2': 'karma',
       };
-
-      languageAndLocale = '';
 
       const SimulatorDriver = require('./SimulatorDriver');
       uut = new SimulatorDriver({ client: {}, emitter });
@@ -79,11 +78,7 @@ describe('IOS simulator driver', () => {
   });
 
   describe('biometrics', () => {
-    let languageAndLocale;
-
     beforeEach(() => {
-      languageAndLocale = '';
-
       const SimulatorDriver = require('./SimulatorDriver');
       sim = new SimulatorDriver({ client: {}, emitter });
     });

--- a/detox/src/errors/DetoxRuntimeError.test.js
+++ b/detox/src/errors/DetoxRuntimeError.test.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const DetoxRuntimeError = require('./DetoxRuntimeError');
 
 describe('DetoxRuntimeError', () => {

--- a/detox/src/server/DetoxConnection.js
+++ b/detox/src/server/DetoxConnection.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { WebSocket } = require('ws');
+const { WebSocket } = require('ws'); // eslint-disable-line no-unused-vars
 
 const DetoxRuntimeError = require('../errors/DetoxRuntimeError');
 const logger = require('../utils/logger').child({ __filename });

--- a/detox/src/utils/exec.test.js
+++ b/detox/src/utils/exec.test.js
@@ -365,12 +365,6 @@ const returnErrorWithValue = (value) => ({
     }
   });
 
-const returnSuccessfulNoValue = () => ({
-    childProcess: {
-      exitCode: 0
-    }
-  });
-
 function mockCppSuccessful(cpp) {
   const successfulResult = returnSuccessfulWithValue('successful result');
   cpp.exec.mockResolvedValueOnce(successfulResult);

--- a/detox/src/utils/getAbsoluteBinaryPath.test.js
+++ b/detox/src/utils/getAbsoluteBinaryPath.test.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 
 const getAbsoluteBinaryPath = require('./getAbsoluteBinaryPath');

--- a/detox/src/utils/resolveModuleFromPath.test.js
+++ b/detox/src/utils/resolveModuleFromPath.test.js
@@ -1,7 +1,5 @@
 const path = require('path');
 
-const _ = require('lodash');
-
 const resolveModuleFromPath = require('./resolveModuleFromPath');
 
 const RELATIVE_PATH_TO_PACKAGE_JSON = '../../package.json';

--- a/detox/src/utils/sh.js
+++ b/detox/src/utils/sh.js
@@ -1,5 +1,3 @@
-const fs = require('fs');
-
 const cpp = require('child-process-promise');
 
 const sh = new Proxy({}, {

--- a/detox/src/utils/shellUtils.test.js
+++ b/detox/src/utils/shellUtils.test.js
@@ -94,7 +94,7 @@ describe('shellUtils', function() {
     describe('.cmd', () => {
       const CMD_CASES = CASES.map(([expected, _shell, input, comment]) => [expected, input, comment]);
 
-      test.each(CMD_CASES)('should return %j for %j because it is %s', (expected, str, comment) => {
+      test.each(CMD_CASES)('should return %j for %j because it is %s', (expected, str, __) => {
         expect(hasUnsafeChars.cmd(str)).toBe(expected);
       });
     });
@@ -102,7 +102,7 @@ describe('shellUtils', function() {
     describe('.shell', () => {
       const SHELL_CASES = CASES.map(([_cmd, expected, input, comment]) => [expected, input, comment]);
 
-      test.each(SHELL_CASES)('should return %j for %j because it is %s', (expected, str, comment) => {
+      test.each(SHELL_CASES)('should return %j for %j because it is %s', (expected, str, __) => {
         expect(hasUnsafeChars.shell(str)).toBe(expected);
       });
     });


### PR DESCRIPTION
## Description
In this pull request, I have:
1. Cleaned-up all known lint issues.
2. Made `no-unused-vars` rule mandatory to comply with (i.e. changed severity warn=>error).
