### PR TITLE
Add some allegedly missing kotlin minification rules

### DIFF
--- a/detox/android/detox/proguard-rules-app.pro
+++ b/detox/android/detox/proguard-rules-app.pro
@@ -7,3 +7,7 @@
 -keep class com.facebook.react.ReactInstanceManager { *; }
 -keep class com.facebook.react.ReactInstanceManager** { *; }
 -keep class com.reactnativecommunity.asyncstorage.** { *; }
+
+-keep class kotlin.jvm.internal.FunctionReference { *; }
+-keep class kotlin.jvm.internal.FunctionReferenceImpl { *; }
+-keep class kotlin.jvm.functions.* { *; }


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #2837

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have (blindly<sup>*</sup>) added pro-guard rules which will force-keep some Kotlin stdlib classes, corresponding to reports of missing class - as in #2837 and #1994.


> <sup>*</sup> Unfortunately, I haven't managed to to have similar crash issues reproduced on our example project. Nevertheless, I've [analyzed the APK's](https://developer.android.com/studio/build/apk-analyzer) alongside R8's output files (`seeds.txt`, in particular), and have managed to prove that indeed with the new rules in place, the missing kotlin classes _do_ get bundled into the **test** apk.