### PR TITLE
Reorganize troubleshooting onto a first-class guide, and ref it in code

### DIFF
--- a/detox/src/client/Client.test.js
+++ b/detox/src/client/Client.test.js
@@ -495,7 +495,7 @@ describe('Client', () => {
       it(`should log an error about the app being unreachable over web sockets`, async () => {
         await client.dumpPendingRequests();
         expect(log.error.mock.calls[0][0]).toEqual({ event: 'APP_UNREACHABLE' });
-        expect(log.error.mock.calls[0][1]).toMatch(/Failed to reach the app over the web socket connection./);
+        expect(log.error.mock.calls[0][1]).toMatch(/Detox can't seem to connect to the test app./);
       });
     });
 

--- a/detox/src/errors/longreads/__snapshots__/failedToReachTheApp.test.js.snap
+++ b/detox/src/errors/longreads/__snapshots__/failedToReachTheApp.test.js.snap
@@ -1,60 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`failedToReachTheApp .evenThoughAppWasLaunched() 1`] = `
-[DetoxRuntimeError: Failed to reach the app over the web socket connection.
+[DetoxRuntimeError: Detox can't seem to connect to the test app(s)!
 
 HINT: 
 
-1. If you don't see your app running on the device, there's a chance
-   that your app has crashed prematurely. To get the crash details,
-   you can run Detox tests with "--record-logs all" CLI option
-   and then inspect the device logs in the artifacts folder.
-
-2. If your app IS running on the device, yet you see this message:
-a) The native part of Detox failed to connect to the Detox server over
-   web sockets. If this is the case, the device's logs should contain
-   messages about those failed connection attempts.
-
-b) The app is running without Detox native code injected.
-   Make sure you don't launch it manually. If you don't, examine the logs
-   from the device. If you see a crash related to Detox native code, you
-   are welcome to report it on our GitHub tracker.
-   In case if you are debugging your native code integration with Detox,
-   these guides may prove helpful:
-
-   * https://github.com/wix/Detox/blob/master/docs/Guide.DebuggingInAndroidStudio.md
-   * https://github.com/wix/Detox/blob/master/docs/Guide.DebuggingInXcode.md]
+The test app might have crashed prematurely, or has had trouble setting up the connection.
+Refer to our troubleshooting guide, for full details: https://github.com/wix/Detox/blob/master/docs/Troubleshooting.RunningTests.md#tests-execution-hangs 
+]
 `;
 
 exports[`failedToReachTheApp .maybeAppWasNotLaunched(action) 1`] = `
-[DetoxRuntimeError: Failed to reach the app over the web socket connection.
+[DetoxRuntimeError: Detox can't seem to connect to the test app(s)!
 
 HINT: 
 
-Have you forgotten to write 'device.launchApp()' at the beginning
-of your test? If that's not the case, see the other options.
+Have you forgotten to call 'device.launchApp()' in the beginning of your test?
+Refer to our troubleshooting guide, for full details: https://github.com/wix/Detox/blob/master/docs/Troubleshooting.RunningTests.md#tests-execution-hangs
 
-1. If you don't see your app running on the device, there's a chance
-   that your app has crashed prematurely. To get the crash details,
-   you can run Detox tests with "--record-logs all" CLI option
-   and then inspect the device logs in the artifacts folder.
-
-
-2. If your app IS running on the device, yet you see this message:
-a) The native part of Detox failed to connect to the Detox server over
-   web sockets. If this is the case, the device's logs should contain
-   messages about those failed connection attempts.
-
-b) The app is running without Detox native code injected.
-   Make sure you don't launch it manually. If you don't, examine the logs
-   from the device. If you see a crash related to Detox native code, you
-   are welcome to report it on our GitHub tracker.
-   In case if you are debugging your native code integration with Detox,
-   these guides may prove helpful:
-
-   * https://github.com/wix/Detox/blob/master/docs/Guide.DebuggingInAndroidStudio.md
-   * https://github.com/wix/Detox/blob/master/docs/Guide.DebuggingInXcode.md
-
+---
 The following package could not be delivered:
 
 {

--- a/detox/src/errors/longreads/failedToReachTheApp.js
+++ b/detox/src/errors/longreads/failedToReachTheApp.js
@@ -1,46 +1,27 @@
 const DetoxRuntimeError = require('../DetoxRuntimeError');
 
-const message = 'Failed to reach the app over the web socket connection.';
+const message = 'Detox can\'t seem to connect to the test app(s)!';
+const troubleshootingRefMessage = 'Refer to our troubleshooting guide, for full details: https://github.com/wix/Detox/blob/master/docs/Troubleshooting.RunningTests.md#tests-execution-hangs';
 
-const hint1_B = `\
-1. If you don't see your app running on the device, there's a chance
-   that your app has crashed prematurely. To get the crash details,
-   you can run Detox tests with "--record-logs all" CLI option
-   and then inspect the device logs in the artifacts folder.\
+const hintMaybeNotLaunched = `\
+Have you forgotten to call 'device.launchApp()' in the beginning of your test?
+${troubleshootingRefMessage}\
 `;
 
-const hint1_A = `\
-Have you forgotten to write 'device.launchApp()' at the beginning
-of your test? If that's not the case, see the other options.
-
-${hint1_B}
+const hintAppWasLaunched = `The test app might have crashed prematurely, or has had trouble setting up the connection.
+${troubleshootingRefMessage} 
 `;
 
-const hint2 = `\
-2. If your app IS running on the device, yet you see this message:
-a) The native part of Detox failed to connect to the Detox server over
-   web sockets. If this is the case, the device's logs should contain
-   messages about those failed connection attempts.
-
-b) The app is running without Detox native code injected.
-   Make sure you don't launch it manually. If you don't, examine the logs
-   from the device. If you see a crash related to Detox native code, you
-   are welcome to report it on our GitHub tracker.
-   In case if you are debugging your native code integration with Detox,
-   these guides may prove helpful:
-
-   * https://github.com/wix/Detox/blob/master/docs/Guide.DebuggingInAndroidStudio.md
-   * https://github.com/wix/Detox/blob/master/docs/Guide.DebuggingInXcode.md\
-`;
-
-const payloadAppendix = `\
+const payloadAppendix = `---
 The following package could not be delivered:\
 `;
+
+const reformatSection = (s) => '\n\n' + s;
 
 function maybeAppWasNotLaunched(action) {
   return new DetoxRuntimeError({
     message,
-    hint: [hint1_A, hint2, payloadAppendix].map(s => '\n\n' + s).join(''),
+    hint: [hintMaybeNotLaunched, payloadAppendix].map(reformatSection).join(''),
     debugInfo: action,
   });
 }
@@ -48,7 +29,7 @@ function maybeAppWasNotLaunched(action) {
 function evenThoughAppWasLaunched() {
   return new DetoxRuntimeError({
     message,
-    hint: [hint1_B, hint2].map(s => '\n\n' + s).join(''),
+    hint: reformatSection(hintAppWasLaunched),
   });
 }
 

--- a/detox/src/server/__tests__/server-integration.test.js
+++ b/detox/src/server/__tests__/server-integration.test.js
@@ -123,7 +123,7 @@ describe('Detox server integration', () => {
 
     // assert tester get a serverError explaining the app is unreachable
     expect(testerSocket.send).toHaveBeenCalledWith(expect.stringContaining('"type":"serverError"'));
-    expect(testerSocket.send).toHaveBeenCalledWith(expect.stringContaining('Failed to reach the app over the web socket connection'));
+    expect(testerSocket.send).toHaveBeenCalledWith(expect.stringContaining('Detox can\'t seem to connect to the test app'));
 
     testerSocket.send.mockReset();
 

--- a/detox/test/e2e/19.crash-handling.test.js
+++ b/detox/test/e2e/19.crash-handling.test.js
@@ -11,7 +11,7 @@ describe('Crash Handling', () => {
   it('Should throw error upon internal app crash', async () => {
     await device.reloadReactNative();
     await expectToThrow(() => element(by.text('Crash')).tap(), 'The app has crashed');
-    await expectToThrow(() => element(by.text('Crash')).tap(), 'Failed to reach the app');
+    await expectToThrow(() => element(by.text('Crash')).tap(), 'Detox can\'t seem to connect to the test app(s)!');
   });
 
   it('Should recover from app crash', async () => {

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -16,7 +16,6 @@
 
   For older Android gradle plugin support use `detox@6.x.x` instead ([previous setup guide here](https://github.com/wix/detox/blob/97654071573053def90e8207be8eba011408f977/docs/Introduction.Android.md)).
 
-
 **Note: As a rule of thumb, we consider all old major versions discontinued; We only support the latest Detox major version.**
 
 ## Setup :gear:
@@ -390,5 +389,5 @@ Please be aware that the `minSdkVersion` needs to be at least 18.
 
 ## Troubleshooting
 
-Please refer to our index of [troubleshooting guides](Troubleshooting.md).
+Please refer to [troubleshooting guide about build issues](Troubleshooting.BuildingTheApp.md#android) for assistance.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,10 +30,7 @@
 
 ### Troubleshooting
 
-- [Troubleshooting Detox Installation](Troubleshooting.Installation.md)
-- [Troubleshooting Failing Tests](Troubleshooting.RunningTests.md)
-- [Troubleshooting Synchronization](Troubleshooting.Synchronization.md)
-- [Dealing With Flakiness in Tests](Troubleshooting.Flakiness.md)
+- [Troubleshooting ToC](Troubleshooting.md)
 
 ### Guides
 
@@ -54,4 +51,3 @@
 ### Contributing to Detox
 
 - [Detox Contribution Guide](Guide.Contributing.md)
-- [Android Support - Current Status](More.AndroidSupportStatus.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,12 @@
 
 ### Troubleshooting
 
-- [Troubleshooting ToC](Troubleshooting.md)
+- [Table of contents](Troubleshooting.md)
+  - [Building the App](Troubleshooting.BuildingTheApp.md)
+
+  - [Running tests](Troubleshooting.RunningTests.md)
+  - [Synchronization issues](Troubleshooting.Synchronization.md)
+  - [General tests stability issues](Troubleshooting.Flakiness.md)
 
 ### Guides
 

--- a/docs/Troubleshooting.BuildingTheApp.md
+++ b/docs/Troubleshooting.BuildingTheApp.md
@@ -1,0 +1,86 @@
+# Dealing With Problems With Building the App & Detox
+
+This page is about issues related to building the app, typically triggerred when running `detox build` (and not `detox test`, for example).
+
+## Android
+
+### Problem: Kotlin stdlib version conflicts
+
+The problems and resolutions here are different if you're using Detox as a precompiled dependency artifact (i.e. an `.aar`) - which is the default, or compiling it yourself.
+
+#### Resolving for a precompiled dependency (`.aar`)
+
+Of all [Kotlin implementation flavours](https://kotlinlang.org/docs/reference/using-gradle.html#configuring-dependencies), Detox assumes the most recent one, namely `kotlin-stdlib-jdk8`. If your Android build fails due to conflicts with implementations coming from other dependencies or even your own app, consider adding an exclusion to either the "other" dependencies or detox itself, for example:
+
+```diff
+dependencies {
+-    androidTestImplementation('com.wix:detox:+')
++    androidTestImplementation('com.wix:detox:+') { 
++        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
++    }
+}
+```
+
+Detox should work with `kotlin-stdlib-jdk7`, as well.
+
+A typical error output formed by `Gradle` in this case is as provided, for example, in [#1380](https://github.com/wix/Detox/issues/1380):
+
+```
+Could not determine the dependencies of task ':detox:compileDebugAidl'.
+> Could not resolve all task dependencies for configuration ':detox:debugCompileClasspath'.
+   > Could not resolve org.jetbrains.kotlin:kotlin-stdlib:1.3.0.
+     Required by:
+         project :detox
+      > Cannot find a version of 'org.jetbrains.kotlin:kotlin-stdlib' that satisfies the version constraints:
+           Dependency path 'OurApp:detox:unspecified' --> 'com.squareup.okhttp3:okhttp:4.0.0-alpha01' --> 'org.jetbrains.kotlin:kotlin-stdlib:1.3.30'
+           Dependency path 'OurApp:detox:unspecified' --> 'com.squareup.okio:okio:2.2.2' --> 'org.jetbrains.kotlin:kotlin-stdlib:1.2.60'
+           Dependency path 'OurApp:detox:unspecified' --> 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.0' --> 'org.jetbrains.kotlin:kotlin-stdlib:1.3.0'
+           Dependency path 'OurApp:detox:unspecified' --> 'com.facebook.react:react-native:0.59.5' --> 'com.squareup.okhttp3:okhttp:4.0.0-alpha01' --> 'org.jetbrains.kotlin:kotlin-stdlib:1.3.30'
+           Dependency path 'OurApp:detox:unspecified' --> 'com.facebook.react:react-native:0.59.5' --> 'com.squareup.okio:okio:2.2.2' --> 'org.jetbrains.kotlin:kotlin-stdlib:1.2.60'
+           Dependency path 'OurApp:detox:unspecified' --> 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.0' --> 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.0' --> 'org.jetbrains.kotlin:kotlin-stdlib:1.3.0'
+           Constraint path 'OurApp:detox:unspecified' --> 'org.jetbrains.kotlin:kotlin-stdlib' strictly '1.3.0' because of the following reason: debugRuntimeClasspath uses version 1.3.0
+           Constraint path 'OurApp:detox:unspecified' --> 'org.jetbrains.kotlin:kotlin-stdlib' strictly '1.3.0' because of the following reason: debugRuntimeClasspath uses version 1.3.0
+
+   > Could not resolve org.jetbrains.kotlin:kotlin-stdlib-common:1.3.0.
+     Required by:
+         project :detox
+      > Cannot find a version of 'org.jetbrains.kotlin:kotlin-stdlib-common' that satisfies the version constraints:
+           Dependency path 'OurApp:detox:unspecified' --> 'com.squareup.okhttp3:okhttp:4.0.0-alpha01' --> 'org.jetbrains.kotlin:kotlin-stdlib:1.3.30' --> 'org.jetbrains.kotlin:kotlin-stdlib-common:1.3.30'
+           Constraint path 'OurApp:detox:unspecified' --> 'org.jetbrains.kotlin:kotlin-stdlib-common' strictly '1.3.0' because of the following reason: debugRuntimeClasspath uses version 1.3.0
+```
+
+(i.e. the project indirectly depends on different versions of `kotlin-stdlib`, such as `1.3.0`, `1.3.30`, `1.2.60`)
+
+#### Resolving for a compiling subproject
+
+Detox requires the Kotlin standard-library as it's own dependency. Due to the [many flavours](https://kotlinlang.org/docs/reference/using-gradle.html#configuring-dependencies) by which Kotlin has been released, multiple dependencies often create a conflict.
+
+For that, Detox allows for the exact specification of the standard library to use using two Gradle globals: `detoxKotlinVersion` and `detoxKotlinStdlib`. You can define both in your  root build-script file (i.e.`android/build.gradle`):
+
+```groovy
+buildscript {
+    // ...
+    ext.detoxKotlinVersion = '1.3.0' // Detox' default is 1.2.0
+    ext.detoxKotlinStdlib = 'kotlin-stdlib-jdk7' // Detox' default is kotlin-stdlib-jdk8
+}
+```
+
+
+
+### Problem: `Duplicate files copied in ...`
+
+If you get an error like this:
+
+```sh
+Execution failed for task ':app:transformResourcesWithMergeJavaResForDebug'.
+> com.android.build.api.transform.TransformException: com.android.builder.packaging.DuplicateFileException: Duplicate files copied in APK META-INF/LICENSE
+```
+
+You need to add this to the `android` section of your `android/app/build.gradle`:
+
+```groovy
+packagingOptions {
+    exclude 'META-INF/LICENSE'
+}
+```
+

--- a/docs/Troubleshooting.BuildingTheApp.md
+++ b/docs/Troubleshooting.BuildingTheApp.md
@@ -2,6 +2,8 @@
 
 This page is about issues related to building the app, typically triggerred when running `detox build` (and not `detox test`, for example).
 
+For troubleshooting of other issue, refer to our [troubleshooting index](Troubleshooting.md).
+
 ## Android
 
 ### Problem: Kotlin stdlib version conflicts

--- a/docs/Troubleshooting.Installation.md
+++ b/docs/Troubleshooting.Installation.md
@@ -1,9 +1,0 @@
-# Installation
-
-### No Simulators Found
-
-In order to run tests on a simulator, you need to have simulator images installed on your machine. This process is performed by Xcode itself. You can list all available simulators using simctl by typing `xcrun simctl list` in terminal.
-
-If you're missing a simulator, make sure Xcode is installed and use it to download the simulator. Take a look at the Preferences screen, some screenshots can be seen [here](http://stackoverflow.com/questions/33738113/how-to-install-ios-9-1-simulator-in-xcode-version-7-1-1-7b1005).
-
-Once the desired simulator is installed and returned by `xcrun simctl list`, double check its name in the list and make sure this name is found in the `detox` configuration entry in `package.json`. The reference for the configuration options is available [here](APIRef.Configuration.md).

--- a/docs/Troubleshooting.RunningTests.md
+++ b/docs/Troubleshooting.RunningTests.md
@@ -2,6 +2,8 @@
 
 This page is about issues related to executing your Detox tests, typically triggerred when running `detox test` (and not `detox build`, for example).
 
+For troubleshooting of other issue, refer to our [troubleshooting index](Troubleshooting.md).
+
 ## Table of Content
 
 * [Trace Mode](#trace-mode)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,0 +1,12 @@
+# Troubleshooting
+
+Issues related to building the app:
+
+* [Building the App](Troubleshooting.BuildingTheApp.md)
+
+Issues related to tests execution & runtime:
+
+* [Running tests](Troubleshooting.RunningTests.md)
+* [Synchronization issues](Troubleshooting.Synchronization.md)
+* [General tests stability issues](Troubleshooting.Flakiness.md)
+


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #2904.

In this pull request, I have collected, aggregated and reorganized troubleshooting instructions Detox has in the various troubleshooting guides.

Originally, the point was to try to better warn regarding mistakes related to `DetoxTest.java`. However, it was not easy to do + much boyscouting seemed to have been necessary, regardless.

Eventually, most work boiled down to documentation improvements. However, in addition, I've had the existing Detox-app connection error messages - in the code itself, trimmed down so as to mostly contain a ref to the associated troubleshooting guide. They were a bit overly verbose, I believe -- making developers not really wanting to read through them through, as they should.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
