### PR TITLE
CI unhappy: Increase timeout to 90sec, make detox exec verbose

### DIFF
--- a/detox/test/scripts/assert_timeout.js
+++ b/detox/test/scripts/assert_timeout.js
@@ -8,7 +8,7 @@ const testProcess = cp.spawn(command, args, { stdio: 'inherit' });
 let handle = setTimeout(() => {
   handle = null;
   testProcess.kill('SIGTERM');
-}, 60000);
+}, 90000);
 
 testProcess.on('exit', (code) => {
   if (code === 0 || !handle) {

--- a/detox/test/scripts/ci_unhappy.sh
+++ b/detox/test/scripts/ci_unhappy.sh
@@ -7,19 +7,19 @@ export DISABLE_JUNIT_REPORTER=1
 platform=$1
 
 echo "Running e2e test for jest-circus timeout handling..."
-node scripts/assert_timeout.js npm run "e2e:$platform" -- -H -o e2e-unhappy/detox-init-timeout/jest-circus/config.js e2e-unhappy 
+node scripts/assert_timeout.js npm run "e2e:$platform" -- -l verbose -H -o e2e-unhappy/detox-init-timeout/jest-circus/config.js e2e-unhappy
 cp coverage/lcov.info "../../coverage/e2e-$platform-timeout-ci.lcov"
 
 echo "Running e2e test for jest-jasmine timeout handling..."
-node scripts/assert_timeout.js npm run "e2e:$platform" -- -H -o e2e-unhappy/detox-init-timeout/jest-jasmine/config.js e2e-unhappy 
+node scripts/assert_timeout.js npm run "e2e:$platform" -- -l verbose -H -o e2e-unhappy/detox-init-timeout/jest-jasmine/config.js e2e-unhappy
 cp coverage/lcov.info "../../coverage/e2e-legacy-jasmine-$platform-timeout-ci.lcov"
 
 echo "Running early syntax error test..."
-node scripts/assert_timeout.js npm run "e2e:$platform" -- -H e2e-unhappy/early-syntax-error.test.js
+node scripts/assert_timeout.js npm run "e2e:$platform" -- -l verbose -H e2e-unhappy/early-syntax-error.test.js
 cp coverage/lcov.info "../../coverage/e2e-early-syntax-error-$platform-ci.lcov"
 
 echo "Running e2e stack trace mangling test (Client.js)..."
-runnerOutput="$(npm run "e2e:$platform" -- -H e2e-unhappy/failing-matcher.test.js 2>&1 | tee /dev/stdout)"
+runnerOutput="$(npm run "e2e:$platform" -- -l verbose -H e2e-unhappy/failing-matcher.test.js 2>&1 | tee /dev/stdout)"
 
 if grep -q "await.*element.*supercalifragilisticexpialidocious" <<< "$runnerOutput" ;
 then
@@ -32,7 +32,7 @@ else
 fi
 
 echo "Running e2e stack trace mangling test (Device.js.js)..."
-runnerOutput="$(npm run "e2e:$platform" -- -H e2e-unhappy/failing-device-method.test.js 2>&1 | tee /dev/stdout)"
+runnerOutput="$(npm run "e2e:$platform" -- -l verbose -H e2e-unhappy/failing-device-method.test.js 2>&1 | tee /dev/stdout)"
 
 if grep -q "await.*device.*selectApp" <<< "$runnerOutput" ;
 then


### PR DESCRIPTION
In this pull request, I have increased the fallback timeout of the ci-unhappy script, suspecting that maybe since the test-runner 30sec timeout is not calculated from the very beginning, the fallback timeout might be pushing it a bit too hard.

Some refs:
https://jenkins-oss.wixpress.com/job/detox-android-64-x-master/22/consoleFull
https://jenkins-oss.wixpress.com/job/detox-android-64-x-master/18/consoleFull
