### PR TITLE
Follwing #2925: remove excess dep is-installed-globally

### DIFF
--- a/detox-cli/package.json
+++ b/detox-cli/package.json
@@ -23,8 +23,7 @@
     "url": "https://github.com/wix/Detox/issues"
   },
   "dependencies": {
-    "chalk": "^4.0.0",
-    "is-installed-globally": "^0.4.0"
+    "chalk": "^4.0.0"
   },
   "homepage": "https://github.com/wix/Detox"
 }


### PR DESCRIPTION
## Description

- This pull request is a follow-up on: #2925

In this pull request, I have remove the `is-installed-globally` dependency from `detox-cli`.