### PR TITLE
fix: emulator shutdown bugs

### DIFF
--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -94,7 +94,7 @@ class Detox {
       this._client = null;
     }
 
-    if (this.device) {
+    if (this.device && this.device.id) {
       await this.device._cleanup();
 
       if (this._behaviorConfig.cleanup.shutdownDevice) {

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -53,6 +53,10 @@ describe('Detox', () => {
     logger = require('./utils/logger');
     Device = require('./devices/Device');
     Device.useRealConstructor();
+    Device.prototype.prepare.mockImplementation(function() {
+      this.id = 'deviceId';
+    });
+
     FakeDriverRegistry = require('./devices/DriverRegistry');
     ArtifactsManager = require('./artifacts/ArtifactsManager');
     invoke = require('./invoke');
@@ -463,17 +467,37 @@ describe('Detox', () => {
       beforeEach(async () => {
         detox = new Detox(detoxConfig);
         await detox.init();
-        await detox.cleanup();
       });
 
-      it(`should not shutdown the device`, () =>
-        expect(device().shutdown).not.toHaveBeenCalled());
+      describe('if the device has not been allocated', () => {
+        beforeEach(async () => {
+          delete device().id;
+          await detox.cleanup();
+        });
 
-      it(`should trigger artifactsManager.onBeforeCleanup()`, () =>
-        expect(artifactsManager().onBeforeCleanup).toHaveBeenCalled());
+        it(`should omit calling device._cleanup()`, async () => {
+          await detox.cleanup();
+          expect(device()._cleanup).not.toHaveBeenCalled();
+        });
+      });
 
-      it(`should dump pending network requests`, () =>
-        expect(client().dumpPendingRequests).toHaveBeenCalled());
+      describe('if the device has been allocated', function() {
+        beforeEach(async () => {
+          await detox.cleanup();
+        });
+
+        it(`should call device._cleanup()`, () =>
+          expect(device()._cleanup).toHaveBeenCalled());
+
+        it(`should not shutdown the device`, () =>
+          expect(device().shutdown).not.toHaveBeenCalled());
+
+        it(`should trigger artifactsManager.onBeforeCleanup()`, () =>
+          expect(artifactsManager().onBeforeCleanup).toHaveBeenCalled());
+
+        it(`should dump pending network requests`, () =>
+          expect(client().dumpPendingRequests).toHaveBeenCalled());
+      });
     });
 
     describe('when behaviorConfig.cleanup.shutdownDevice = true', () => {
@@ -485,6 +509,15 @@ describe('Detox', () => {
       it(`should shutdown the device on detox.cleanup()`, async () => {
         await detox.cleanup();
         expect(device().shutdown).toHaveBeenCalled();
+      });
+
+      describe('if the device has not been allocated', () => {
+        beforeEach(() => { delete device().id; });
+
+        it(`should omit the shutdown`, async () => {
+          await detox.cleanup();
+          expect(device().shutdown).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/detox/src/devices/drivers/android/emulator/EmulatorDriver.js
+++ b/detox/src/devices/drivers/android/emulator/EmulatorDriver.js
@@ -28,7 +28,11 @@ class EmulatorDriver extends AndroidDriver {
     this._deviceRegistry = DeviceRegistry.forAndroid();
 
     const emulatorExec = new EmulatorExec();
-    this._emulatorLauncher = new EmulatorLauncher(emulatorExec, this.emitter);
+    this._emulatorLauncher = new EmulatorLauncher({
+      adb: this.adb,
+      emulatorExec,
+      eventEmitter: this.emitter,
+    });
     this._emuVersionResolver = new EmulatorVersionResolver(emulatorExec);
 
     const avdsResolver = new AVDsResolver(emulatorExec);
@@ -82,6 +86,7 @@ class EmulatorDriver extends AndroidDriver {
   }
 
   async shutdown(deviceId) {
+    await this.instrumentation.setTerminationFn(null);
     await this._emulatorLauncher.shutdown(deviceId);
   }
 

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.js
@@ -36,9 +36,9 @@ class EmulatorLauncher extends AndroidDeviceLauncher {
     await this._notifyPreShutdown(adbName);
     await this._adb.emuKill(adbName);
     await retry({
-      retries: 6,
-      interval: 500,
-      backoff: 'none',
+      retries: 5,
+      interval: 1000,
+      initialSleep: 2000,
     }, async () => {
       if (await this._adb.getState(adbName) !== 'none') {
         throw new DetoxRuntimeError({

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
@@ -84,7 +84,7 @@ describe('Emulator launcher', () => {
       });
 
       it('should keep polling the emulator status until it is "none"', async () => {
-        expect(adb.getState).toHaveBeenCalledTimes(6);
+        expect(adb.getState).toHaveBeenCalledTimes(5);
       });
 
       it('should not emit shutdownDevice prematurely', async () => {

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
@@ -1,34 +1,39 @@
 const adbName = 'mock_adb_name-1117';
 
+jest.setTimeout(15000);
+
 describe('Emulator launcher', () => {
   let retry;
   let eventEmitter;
-  let emulatorTelnet;
   let emulatorExec;
   let uut;
+  let adb;
+
   beforeEach(() => {
     jest.mock('../../../../../utils/logger');
 
     jest.mock('../../../../../utils/retry');
     retry = require('../../../../../utils/retry');
-    retry.mockImplementation((options, func) => func());
 
     jest.mock('../../../../../utils/trace', () => ({
       traceCall: jest.fn().mockImplementation((__, func) => func()),
     }));
 
-    const AsyncEmitter = jest.genMockFromModule('../../../../..//utils/AsyncEmitter');
-    eventEmitter = new AsyncEmitter();
+    const ADB = jest.genMockFromModule('../../exec/ADB');
+    adb = new ADB();
 
-    const EmulatorTelnet = jest.genMockFromModule('../../tools/EmulatorTelnet');
-    emulatorTelnet = new EmulatorTelnet();
-    jest.mock('../../tools/EmulatorTelnet');
+    const AsyncEmitter = jest.genMockFromModule('../../../../../utils/AsyncEmitter');
+    eventEmitter = new AsyncEmitter();
 
     const { EmulatorExec } = jest.genMockFromModule('../../exec/EmulatorExec');
     emulatorExec = new EmulatorExec();
 
     const EmulatorLauncher = require('./EmulatorLauncher');
-    uut = new EmulatorLauncher(emulatorExec, eventEmitter, () => emulatorTelnet);
+    uut = new EmulatorLauncher({
+      adb,
+      emulatorExec,
+      eventEmitter,
+    });
   });
 
   describe('launch', () => {
@@ -36,33 +41,57 @@ describe('Emulator launcher', () => {
   });
 
   describe('shutdown', () => {
-    it('should kill device via telnet', async () => {
-      await uut.shutdown(adbName);
-
-      expect(emulatorTelnet.connect).toHaveBeenCalledWith('1117');
-      expect(emulatorTelnet.kill).toHaveBeenCalled();
+    beforeEach(() => {
+      retry.mockImplementation(async ({ retries }, func) => {
+        while (retries > 0) {
+          try {
+            return await func();
+          } catch (e) {
+            if (!--retries) throw e;
+          }
+        }
+      });
     });
 
-    it('should emit associated events', async () => {
-      await uut.shutdown(adbName);
+    describe('if it goes as expected', () => {
+      beforeEach(async () => {
 
-      expect(eventEmitter.emit).toHaveBeenCalledWith('beforeShutdownDevice', { deviceId: adbName });
-      expect(eventEmitter.emit).toHaveBeenCalledWith('shutdownDevice', { deviceId: adbName });
+        adb.getState.mockResolvedValueOnce('device');
+        adb.getState.mockResolvedValueOnce('offline');
+        adb.getState.mockResolvedValueOnce('none');
+
+        await uut.shutdown(adbName);
+      });
+
+      it('should kill device via adb', async () => {
+        expect(adb.emuKill).toHaveBeenCalledWith(adbName);
+      });
+
+      it('should wait until the device cannot be found', async () => {
+        expect(adb.getState).toHaveBeenCalledTimes(3);
+      });
+
+      it('should emit associated events', async () => {
+        expect(eventEmitter.emit).toHaveBeenCalledWith('beforeShutdownDevice', { deviceId: adbName });
+        expect(eventEmitter.emit).toHaveBeenCalledWith('shutdownDevice', { deviceId: adbName });
+      });
     });
 
-    it('should not emit shutdownDevice prematurely', async () => {
-      emulatorTelnet.kill.mockRejectedValue(new Error());
+    describe('if shutdown does not go well', () => {
+      beforeEach(async () => {
+        adb.getState.mockResolvedValue('offline');
+        await expect(uut.shutdown(adbName)).rejects.toThrowError(new RegExp(`Failed to shut down.*${adbName}`));
+      });
 
-      await expect(uut.shutdown(adbName)).rejects.toThrowError();
-      expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
-      expect(eventEmitter.emit).not.toHaveBeenCalledWith('shutdownDevice', expect.any(Object));
-    });
+      it('should keep polling the emulator status until it is "none"', async () => {
+        expect(adb.getState).toHaveBeenCalledTimes(6);
+      });
 
-    it('should resort to a default telnet generator func', async () => {
-      const EmulatorLauncher = require('./EmulatorLauncher');
-      uut = new EmulatorLauncher(emulatorExec, eventEmitter);
-
-      await uut.shutdown(adbName);
+      it('should not emit shutdownDevice prematurely', async () => {
+        expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+        expect(eventEmitter.emit).toHaveBeenCalledWith('beforeShutdownDevice', expect.any(Object));
+        expect(eventEmitter.emit).not.toHaveBeenCalledWith('shutdownDevice', expect.any(Object));
+      });
     });
   });
 });

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.test.js
@@ -1,7 +1,5 @@
 const adbName = 'mock_adb_name-1117';
 
-jest.setTimeout(15000);
-
 describe('Emulator launcher', () => {
   let retry;
   let eventEmitter;

--- a/detox/src/devices/drivers/android/exec/ADB.js
+++ b/detox/src/devices/drivers/android/exec/ADB.js
@@ -27,6 +27,23 @@ class ADB {
     return { devices, stdout };
   }
 
+  async getState(deviceId) {
+    try {
+      const output = await this.adbCmd(deviceId, `get-state`, {
+        verbosity: 'low'
+      });
+
+      return output.stdout.trim();
+    } catch (e) {
+      const stderr = e.stderr || '';
+      if (stderr.includes('not found')) {
+        return 'none';
+      } else {
+        throw e;
+      }
+    }
+  }
+
   async unlockScreen(deviceId) {
     const {
       mWakefulness,
@@ -300,6 +317,10 @@ class ADB {
 
   async reverseRemove(deviceId, port) {
     return this.adbCmd(deviceId, `reverse --remove tcp:${port}`);
+  }
+
+  async emuKill(deviceId) {
+    return this.adbCmd(deviceId, `emu kill`);
   }
 
   // TODO refactor the whole thing so as to make usage of BinaryExec -- similar to EmulatorExec

--- a/detox/src/utils/retry.js
+++ b/detox/src/utils/retry.js
@@ -1,5 +1,6 @@
 const sleep = require('./sleep');
 
+const DEFAULT_INITIAL_SLEEP = 0;
 const DEFAULT_RETRIES = 9;
 const DEFAULT_INTERVAL = 500;
 const DEFAULT_CONDITION_FN = () => true;
@@ -21,9 +22,14 @@ async function retry(optionsOrFunc, func) {
     interval = DEFAULT_INTERVAL,
     backoff = DEFAULT_BACKOFF_MODE,
     conditionFn = DEFAULT_CONDITION_FN,
+    initialSleep = DEFAULT_INITIAL_SLEEP,
   } = options;
 
   const backoffFn = backoffModes[backoff]();
+
+  if (initialSleep) {
+    await sleep(initialSleep);
+  }
 
   // eslint-disable-next-line no-constant-condition
   for (let totalTries = 1, lastError = null; true; totalTries++) {

--- a/detox/src/utils/retry.test.js
+++ b/detox/src/utils/retry.test.js
@@ -30,6 +30,20 @@ describe('retry', () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
+  it('should sleep before calling a function if initialSleep is set', async () => {
+    const mockFn = jest.fn();
+
+    try {
+      await retry({ initialSleep: 1234, retries: 999, interval: 0 }, mockFn);
+    } catch (e) {
+      fail('expected retry not to fail');
+    }
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(1234);
+  });
+
   it('should retry multiple times', async () => {
     const mockFn = mockFailingTwiceUserFn();
     await retry({ retries: 999, interval: 0 }, mockFn);


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #1975

In this pull request, I have:

- added clearing callback for "app instrumentation end" when shutting down the device, because `adb.unreverseTcpPort` will fail if the device in the middle of shutting down;
- changed the implementation for shutting down an emulator: `adb -s SERIAL emu kill` instead of telnet
- added waiting until the emulator indeed shuts down - that prevents a telnet error in the next suite:
```
detox[31857] DEBUG: [EXEC_CMD, #123] "/Users/yaroslavs/Library/Android/Sdk/platform-tools/adb" -s emulator-18638 emu kill
detox[31857] TRACE: [SESSION_TORN] app exited session 2c5620bd-9097-a376-82ca-31c6b2d4965b
detox[31857] TRACE: [EXEC_SUCCESS, #122]
detox[31857] TRACE: [EXEC_SUCCESS, #123] OK: killing emulator, bye bye
OK

detox[31857] DEBUG: [EXEC_CMD, #124] "/Users/yaroslavs/Library/Android/Sdk/platform-tools/adb" -s emulator-18638 get-state
detox[31857] TRACE: [EXEC_SUCCESS, #124] device

detox[31857] DEBUG: [EXEC_CMD, #125] "/Users/yaroslavs/Library/Android/Sdk/platform-tools/adb" -s emulator-18638 get-state
detox[31857] DEBUG: [EXEC_FAIL, #125] ""/Users/yaroslavs/Library/Android/Sdk/platform-tools/adb" -s emulator-18638 get-state" failed with error = ChildProcessError: Command failed: "/Users/yaroslavs/Library/Android/Sdk/platform-tools/adb" -s emulator-18638 get-state
error: device 'emulator-18638' not found
 `"/Users/yaroslavs/Library/Android/Sdk/platform-tools/adb" -s emulator-18638 get-state` (exited with error code 1) (code=1), stdout and stderr:

detox[31857] DEBUG: [EXEC_FAIL, #125]
detox[31857] DEBUG: [EXEC_FAIL, #125] error: device 'emulator-18638' not found
```