### PR TITLE
feat(cli): add -i, --if-missing to detox build

### DIFF
--- a/detox/local-cli/build.js
+++ b/detox/local-cli/build.js
@@ -20,6 +20,13 @@ module.exports.builder = {
     describe:
       "Select a device configuration from your defined configurations, if not supplied, and there's only one configuration, detox will default to it",
   },
+  i: {
+    alias: 'if-missing',
+    group: 'Configuration:',
+    boolean: true,
+    describe:
+      'Execute the build command only if the app binary is missing.',
+  },
   s: {
     alias: 'silent',
     group: 'Configuration:',
@@ -35,6 +42,11 @@ module.exports.handler = async function build(argv) {
 
   for (const [appName, app] of apps) {
     const buildScript = app.build;
+
+    if (argv['if-missing'] && app.binaryPath && fs.existsSync(app.binaryPath)) {
+      log.info(`Skipping build for "${appName}" app...`);
+      continue;
+    }
 
     if (buildScript) {
       try {

--- a/detox/local-cli/build.test.js
+++ b/detox/local-cli/build.test.js
@@ -43,6 +43,18 @@ describe('build', () => {
     expect(execSync).toHaveBeenCalledWith('yet another command', expect.anything());
   });
 
+  it('skips building the app if the binary exists and --if-missing flag is set', async () => {
+    detoxConfig.appsConfig.default = { build: 'yet another command', binaryPath: __filename };
+
+    await callCli('./build', 'build -i');
+    expect(execSync).not.toHaveBeenCalled();
+
+    await callCli('./build', 'build --if-missing');
+    expect(execSync).not.toHaveBeenCalled();
+
+    expect(log.info).toHaveBeenCalledWith('Skipping build for "default" app...');
+  });
+
   it('fails with an error if a build script has not been found', async () => {
     detoxConfig.appsConfig.default = {};
     await expect(callCli('./build', 'build')).rejects.toThrowError(/Failed to build/);

--- a/docs/APIRef.DetoxCLI.md
+++ b/docs/APIRef.DetoxCLI.md
@@ -57,6 +57,8 @@ Run the command defined in `build` property of the specified **configuration**.
 | --- | --- |
 | -c, --configuration \<device config\> | Select a device configuration from your defined configurations, if not supplied, and there's only one configuration, detox will default to it |
 | -C, --config-path \<configPath\>      | Specify Detox config file path. If not supplied, detox searches for .detoxrc[.js] or "detox" section in package.json |
+| -i, --if-missing                      | Execute the build command only if the app binary is missing. |
+| -s, --silent                          | Do not fail with error if an app config has no build command. |
 | --help                                | Show help |
 
 ### test


### PR DESCRIPTION
## Description

This pull request adds `-i, --if-missing` CLI argument to `detox build`, so that you don't have sometimes to write extra checks in your CI build scripts whether the binary exists or not.

```
  -i, --if-missing     Execute the build command only if the app binary is missing.  [boolean]
```

```
➜  test git:(feat/lazy-build) npx detox build -c ios.sim.release --if-missing
detox[34137] INFO:  [build.js] Skipping build for "example" app...
```

In this pull request, I have …

> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.
