### PR TITLE
fix(artifacts): save app artifacts before its uninstall

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "detox",
   "description": "E2E tests and automation for mobile",
-  "version": "18.20.2",
+  "version": "18.20.3-smoke.0",
   "bin": {
     "detox": "local-cli/cli.js"
   },

--- a/detox/package.json
+++ b/detox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "detox",
   "description": "E2E tests and automation for mobile",
-  "version": "18.20.3-smoke.0",
+  "version": "18.20.3-smoke.1",
   "bin": {
     "detox": "local-cli/cli.js"
   },

--- a/detox/src/artifacts/templates/artifact/FileArtifact.js
+++ b/detox/src/artifacts/templates/artifact/FileArtifact.js
@@ -1,4 +1,6 @@
 const fs = require('fs-extra');
+const path = require('path');
+const tempfile = require('tempfile');
 
 const appendFile = require('../../../utils/appendFile');
 
@@ -12,6 +14,16 @@ class FileArtifact extends Artifact {
       this.start();
       this.stop();
     }
+  }
+
+  async relocate() {
+    if (!this.temporaryPath || !(await fs.exists(this.temporaryPath))) {
+      return;
+    }
+
+    const newTemporaryPath = tempfile(path.extname(this.temporaryPath));
+    await FileArtifact.moveTemporaryFile(this.logger, this.temporaryPath, newTemporaryPath);
+    this.temporaryPath = newTemporaryPath;
   }
 
   async doSave(artifactPath, options = {}) {

--- a/detox/src/artifacts/templates/artifact/FileArtifact.js
+++ b/detox/src/artifacts/templates/artifact/FileArtifact.js
@@ -1,5 +1,6 @@
-const fs = require('fs-extra');
 const path = require('path');
+
+const fs = require('fs-extra');
 const tempfile = require('tempfile');
 
 const appendFile = require('../../../utils/appendFile');

--- a/detox/src/artifacts/templates/artifact/FileArtifact.test.js
+++ b/detox/src/artifacts/templates/artifact/FileArtifact.test.js
@@ -148,6 +148,84 @@ describe('FileArtifact', () => {
     });
   });
 
+  describe('relocate', () => {
+    beforeEach(() => {
+      jest.spyOn(FileArtifact, 'moveTemporaryFile').mockImplementation(_.noop);
+      jest.spyOn(FileArtifact, 'writeFile').mockImplementation(_.noop);
+    });
+
+    describe('if temporary file is passed to constructor', () => {
+      beforeEach(() => {
+        fileArtifact = new FileArtifact({
+          name: 'CustomArtifact',
+          temporaryPath,
+        });
+      });
+
+      describe('when called', () => {
+        beforeEach(async () => {
+          await fileArtifact.relocate();
+        });
+
+        it('should call FileArtifact.moveTemporaryFile', async () => {
+          expect(FileArtifact.moveTemporaryFile).toHaveBeenCalledWith(logger, temporaryPath, expect.stringMatching(/\.artifact$/));
+        });
+      });
+    });
+
+    describe('if temporary file is created in start()', () => {
+      beforeEach(() => {
+        fileArtifact = new FileArtifact({
+          name: 'CustomArtifact',
+          async start() {
+            await fs.ensureFile(temporaryPath);
+            this.temporaryPath = temporaryPath;
+          }
+        });
+      });
+
+      describe('when relocate() is called without start()', () => {
+        beforeEach(async () => {
+          await fileArtifact.relocate();
+        });
+
+        it('should not call FileArtifact.moveTemporaryFile', async () => {
+          expect(FileArtifact.moveTemporaryFile).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('and start() was called', () => {
+        beforeEach(async () => {
+          await fileArtifact.start();
+          await fileArtifact.relocate();
+        });
+
+        it('should call FileArtifact.moveTemporaryFile', async () => {
+          expect(FileArtifact.moveTemporaryFile).toHaveBeenCalledWith(logger, temporaryPath, expect.stringMatching(/\.artifact$/));
+        });
+      });
+    });
+
+    describe('if temporary data is passed to constructor', () => {
+      beforeEach(() => {
+        fileArtifact = new FileArtifact({
+          name: 'CustomArtifact',
+          temporaryData,
+        });
+      });
+
+      describe('when called', () => {
+        beforeEach(async () => {
+          await fileArtifact.relocate();
+        });
+
+        it('should not do anything', async () => {
+          expect(FileArtifact.moveTemporaryFile).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
   describe('static helper methods', () => {
     describe('.moveTemporaryFile', () => {
       describe('if temporary file does not exist', () => {

--- a/detox/src/artifacts/templates/artifact/FileArtifact.test.js
+++ b/detox/src/artifacts/templates/artifact/FileArtifact.test.js
@@ -162,13 +162,35 @@ describe('FileArtifact', () => {
         });
       });
 
-      describe('when called', () => {
+      describe('and the file exists', () => {
         beforeEach(async () => {
-          await fileArtifact.relocate();
+          await fs.ensureFile(temporaryPath);
         });
 
-        it('should call FileArtifact.moveTemporaryFile', async () => {
-          expect(FileArtifact.moveTemporaryFile).toHaveBeenCalledWith(logger, temporaryPath, expect.stringMatching(/\.artifact$/));
+        describe('when called', () => {
+          beforeEach(async () => {
+            await fileArtifact.relocate();
+          });
+
+          it('should call FileArtifact.moveTemporaryFile', async () => {
+            expect(FileArtifact.moveTemporaryFile).toHaveBeenCalledWith(logger, temporaryPath, expect.stringMatching(/\.artifact$/));
+          });
+        });
+      });
+
+      describe('and the file does not exist', () => {
+        beforeEach(async () => {
+          await fs.remove(temporaryPath);
+        });
+
+        describe('when called', () => {
+          beforeEach(async () => {
+            await fileArtifact.relocate();
+          });
+
+          it('should call FileArtifact.moveTemporaryFile', async () => {
+            expect(FileArtifact.moveTemporaryFile).not.toHaveBeenCalled();
+          });
         });
       });
     });

--- a/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.js
+++ b/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
+const DetoxInternalError = require('../../errors/DetoxInternalError');
 const setUniqueProperty = require('../../utils/setUniqueProperty');
 const FileArtifact = require('../templates/artifact/FileArtifact');
 const ArtifactPlugin = require('../templates/plugin/ArtifactPlugin');
@@ -32,7 +32,7 @@ class IosUIHierarchyPlugin extends ArtifactPlugin {
 
   async onCreateExternalArtifact(e) {
     if (!e.artifact) {
-      throw new DetoxRuntimeError('Internal error: expected Artifact instance in the event');
+      throw new DetoxInternalError('Expected Artifact instance in the event');
     }
 
     this._registerSnapshot(e.name, e.artifact);
@@ -67,6 +67,16 @@ class IosUIHierarchyPlugin extends ArtifactPlugin {
 
     this.context.testSummary = null;
     await this._flushArtifacts();
+  }
+
+  async onBeforeUninstallApp(event) {
+    const artifacts = [
+      ...Object.values(this._artifacts.perTest),
+      ...Object.values(this._artifacts.perSession)
+    ];
+
+    await Promise.all(artifacts.map(s => s && s.relocate()));
+    await super.onBeforeUninstallApp(event);
   }
 
   async onBeforeCleanup() {

--- a/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.test.js
+++ b/detox/src/artifacts/uiHierarchy/IosUIHierarchyPlugin.test.js
@@ -61,13 +61,27 @@ describe('IosUIHierarchyPlugin', () => {
       expect(session2.save).toHaveBeenCalledWith('artifacts/ui2.viewhierarchy');
       expect(test1.save).toHaveBeenCalledWith('artifacts/test/ui.viewhierarchy');
       expect(test2.save).toHaveBeenCalledWith('artifacts/test/ui2.viewhierarchy');
-    }); });
+    });
+
+    it('should relocate existing artifacts before the app gets uninstalled', async () => {
+      await plugin.onTestStart(testSummaries.running());
+      onTestFailed(aTestFailedPayload(1));
+      onTestFailed(aTestFailedPayload(2));
+
+      await plugin.onBeforeUninstallApp({ deviceId: 'deviceId', bundleId: 'bundleId' });
+
+      const [test1, test2] = FileArtifact.mock.instances;
+
+      expect(test1.relocate).toHaveBeenCalled();
+      expect(test2.relocate).toHaveBeenCalled();
+    });
+  });
 
   describe('behavior for externally created artifacts', () => {
     it('should validate event.artifact', async () => {
       await expect(plugin.onCreateExternalArtifact({ name: 'invalid' }))
         .rejects
-        .toThrowError(/Internal error/);
+        .toThrowError(/Expected Artifact instance/);
     });
 
     it('should register snapshots inside and outside of running test', async () => {

--- a/detox/src/artifacts/utils/temporaryPath.js
+++ b/detox/src/artifacts/utils/temporaryPath.js
@@ -4,6 +4,7 @@ const tempfile = require('tempfile');
 
 module.exports = {
   for: {
+    directory: () => tempfile(),
     png: () => tempfile('.detox.png'),
     log: () => tempfile('.detox.log'),
     mp4: () => tempfile('.detox.mp4'),

--- a/detox/src/artifacts/utils/temporaryPath.js
+++ b/detox/src/artifacts/utils/temporaryPath.js
@@ -4,7 +4,6 @@ const tempfile = require('tempfile');
 
 module.exports = {
   for: {
-    directory: () => tempfile(),
     png: () => tempfile('.detox.png'),
     log: () => tempfile('.detox.log'),
     mp4: () => tempfile('.detox.mp4'),

--- a/detox/src/utils/fsext.js
+++ b/detox/src/utils/fsext.js
@@ -2,6 +2,11 @@ const path = require('path');
 
 const fs = require('fs-extra');
 
+async function isDirEmpty(dirPath) {
+  const files = await fs.readdir(dirPath);
+  return files.length === 0;
+}
+
 async function getDirectories (rootPath) {
   let files = await fs.readdir(rootPath);
   let dirs = [];
@@ -15,5 +20,6 @@ async function getDirectories (rootPath) {
 }
 
 module.exports = {
-  getDirectories
+  getDirectories,
+  isDirEmpty,
 };

--- a/detox/src/utils/fsext.test.js
+++ b/detox/src/utils/fsext.test.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+const fs = require('fs-extra');
+const tempfile = require('tempfile');
+
+const fsext = require('./fsext');
+
+test('isDirEmpty', async () => {
+  const tempDir = tempfile();
+  try {
+    await expect(fsext.isDirEmpty(tempDir)).rejects.toThrowError(/ENOENT/);
+
+    await fs.ensureDir(tempDir);
+    await expect(fsext.isDirEmpty(tempDir)).resolves.toBe(true);
+
+    await fs.ensureFile(path.join(tempDir, '1'));
+    await expect(fsext.isDirEmpty(tempDir)).resolves.toBe(false);
+  } finally {
+    await fs.remove(tempDir);
+  }
+});

--- a/detox/test/e2e/21.artifacts.test.js
+++ b/detox/test/e2e/21.artifacts.test.js
@@ -1,35 +1,42 @@
 const fs = require('fs');
 const path = require('path');
+
 const { PNG } = require('pngjs');
+
+const {
+  assertArtifactExists,
+  assertDirExists,
+  waitUntilArtifactsManagerIsIdle,
+} = require('./utils/artifactUtils');
 
 describe('Artifacts', () => {
   describe('screenshots', () => {
     beforeAll(async () => {
       await device.sendToHome();
-      await device.takeScreenshot('Artifacts/before all').then(printDimensions);
-      await device.launchApp({newInstance: true});
+      await device.takeScreenshot('Artifacts/before all').then(printPNGDimensions);
+      await device.launchApp({ newInstance: true });
     });
 
     beforeEach(async () => {
       // implicitly taking screenshot - beforeEach.png
       await device.reloadReactNative();
-      await device.takeScreenshot('in main menu').then(printDimensions);
+      await device.takeScreenshot('in main menu').then(printPNGDimensions);
 
       await element(by.text('Actions')).tap();
-      await device.takeScreenshot('Actions').then(printDimensions);
+      await device.takeScreenshot('Actions').then(printPNGDimensions);
     });
 
     it('should take screenshots inside test', async () => {
       await element(by.id('UniqueId819')).tap();
-      await device.takeScreenshot('taps - 1').then(printDimensions);
+      await device.takeScreenshot('taps - 1').then(printPNGDimensions);
 
       await element(by.id('UniqueId819')).tap();
-      await device.takeScreenshot('taps - 2').then(printDimensions);
+      await device.takeScreenshot('taps - 2').then(printPNGDimensions);
     });
 
     afterEach(async () => {
       await element(by.text('Tap Me')).tap();
-      await device.takeScreenshot('tap working').then(printDimensions);
+      await device.takeScreenshot('tap working').then(printPNGDimensions);
 
       await device.reloadReactNative();
       // implicitly taking screenshot - afterEach.png
@@ -37,14 +44,22 @@ describe('Artifacts', () => {
 
     afterAll(async () => {
       await device.sendToHome();
-      await device.takeScreenshot('Artifacts/after all').then(printDimensions);
+      await device.takeScreenshot('Artifacts/after all').then(printPNGDimensions);
       await device.launchApp();
     });
 
-    function printDimensions(pathToScreenshot) {
+    afterAll(async () => {
+      await waitUntilArtifactsManagerIsIdle();
+
+      assertArtifactExists('Artifacts_before all.png');
+      assertArtifactExists('✓ Artifacts screenshots should take screenshots inside test/taps - 1.png');
+      assertArtifactExists('✓ Artifacts screenshots should take screenshots inside test/taps - 2.png');
+    });
+
+    function printPNGDimensions(pathToScreenshot) {
       const buffer = fs.readFileSync(pathToScreenshot);
       const filename = path.basename(pathToScreenshot);
-      const {width, height} = PNG.sync.read(buffer);
+      const { width, height } = PNG.sync.read(buffer);
 
       console.log(`Took a screenshot: ${filename} (${width}x${height})`);
     }
@@ -52,42 +67,59 @@ describe('Artifacts', () => {
 
   describe(':ios: View Hierarchy', () => {
     beforeAll(async () => {
-      await device.launchApp({newInstance: true});
-
-      [
-        await device.captureViewHierarchy(), // = 'capture'
-        await device.captureViewHierarchy('before tests'),
-      ].forEach(assertDirExists);
+      await device.launchApp({ newInstance: true });
+      await device.captureViewHierarchy('before tests').then(assertDirExists);
     });
 
-    it('should capture view hierarchies in test and upon multiple invocation failures', async () => {
-      try {
-        await element(by.id('nonExistentId')).tap();
-        fail('should have failed');
-      } catch (e) {
-        [
-          await device.captureViewHierarchy(), // = 'capture'
-          await device.captureViewHierarchy('named capture'),
-        ].forEach(assertDirExists);
-      }
+    it('should capture anonymous view hierarchies upon manual request', async () => {
+      await device.captureViewHierarchy().then(assertDirExists);
+      await device.captureViewHierarchy().then(assertDirExists);
+    });
 
-      try {
-        await element(by.id('nonExistentId2')).tap();
-        fail('should have failed too');
-      } catch (e) {
-        [
-          await device.captureViewHierarchy(), // = 'capture'
-          await device.captureViewHierarchy('named capture'),
-        ].forEach(assertDirExists);
-      }
+    it('should capture named view hierarchies upon manual request', async () => {
+      await device.captureViewHierarchy('named capture').then(assertDirExists);
+      await device.captureViewHierarchy('named capture').then(assertDirExists);
+    });
 
-      // Artifacts folder should contain the following *.viewhierarchy folders: ui, capture, named capture, ui2, capture2, named capture2
+    it('should capture hierarchy upon multiple invocation failures', async () => {
+      for (let i = 0; i < 2; i++) {
+        try {
+          await element(by.id('nonExistentId')).tap();
+          fail('should have failed');
+        } catch (e) {
+        }
+      }
+    });
+
+    afterAll(async () => {
+      await waitUntilArtifactsManagerIsIdle();
+      assertArtifactExists('before tests.viewhierarchy');
+      assertArtifactExists('✓ Artifacts _ios_ View Hierarchy should capture anonymous view hierarchies upon manual request/capture.viewhierarchy');
+      assertArtifactExists('✓ Artifacts _ios_ View Hierarchy should capture anonymous view hierarchies upon manual request/capture.viewhierarchy');
+      assertArtifactExists('✓ Artifacts _ios_ View Hierarchy should capture named view hierarchies upon manual request/named capture.viewhierarchy');
+      assertArtifactExists('✓ Artifacts _ios_ View Hierarchy should capture named view hierarchies upon manual request/named capture2.viewhierarchy');
+      assertArtifactExists('✓ Artifacts _ios_ View Hierarchy should capture hierarchy upon multiple invocation failures/ui.viewhierarchy');
+      assertArtifactExists('✓ Artifacts _ios_ View Hierarchy should capture hierarchy upon multiple invocation failures/ui2.viewhierarchy');
+    });
+
+    describe('edge uninstall case', () => {
+      it('should capture hierarchy regardless', async () => {
+          try {
+            await element(by.id('nonExistentId')).tap();
+            fail('should have failed');
+          } catch (e) {
+            await device.uninstallApp();
+          }
+      });
+
+      afterAll(async () => {
+        await waitUntilArtifactsManagerIsIdle();
+        assertArtifactExists('✓ Artifacts _ios_ View Hierarchy edge uninstall case should capture hierarchy regardless/ui3.viewhierarchy');
+      });
+
+      afterAll(async () => {
+        await device.installApp();
+      });
     });
   });
-
-  function assertDirExists(dirPath) {
-    if (!fs.statSync(dirPath).isDirectory()) {
-      throw new Error('Expected to find a directory at path: ' + dirPath);
-    }
-  }
 });

--- a/detox/test/e2e/utils/artifactUtils.js
+++ b/detox/test/e2e/utils/artifactUtils.js
@@ -16,6 +16,12 @@ function getLatestArtifactsDir() {
     .maxBy((dir) => stats[dir].mtime);
 }
 
+function assertDirExists(dirPath) {
+  if (!fs.statSync(dirPath).isDirectory()) {
+    throw new Error('Expected to find a directory at path: ' + dirPath);
+  }
+}
+
 function assertArtifactExists(name) {
   const artifactsRootDir = getLatestArtifactsDir();
   const artifactPath = path.join(artifactsRootDir, name);
@@ -33,5 +39,6 @@ async function waitUntilArtifactsManagerIsIdle() {
 module.exports = {
   getLatestArtifactsDir,
   assertArtifactExists,
+  assertDirExists,
   waitUntilArtifactsManagerIsIdle,
 };

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-test",
-  "version": "18.20.3-smoke.0",
+  "version": "18.20.3-smoke.1",
   "private": true,
   "engines": {
     "node": ">=8.3.0"
@@ -40,7 +40,7 @@
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
     "@types/node": "^14.14.20",
-    "detox": "^18.20.3-smoke.0",
+    "detox": "^18.20.3-smoke.1",
     "dtslint": "^4.0.6",
     "express": "^4.15.3",
     "jest": "^27.0.0",

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-test",
-  "version": "18.20.2",
+  "version": "18.20.3-smoke.0",
   "private": true,
   "engines": {
     "node": ">=8.3.0"
@@ -40,7 +40,7 @@
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
     "@types/node": "^14.14.20",
-    "detox": "^18.20.2",
+    "detox": "^18.20.3-smoke.0",
     "dtslint": "^4.0.6",
     "express": "^4.15.3",
     "jest": "^27.0.0",

--- a/examples/demo-native-android/package.json
+++ b/examples/demo-native-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-demo-native-android",
-  "version": "18.20.3-smoke.0",
+  "version": "18.20.3-smoke.1",
   "private": true,
   "scripts": {
     "packager": "react-native start",
@@ -8,7 +8,7 @@
     "e2e": "mocha e2e --opts ./e2e/mocha.opts"
   },
   "devDependencies": {
-    "detox": "^18.20.3-smoke.0",
+    "detox": "^18.20.3-smoke.1",
     "mocha": "^6.1.3"
   },
   "detox": {}

--- a/examples/demo-native-android/package.json
+++ b/examples/demo-native-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-demo-native-android",
-  "version": "18.20.2",
+  "version": "18.20.3-smoke.0",
   "private": true,
   "scripts": {
     "packager": "react-native start",
@@ -8,7 +8,7 @@
     "e2e": "mocha e2e --opts ./e2e/mocha.opts"
   },
   "devDependencies": {
-    "detox": "^18.20.2",
+    "detox": "^18.20.3-smoke.0",
     "mocha": "^6.1.3"
   },
   "detox": {}

--- a/examples/demo-native-ios/package.json
+++ b/examples/demo-native-ios/package.json
@@ -1,9 +1,9 @@
 {
   "name": "detox-demo-native-ios",
-  "version": "18.20.2",
+  "version": "18.20.3-smoke.0",
   "private": true,
   "devDependencies": {
-    "detox": "^18.20.2",
+    "detox": "^18.20.3-smoke.0",
     "mocha": "^6.1.3"
   },
   "detox": {

--- a/examples/demo-native-ios/package.json
+++ b/examples/demo-native-ios/package.json
@@ -1,9 +1,9 @@
 {
   "name": "detox-demo-native-ios",
-  "version": "18.20.3-smoke.0",
+  "version": "18.20.3-smoke.1",
   "private": true,
   "devDependencies": {
-    "detox": "^18.20.3-smoke.0",
+    "detox": "^18.20.3-smoke.1",
     "mocha": "^6.1.3"
   },
   "detox": {

--- a/examples/demo-react-native-detox-instruments/package.json
+++ b/examples/demo-react-native-detox-instruments/package.json
@@ -1,10 +1,10 @@
 {
   "name": "demo-react-native-detox-instruments",
-  "version": "18.20.3-smoke.0",
+  "version": "18.20.3-smoke.1",
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "detox": "^18.20.3-smoke.0",
+    "detox": "^18.20.3-smoke.1",
     "mocha": "6.x.x"
   },
   "detox": {

--- a/examples/demo-react-native-detox-instruments/package.json
+++ b/examples/demo-react-native-detox-instruments/package.json
@@ -1,10 +1,10 @@
 {
   "name": "demo-react-native-detox-instruments",
-  "version": "18.20.2",
+  "version": "18.20.3-smoke.0",
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "detox": "^18.20.2",
+    "detox": "^18.20.3-smoke.0",
     "mocha": "6.x.x"
   },
   "detox": {

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-react-native-jest",
-  "version": "18.20.3-smoke.0",
+  "version": "18.20.3-smoke.1",
   "private": true,
   "scripts": {
     "test:ios-release": "detox test --configuration ios.sim.release -l verbose",
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",
-    "detox": "^18.20.3-smoke.0",
+    "detox": "^18.20.3-smoke.1",
     "jest": "^27.0.0",
     "sanitize-filename": "^1.6.1",
     "ts-jest": "^27.0.0",

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-react-native-jest",
-  "version": "18.20.2",
+  "version": "18.20.3-smoke.0",
   "private": true,
   "scripts": {
     "test:ios-release": "detox test --configuration ios.sim.release -l verbose",
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",
-    "detox": "^18.20.2",
+    "detox": "^18.20.3-smoke.0",
     "jest": "^27.0.0",
     "sanitize-filename": "^1.6.1",
     "ts-jest": "^27.0.0",

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "18.20.3-smoke.0",
+  "version": "18.20.3-smoke.1",
   "private": true,
   "scripts": {
     "start": "react-native start",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^8.2.0",
-    "detox": "^18.20.3-smoke.0",
+    "detox": "^18.20.3-smoke.1",
     "mocha": "^6.1.3",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "18.20.2",
+  "version": "18.20.3-smoke.0",
   "private": true,
   "scripts": {
     "start": "react-native start",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^8.2.0",
-    "detox": "^18.20.2",
+    "detox": "^18.20.3-smoke.0",
     "mocha": "^6.1.3",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
     "generation",
     "."
   ],
-  "version": "18.20.3-smoke.0",
+  "version": "18.20.3-smoke.1",
   "npmClient": "npm",
   "command": {
     "publish": {

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
     "generation",
     "."
   ],
-  "version": "18.20.2",
+  "version": "18.20.3-smoke.0",
   "npmClient": "npm",
   "command": {
     "publish": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "semver": "5.x.x",
     "shell-utils": "1.x.x"
   },
-  "version": "18.20.3-smoke.0"
+  "version": "18.20.3-smoke.1"
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "semver": "5.x.x",
     "shell-utils": "1.x.x"
   },
-  "version": "18.20.2"
+  "version": "18.20.3-smoke.0"
 }


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here:

If there are pending app artifacts (iOS view hierarchies, screenshots made by app - e.g. visibility failures), and the app is being uninstalled – they just get lost in the middle. Artifacts plugin prints many warnings about missing files.

This is why here I improve the E2E test suite for this edge cases and make sure `uninstallApp()` does not affect the artifacts collection.

- In this pull request, I have implemented an artifact relocation mechanism for two plugins: UI hierarchy and screenshot plugin. If the app is about to be uninstalled, they will relocated all the pending artifacts (not saved and not deleted ones).
