### PR TITLE
Apply an attempt to make setLocation e2e stable with Genycloud

### DIFF
--- a/detox/test/e2e/16.location.test.js
+++ b/detox/test/e2e/16.location.test.js
@@ -37,7 +37,7 @@ describe('location', () => {
     await device.setLocation(lat, lon);
     await element(by.text('Location')).tap();
     await element(by.id('getLocationButton')).tap();
-    await waitFor(element(by.text(`Latitude: ${lat}`))).toBeVisible().withTimeout(10500);
+    await waitFor(element(by.text(`Latitude: ${lat}`))).toBeVisible().withTimeout(5500);
 
     await expect(element(by.text(`Latitude: ${lat}`))).toBeVisible();
     await expect(element(by.text(`Longitude: ${lon}`))).toBeVisible();

--- a/detox/test/src/Screens/LocationScreen.js
+++ b/detox/test/src/Screens/LocationScreen.js
@@ -33,9 +33,9 @@ export default class LocationScreen extends Component {
     }
   }
 
-  onLocationReceived = (pos) => {
+  onLocationReceived = (position) => {
     this.setState({
-      coordinates: pos.coords,
+      coordinates: position.coords,
       error: '',
     });
   };
@@ -48,13 +48,14 @@ export default class LocationScreen extends Component {
   };
 
   requestLocation = async () => {
-    this.setState({ locationRequested: true });
-
-    await Geolocation.getCurrentPosition(this.onLocationReceived, this.onLocationError, {
+    const options = {
       enableHighAccuracy: true,
-      timeout: 10000,
+      timeout: 5000,
       maximumAge: 0,
-    });
+    };
+
+    this.setState({ locationRequested: true }, () =>
+      Geolocation.watchPosition(this.onLocationReceived, this.onLocationError, options));
   }
 
   render() {


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request is associated with #1935.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have changed our test-app's usage of `@react-native-community/geolocation` in an attempt to make it more stable with Genymotion-cloud emulators. ATM, these tests are flaky on our CI.

Follow-up:
- [ ] If this proves to work - must updates API notes to say `Geolocation.watchLocation` is preferable when Genymotion is used.