### PR TITLE
Add support for launch argument detoxURLBlacklistRegex on Android

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/DetoxMain.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/DetoxMain.kt
@@ -32,6 +32,7 @@ object DetoxMain {
         initCrashHandler(externalAdapter)
         initANRListener(externalAdapter)
         initReactNativeIfNeeded(rnHostHolder)
+        initBlacklistIfNeeded()
     }
 
     private fun doTeardown(serverAdapter: DetoxServerAdapter, actionsDispatcher: DetoxActionsDispatcher, testEngineFacade: TestEngineFacade) {
@@ -100,5 +101,13 @@ object DetoxMain {
 
     private fun initReactNativeIfNeeded(rnHostHolder: Context) {
         ReactNativeExtension.waitForRNBootstrap(rnHostHolder)
+    }
+
+    private fun initBlacklistIfNeeded() {
+        val launchArgs = LaunchArgs()
+        if (launchArgs.hasBlacklist()) {
+            val blacklistUrls = launchArgs.getBlacklist()
+            ReactNativeExtension.setBlacklistUrls(blacklistUrls)
+        }
     }
 }

--- a/detox/android/detox/src/full/java/com/wix/detox/DetoxMain.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/DetoxMain.kt
@@ -32,7 +32,6 @@ object DetoxMain {
         initCrashHandler(externalAdapter)
         initANRListener(externalAdapter)
         initReactNativeIfNeeded(rnHostHolder)
-        initBlacklistIfNeeded()
     }
 
     private fun doTeardown(serverAdapter: DetoxServerAdapter, actionsDispatcher: DetoxActionsDispatcher, testEngineFacade: TestEngineFacade) {
@@ -101,13 +100,5 @@ object DetoxMain {
 
     private fun initReactNativeIfNeeded(rnHostHolder: Context) {
         ReactNativeExtension.waitForRNBootstrap(rnHostHolder)
-    }
-
-    private fun initBlacklistIfNeeded() {
-        val launchArgs = LaunchArgs()
-        if (launchArgs.hasBlacklist()) {
-            val blacklistUrls = launchArgs.getBlacklist()
-            ReactNativeExtension.setBlacklistUrls(blacklistUrls)
-        }
     }
 }

--- a/detox/android/detox/src/full/java/com/wix/detox/LaunchArgs.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/LaunchArgs.java
@@ -28,11 +28,11 @@ public class LaunchArgs {
         return InstrumentationRegistry.getArguments().containsKey(DETOX_URL_OVERRIDE_ARG);
     }
 
-    public String getBlacklist() {
+    public String getURLBlacklist() {
         return InstrumentationRegistry.getArguments().getString(DETOX_BLACKLIST_URLS_ARG);
     }
 
-    public boolean hasBlacklist() {
+    public boolean hasURLBlacklist() {
         return InstrumentationRegistry.getArguments().containsKey(DETOX_BLACKLIST_URLS_ARG);
     }
 

--- a/detox/android/detox/src/full/java/com/wix/detox/LaunchArgs.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/LaunchArgs.java
@@ -12,6 +12,7 @@ public class LaunchArgs {
     private static final String DETOX_SERVER_URL_ARG = "detoxServer";
     private static final String DETOX_SESSION_ID_ARG_KEY = "detoxSessionId";
     private static final String DETOX_NOTIFICATION_PATH_ARG = "detoxUserNotificationDataURL";
+    private static final String DETOX_BLACKLIST_URLS_ARG = "detoxURLBlacklistRegex";
     private static final String DETOX_URL_OVERRIDE_ARG = "detoxURLOverride";
     private static final List<String> RESERVED_INSTRUMENTATION_ARGS = Arrays.asList("class", "package", "func", "unit", "size", "perf", "debug", "log", "emma", "coverageFile");
 
@@ -25,6 +26,14 @@ public class LaunchArgs {
 
     public boolean hasUrlOverride() {
         return InstrumentationRegistry.getArguments().containsKey(DETOX_URL_OVERRIDE_ARG);
+    }
+
+    public String getBlacklist() {
+        return InstrumentationRegistry.getArguments().getString(DETOX_BLACKLIST_URLS_ARG);
+    }
+
+    public boolean hasBlacklist() {
+        return InstrumentationRegistry.getArguments().containsKey(DETOX_BLACKLIST_URLS_ARG);
     }
 
     public String getUrlOverride() {

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/ReactNativeExtension.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/ReactNativeExtension.kt
@@ -63,6 +63,11 @@ object ReactNativeExtension {
     }
 
     @JvmStatic
+    fun setBlacklistUrls(blacklistUrls: String) {
+        rnIdlingResources?.setBlacklistUrls(blacklistUrls)
+    }
+
+    @JvmStatic
     fun enableAllSynchronization(applicationContext: ReactApplication) {
         val reactContext = getCurrentReactContextSafe(applicationContext)
 

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/ReactNativeExtension.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/ReactNativeExtension.kt
@@ -7,6 +7,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.bridge.ReactContext
+import com.wix.detox.LaunchArgs
 
 private const val LOG_TAG = "DetoxRNExt"
 
@@ -124,7 +125,9 @@ object ReactNativeExtension {
     }
 
     private fun setupIdlingResources(reactContext: ReactContext, networkSyncEnabled: Boolean = true) {
-        rnIdlingResources = ReactNativeIdlingResources(reactContext, networkSyncEnabled).apply {
+        val launchArgs = LaunchArgs()
+
+        rnIdlingResources = ReactNativeIdlingResources(reactContext, launchArgs, networkSyncEnabled).apply {
             registerAll()
         }
     }

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/ReactNativeIdlingResources.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/ReactNativeIdlingResources.kt
@@ -200,4 +200,16 @@ class ReactNativeIdlingResources constructor(
             networkIdlingResource = null
         }
     }
+
+    private fun toFormattedUrlArray(urlList: String): List<String> {
+        var formattedUrls = urlList
+        formattedUrls = formattedUrls.replace(Regex("""[()"]"""), "");
+        formattedUrls = formattedUrls.trim();
+        return formattedUrls.split(',');
+    }
+
+    fun setBlacklistUrls(urlList: String) {
+        val urlArray = toFormattedUrlArray(urlList)
+        NetworkIdlingResource.setURLBlacklist(urlArray);
+    }
 }

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/ReactNativeIdlingResources.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/ReactNativeIdlingResources.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.base.IdlingResourceRegistry
 import com.facebook.react.bridge.ReactContext
+import com.wix.detox.LaunchArgs
 import com.wix.detox.reactnative.idlingresources.*
 import com.wix.detox.reactnative.idlingresources.timers.TimersIdlingResource
 import com.wix.detox.reactnative.idlingresources.timers.getInterrogationStrategy
@@ -45,7 +46,9 @@ private class MQThreadReflected(private val queue: Any?, private val queueName: 
 
 class ReactNativeIdlingResources constructor(
         private val reactContext: ReactContext,
-        internal var networkSyncEnabled: Boolean = true)
+        private var launchArgs: LaunchArgs,
+        internal var networkSyncEnabled: Boolean = true
+        )
 
     {
 
@@ -67,6 +70,11 @@ class ReactNativeIdlingResources constructor(
         Log.i(LOG_TAG, "Setting up Espresso Idling Resources for React Native")
 
         unregisterAll()
+
+        if (launchArgs.hasURLBlacklist()) {
+            val blacklistUrls = launchArgs.getURLBlacklist()
+            setBlacklistUrls(blacklistUrls)
+        }
 
         setupMQThreadsInterrogators()
         syncIdlingResources()

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
@@ -43,7 +43,7 @@ public class NetworkIdlingResource extends DetoxBaseIdlingResource implements Ch
      *
      * @param urls list of regexes of blacklisted urls
      */
-    public static void setURLBlacklist(ArrayList<String> urls) {
+    public static void setURLBlacklist(List<String> urls) {
         blacklist.clear();
         if (urls == null) return;
 

--- a/detox/test/e2e/14.network.test.js
+++ b/detox/test/e2e/14.network.test.js
@@ -6,6 +6,11 @@ describe('Network Synchronization', () => {
   beforeAll(async () => {
     mockServer.init();
     await device.reverseTcpPort(mockServer.port);
+
+    await device.launchApp({
+      newInstance: true,
+      launchArgs: { detoxURLBlacklistRegex: ' http://192.168.1.253:19001/onchange, https://e.crashlytics.com/spi/v2/events, .*localhost.* ' },
+    });
   });
 
   afterAll(async () => {

--- a/detox/test/e2e/14.network.test.js
+++ b/detox/test/e2e/14.network.test.js
@@ -52,7 +52,7 @@ describe('Network Synchronization', () => {
   it('launchArgs with detoxURLBlacklistRegex should set the blacklist', async () => {
     await device.launchApp({
       newInstance: true,
-      launchArgs: { detoxURLBlacklistRegex: ' \\("^http://localhost:\\d{4}?/[a-z]+/\\d{4}?$"\\)' },
+      launchArgs: { detoxURLBlacklistRegex: ' \\("^http:\/\/localhost:\\d{4}?\/[a-z]+\/\\d{4}?$"\\)' },
     });
 
     await element(by.text('Network')).tap();

--- a/detox/test/e2e/14.network.test.js
+++ b/detox/test/e2e/14.network.test.js
@@ -48,4 +48,21 @@ describe('Network Synchronization', () => {
 
     await device.setURLBlacklist([]);
   });
+
+  it('launchArgs with detoxURLBlacklistRegex should set the blacklist', async () => {
+    await device.launchApp({
+      newInstance: true,
+      launchArgs: { detoxURLBlacklistRegex: ' \\("http://192.168.1.253:19001/onchange","https://e.crashlytics.com/spi/v2/events",".*localhost.*"\\)' },
+    });
+
+    await device.reloadReactNative();
+    await element(by.text('Network')).tap();
+
+    await element(by.id('LongNetworkRequest')).tap();
+    await expect(element(by.text('Long Network Request Working!!!'))).not.toBeVisible();
+    await waitFor(element(by.text('Long Network Request Working!!!'))).toBeVisible().withTimeout(4000);
+    await expect(element(by.text('Long Network Request Working!!!'))).toBeVisible();
+
+    await device.setURLBlacklist([]);
+  });
 });

--- a/detox/test/e2e/14.network.test.js
+++ b/detox/test/e2e/14.network.test.js
@@ -52,12 +52,10 @@ describe('Network Synchronization', () => {
   it('launchArgs with detoxURLBlacklistRegex should set the blacklist', async () => {
     await device.launchApp({
       newInstance: true,
-      launchArgs: { detoxURLBlacklistRegex: ' \\("http://192.168.1.253:19001/onchange","https://e.crashlytics.com/spi/v2/events",".*localhost.*"\\)' },
+      launchArgs: { detoxURLBlacklistRegex: ' \\("^http://localhost:\\d{4}?/[a-z]+/\\d{4}?$"\\)' },
     });
 
-    await device.reloadReactNative();
     await element(by.text('Network')).tap();
-
     await element(by.id('LongNetworkRequest')).tap();
     await expect(element(by.text('Long Network Request Working!!!'))).not.toBeVisible();
     await waitFor(element(by.text('Long Network Request Working!!!'))).toBeVisible().withTimeout(4000);

--- a/detox/test/e2e/14.network.test.js
+++ b/detox/test/e2e/14.network.test.js
@@ -55,6 +55,8 @@ describe('Network Synchronization', () => {
       launchArgs: { detoxURLBlacklistRegex: ' \\("^http:\/\/localhost:\\d{4}?\/[a-z]+\/\\d{4}?$"\\)' },
     });
 
+    await device.reloadReactNative();
+
     await element(by.text('Network')).tap();
     await element(by.id('LongNetworkRequest')).tap();
     await expect(element(by.text('Long Network Request Working!!!'))).not.toBeVisible();

--- a/detox/test/e2e/14.network.test.js
+++ b/detox/test/e2e/14.network.test.js
@@ -49,7 +49,7 @@ describe('Network Synchronization', () => {
     await device.setURLBlacklist([]);
   });
 
-  it('launchArgs with detoxURLBlacklistRegex should set the blacklist', async () => {
+  it(':android: launchArgs with detoxURLBlacklistRegex should set the blacklist', async () => {
     await device.launchApp({
       newInstance: true,
       launchArgs: { detoxURLBlacklistRegex: ' \\("^http:\/\/localhost:\\d{4}?\/[a-z]+\/\\d{4}?$"\\)' },

--- a/detox/test/e2e/14.network.test.js
+++ b/detox/test/e2e/14.network.test.js
@@ -6,11 +6,6 @@ describe('Network Synchronization', () => {
   beforeAll(async () => {
     mockServer.init();
     await device.reverseTcpPort(mockServer.port);
-
-    await device.launchApp({
-      newInstance: true,
-      launchArgs: { detoxURLBlacklistRegex: ' http://192.168.1.253:19001/onchange, https://e.crashlytics.com/spi/v2/events, .*localhost.* ' },
-    });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Until now, the launchArgs detoxURLBlacklistRegex was supported only on ios - this PR adds support on Android. Relates to issue https://github.com/wix/Detox/issues/1695. 

