### PR TITLE
fix(config): extends: ./relative/path

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "detox",
   "description": "E2E tests and automation for mobile",
-  "version": "18.18.1",
+  "version": "18.18.2-smoke.0",
   "bin": {
     "detox": "local-cli/cli.js"
   },

--- a/detox/src/configuration/__mocks__/configuration/extends/.detoxrc.js
+++ b/detox/src/configuration/__mocks__/configuration/extends/.detoxrc.js
@@ -1,8 +1,0 @@
-module.exports = {
-  extends: require.resolve('./middle'),
-  artifacts: {
-    plugins: {
-      video: 'all',
-    },
-  },
-}

--- a/detox/src/configuration/__mocks__/configuration/extends/.detoxrc.json
+++ b/detox/src/configuration/__mocks__/configuration/extends/.detoxrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./middle",
+  "artifacts": {
+    "plugins": {
+      "video": "all"
+    }
+  }
+}

--- a/detox/src/configuration/__mocks__/configuration/extends/middle/index.js
+++ b/detox/src/configuration/__mocks__/configuration/extends/middle/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: require.resolve('./base.json'),
+  extends: '../base.json',
   artifacts: {
     rootDir: 'someRootDir',
     plugins: {

--- a/detox/src/configuration/loadExternalConfig.js
+++ b/detox/src/configuration/loadExternalConfig.js
@@ -90,7 +90,7 @@ async function loadExternalConfig({ errorComposer, configPath, cwd }) {
 
     result.config = await tryExtendConfig({
       config: result.config,
-      cwd,
+      cwd: path.dirname(resolvedConfigPath),
       errorComposer,
     });
 

--- a/detox/src/configuration/loadExternalConfig.test.js
+++ b/detox/src/configuration/loadExternalConfig.test.js
@@ -60,9 +60,9 @@ describe('loadExternalConfig', () => {
   it('should merge in the base config from "extends" property', async () => {
     const { filepath, config } = await loadExternalConfig({ cwd: DIR_EXTENDS });
 
-    expect(filepath).toBe(path.join(DIR_EXTENDS, '.detoxrc.js'));
+    expect(filepath).toBe(path.join(DIR_EXTENDS, '.detoxrc.json'));
     expect(config).toEqual({
-      extends: path.join(DIR_EXTENDS, 'middle.js'),
+      extends: './middle',
       artifacts: {
         rootDir: 'someRootDir',
         plugins: {

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-test",
-  "version": "18.18.1",
+  "version": "18.18.2-smoke.0",
   "private": true,
   "engines": {
     "node": ">=8.3.0"
@@ -40,7 +40,7 @@
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
     "@types/node": "^14.14.20",
-    "detox": "^18.18.1",
+    "detox": "^18.18.2-smoke.0",
     "dtslint": "^4.0.6",
     "express": "^4.15.3",
     "jest": "^27.0.0",

--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -30,7 +30,17 @@ distribute them as `npm` modules for reuse across multiple projects, e.g.:
 }
 ```
 
-Please note that `extends` has to be a valid Node module path.
+Please note that `extends` has to be a valid Node module path. Relative module paths will be resolved relatively
+to the Detox config file which contains that specific `extends` property, e.g.:
+
+```js
+// given: ~/Projects/my-project/.detoxrc.json
+{ extends: "./e2e/detox-base-config" }
+// goes to: ~/Projects/my-project/e2e/detox-base-config.js
+{ extends: "./configs/base" }
+// then goes to: ~/Projects/my-project/e2e/configs/base/index.js
+// and so on...
+```
 
 ### Individual Configurations
 

--- a/examples/demo-native-android/package.json
+++ b/examples/demo-native-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-demo-native-android",
-  "version": "18.18.1",
+  "version": "18.18.2-smoke.0",
   "private": true,
   "scripts": {
     "packager": "react-native start",
@@ -8,7 +8,7 @@
     "e2e": "mocha e2e --opts ./e2e/mocha.opts"
   },
   "devDependencies": {
-    "detox": "^18.18.1",
+    "detox": "^18.18.2-smoke.0",
     "mocha": "^6.1.3"
   },
   "detox": {}

--- a/examples/demo-native-ios/package.json
+++ b/examples/demo-native-ios/package.json
@@ -1,9 +1,9 @@
 {
   "name": "detox-demo-native-ios",
-  "version": "18.18.1",
+  "version": "18.18.2-smoke.0",
   "private": true,
   "devDependencies": {
-    "detox": "^18.18.1",
+    "detox": "^18.18.2-smoke.0",
     "mocha": "^6.1.3"
   },
   "detox": {

--- a/examples/demo-react-native-detox-instruments/package.json
+++ b/examples/demo-react-native-detox-instruments/package.json
@@ -1,10 +1,10 @@
 {
   "name": "demo-react-native-detox-instruments",
-  "version": "18.18.1",
+  "version": "18.18.2-smoke.0",
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "detox": "^18.18.1",
+    "detox": "^18.18.2-smoke.0",
     "mocha": "6.x.x"
   },
   "detox": {

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-react-native-jest",
-  "version": "18.18.1",
+  "version": "18.18.2-smoke.0",
   "private": true,
   "scripts": {
     "test:ios-release": "detox test --configuration ios.sim.release -l verbose",
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
-    "detox": "^18.18.1",
+    "detox": "^18.18.2-smoke.0",
     "jest": "^26.5.0",
     "jest-circus": "^26.5.2",
     "sanitize-filename": "^1.6.1",

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "18.18.1",
+  "version": "18.18.2-smoke.0",
   "private": true,
   "scripts": {
     "start": "react-native start",
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^8.2.0",
-    "detox": "^18.18.1",
+    "detox": "^18.18.2-smoke.0",
     "mocha": "^6.1.3",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
     "generation",
     "."
   ],
-  "version": "18.18.1",
+  "version": "18.18.2-smoke.0",
   "npmClient": "npm",
   "command": {
     "publish": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "semver": "5.x.x",
     "shell-utils": "1.x.x"
   },
-  "version": "18.18.1"
+  "version": "18.18.2-smoke.0"
 }


### PR DESCRIPTION
## Description

The recent `extends` feature (https://github.com/wix/Detox/pull/2707) has undefined behavior when it boils down to relative Node module paths. Moreover, I consider the present implementation of relative `extends` incorrect, because it always resolves relative paths relatively to `process.cwd()` and not the current directory of the current Detox config file.

This is why I am adding the relevant tests and mentions in the docs together with the fix:

> Please note that `extends` has to be a valid Node module path. Relative module paths will be resolved relatively
to the Detox config file which contains that specific `extends` property, e.g.:

```js
// given: ~/Projects/my-project/.detoxrc.json
{ extends: "./e2e/detox-base-config" }
// goes to: ~/Projects/my-project/e2e/detox-base-config.js
{ extends: "./configs/base" }
// then goes to: ~/Projects/my-project/e2e/configs/base/index.js
// and so on...
```