### PR TITLE
Pass --workers=0 to NOT pass --maxWorkers to Jest at all.

### DIFF
--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -155,16 +155,20 @@ function prepareMochaArgs({ cliConfig, runnerArgs, runnerConfig, platform }) {
 function prepareJestArgs({ cliConfig, runnerArgs, runnerConfig, platform }) {
   const { specs, passthrough } = splitArgv.jest(runnerArgs);
   const platformFilter = getPlatformSpecificString(platform);
+  const argv = {
+    color: !cliConfig.noColor && undefined,
+    config: runnerConfig.runnerConfig /* istanbul ignore next */ || undefined,
+    testNamePattern: platformFilter ? `^((?!${platformFilter}).)*$` : undefined,
+    ...passthrough,
+  };
+
+  // Pass --workers=0 to NOT send --maxWorkers to Jest at all.
+  if (cliConfig.workers) {
+    argv.maxWorkers = cliConfig.workers;
+  }
 
   return {
-    argv: {
-      color: !cliConfig.noColor && undefined,
-      config: runnerConfig.runnerConfig /* istanbul ignore next */ || undefined,
-      testNamePattern: platformFilter ? `^((?!${platformFilter}).)*$` : undefined,
-      maxWorkers: cliConfig.workers,
-
-      ...passthrough,
-    },
+    argv,
 
     env: _.omitBy({
       DETOX_APP_LAUNCH_ARGS: cliConfig.appLaunchArgs,

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -452,6 +452,11 @@ describe('CLI', () => {
       expect(cliCall().command).toContain('--maxWorkers 2');
     });
 
+    test.each([['-w'], ['--workers']])('%s 0 should not pass --maxWorkers at all', async (__workers) => {
+      await run(`${__workers} 0`);
+      expect(cliCall().command).not.toContain('--maxWorkers 1');
+    });
+
     test.each([['-w'], ['--workers']])('%s <value> should be replaced with --maxWorkers <value>', async (__workers) => {
       await run(`${__workers} 2 --maxWorkers 3`);
 

--- a/docs/Guide.Jest.md
+++ b/docs/Guide.Jest.md
@@ -178,6 +178,21 @@ If you wish to force-enable it nonetheless, the [`--jest-report-specs`](APIRef.D
 detox test --configuration <yourConfigurationName> --workers 2 --jest-report-specs
 ```
 
+## runInBand + maxWorkers
+
+Jest sets `maxWorkers = 1` when you use its `--runInBand` option. However, Jest does not allow explicitly specifying `--maxWorkers=1` in that case. The error message from Jest looks like this:
+
+```
+Both --runInBand and --maxWorkers were specified, but these two options do not make sense together. Which is it?
+Command failed: jest --config e2e/config.json --testNamePattern '^((?!:android:).)*$' --maxWorkers 1 --runInBand e2e
+```
+
+To prevent Detox from adding its own default `--maxWorkers=1`, instead pass `--workers=0`, e.g.:
+
+```bash
+detox test --configuration <yourConfigurationName> --workers 0
+```
+
 ## How to Run Unit and E2E Tests in the Same Project
 
 - Create different Jest configs for unit and E2E tests, e.g. in `e2e/config.json` (for Detox) and `jest.config.js`


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: https://github.com/wix/Detox/issues/2862

Running `detox test --configuration e2e/config.json --runInBand e2e` will show this Jest error:

```
Both --runInBand and --maxWorkers were specified, but these two options do not make sense together. Which is it?
Command failed: jest --config e2e/config.json --testNamePattern '^((?!:android:).)*$' --maxWorkers 1 --runInBand e2e
```

With this PR, the error can be avoided by running `detox test --configuration e2e/config.json --runInBand --workers 0 e2e`, which turns into:

```
jest --config e2e/config.json --testNamePattern '^((?!:android:).)*$' --runInBand e2e
```

---

In this pull request, I have …

> _For features/enhancements:_
 - [X] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.
