### PR TITLE
Align device.id for Genymotion to ext-api contract

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -70,7 +70,7 @@ class Device {
   }
 
   get id() {
-    return this._deviceId;
+    return this.deviceDriver.getExternalId(this._deviceId);
   }
 
   get name() {

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -55,6 +55,10 @@ describe('Device', () => {
       });
     }
 
+    expectExternalIdCalled(deviceId) {
+      expect(this.driver.getExternalId).toHaveBeenCalledWith(deviceId);
+    }
+
     expectLaunchCalledWithArgs(device, expectedArgs, languageAndLocale) {
       expect(this.driver.launchApp).toHaveBeenCalledWith(device.id, device._bundleId, expectedArgs, languageAndLocale);
     }
@@ -114,9 +118,9 @@ describe('Device', () => {
       ...overrides,
     });
 
+    device.deviceDriver.getExternalId.mockImplementation((deviceId) => deviceId);
     device.deviceDriver.acquireFreeDevice.mockReturnValue('mockDeviceId');
     device.deviceDriver.getBundleIdFromBinary.mockReturnValue('test.bundle');
-
     return device;
   }
 
@@ -168,7 +172,11 @@ describe('Device', () => {
   it('should return the device ID, as provided by acquireFreeDevice', async () => {
     const device = await aValidUnpreparedDevice();
     await device.prepare();
-    expect(device.id).toEqual('mockDeviceId');
+
+    driverMock.driver.getExternalId.mockReturnValue('mockExternalId');
+    expect(device.id).toEqual('mockExternalId');
+
+    driverMock.expectExternalIdCalled('mockDeviceId');
   });
 
   describe('selectApp()', () => {

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -15,6 +15,10 @@ class DeviceDriverBase {
     return 'UNSPECIFIED_DEVICE';
   }
 
+  getExternalId(deviceId) {
+    return deviceId;
+  }
+
   declareArtifactPlugins() {
     return {};
   }

--- a/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.js
@@ -45,6 +45,10 @@ class GenyCloudDriver extends AndroidDriver {
     this._authService = new AuthService(this._exec);
   }
 
+  getExternalId(instance) {
+    return instance.adbName;
+  }
+
   get name() {
     return this._name;
   }

--- a/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.test.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.test.js
@@ -120,8 +120,13 @@ describe('Genymotion-cloud driver', () => {
       expect(uut.name).toEqual('Unspecified GMSaaS Emulator');
     });
 
-    it('should initialize the common executable using the path set by the environment', async () => {
+    it('should initialize the common executable using the path set by the environment', () => {
       expect(Exec).toHaveBeenCalledWith(MOCK_GMSAAS_PATH);
+    });
+
+    it('should return the adb-name as the external ID', () => {
+      const instance = anInstance();
+      expect(uut.getExternalId(instance)).toEqual(instance.adbName);
     });
 
     describe('preparation', () => {


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #<?>

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have aligned `device.id` for the Genymotion-cloud case, which - according to our existing contract, should return `adbName` (and instead returns a fancy, highly-detailed description).

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
