### PR TITLE
fix: deallocate devices on cold boot errors

### DIFF
--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorDeviceAllocation.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorDeviceAllocation.js
@@ -29,7 +29,12 @@ class EmulatorDeviceAllocation extends AndroidDeviceAllocation {
 
     const coldBoot = !!placeholderPort;
     if (coldBoot) {
-      await this._launchEmulator(avdName, placeholderPort);
+      try {
+        await this._launchEmulator(avdName, placeholderPort);
+      } catch (e) {
+        await this.deallocateDevice(adbName);
+        throw e;
+      }
     }
     await this._awaitEmulatorBoot(adbName);
     await this._notifyAllocation(adbName, avdName, coldBoot);

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorDeviceAllocation.test.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorDeviceAllocation.test.js
@@ -109,11 +109,13 @@ describe('Android emulator device allocation', () => {
       expect(emulatorLauncher.launch).not.toHaveBeenCalled();
     });
 
-    it('should fail if emulator launch fails', async () => {
+    it('should fail and deallocate the device if emulator launch fails', async () => {
       givenNoFreeDevices();
       givenEmulatorLaunchError();
+      jest.spyOn(uut, 'deallocateDevice');
 
       await expect(uut.allocateDevice(avdName)).rejects.toThrowError();
+      await expect(uut.deallocateDevice).toHaveBeenCalledWith(expect.stringMatching(/emulator-\d+/));
     });
 
     it('should randomize a custom port for a newly launched emulator, in the 10000-20000 range', async () => {

--- a/detox/src/devices/drivers/android/genycloud/helpers/GenyCloudInstanceAllocation.js
+++ b/detox/src/devices/drivers/android/genycloud/helpers/GenyCloudInstanceAllocation.js
@@ -20,7 +20,12 @@ class GenyCloudInstanceAllocation extends AndroidDeviceAllocation {
     this._logAllocationResult(recipe, instance);
 
     if (isNew) {
-      await this._instanceLauncher.launch(instance);
+      try {
+        await this._instanceLauncher.launch(instance);
+      } catch (e) {
+        await this.deallocateDevice(instance.uuid);
+        throw e;
+      }
     }
 
     instance = await this._waitForInstanceBoot(instance);

--- a/detox/src/devices/drivers/ios/SimulatorDriver.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.js
@@ -72,8 +72,15 @@ class SimulatorDriver extends IosDriver {
       throw new DetoxRuntimeError(`Failed to find device matching ${deviceComment}`);
     }
 
-    await this._boot(udid, deviceQuery.type || deviceQuery);
     this._name = `${udid} ${deviceComment}`;
+
+    try {
+      await this._boot(udid, deviceQuery.type || deviceQuery);
+    } catch (e) {
+      await this.deviceRegistry.disposeDevice(udid);
+      throw e;
+    }
+
     return udid;
   }
 


### PR DESCRIPTION
## Description

### iOS simulator 

Adds an emergency simulator deallocation for cases when `boot` fails in the middle.

```js
await this._boot(udid, deviceQuery.type || deviceQuery);
```

```
detox[22859] DEBUG: [EXEC_CMD, #37] applesimutils --list --byId EB449DF0-39DC-457A-B2D7-25CE51BB1A2E --maxResults 1
detox[22859] ERROR: [EXEC_FAIL, #37] "applesimutils --list --byId EB449DF0-39DC-457A-B2D7-25CE51BB1A2E --maxResults 1" failed with error = ChildProcessError: Command failed: applesimutils --list --byId EB449DF0-39DC-457A-B2D7-25CE51BB1A2E --maxResults 1
```

In this pull request, I'm catching unexpected errors and rethrow them after deallocating the device UDID.

### Android emulator

```js
await this._launchEmulator(avdName, placeholderPort);
```

### Android emulator (Genymotion Cloud)

```js
await this._instanceLauncher.launch(instance);
```