### PR TITLE
feat(config): skipLegacyWorkersInjection

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -47,6 +47,12 @@ declare global {
              */
             testRunner?: string;
             /**
+             * Stops passing default `--maxWorkers 1` to the test runner,
+             * presuming that from now on you have that already configured
+             * in your test runner config as a default.
+             */
+            skipLegacyWorkersInjection?: boolean;
+            /**
              * @example runnerConfig: 'e2e/config.js'
              */
             runnerConfig?: string;

--- a/detox/local-cli/init.js
+++ b/detox/local-cli/init.js
@@ -102,6 +102,7 @@ function createJestFolderE2E() {
   createFile('.detoxrc.json', JSON.stringify({
     testRunner: 'jest',
     runnerConfig: 'e2e/config.json',
+    skipLegacyWorkersInjection: true,
     ...createDefaultConfigurations(),
   }, null, 2));
 }

--- a/detox/local-cli/templates/jest.js
+++ b/detox/local-cli/templates/jest.js
@@ -1,6 +1,7 @@
 const firstTestContent = require('./firstTestContent');
 
 const runnerConfig = `{
+    "maxWorkers": 1,
     "testEnvironment": "./environment",
     "testRunner": "jest-circus/runner",
     "testTimeout": 120000,

--- a/detox/local-cli/utils/jestInternals.js
+++ b/detox/local-cli/utils/jestInternals.js
@@ -1,0 +1,70 @@
+const Module = require('module');
+const path = require('path');
+
+const resolveFrom = require('resolve-from');
+
+const DetoxRuntimeError = require('../../src/errors/DetoxRuntimeError');
+
+const getNodeModulePaths = (dir) => Module._nodeModulePaths(dir);
+
+function getJestLocation() {
+  const cwd = process.cwd();
+
+  if (!resolveFrom.silent(cwd, 'jest')) {
+    throw new DetoxRuntimeError({
+      message: 'Could not resolve "jest" package from the current working directory.\n\n' +
+        'This means that Detox could not find it in any of the following locations:\n' +
+        getNodeModulePaths(cwd).map(p => `* ${p}`).join('\n'),
+      hint: `Try installing "jest": npm install jest --save-dev`,
+    });
+  }
+
+  return path.dirname(resolveFrom(cwd, 'jest/package.json'));
+}
+
+function resolveJestDependency(jestLocation, dependencyName) {
+  const result = resolveFrom.silent(jestLocation, dependencyName);
+  if (!result) {
+    throw new DetoxRuntimeError({
+      message: `Could not resolve "${dependencyName}" package from the "jest" npm package directory.\n\n` +
+        'This means that Detox could not find it in any of the following locations:\n' +
+        getNodeModulePaths(jestLocation).map(p => `* ${p}`).join('\n'),
+      hint: 'Consider reporting this as an issue at: https://github.com/wix/Detox/issues'
+    });
+  }
+
+  return result;
+}
+
+function requireJestDependency(jestLocation, dependencyName) {
+  return require(resolveJestDependency(jestLocation, dependencyName));
+}
+
+function resolveJestCliArgs() {
+  const jestLocation = getJestLocation();
+  resolveJestDependency(jestLocation, 'jest-cli');
+
+  try {
+    const jestCliManifest = resolveJestDependency(jestLocation, 'jest-cli/package.json');
+    const argsJsFile = path.join(path.dirname(jestCliManifest), 'build/cli/args.js');
+
+    return require(argsJsFile);
+  } catch (e) {
+    throw new DetoxRuntimeError({
+      message: 'Could not parse CLI arguments supported by "jest-cli" package, see the error below.',
+      hint: 'Consider reporting this as an issue at: https://github.com/wix/Detox/issues',
+      debugInfo: e,
+    });
+  }
+}
+
+async function readJestConfig(argv) {
+  const jestLocation = getJestLocation();
+  const { readConfig } = requireJestDependency(jestLocation, 'jest-config');
+  return readConfig(argv, process.cwd(), false);
+}
+
+module.exports = {
+  resolveJestCliArgs,
+  readJestConfig,
+};

--- a/detox/local-cli/utils/testCommandArgs.js
+++ b/detox/local-cli/utils/testCommandArgs.js
@@ -106,7 +106,6 @@ module.exports = {
     group: 'Execution:',
     describe: 'Specifies the number of workers the test runner should spawn. Requires a test runner with parallel execution support (e.g. Jest)',
     number: true,
-    default: 1,
   },
   'jest-report-specs': {
     group: 'Execution:',

--- a/detox/package.json
+++ b/detox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "detox",
   "description": "E2E tests and automation for mobile",
-  "version": "18.18.2-smoke.0",
+  "version": "18.19.0-smoke.0",
   "bin": {
     "detox": "local-cli/cli.js"
   },

--- a/detox/src/configuration/composeRunnerConfig.js
+++ b/detox/src/configuration/composeRunnerConfig.js
@@ -11,6 +11,7 @@ function composeRunnerConfig({ globalConfig, cliConfig }) {
     testRunner,
     runnerConfig: customRunnerConfig || defaultRunnerConfig,
     specs: globalConfig.specs || 'e2e',
+    skipLegacyWorkersInjection: Boolean(globalConfig.skipLegacyWorkersInjection),
   };
 }
 

--- a/detox/test/e2e/config.js
+++ b/detox/test/e2e/config.js
@@ -11,6 +11,7 @@ module.exports = {
     : ['<rootDir>/runners/jest/streamlineReporter', '<rootDir>/test/node_modules/jest-junit'],
   'verbose': true,
   'bail': false,
+  'maxWorkers': 1,
   'collectCoverageFrom': [
     'src/**/*.js',
     '!**/__test/**',

--- a/detox/test/e2e/detox.config.js
+++ b/detox/test/e2e/detox.config.js
@@ -9,6 +9,8 @@ const config = {
   testRunner: 'nyc jest',
   runnerConfig: 'e2e/config.js',
   specs: 'e2e/*.test.js',
+  skipLegacyWorkersInjection: true,
+
   behavior: {
     init: {
       exposeGlobals: true

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-test",
-  "version": "18.18.2-smoke.0",
+  "version": "18.19.0-smoke.0",
   "private": true,
   "engines": {
     "node": ">=8.3.0"
@@ -40,7 +40,7 @@
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
     "@types/node": "^14.14.20",
-    "detox": "^18.18.2-smoke.0",
+    "detox": "^18.19.0-smoke.0",
     "dtslint": "^4.0.6",
     "express": "^4.15.3",
     "jest": "^27.0.0",

--- a/detox/test/types/detox-jest-circus-setup-tests.ts
+++ b/detox/test/types/detox-jest-circus-setup-tests.ts
@@ -24,6 +24,7 @@ beforeAll(async () => {
     testRunner: "nyc jest",
     runnerConfig: "e2e/config.js",
     specs: "e2e/*.test.js",
+    skipLegacyWorkersInjection: true,
     behavior: {
       init: {
         reinstallApp: true,

--- a/docs/Guide.Jest.md
+++ b/docs/Guide.Jest.md
@@ -56,6 +56,7 @@ Even if `detox init` passes well, and everything is green, we still recommend go
 | ---------------------- | ---------------------------------------------- | ------------------------------------------------------------ |
 | `testRunner`    | `"jest"`                                       | *Required.* Should be `"jest"` for the proper `detox test` CLI functioning. |
 | `runnerConfig ` | (optional path to Jest config file)            | *Optional.* This field tells `detox test` CLI where to look for Jest's config file. If omitted, the default value is `e2e/config.json`. |
+| `skipLegacyWorkersInjection ` | `false` or `true`            | *Optional.* This field tells `detox test` to stop appending `--maxWorkers 1` argument to `jest ...` command by default. Since `detox@18.19.0`, the control over `maxWorkers` count has been transfered to Jest config files, and that allows you to set any other value as a default `maxWorkers` count. |
 
 A typical Detox configuration in `.detoxrc.json` file looks like:
 
@@ -63,6 +64,7 @@ A typical Detox configuration in `.detoxrc.json` file looks like:
 {
   "testRunner": "jest",
   "runnerConfig": "e2e/config.json",
+  "skipLegacyWorkersInjection": true,
   "devices": {
     "simulator": {
       "type": "ios.simulator",
@@ -91,6 +93,7 @@ A typical Detox configuration in `.detoxrc.json` file looks like:
 
 | Property               | Value                                          | Description                                                  |
 | ---------------------- | ---------------------------------------------- | ------------------------------------------------------------ |
+| `maxWorkers `          | `1`                | *Recommended.* When being used with `skipLegacyWorkersInjection: true` in Detox config, it prevents overallocation of mobile devices in the light of Jest's default logic (`= cpusCount — 1`), when you do not pass any specific worker count. To override it, [use CLI arguments](APIRef.DetoxCLI.md#test), or see [Jest documentation](https://jestjs.io/docs/configuration#maxworkers-number--string) if you plan to change the default value in the config. |
 | `testEnvironment `     | `"./environment"`               | *Required.* Needed for the proper functioning of Jest and Detox. See [Jest documentation](https://jestjs.io/docs/en/configuration#testenvironment-string) for more details. |
 | `testRunner `          | `"jest-circus/runner"`                           | *Required.* Needed for the proper functioning of Jest and Detox. See [Jest documentation](https://jestjs.io/docs/en/configuration#testrunner-string) for more details.  |
 | `testTimeout `          | `120000`                           | *Required*. Overrides the default timeout (5 seconds), which is usually too short to complete a single end-to-end test. |

--- a/examples/demo-native-android/package.json
+++ b/examples/demo-native-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-demo-native-android",
-  "version": "18.18.2-smoke.0",
+  "version": "18.19.0-smoke.0",
   "private": true,
   "scripts": {
     "packager": "react-native start",
@@ -8,7 +8,7 @@
     "e2e": "mocha e2e --opts ./e2e/mocha.opts"
   },
   "devDependencies": {
-    "detox": "^18.18.2-smoke.0",
+    "detox": "^18.19.0-smoke.0",
     "mocha": "^6.1.3"
   },
   "detox": {}

--- a/examples/demo-native-ios/package.json
+++ b/examples/demo-native-ios/package.json
@@ -1,9 +1,9 @@
 {
   "name": "detox-demo-native-ios",
-  "version": "18.18.2-smoke.0",
+  "version": "18.19.0-smoke.0",
   "private": true,
   "devDependencies": {
-    "detox": "^18.18.2-smoke.0",
+    "detox": "^18.19.0-smoke.0",
     "mocha": "^6.1.3"
   },
   "detox": {

--- a/examples/demo-react-native-detox-instruments/package.json
+++ b/examples/demo-react-native-detox-instruments/package.json
@@ -1,10 +1,10 @@
 {
   "name": "demo-react-native-detox-instruments",
-  "version": "18.18.2-smoke.0",
+  "version": "18.19.0-smoke.0",
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "detox": "^18.18.2-smoke.0",
+    "detox": "^18.19.0-smoke.0",
     "mocha": "6.x.x"
   },
   "detox": {

--- a/examples/demo-react-native-jest/e2e/config.json
+++ b/examples/demo-react-native-jest/e2e/config.json
@@ -2,6 +2,7 @@
     "globalSetup": "./global-setup.js",
     "globalTeardown": "./global-teardown.js",
     "setupFilesAfterEnv": ["./setup.ts"],
+    "maxWorkers": 1,
     "testEnvironment": "./environment",
     "testRunner": "jest-circus/runner",
     "testTimeout": 120000,

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -11,12 +11,11 @@
     "test:android-genycloud-release-ci": "detox test --configuration android.genycloud.release -l verbose --workers 2 --record-logs all --take-screenshots all"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.19",
+    "@types/jest": "^26.0.24",
     "detox": "^18.19.0-smoke.0",
-    "jest": "^26.5.0",
-    "jest-circus": "^26.5.2",
+    "jest": "^27.0.0",
     "sanitize-filename": "^1.6.1",
-    "ts-jest": "^26.4.4",
+    "ts-jest": "^27.0.0",
     "typescript": "^4.1.3"
   },
   "dependencies": {

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-react-native-jest",
-  "version": "18.18.2-smoke.0",
+  "version": "18.19.0-smoke.0",
   "private": true,
   "scripts": {
     "test:ios-release": "detox test --configuration ios.sim.release -l verbose",
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
-    "detox": "^18.18.2-smoke.0",
+    "detox": "^18.19.0-smoke.0",
     "jest": "^26.5.0",
     "jest-circus": "^26.5.2",
     "sanitize-filename": "^1.6.1",

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "18.18.2-smoke.0",
+  "version": "18.19.0-smoke.0",
   "private": true,
   "scripts": {
     "start": "react-native start",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^8.2.0",
-    "detox": "^18.18.2-smoke.0",
+    "detox": "^18.19.0-smoke.0",
     "mocha": "^6.1.3",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
     "generation",
     "."
   ],
-  "version": "18.18.2-smoke.0",
+  "version": "18.19.0-smoke.0",
   "npmClient": "npm",
   "command": {
     "publish": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "semver": "5.x.x",
     "shell-utils": "1.x.x"
   },
-  "version": "18.18.2-smoke.0"
+  "version": "18.19.0-smoke.0"
 }


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #2862.

In this pull request, I have added `skipLegacyWorkersInjection: boolean` to `Detox.DetoxConfig`, so that `detox test` command avoids the permanent passthrough of `--workers 1` to Jest by default. For the opposite case, when a user specifies a custom workers number via [`-w, --workers <count>` CLI option](https://github.com/wix/Detox/blob/28a34feb5ed6b2f4fb62bda188b12125379337bd/docs/APIRef.DetoxCLI.md#test), the previous behavior remains the same.

From now on, the default Jest config file generated by `detox init -r jest` contains `maxWorkers: 1` to prevent an unintended overallocation of devices if there are multiple test files — an average personal computer is likely to have a problem with more than 3-4 simulators/emulators running at once, therefore we add a safeguard mechanism this way.

The temporary flag, `skipLegacyWorkersInjection` is intended to be removed in the next Detox major release in favor of the new behavior added with this pull request.

> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.