### PR TITLE
Added Typescript definitions for element.pinch() and element.takeScreenshot()

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1111,6 +1111,7 @@ declare global {
 
             /**
              * Pinches with the given scale, speed, and angle. (iOS only)
+             * @param speed default is `fast`
              * @param angle value in radiant, default is `0`
              * @example
              * await element(by.id('PinchableScrollView')).pinch(1.1);

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1122,6 +1122,7 @@ declare global {
 
             /**
              * Takes a screenshot of the element and schedules putting it in the artifacts folder upon completion of the current test.
+             * For more information, see {@link https://github.com/wix/Detox/blob/master/docs/APIRef.Screenshots.md#element-level-screenshots}
              * @param {string} name for the screenshot artifact
              * @returns {Promise<string>} a temporary path to the screenshot.
              * @example

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1118,6 +1118,21 @@ declare global {
              * await element(by.id('PinchableScrollView')).pinch(0.001);
              */
             pinch(scale: number, speed?: Speed, angle?: number): Promise<void>;
+
+            /**
+             * Takes a screenshot of the element and schedules putting it in the artifacts folder upon completion of the current test.
+             * @param {string} name for the screenshot artifact
+             * @returns {Promise<string>} a temporary path to the screenshot.
+             * @example
+             * test('Menu items should have logout', async () => {
+             *   const imagePath = await element(by.id('menuRoot')).takeScreenshot('tap on menu');
+             *   // The temporary path will remain valid until the test completion.
+             *   // Afterwards, the screenshot will be moved, e.g.:
+             *   // * on success, to: <artifacts-location>/✓ Menu items should have Logout/tap on menu.png
+             *   // * on failure, to: <artifacts-location>/✗ Menu items should have Logout/tap on menu.png
+             * });
+             */
+             takeScreenshot(name: string): Promise<string>;
         }
 
         interface WebExpect<R = Promise<void>> {

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1117,7 +1117,7 @@ declare global {
              * await element(by.id('PinchableScrollView')).pinch(2.0);
              * await element(by.id('PinchableScrollView')).pinch(0.001);
              */
-            pinch(scale: number, speed: Speed, angle: number): Promise<void>;
+            pinch(scale: number, speed?: Speed, angle?: number): Promise<void>;
         }
 
         interface WebExpect<R = Promise<void>> {


### PR DESCRIPTION
I noticed that some of the advertised APIs in the Docs weren't working with the latest version (I'm on 18.20.1). This makes two changes:

* `element().pinch()` has its `speed` and `angle` parameters marked as optional
* Added the missing API for `element().takeScreenshot()`, previously it only existed on `Device`

I happened to need both of these APIs in a new test I'm writing (iOS) and can confirm that the current functionality works just fine with this API definition.