### PR TITLE
Use `-rg` in adb install with API < 23

### DIFF
--- a/detox/src/devices/drivers/android/exec/ADB.js
+++ b/detox/src/devices/drivers/android/exec/ADB.js
@@ -108,7 +108,8 @@ class ADB {
     if (apiLvl >= 23) {
       childProcess = await this.adbCmd(deviceId, `install -r -g -t ${apkPath}`);
     } else {
-      childProcess = await this.adbCmd(deviceId, `install -r -g ${apkPath}`);
+      // NOTICE: MUST be in `-rg` form instead of individual `-g` form when API < 23
+      childProcess = await this.adbCmd(deviceId, `install -rg ${apkPath}`);
     }
 
     const [failure] = (childProcess.stdout || '').match(/^Failure \[.*\]$/m) || [];
@@ -126,7 +127,8 @@ class ADB {
     if (apiLvl >= 23) {
       return this.shell(deviceId, `pm install -r -g -t ${path}`);
     } else {
-      return this.shell(deviceId, `pm install -r -g ${path}`);
+      // NOTICE: MUST be in `-rg` form instead of individual `-g` form when API < 23
+      return this.shell(deviceId, `pm install -rg ${path}`);
     }
   }
 

--- a/detox/src/devices/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/drivers/android/exec/ADB.test.js
@@ -92,7 +92,7 @@ describe('ADB', () => {
     await adb.install('emulator-5556', 'path inside "quotes" to/app');
 
     expect(exec).toHaveBeenCalledWith(
-      expect.stringContaining('adb" -s emulator-5556 install -r -g "path inside \\"quotes\\" to/app"'),
+      expect.stringContaining('adb" -s emulator-5556 install -rg "path inside \\"quotes\\" to/app"'),
       { retries: 1 });
   });
 
@@ -158,7 +158,7 @@ describe('ADB', () => {
     await adb.remoteInstall(deviceId, binaryPath);
 
     expect(exec).toHaveBeenCalledWith(
-      expect.stringContaining(`-s mockEmulator shell "pm install -r -g ${binaryPath}"`),
+      expect.stringContaining(`-s mockEmulator shell "pm install -rg ${binaryPath}"`),
       expect.anything());
   });
 


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: 
  - #2527
  - #2919
  - #274
 
These issues have been solved before, but broke again after #2922.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

Under API 23, `pm install` only accept `-rg` instead of individual `-g` option.

I also added notice comments because this argument has been changed to `-r -g` several times in other PRs, these notice may be helpful while editing.

ref: https://github.com/wix/Detox/pull/2922#pullrequestreview-743410234
ref: https://github.com/wix/detox/issues/274#issuecomment-356529351

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.

note: This is a bug fix. Not changing API and adding features.