### PR TITLE
fix(genycloud): prevent device stealing

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -47,12 +47,12 @@ module.exports.handler = async function test(argv) {
     forwardedArgs.argv.$0 = runnerConfig.testRunner;
   }
 
-  if (!cliConfig.keepLockFile) {
-    await resetLockFile({ platform });
-  }
-
   const retries = runner === 'jest' ? detoxArgs.retries : 0;
-  await runTestRunnerWithRetries(forwardedArgs, retries);
+  await runTestRunnerWithRetries(forwardedArgs, {
+    keepLockFile: cliConfig.keepLockFile,
+    platform,
+    retries,
+  });
 };
 
 module.exports.middlewares = [
@@ -234,7 +234,7 @@ function hasMultipleWorkers(cliConfig) {
   return cliConfig.workers != 1;
 }
 
-async function runTestRunnerWithRetries(forwardedArgs, retries) {
+async function runTestRunnerWithRetries(forwardedArgs, { keepLockFile, platform, retries }) {
   let runsLeft = 1 + retries;
   let launchError;
 
@@ -246,6 +246,10 @@ async function runTestRunnerWithRetries(forwardedArgs, retries) {
           `There were failing tests in the following files:\n${list}\n\n` +
           'Detox CLI is going to restart the test runner with those files...\n'
         );
+      }
+
+      if (!keepLockFile) {
+        await resetLockFile({ platform });
       }
 
       await resetLastFailedTests();

--- a/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.js
@@ -79,7 +79,9 @@ class GenyCloudDriver extends AndroidDriver {
       try {
         await super.cleanup(instance, bundleId);
       } finally {
-        await this._instanceAllocation.deallocateDevice(instance.uuid);
+        if (instance) {
+          await this._instanceAllocation.deallocateDevice(instance.uuid);
+        }
       }
   }
 

--- a/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.test.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.test.js
@@ -285,6 +285,11 @@ describe('Genymotion-cloud driver', () => {
         Instrumentation = require('../tools/MonitoredInstrumentation');
       });
 
+      it('should no-op if there is no instance given', async () => {
+        await uut.cleanup(undefined, 'bundle-id');
+        expect(instanceAllocation().deallocateDevice).not.toHaveBeenCalled();
+      });
+
       it('should deallocate an instance based on its UUID', async () => {
         const instance = anInstance();
         await uut.cleanup(instance, 'bundle-id');

--- a/detox/src/devices/drivers/android/genycloud/services/GenyInstanceNaming.js
+++ b/detox/src/devices/drivers/android/genycloud/services/GenyInstanceNaming.js
@@ -1,16 +1,18 @@
+const getWorkerId = require('../../../../../utils/getWorkerId');
+
 class GenyInstanceNaming {
   constructor(nowProvider = () => new Date().getTime()) {
     this.uniqueSessionId = Number(process.env.DETOX_START_TIMESTAMP);
     this.nowProvider = nowProvider;
+    this._workerId = getWorkerId() || (this.nowProvider() - this.uniqueSessionId);
   }
 
   generateName() {
-    const uniqueDeviceId = process.env.JEST_WORKER_ID || (this.nowProvider() - this.uniqueSessionId);
-    return `Detox-${this.uniqueSessionId}.${uniqueDeviceId}`;
+    return `Detox-${this.uniqueSessionId}.${this._workerId}`;
   }
 
   isFamilial(name) {
-    return name.startsWith(`Detox-${this.uniqueSessionId}.`);
+    return name.startsWith(`Detox-${this.uniqueSessionId}.${this._workerId}`);
   }
 }
 

--- a/detox/src/devices/drivers/android/genycloud/services/GenyInstanceNaming.test.js
+++ b/detox/src/devices/drivers/android/genycloud/services/GenyInstanceNaming.test.js
@@ -1,68 +1,73 @@
+jest.mock('../../../../../utils/getWorkerId');
+
 describe('Genymotion-Cloud instance unique-name strategy', () => {
-  let JEST_WORKER_ID = process.env.JEST_WORKER_ID;
-
+  let getWorkerId;
   let now;
-  let uut;
-  beforeEach(() => {
-    process.env.DETOX_START_TIMESTAMP = '123456';
 
-    now = 123534;
-    const nowProvider = () => now;
-
+  function uut() {
     const GenyInstanceNaming = require('./GenyInstanceNaming');
-    uut = new GenyInstanceNaming(nowProvider);
+    return new GenyInstanceNaming(() => now);
+  }
+
+  beforeEach(() => {
+    getWorkerId = require('../../../../../utils/getWorkerId');
+    process.env.DETOX_START_TIMESTAMP = '123456';
+    now = 123534;
   });
 
   afterAll(() => {
     delete process.env.DETOX_START_TIMESTAMP;
-    process.env.JEST_WORKER_ID = JEST_WORKER_ID;
   });
 
   it('should generate a session-scope unique name', () => {
-    expect(uut.generateName().startsWith('Detox-123456.')).toEqual(true);
+    expect(uut().generateName()).toMatch(/^Detox-123456\./);
   });
 
   it('should generate an instance-scope unique name based on jest-worker IDs', () => {
-    process.env.JEST_WORKER_ID = '777';
-    expect(uut.generateName()).toEqual('Detox-123456.777');
+    getWorkerId.mockReturnValue('777');
+    expect(uut().generateName()).toEqual('Detox-123456.777');
   });
 
   it('should generate an instance-scope unique name based on time delta, as a fallback', () => {
-    process.env.JEST_WORKER_ID = '';
-    expect(uut.generateName()).toEqual('Detox-123456.78');
+    getWorkerId.mockReturnValue('');
+    expect(uut().generateName()).toEqual('Detox-123456.78');
   });
 
   it('should generate an instance-scope unique name', () => {
-    process.env.JEST_WORKER_ID = '';
+    getWorkerId.mockReturnValue('');
 
-    const name1 = uut.generateName();
+    const name1 = uut().generateName();
     now = now + 1;
-    const name2 = uut.generateName();
+    const name2 = uut().generateName();
 
     expect(name1).not.toEqual(name2);
   });
 
-  it('should accept names with the correct timestamp as valid', () =>
-    expect(uut.isFamilial('Detox-123456.10')).toEqual(true));
+  it('should accept names with the correct timestamp and matching worker id', () => {
+    getWorkerId.mockReturnValue('10');
+    expect(uut().isFamilial('Detox-123456.10')).toEqual(true);
+  });
+
+  it('should deny names with the correct timestamp and incorrect worker id', () =>
+    expect(uut().isFamilial('Detox-123456.10')).toEqual(false));
 
   it('should deny names with the incorrect timestamp', () =>
-    expect(uut.isFamilial('Detox-123457.10')).toEqual(false));
+    expect(uut().isFamilial('Detox-123457.10')).toEqual(false));
 
   it('should deny names not starting with "Detox-"', () =>
-    expect(uut.isFamilial('Dtx-123456.10')).toEqual(false));
+    expect(uut().isFamilial('Dtx-123456.10')).toEqual(false));
 
   it('should deny names in wrong sections orders', () =>
-    expect(uut.isFamilial('123456-Detox-.10')).toEqual(false));
+    expect(uut().isFamilial('123456-Detox-.10')).toEqual(false));
 
   it('should deny names with the wrong prefix', () =>
-    expect(uut.isFamilial('_Detox-123456.10')).toEqual(false));
+    expect(uut().isFamilial('_Detox-123456.10')).toEqual(false));
 
   it('should deny names not containing a dot separator', () =>
-    expect(uut.isFamilial('Detox-123456-10')).toEqual(false));
+    expect(uut().isFamilial('Detox-123456-10')).toEqual(false));
 
   it('should have a default now-provider', () => {
     const GenyInstanceNaming = require('./GenyInstanceNaming');
-    uut = new GenyInstanceNaming(undefined);
-    expect(uut.generateName().startsWith('Detox-')).toEqual(true);
+    expect(new GenyInstanceNaming().generateName()).toMatch(/^Detox-/);
   });
 });

--- a/detox/src/utils/getWorkerId.js
+++ b/detox/src/utils/getWorkerId.js
@@ -1,0 +1,5 @@
+function getWorkerId() {
+  return process.env.JEST_WORKER_ID;
+}
+
+module.exports = getWorkerId;

--- a/detox/src/utils/getWorkerId.test.js
+++ b/detox/src/utils/getWorkerId.test.js
@@ -1,0 +1,9 @@
+const getWorkerId = require('./getWorkerId');
+
+describe('getWorkerId', () => {
+  it('should return process.env.JEST_WORKER_ID', async () => {
+    expect(process.env.JEST_WORKER_ID).not.toBe(undefined);
+    expect(getWorkerId()).toBe(process.env.JEST_WORKER_ID);
+  });
+});
+


### PR DESCRIPTION
## Description

This pull request addresses the issue described here: #2842

* Prevents cleanup when device id is null (otherwise, we'll get a fatal error) — useful for situations when `gmsaas` CLI exits with an error early
* Forbids taking devices that do not belong to a specific worker
* When running with `--retries N`, it resets lock file before EACH (not only the first) run.