### PR TITLE
Android: Remove code associated with SDK<21 (Detox's min)

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/common/SDKSupports.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/common/SDKSupports.kt
@@ -1,7 +1,0 @@
-package com.wix.detox.common
-
-import android.os.Build
-
-internal object SDKSupports {
-    val API_19_KITKAT = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
-}

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/ViewScreenshot.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/ViewScreenshot.kt
@@ -4,13 +4,12 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.util.Base64
 import android.view.View
-import com.wix.detox.common.SDKSupports
 import java.io.ByteArrayOutputStream
 
 class ScreenshotResult(private val bitmap: Bitmap) {
     fun asBitmap() = bitmap
     fun asRawBytes(): ByteArray {
-        val outStream = ByteArrayOutputStream(if (SDKSupports.API_19_KITKAT) bitmap.allocationByteCount else bitmap.byteCount)
+        val outStream = ByteArrayOutputStream(bitmap.allocationByteCount)
         bitmap.compress(Bitmap.CompressFormat.PNG, 100, outStream)
         return outStream.toByteArray()
     }


### PR DESCRIPTION
## Description


- This pull request addresses the issue described here: #<?>

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have removed code-leftovers, associated with Android SDK version lower than our new minimum (21).

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
