### PR TITLE
perf: skip initial multi-app reinstalls when binary paths are the same

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -122,7 +122,8 @@
       "src/utils/environment.js",
       "src/utils/logger.js",
       "src/utils/pipeCommands.js",
-      "src/utils/pressAnyKey.js"
+      "src/utils/pressAnyKey.js",
+      "src/utils/shellUtils.js"
     ],
     "resetMocks": true,
     "resetModules": true,

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -216,7 +216,11 @@ class Detox {
   }
 
   async _reinstallAppsOnDevice() {
-    const appNames = Object.keys(this._appsConfig);
+    const appNames = _(this._appsConfig)
+      .map((config, key) => [key, `${config.binaryPath}:${config.testBinaryPath}`])
+      .uniqBy(1)
+      .map(0)
+      .value();
 
     for (const appName of appNames) {
       await this.device.selectApp(appName);

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -198,14 +198,23 @@ describe('Detox', () => {
           type: 'ios.app',
           binaryPath: 'path/to/app',
         };
+
+        detoxConfig.appsConfig['extraAppWithAnotherArguments'] = {
+          type: 'ios.app',
+          binaryPath: 'path/to/app',
+          launchArgs: {
+            overrideArg: 2,
+          },
+        };
       });
 
       beforeEach(init);
 
-      it('should unselect the selected device app', () => {
+      it('should install only apps with unique binary paths, and deselect app on device', () => {
+        expect(detox.device.uninstallApp).toHaveBeenCalledTimes(2);
         expect(detox.device.installApp).toHaveBeenCalledTimes(2);
-        expect(detox.device.selectApp).toHaveBeenCalledTimes(3);
 
+        expect(detox.device.selectApp).toHaveBeenCalledTimes(3);
         expect(detox.device.selectApp.mock.calls[0]).toEqual(['default']);
         expect(detox.device.selectApp.mock.calls[1]).toEqual(['extraApp']);
         expect(detox.device.selectApp.mock.calls[2]).toEqual([null]);


### PR DESCRIPTION
## Description

This is another approach to crack the problem originally addressed by #2858.

The introduced optimization should eliminate that silly double uninstall-install process on our CI.

The implementation idea is to compare `binaryPath + testBinaryPath` for their uniqueness before calling uninstallApp/reinstallApp.