### PR TITLE
fix(device): launchApp with explicit bundleId

### DIFF
--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -338,8 +338,12 @@ class Device {
       await this.terminateApp(bundleId);
     }
 
+    const currentAppLaunchArgs = this._currentApp
+      ? this._currentApp.launchArgs
+      : null;
+
     const baseLaunchArgs = {
-      ...this._currentApp.launchArgs,
+      ...currentAppLaunchArgs,
       ...params.launchArgs,
     };
 


### PR DESCRIPTION
## Description

Fixes an edge case when the device is started with no apps at all, yet all its app-related methods are used by passing `bundleId` explicitly.

```json
{
  "configurations": {
    "ios.noapps": {
      "device": "ios.phone",
      "apps": []
    }
  }
}
```

It appears, that I made a mistake in `launchApp` implementation which makes it unusable in this rare situation – it throws an error instead of letting the app run via the explicit bundle identifier.

```js
await device.launchApp({}, 'explicit.app.identifier');
```