### PR TITLE
Fixed Android < 23

### DIFF
--- a/detox/android/detox/src/main/java/org/joor/Reflect.java
+++ b/detox/android/detox/src/main/java/org/joor/Reflect.java
@@ -233,12 +233,16 @@ public class Reflect {
         try {
             Field field = field0(name);
             if ((field.getModifiers() & Modifier.FINAL) == Modifier.FINAL) {
+                try {
 // Note (d4vidi): this is an important change, compared to the original implementation!!!
 // See here: https://stackoverflow.com/a/64378131/453052
 //                Field modifiersField = Field.class.getDeclaredField("modifiers");
-                Field modifiersField = Field.class.getDeclaredField("accessFlags");
-                modifiersField.setAccessible(true);
-                modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+                    Field modifiersField = Field.class.getDeclaredField("accessFlags");
+                    modifiersField.setAccessible(true);
+                    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+                }
+                // Android < 23 doesn't have the accessFlags field
+                catch (NoSuchFieldException ignore) {}
             }
             field.set(object, unwrap(value));
             return this;

--- a/detox/src/devices/drivers/android/exec/ADB.js
+++ b/detox/src/devices/drivers/android/exec/ADB.js
@@ -105,7 +105,7 @@ class ADB {
     const apiLvl = await this.apiLevel(deviceId);
 
     let childProcess;
-    if (apiLvl >= 24) {
+    if (apiLvl >= 23) {
       childProcess = await this.adbCmd(deviceId, `install -r -g -t ${apkPath}`);
     } else {
       childProcess = await this.adbCmd(deviceId, `install -rg ${apkPath}`);
@@ -120,8 +120,14 @@ class ADB {
     }
   }
 
-  /*async*/ remoteInstall(deviceId, path) {
-    return this.shell(deviceId, `pm install -r -g -t ${path}`);
+  async remoteInstall(deviceId, path) {
+    const apiLvl = await this.apiLevel(deviceId);
+
+    if (apiLvl >= 23) {
+      return this.shell(deviceId, `pm install -r -g -t ${path}`);
+    } else {
+      return this.shell(deviceId, `pm install -rg ${path}`);
+    }
   }
 
   async uninstall(deviceId, appId) {

--- a/detox/src/devices/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/drivers/android/exec/ADB.test.js
@@ -91,6 +91,15 @@ describe('ADB', () => {
       { retries: 1 });
   });
 
+  it(`install api 23`, async () => {
+    jest.spyOn(adb, 'apiLevel').mockImplementation(async () => 23);
+    await adb.install('emulator-5556', 'path inside "quotes" to/app');
+
+    expect(exec).toHaveBeenCalledWith(
+      expect.stringContaining('adb" -s emulator-5556 install -r -g -t "path inside \\"quotes\\" to/app"'),
+      { retries: 1 });
+  });
+
   it(`uninstall`, async () => {
     await adb.uninstall('com.package');
     expect(exec).toHaveBeenCalledTimes(1);
@@ -139,6 +148,16 @@ describe('ADB', () => {
   });
 
   it('remote-install', async () => {
+    const binaryPath = '/mock-path/filename.mock';
+    await adb.remoteInstall(deviceId, binaryPath);
+
+    expect(exec).toHaveBeenCalledWith(
+      expect.stringContaining(`-s mockEmulator shell "pm install -rg ${binaryPath}"`),
+      expect.anything());
+  });
+
+  it('remote-install api 23', async () => {
+    jest.spyOn(adb, 'apiLevel').mockImplementation(async () => 23);
     const binaryPath = '/mock-path/filename.mock';
     await adb.remoteInstall(deviceId, binaryPath);
 


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #2527

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

As the issue describes older Android versions require `pm install -rg` instead of `pm install -r -g -t` (and similar for `adb install`).

In addition the reflection library tries to access the `accessFlags` field to change it's accessibility however from testing/investigation that field isn't present until API 23 therefore the missing field should be ignored.

I've also added tests for both ADB.install and ADB.remoteInstall checking the correct commands are sent for >= 23.

I've tested installing on Android 21-24.

### Dump of `getDeclaredFields()`

Dumped at `com.wix.detox.espresso.EventsInjectorReflected.setEventsInjectionStrategy(UiControllerSpy.kt:36)` to justify that the missing `accessFlags` field can be ignored.

#### API 22:

```
private final java.lang.reflect.ArtField java.lang.reflect.Field.artField
public static final java.util.Comparator java.lang.reflect.Field.ORDER_BY_NAME_AND_DECLARING_CLAS
```

#### API 23

```
private int java.lang.reflect.Field.accessFlags
private java.lang.Class java.lang.reflect.Field.declaringClass
private int java.lang.reflect.Field.dexFieldIndex
private int java.lang.reflect.Field.offset
private java.lang.Class java.lang.reflect.Field.type
public static final java.util.Comparator java.lang.reflect.Field.ORDER_BY_NAME_AND_DECLARING_CLASS
```

#### API 24:

```
private int java.lang.reflect.Field.accessFlags
private java.lang.Class java.lang.reflect.Field.declaringClass
private int java.lang.reflect.Field.dexFieldIndex
private int java.lang.reflect.Field.offset
private java.lang.Class java.lang.reflect.Field.type
```

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
