### PR TITLE
test: fix double app install issue

### DIFF
--- a/detox/test/e2e/22.launch-args.test.js
+++ b/detox/test/e2e/22.launch-args.test.js
@@ -1,3 +1,7 @@
+/**
+ * @detox-config-path ./detox-multiapps.config.json
+ */
+
 const _ = require('lodash');
 
 // Note: Android-only as, according to Leo, on iOS there's no added value here compared to

--- a/detox/test/e2e/detox-multiapps.config.json
+++ b/detox/test/e2e/detox-multiapps.config.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./detox.config",
+  "configurations": {
+    "android.manual": {
+      "apps": ["android.debug", "android.debug.withArgs"]
+    },
+    "android.emu.debug": {
+      "apps": ["android.debug", "android.debug.withArgs"]
+    },
+    "android.emu.debug.fromSource": {
+      "apps": ["android.fromSource", "android.fromSource.withArgs"]
+    },
+    "android.emu.release": {
+      "apps": ["android.release", "android.release.withArgs"]
+    },
+    "android.genycloud.release": {
+      "apps": ["android.release", "android.release.withArgs"]
+    },
+    "android.genycloud.release2": {
+      "apps": ["android.release", "android.release.withArgs"]
+    }
+  }
+}

--- a/detox/test/e2e/detox.config.js
+++ b/detox/test/e2e/detox.config.js
@@ -162,7 +162,7 @@ const config = {
     },
     'android.manual': {
       device: 'android.emulator',
-      apps: ['android.debug', 'android.debug.withArgs'],
+      apps: ['android.debug'],
       artifacts: false,
       behavior: {
         launchApp: 'manual'
@@ -175,23 +175,23 @@ const config = {
     },
     'android.emu.debug': {
       device: 'android.emulator',
-      apps: ['android.debug', 'android.debug.withArgs'],
+      apps: ['android.debug'],
     },
     'android.emu.debug.fromSource': {
       device: 'android.emulator',
-      apps: ['android.fromSource', 'android.fromSource.withArgs'],
+      apps: ['android.fromSource'],
     },
     'android.emu.release': {
       device: 'android.emulator',
-      apps: ['android.release', 'android.release.withArgs'],
+      apps: ['android.release'],
     },
     'android.genycloud.release': {
       device: 'android.genycloud.uuid',
-      apps: ['android.release', 'android.release.withArgs'],
+      apps: ['android.release'],
     },
     'android.genycloud.release2': {
       device: 'android.genycloud.name',
-      apps: ['android.release', 'android.release.withArgs'],
+      apps: ['android.release'],
     },
     'stub': {
       type: './integration/stub',

--- a/detox/test/e2e/environment.js
+++ b/detox/test/e2e/environment.js
@@ -6,6 +6,8 @@ class CustomDetoxEnvironment extends DetoxCircusEnvironment {
   constructor(config, context) {
     super(config, context);
 
+    this._detoxConfigOverride = context.docblockPragmas['detox-config-path'];
+
     this.registerListeners({
       SpecReporterCircus,
       WorkerAssignReporterCircus,
@@ -13,7 +15,13 @@ class CustomDetoxEnvironment extends DetoxCircusEnvironment {
   }
 
   async initDetox() {
-    const instance = await super.initDetox();
+    let overrides;
+
+    if (this._detoxConfigOverride) {
+      overrides = require(this._detoxConfigOverride);
+    }
+
+    const instance = await this.detox.init(overrides);
 
     this.global.detox.__waitUntilArtifactsManagerIsIdle__ = () => {
       return instance._artifactsManager._idlePromise;

--- a/detox/test/e2e/setup.js
+++ b/detox/test/e2e/setup.js
@@ -1,6 +1,7 @@
 const { device } = require('detox');
 
 beforeAll(async () => {
-  await device.selectApp('example');
-  await device.launchApp();
+  if (device._currentApp) { // HACK: currently there's no API to tell whether we are in multi-apps mode or not
+    await device.launchApp();
+  }
 });


### PR DESCRIPTION
## Description

This is an idea of how to fix that double `device.installApp()` happening in our E2E self-test suite, and add a live example of advanced Jest environment use, i.e.: Detox + Jest docblockPragmas. That should cut down build time on our Jenkins OSS CI.