### PR TITLE
revert(global-cli): is installed globally

### DIFF
--- a/detox-cli/cli.js
+++ b/detox-cli/cli.js
@@ -3,7 +3,6 @@ const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
-const isInstalledGlobally = require('is-installed-globally');
 
 /**
  * @param {string} msg
@@ -14,15 +13,6 @@ function log(msg) {
 
 function main([_$0, _detox, ...cliArgs]) {
   const [command] = cliArgs;
-
-  if (process.platform !== 'win32' && !isInstalledGlobally) {
-    log('Error: "detox-cli" package is not meant to be installed locally, exiting...');
-    log('HINT: Remove the local installation and reinstall it globally:');
-    log('  npm uninstall detox-cli');
-    log('  npm install -g detox-cli\n');
-
-    return 1;
-  }
 
   if (command === 'recorder' && process.platform === 'darwin') {
     return spawnRecorder(cliArgs);


### PR DESCRIPTION
## Description

Resolves #2825.
Reopens #2750. 😢 

Since #2750 is not pleasant but not blocking, while #2825 is a dealbreaker, I have to revert the implementation which relies on `is-installed-globally`.

I'll need to submit fixes to that package, `is-installed-globally`, before I can return these checks back.