### PR TITLE
feat: CLI and JS config parity

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -217,6 +217,7 @@ declare global {
         interface DetoxIosSimulatorDriverConfig {
             type: 'ios.simulator';
             device: string | Partial<IosSimulatorQuery>;
+            bootArgs?: string;
         }
 
         interface DetoxIosNoneDriverConfig {
@@ -225,22 +226,28 @@ declare global {
             device?: string | Partial<IosSimulatorQuery>;
         }
 
-        interface DetoxAttachedAndroidDriverConfig {
+        interface DetoxSharedAndroidDriverConfig {
+            forceAdbInstall?: boolean;
+            utilBinaryPaths?: string[];
+        }
+
+        interface DetoxAttachedAndroidDriverConfig extends DetoxSharedAndroidDriverConfig {
             type: 'android.attached';
             device: string | { adbName: string };
-            utilBinaryPaths?: string[];
         }
 
-        interface DetoxAndroidEmulatorDriverConfig {
+        interface DetoxAndroidEmulatorDriverConfig extends DetoxSharedAndroidDriverConfig {
             type: 'android.emulator';
             device: string | { avdName: string };
-            utilBinaryPaths?: string[];
+            bootArgs?: string;
+            gpuMode?: 'auto' | 'host' | 'swiftshader_indirect' | 'angle_indirect' | 'guest';
+            headless?: boolean;
+            readonly?: boolean;
         }
 
-        interface DetoxGenymotionCloudDriverConfig {
+        interface DetoxGenymotionCloudDriverConfig extends DetoxSharedAndroidDriverConfig {
             type: 'android.genycloud';
             device: string | { recipeUUID: string; } | { recipeName: string; };
-            utilBinaryPaths?: string[];
         }
 
         interface DetoxCustomDriverConfig {

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -36,6 +36,7 @@ module.exports.handler = async function test(argv) {
 
   const forwardedArgs = await prepareArgs({
     cliConfig,
+    deviceConfig,
     runnerConfig,
     runnerArgs,
     platform,
@@ -164,7 +165,7 @@ function prepareMochaArgs({ cliConfig, runnerArgs, runnerConfig, platform }) {
   };
 }
 
-async function prepareJestArgs({ cliConfig, runnerArgs, runnerConfig, platform }) {
+async function prepareJestArgs({ cliConfig, deviceConfig, runnerArgs, runnerConfig, platform }) {
   const { specs, passthrough } = splitArgv.jest(runnerArgs);
   const platformFilter = getPlatformSpecificString(platform);
 
@@ -198,7 +199,7 @@ async function prepareJestArgs({ cliConfig, runnerArgs, runnerConfig, platform }
       DETOX_GPU: cliConfig.gpu,
       DETOX_HEADLESS: cliConfig.headless,
       DETOX_LOGLEVEL: cliConfig.loglevel,
-      DETOX_READ_ONLY_EMU: platform === 'android' ? hasMultipleWorkers : undefined,
+      DETOX_READ_ONLY_EMU: deviceConfig.type === 'android.emulator' ? hasMultipleWorkers : undefined,
       DETOX_RECORD_LOGS: cliConfig.recordLogs,
       DETOX_RECORD_PERFORMANCE: cliConfig.recordPerformance,
       DETOX_RECORD_TIMELINE: cliConfig.recordTimeline,

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -199,7 +199,7 @@ async function prepareJestArgs({ cliConfig, deviceConfig, runnerArgs, runnerConf
       DETOX_GPU: cliConfig.gpu,
       DETOX_HEADLESS: cliConfig.headless,
       DETOX_LOGLEVEL: cliConfig.loglevel,
-      DETOX_READ_ONLY_EMU: deviceConfig.type === 'android.emulator' ? hasMultipleWorkers : undefined,
+      DETOX_READ_ONLY_EMU: deviceConfig.type === 'android.emulator' && hasMultipleWorkers ? true : undefined,
       DETOX_RECORD_LOGS: cliConfig.recordLogs,
       DETOX_RECORD_PERFORMANCE: cliConfig.recordPerformance,
       DETOX_RECORD_TIMELINE: cliConfig.recordTimeline,

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -17,7 +17,7 @@ const { readJestConfig } = require('./utils/jestInternals');
 const { getPlatformSpecificString, printEnvironmentVariables } = require('./utils/misc');
 const { prependNodeModulesBinToPATH } = require('./utils/misc');
 const splitArgv = require('./utils/splitArgv');
-const { DETOX_ARGV_OVERRIDE_NOTICE } = require('./utils/warnings');
+const { DETOX_ARGV_OVERRIDE_NOTICE, DEVICE_LAUNCH_ARGS_DEPRECATION } = require('./utils/warnings');
 
 module.exports.command = 'test';
 module.exports.desc = 'Run your test suite with the test runner specified in package.json';
@@ -68,6 +68,14 @@ module.exports.middlewares = [
         ...process.argv.slice(2),
         ...parse(process.env.DETOX_ARGV_OVERRIDE),
       ]);
+    }
+
+    return argv;
+  },
+
+  function warnDeviceAppLaunchArgsDeprecation(argv) {
+    if (argv['device-boot-args'] && process.argv.some(a => a.startsWith('--device-launch-args'))) {
+      log.warn(DEVICE_LAUNCH_ARGS_DEPRECATION);
     }
 
     return argv;
@@ -150,7 +158,7 @@ function prepareMochaArgs({ cliConfig, runnerArgs, runnerConfig, platform }) {
     },
     env: _.omitBy({
       DETOX_APP_LAUNCH_ARGS: cliConfig.appLaunchArgs,
-      DETOX_DEVICE_LAUNCH_ARGS: cliConfig.deviceLaunchArgs,
+      DETOX_DEVICE_BOOT_ARGS: cliConfig.deviceBootArgs,
     }, _.isUndefined),
     specs: _.isEmpty(specs) ? [runnerConfig.specs] : specs,
   };
@@ -184,7 +192,7 @@ async function prepareJestArgs({ cliConfig, runnerArgs, runnerConfig, platform }
       DETOX_CONFIGURATION: cliConfig.configuration,
       DETOX_CONFIG_PATH: cliConfig.configPath,
       DETOX_DEBUG_SYNCHRONIZATION: cliConfig.debugSynchronization,
-      DETOX_DEVICE_LAUNCH_ARGS: cliConfig.deviceLaunchArgs,
+      DETOX_DEVICE_BOOT_ARGS: cliConfig.deviceBootArgs,
       DETOX_DEVICE_NAME: cliConfig.deviceName,
       DETOX_FORCE_ADB_INSTALL: platform === 'android' ? cliConfig.forceAdbInstall : undefined,
       DETOX_GPU: cliConfig.gpu,

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -311,7 +311,6 @@ describe('CLI', () => {
           DETOX_CONFIG_PATH: expect.any(String),
           DETOX_REPORT_SPECS: true,
           DETOX_USE_CUSTOM_LOGGER: true,
-          DETOX_READ_ONLY_EMU: false,
         });
       });
     });
@@ -526,10 +525,10 @@ describe('CLI', () => {
         expect(cliCall().env).not.toHaveProperty('DETOX_READ_ONLY_EMU');
       });
 
-      test.each([['-w'], ['--workers']])('%s <value> should put readOnlyEmu environment variable for Android if there is a single worker', async (__workers) => {
+      test.each([['-w'], ['--workers']])('%s <value> should not put readOnlyEmu environment variable for android.emulator if there is a single worker', async (__workers) => {
         singleConfig().type = 'android.emulator';
         await run(`${__workers} 1`);
-        expect(cliCall().env).toEqual(expect.objectContaining({ DETOX_READ_ONLY_EMU: false }));
+        expect(cliCall().env).not.toHaveProperty('DETOX_READ_ONLY_EMU');
       });
 
       test.each([['-w'], ['--workers']])('%s <value> should put readOnlyEmu environment variable for Android if there are multiple workers', async (__workers) => {

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -520,6 +520,12 @@ describe('CLI', () => {
         expect(cliCall().env).not.toHaveProperty('DETOX_READ_ONLY_EMU');
       });
 
+      test.each([['-w'], ['--workers']])('%s <value> should not put readOnlyEmu environment variable for android.attached', async (__workers) => {
+        singleConfig().type = 'android.attached';
+        await run(`${__workers} 2`);
+        expect(cliCall().env).not.toHaveProperty('DETOX_READ_ONLY_EMU');
+      });
+
       test.each([['-w'], ['--workers']])('%s <value> should put readOnlyEmu environment variable for Android if there is a single worker', async (__workers) => {
         singleConfig().type = 'android.emulator';
         await run(`${__workers} 1`);

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -8,6 +8,8 @@ const fs = require('fs-extra');
 const _ = require('lodash');
 const yargs = require('yargs');
 
+const { DEVICE_LAUNCH_ARGS_DEPRECATION } = require('./utils/warnings');
+
 describe('CLI', () => {
   let cp;
   let logger;
@@ -178,11 +180,20 @@ describe('CLI', () => {
       expect(cliCall().command).toContain('--gpu angle_indirect');
     });
 
-    test('--device-launch-args should be passed as an environment variable', async () => {
+    test('--device-boot-args should be passed as an environment variable (without deprecation warnings)', async () => {
+      await run(`--device-boot-args "--verbose"`);
+      expect(cliCall().env).toEqual({
+        DETOX_DEVICE_BOOT_ARGS: '--verbose',
+      });
+      expect(logger.warn).not.toHaveBeenCalledWith(DEVICE_LAUNCH_ARGS_DEPRECATION);
+    });
+
+    test('--device-launch-args should serve as a deprecated alias to --device-boot-args', async () => {
       await run(`--device-launch-args "--verbose"`);
       expect(cliCall().env).toEqual({
-        DETOX_DEVICE_LAUNCH_ARGS: '--verbose',
+        DETOX_DEVICE_BOOT_ARGS: '--verbose',
       });
+      expect(logger.warn).toHaveBeenCalledWith(DEVICE_LAUNCH_ARGS_DEPRECATION);
     });
 
     test('--app-launch-args should be passed as an environment variable', async () => {
@@ -300,7 +311,6 @@ describe('CLI', () => {
           DETOX_CONFIG_PATH: expect.any(String),
           DETOX_REPORT_SPECS: true,
           DETOX_USE_CUSTOM_LOGGER: true,
-          DETOX_FORCE_ADB_INSTALL: false,
           DETOX_READ_ONLY_EMU: false,
         });
       });
@@ -568,11 +578,18 @@ describe('CLI', () => {
       expect(cliCall().env).toEqual(expect.objectContaining({ DETOX_GPU: 'angle_indirect' }));
     });
 
-    test('--device-launch-args should be passed as environment variable', async () => {
-      await run(`--device-launch-args "--verbose"`);
+    test('--device-boot-args should be passed as an environment variable (without deprecation warnings)', async () => {
+      await run(`--device-boot-args "--verbose"`);
       expect(cliCall().env).toEqual(expect.objectContaining({
-        DETOX_DEVICE_LAUNCH_ARGS: '--verbose'
+        DETOX_DEVICE_BOOT_ARGS: '--verbose'
       }));
+      expect(logger.warn).not.toHaveBeenCalledWith(DEVICE_LAUNCH_ARGS_DEPRECATION);
+    });
+
+    test('--device-launch-args should serve as a deprecated alias to --device-boot-args', async () => {
+      await run(`--device-launch-args "--verbose"`);
+      expect(cliCall().env.DETOX_DEVICE_BOOT_ARGS).toBe('--verbose');
+      expect(logger.warn).toHaveBeenCalledWith(DEVICE_LAUNCH_ARGS_DEPRECATION);
     });
 
     test('--app-launch-args should be passed as an environment variable', async () => {
@@ -691,9 +708,9 @@ describe('CLI', () => {
     });
 
     test('-- <...explicitPassthroughArgs> should be forwarded to the test runner CLI as-is', async () => {
-      await run('--device-launch-args detoxArgs e2eFolder -- a -a --a --device-launch-args runnerArgs');
-      expect(cliCall().command).toMatch(/a -a --a --device-launch-args runnerArgs .* e2eFolder$/);
-      expect(cliCall().env).toEqual(expect.objectContaining({ DETOX_DEVICE_LAUNCH_ARGS: 'detoxArgs' }));
+      await run('--device-boot-args detoxArgs e2eFolder -- a -a --a --device-boot-args runnerArgs');
+      expect(cliCall().command).toMatch(/a -a --a --device-boot-args runnerArgs .* e2eFolder$/);
+      expect(cliCall().env).toEqual(expect.objectContaining({ DETOX_DEVICE_BOOT_ARGS: 'detoxArgs' }));
     });
 
     test('-- <...explicitPassthroughArgs> should omit double-dash "--" itself, when forwarding args', async () => {

--- a/detox/local-cli/utils/testCommandArgs.js
+++ b/detox/local-cli/utils/testCommandArgs.js
@@ -132,9 +132,10 @@ module.exports = {
     group: 'Configuration:',
     describe: 'Override the device name specified in a configuration. Useful for running a single build configuration on multiple devices.',
   },
-  'device-launch-args': {
+  'device-boot-args': {
+    alias: 'device-launch-args',
     group: 'Execution:',
-    describe: 'Custom arguments to pass (through) onto the device (emulator/simulator) binary when launched.',
+    describe: 'Custom arguments to pass (through) onto the device (emulator/simulator) binary when booted.',
   },
   'app-launch-args': {
     group: 'Execution:',
@@ -148,7 +149,6 @@ module.exports = {
   },
   'force-adb-install': {
     boolean: true,
-    default: false,
     group: 'Execution:',
     describe: `Due to problems with the "adb install" command on Android, Detox resorts to a different scheme for install APK's. Setting true will disable that and force usage of "adb install", instead.`,
   },

--- a/detox/local-cli/utils/warnings.js
+++ b/detox/local-cli/utils/warnings.js
@@ -1,3 +1,4 @@
+const { DEVICE_LAUNCH_ARGS_DEPRECATION } = require('../../src/configuration/utils/warnings');
 const log = require('../../src/utils/logger').child({ __filename });
 
 function coerceDeprecation(option) {
@@ -31,4 +32,5 @@ const DETOX_ARGV_OVERRIDE_NOTICE = `
 module.exports = {
   coerceDeprecation,
   DETOX_ARGV_OVERRIDE_NOTICE,
+  DEVICE_LAUNCH_ARGS_DEPRECATION,
 };

--- a/detox/src/artifacts/templates/artifact/Artifact.test.js
+++ b/detox/src/artifacts/templates/artifact/Artifact.test.js
@@ -2,28 +2,31 @@ const util = require('util');
 
 const _ = require('lodash');
 
-const Artifact = require('./Artifact');
-
 describe('Artifact', () => {
+  let Artifact;
+
   beforeEach(() => {
     jest.mock('../../../utils/logger');
+    Artifact = require('./Artifact');
   });
 
   describe('extends Artifact', () => {
     let artifact;
+    let ArifactExtensionTest;
 
-    class ArifactExtensionTest extends Artifact {
-      constructor() {
-        super();
-
-        this.doStart = jest.fn().mockImplementation(() => super.doStart());
-        this.doStop = jest.fn().mockImplementation(() => super.doStop());
-        this.doSave = jest.fn().mockImplementation(() => super.doSave());
-        this.doDiscard = jest.fn().mockImplementation(() => super.doDiscard());
-      }
-    }
 
     beforeEach(() => {
+      ArifactExtensionTest = class extends Artifact {
+        constructor() {
+          super();
+
+          this.doStart = jest.fn().mockImplementation(() => super.doStart());
+          this.doStop = jest.fn().mockImplementation(() => super.doStop());
+          this.doSave = jest.fn().mockImplementation(() => super.doSave());
+          this.doDiscard = jest.fn().mockImplementation(() => super.doDiscard());
+        }
+      };
+
       artifact = new ArifactExtensionTest();
     });
 

--- a/detox/src/configuration/collectCliConfig.js
+++ b/detox/src/configuration/collectCliConfig.js
@@ -52,7 +52,7 @@ function collectCliConfig({ argv }) {
     configPath: get('config-path'),
     configuration: get('configuration'),
     debugSynchronization: asNumber(get('debug-synchronization')),
-    deviceBootArgs: get('device-boot-args', deprecateDeviceLaunchArgs(get('device-launch-args'))),
+    deviceBootArgs: get('device-boot-args', deprecateDeviceLaunchArgs(argparse.getEnvValue('device-launch-args'))),
     appLaunchArgs: get('app-launch-args'),
     deviceName: get('device-name'),
     forceAdbInstall: asBoolean(get('force-adb-install')),

--- a/detox/src/configuration/collectCliConfig.js
+++ b/detox/src/configuration/collectCliConfig.js
@@ -1,10 +1,44 @@
 const _ = require('lodash');
 
 const argparse = require('../utils/argparse');
+const log = require('../utils/logger').child({ __filename });
+
+const { DEVICE_LAUNCH_ARGS_GENERIC_DEPRECATION } = require('./utils/warnings');
+
+const asBoolean = (value) => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  return value != null
+    ? (value !== 'false' && value !== '0' && value !== '')
+    : undefined;
+};
+
+const asNumber = (value) => {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  return value != null && value !== ''
+    ? Number(value)
+    : undefined;
+};
+
+const deprecateDeviceLaunchArgs = (value) => {
+  if (value) {
+    log.warn(DEVICE_LAUNCH_ARGS_GENERIC_DEPRECATION);
+  }
+
+  return value;
+};
 
 function collectCliConfig({ argv }) {
   const env = (key) => argparse.getArgValue(key);
-  const get = (key) => argv ? argv[key] : env(key);
+  const get = (key, fallback) => {
+    const value = argv ? argv[key] : env(key);
+    return value === undefined ? fallback : value;
+  };
 
   return _.omitBy({
     artifactsLocation: get('artifacts-location'),
@@ -14,25 +48,25 @@ function collectCliConfig({ argv }) {
     recordVideos: get('record-videos'),
     recordPerformance: get('record-performance'),
     recordTimeline: get('record-timeline'),
-    cleanup: get('cleanup'),
+    cleanup: asBoolean(get('cleanup')),
     configPath: get('config-path'),
     configuration: get('configuration'),
-    debugSynchronization: get('debug-synchronization'),
-    deviceLaunchArgs: get('device-launch-args'),
+    debugSynchronization: asNumber(get('debug-synchronization')),
+    deviceBootArgs: get('device-boot-args', deprecateDeviceLaunchArgs(get('device-launch-args'))),
     appLaunchArgs: get('app-launch-args'),
     deviceName: get('device-name'),
-    forceAdbInstall: get('force-adb-install'),
+    forceAdbInstall: asBoolean(get('force-adb-install')),
     gpu: get('gpu'),
-    headless: get('headless'),
-    jestReportSpecs: get('jest-report-specs'),
-    keepLockFile: get('keepLockFile'),
+    headless: asBoolean(get('headless')),
+    jestReportSpecs: asBoolean(get('jest-report-specs')),
+    keepLockFile: asBoolean(get('keepLockFile')),
     loglevel: get('loglevel'),
-    noColor: get('no-color'),
-    reuse: get('reuse'),
+    noColor: asBoolean(get('no-color')),
+    reuse: asBoolean(get('reuse')),
     runnerConfig: get('runner-config'),
-    useCustomLogger: get('use-custom-logger'),
-    workers: get('workers'),
-    inspectBrk: get('inspect-brk'),
+    useCustomLogger: asBoolean(get('use-custom-logger')),
+    workers: asNumber(get('workers')),
+    inspectBrk: asBoolean(get('inspect-brk')),
   }, _.isUndefined);
 }
 

--- a/detox/src/configuration/collectCliConfig.js
+++ b/detox/src/configuration/collectCliConfig.js
@@ -58,6 +58,7 @@ function collectCliConfig({ argv }) {
     forceAdbInstall: asBoolean(get('force-adb-install')),
     gpu: get('gpu'),
     headless: asBoolean(get('headless')),
+    readonlyEmu: asBoolean(env('readOnlyEmu')),
     jestReportSpecs: asBoolean(get('jest-report-specs')),
     keepLockFile: asBoolean(get('keepLockFile')),
     loglevel: get('loglevel'),

--- a/detox/src/configuration/collectCliConfig.test.js
+++ b/detox/src/configuration/collectCliConfig.test.js
@@ -1,6 +1,15 @@
+const inspect = require('util').inspect;
+
+const { DEVICE_LAUNCH_ARGS_GENERIC_DEPRECATION } = require('./utils/warnings');
+
+jest.mock('../utils/logger');
+
+const J = x => inspect(x);
+
 describe('collectCliConfig', () => {
   let collectCliConfig;
   let argv, env;
+  let logger;
   let __env__;
 
   beforeEach(() => {
@@ -9,54 +18,103 @@ describe('collectCliConfig', () => {
     argv = {};
 
     collectCliConfig = require('./collectCliConfig');
+    logger = require('../utils/logger');
   });
 
   afterEach(() => {
     process.env = __env__;
   });
 
+  function multiplyTest(testCase, pairs) {
+    return pairs.map(([input, expected]) => [...testCase, input, expected]);
+  }
+
+  function asString(testCase) {
+    return multiplyTest(testCase, [
+      [undefined, undefined],
+      ['', ''],
+      ['some', 'some'],
+    ]);
+  }
+
+  function asNumber(testCase) {
+    return multiplyTest(testCase, [
+      [undefined, undefined],
+      [null, undefined],
+      ['', undefined],
+      ['some', NaN],
+      ['0', 0],
+      ['1', 1],
+      ['3000', 3000],
+      [-10.3, -10.3],
+    ]);
+  }
+
+  function asBoolean(testCase) {
+    return multiplyTest(testCase, [
+      [undefined, undefined],
+      [null, undefined],
+      ['', false],
+      ['false', false],
+      ['0', false],
+      ['1', true],
+      ['true', true],
+      ['anything', true],
+      [false, false],
+      [true, true],
+    ]);
+  }
+
   describe.each([
-    ['artifactsLocation',    'DETOX_ARTIFACTS_LOCATION',    'artifacts-location'],
-    ['captureViewHierarchy', 'DETOX_CAPTURE_VIEW_HIERARCHY','capture-view-hierarchy'],
-    ['recordLogs',           'DETOX_RECORD_LOGS',           'record-logs'],
-    ['takeScreenshots',      'DETOX_TAKE_SCREENSHOTS',      'take-screenshots'],
-    ['recordVideos',         'DETOX_RECORD_VIDEOS',         'record-videos'],
-    ['recordPerformance',    'DETOX_RECORD_PERFORMANCE',    'record-performance'],
-    ['recordTimeline',       'DETOX_RECORD_TIMELINE',       'record-timeline'],
-    ['cleanup',              'DETOX_CLEANUP',               'cleanup'],
-    ['configPath',           'DETOX_CONFIG_PATH',           'config-path'],
-    ['configuration',        'DETOX_CONFIGURATION',         'configuration'],
-    ['debugSynchronization', 'DETOX_DEBUG_SYNCHRONIZATION', 'debug-synchronization'],
-    ['deviceLaunchArgs',     'DETOX_DEVICE_LAUNCH_ARGS',    'device-launch-args'],
-    ['appLaunchArgs',        'DETOX_APP_LAUNCH_ARGS',       'app-launch-args'],
-    ['deviceName',           'DETOX_DEVICE_NAME',           'device-name'],
-    ['forceAdbInstall',      'DETOX_FORCE_ADB_INSTALL',     'force-adb-install'],
-    ['gpu',                  'DETOX_GPU',                   'gpu'],
-    ['headless',             'DETOX_HEADLESS',              'headless'],
-    ['jestReportSpecs',      'DETOX_JEST_REPORT_SPECS',     'jest-report-specs'],
-    ['keepLockFile',         'DETOX_KEEP_LOCK_FILE',        'keepLockFile'],
-    ['loglevel',             'DETOX_LOGLEVEL',              'loglevel'],
-    ['noColor',              'DETOX_NO_COLOR',              'no-color'],
-    ['reuse',                'DETOX_REUSE',                 'reuse'],
-    ['runnerConfig',         'DETOX_RUNNER_CONFIG',         'runner-config'],
-    ['useCustomLogger',      'DETOX_USE_CUSTOM_LOGGER',     'use-custom-logger'],
-    ['workers',              'DETOX_WORKERS',               'workers'],
-    ['inspectBrk',           'DETOX_INSPECT_BRK',           'inspect-brk'],
-  ])('.%s property' , (key, envName, argName) => {
+    ...asString( ['artifactsLocation',    'DETOX_ARTIFACTS_LOCATION',     'artifacts-location']),
+    ...asString( ['captureViewHierarchy', 'DETOX_CAPTURE_VIEW_HIERARCHY', 'capture-view-hierarchy']),
+    ...asString( ['recordLogs',           'DETOX_RECORD_LOGS',            'record-logs']),
+    ...asString( ['takeScreenshots',      'DETOX_TAKE_SCREENSHOTS',       'take-screenshots']),
+    ...asString( ['recordVideos',         'DETOX_RECORD_VIDEOS',          'record-videos']),
+    ...asString( ['recordPerformance',    'DETOX_RECORD_PERFORMANCE',     'record-performance']),
+    ...asString( ['recordTimeline',       'DETOX_RECORD_TIMELINE',        'record-timeline']),
+    ...asBoolean(['cleanup',              'DETOX_CLEANUP',                'cleanup']),
+    ...asString( ['configPath',            'DETOX_CONFIG_PATH',            'config-path']),
+    ...asString( ['configuration' ,        'DETOX_CONFIGURATION',          'configuration']),
+    ...asNumber( ['debugSynchronization', 'DETOX_DEBUG_SYNCHRONIZATION',  'debug-synchronization']),
+    ...asString( ['deviceBootArgs',       'DETOX_DEVICE_BOOT_ARGS',       'device-boot-args']),
+    ...asString( ['deviceBootArgs',       'DETOX_DEVICE_LAUNCH_ARGS',     'device-launch-args']),
+    ...asString( ['appLaunchArgs',        'DETOX_APP_LAUNCH_ARGS',        'app-launch-args']),
+    ...asString( ['deviceName',           'DETOX_DEVICE_NAME',            'device-name']),
+    ...asBoolean(['forceAdbInstall',      'DETOX_FORCE_ADB_INSTALL',      'force-adb-install']),
+    ...asString( ['gpu',                  'DETOX_GPU',                    'gpu']),
+    ...asBoolean(['headless',             'DETOX_HEADLESS',               'headless']),
+    ...asBoolean(['jestReportSpecs',      'DETOX_JEST_REPORT_SPECS',      'jest-report-specs']),
+    ...asBoolean(['keepLockFile',         'DETOX_KEEP_LOCK_FILE',         'keepLockFile']),
+    ...asString( ['loglevel',             'DETOX_LOGLEVEL',               'loglevel']),
+    ...asBoolean(['noColor',              'DETOX_NO_COLOR',               'no-color']),
+    ...asBoolean(['reuse',                'DETOX_REUSE',                  'reuse']),
+    ...asString( ['runnerConfig',          'DETOX_RUNNER_CONFIG',          'runner-config']),
+    ...asBoolean(['useCustomLogger',      'DETOX_USE_CUSTOM_LOGGER',      'use-custom-logger']),
+    ...asNumber( ['workers',              'DETOX_WORKERS',                'workers']),
+    ...asBoolean(['inspectBrk',           'DETOX_INSPECT_BRK',            'inspect-brk']),
+  ])('.%s property' , (key, envName, argName, input, expected) => {
     beforeEach(() => {
-      env[envName] = Math.random();
-      argv[argName] = Math.random();
+      env[envName] = input;
+      argv[argName] = input;
     });
 
-    it('should be extracted from argv if it is provided', () => {
-      const expected = argv[argName];
+    it(`should be extracted from argv if it is provided (${J(input)} -> ${J(expected)})`, () => {
       expect(collectCliConfig({ argv })[key]).toBe(expected);
     });
 
-    it('should be extracted from environment in DETOX_SNAKE_CASE otherwise', () => {
-      const expected = env[envName];
-
+    it(`should be extracted from environment in DETOX_SNAKE_CASE otherwise (${J(input)} -> ${J(expected)})`, () => {
       expect(collectCliConfig({})[key]).toBe(expected);
     });
+
+    if (key === 'deviceLaunchArgs') {
+      it(`should print a warning`, () => {
+        expect(logger.warn).toHaveBeenCalledWith(DEVICE_LAUNCH_ARGS_GENERIC_DEPRECATION);
+      });
+    } else {
+      it(`should not print warnings`, () => {
+        expect(logger.warn).not.toHaveBeenCalled();
+      });
+    }
   });
 });

--- a/detox/src/configuration/composeDeviceConfig.test.js
+++ b/detox/src/configuration/composeDeviceConfig.test.js
@@ -2,22 +2,126 @@ const _ = require('lodash');
 
 const DetoxConfigErrorComposer = require('../errors/DetoxConfigErrorComposer');
 
-const { appWithRelativeBinaryPath, iosSimulatorWithShorthandQuery } = require('./configurations.mock');
-
 describe('composeDeviceConfig', () => {
+  /** @type {Function} */
   let composeDeviceConfig;
   /** @type {*} */
   let cliConfig;
   /** @type {Detox.DetoxConfiguration} */
   let localConfig;
+  /** @type {Detox.DetoxDeviceConfig} */
+  let deviceConfig;
   /** @type {Detox.DetoxConfig} */
   let globalConfig;
   /** @type {DetoxConfigErrorComposer} */
   let errorComposer;
   /** @type {DriverRegistry} */
   let driverRegistry;
+  /** @type {Logger} */
+  let logger;
+
+  const compose = () => composeDeviceConfig({
+    errorComposer,
+    globalConfig,
+    localConfig,
+    cliConfig,
+  });
+
+  const KNOWN_CONFIGURATIONS = [['plain'], ['inline'], ['aliased']];
+
+  const KNOWN_DEVICES = [
+    'ios.none',
+    'ios.simulator',
+    'android.attached',
+    'android.emulator',
+    'android.genycloud',
+    './customDriver'
+  ];
+
+  const KNOWN_GPU_MODES = ['auto', 'host', 'swiftshader_indirect', 'angle_indirect', 'guest'];
+
+  /**
+   * @param {'ios.none' | 'ios.simulator' | 'android.attached' | 'android.emulator' | 'android.genycloud' | './customDriver'} deviceType
+   * @param {'plain' | 'inline' | 'aliased' } configType
+   */
+  function setConfig(deviceType, configType = 'aliased') {
+    const mixins = {
+      bootArgs: { bootArgs: '--someArg' },
+      forceAdbInstall: { forceAdbInstall: false },
+      utilBinaryPaths: { utilBinaryPaths: ['/path/to/apk'] },
+      iosDevice: {
+        device: {
+          type: 'iPhone 7 Plus',
+          os: 'iOS 10.2',
+        },
+      },
+    };
+
+    const deviceTemplates = {
+      'ios.none': {
+        type: 'ios.none',
+        ...mixins.iosDevice,
+      },
+      'ios.simulator': {
+        type: 'ios.simulator',
+        ...mixins.iosDevice,
+        ...mixins.bootArgs,
+      },
+      'android.attached': {
+        type: 'android.attached',
+        device: { adbName: 'emulator-5554' },
+        ...mixins.utilBinaryPaths,
+        ...mixins.forceAdbInstall,
+      },
+      'android.emulator': {
+        type: 'android.emulator',
+        device: { avdName: 'Pixel_API_28' },
+        gpu: 'auto',
+        headless: true,
+        readonly: true,
+        ...mixins.bootArgs,
+        ...mixins.utilBinaryPaths,
+        ...mixins.forceAdbInstall,
+      },
+      'android.genycloud': {
+        type: 'android.genycloud',
+        device: { recipeName: 'myRecipe' },
+        ...mixins.utilBinaryPaths,
+        ...mixins.forceAdbInstall,
+      },
+      './customDriver': {
+        type: './customDriver',
+        device: 'firefox',
+        binaryPath: 'https://example.com',
+      },
+    };
+
+    const deviceId = _.uniqueId('device');
+    deviceConfig = _.cloneDeep(deviceTemplates[deviceType] || deviceTemplates[undefined]);
+
+    if (deviceType === './customDriver') {
+      driverRegistry.resolve = () => (class SomeDriver {});
+    }
+
+    switch (configType) {
+      case 'plain':
+        Object.assign(localConfig, deviceConfig);
+        localConfig.binaryPath = deviceConfig.binaryPath || _.uniqueId('/path/to/app');
+        break;
+      case 'inline':
+        localConfig.device = deviceConfig;
+        break;
+      case 'aliased':
+        localConfig.device = deviceId;
+        globalConfig.devices = { [deviceId]: deviceConfig };
+        break;
+    }
+ }
 
   beforeEach(() => {
+    jest.mock('../utils/logger');
+    logger = require('../utils/logger');
+
     jest.mock('../devices/DriverRegistry', () => {
       const DriverRegistry = jest.requireActual('../devices/DriverRegistry');
       driverRegistry = DriverRegistry.default;
@@ -26,6 +130,7 @@ describe('composeDeviceConfig', () => {
 
     cliConfig = {};
     localConfig = {};
+    deviceConfig = null;
     globalConfig = {
       configurations: {
         someConfig: localConfig,
@@ -39,251 +144,567 @@ describe('composeDeviceConfig', () => {
     composeDeviceConfig = require('./composeDeviceConfig');
   });
 
-  const compose = () => composeDeviceConfig({
-    errorComposer,
-    globalConfig,
-    localConfig,
-    cliConfig,
-  });
+  describe('by config type', () => {
+    describe.each(KNOWN_DEVICES)('given a device (%j)', (deviceType) => {
+      describe('plain', () => {
+        beforeEach(() => {
+          setConfig(deviceType, 'plain');
 
-  describe('given a plain configuration', () => {
-    beforeEach(() => {
-      localConfig = {
-        ...appWithRelativeBinaryPath,
-        ...iosSimulatorWithShorthandQuery,
-      };
-    });
+          // NOTE: these properties are ignored for plain configurations
+          delete deviceConfig.bootArgs;
+          delete deviceConfig.forceAdbInstall;
+          delete deviceConfig.gpu;
+          delete deviceConfig.headless;
+          delete deviceConfig.readonly;
+        });
 
-    it('should extract type, device and utilBinaryPaths', () => {
-      localConfig.utilBinaryPaths = ['someApp'];
-      expect(compose()).toEqual({
-        type: localConfig.type,
-        device: localConfig.device,
-        utilBinaryPaths: localConfig.utilBinaryPaths,
-      });
-    });
+        it('should extract type and device', () =>
+          expect(compose()).toEqual(deviceConfig));
 
-    it('should extract type and device <- name', () => {
-      localConfig.name = localConfig.device;
-      delete localConfig.device;
+        // region supported devices
+        if (deviceType === './customDriver') return;
 
-      expect(compose()).toEqual({
-        type: localConfig.type,
-        device: localConfig.name,
-      });
-    });
+        it('should have a fallback for known devices: .name -> .device', () => {
+          const expected = compose();
 
-    describe('with unknown device type', () => {
-      const values = {
-        type: './customDriver',
-        device: 'firefox',
-        binaryPath: 'https://example.com',
-      };
+          localConfig.name = localConfig.device;
+          delete localConfig.device;
 
-      beforeEach(() => {
-        Object.assign(localConfig, values);
-        driverRegistry.resolve = () => (class SomeDriver {});
+          const actual = compose();
+          expect(actual).toEqual(expected);
+        });
+
+        it('should extract type, utilBinaryPaths and unpack device query', () => {
+          localConfig.device = Object.values(deviceConfig.device).join(', ');
+
+          expect(compose()).toEqual({
+            type: deviceConfig.type,
+            device: deviceConfig.device,
+            utilBinaryPaths: deviceConfig.utilBinaryPaths,
+          });
+        });
+        // endregion
       });
 
-      it('should take it as is, for backward compatibility', () => {
-        expect(compose()).toEqual(values);
+      describe('inlined', () => {
+        beforeEach(() => setConfig(deviceType, 'inline'));
+
+        it('should extract type and device', () =>
+          expect(compose()).toEqual(deviceConfig));
+
+        describe('unhappy scenarios', () => {
+          test('should throw if device config is not found', () => {
+            delete localConfig.device;
+            expect(compose).toThrow(errorComposer.deviceConfigIsUndefined());
+          });
+
+          test('should throw on no .type in device config', () => {
+            delete deviceConfig.type;
+            expect(compose).toThrow(errorComposer.missingDeviceType(undefined));
+          });
+        });
       });
-    });
 
-    describe('and there is a CLI override', () => {
-      beforeEach(givenCLIOverride('iPad'));
+      describe('aliased', () => {
+        beforeEach(() => setConfig(deviceType, 'aliased'));
 
-      it('should be override .device property', assertCLIOverridesDevice({
-        type: 'ios.simulator',
-        device: 'iPad',
-      }));
-    });
-  });
+        it('should extract type and device', () =>
+          expect(compose()).toEqual(deviceConfig));
 
-  describe('given an aliased configuration', () => {
-    beforeEach(() => {
-      localConfig = { device: 'iphone' };
-      globalConfig = { devices: { iphone: { type: 'ios.none' } } };
-    });
+        describe('unhappy scenarios', () => {
+          test('should throw if devices are not declared', () => {
+            globalConfig.devices = {};
+            expect(compose).toThrow(errorComposer.thereAreNoDeviceConfigs(localConfig.device));
+          });
 
-    it('should extract type and device', () => {
-      expect(compose()).toEqual({
-        type: 'ios.none',
+          test('should throw if device config is not found', () => {
+            localConfig.device = 'unknownDevice';
+            expect(compose).toThrow(errorComposer.cantResolveDeviceAlias('unknownDevice'));
+          });
+
+          test('should throw on no .type in device config', () => {
+            delete deviceConfig.type;
+            expect(compose).toThrow(errorComposer.missingDeviceType(localConfig.device));
+          });
+        });
       });
-    });
-
-    describe('and there is a CLI override', () => {
-      beforeEach(givenCLIOverride('iPad'));
-
-      it('should be override .device property', assertCLIOverridesDevice({
-        type: 'ios.none',
-        device: 'iPad',
-      }));
-    });
-  });
-
-  describe('given an aliased configuration with inlined device', () => {
-    beforeEach(() => {
-      localConfig = {
-        device: {
-          type: 'ios.simulator',
-          device: { type: 'iPhone X' }
-        },
-        artifacts: false,
-      };
-    });
-
-    it('should extract type and device', () => {
-      expect(compose()).toEqual({
-        type: 'ios.simulator',
-        device: { type: 'iPhone X' }
-      });
-    });
-
-    describe('and there is a CLI override', () => {
-      beforeEach(givenCLIOverride('iPad'));
-
-      it('should be override .device property', assertCLIOverridesDevice({
-        type: 'ios.simulator',
-        device: 'iPad',
-      }));
     });
   });
 
-  function givenCLIOverride(deviceName) {
-    return function () {
-      cliConfig.deviceName = deviceName;
-    };
-  }
+  describe('by device type', () => {
+    describe.each(KNOWN_CONFIGURATIONS)('given %s configuration', (configType) => {
+      let alias = () => configType === 'aliased' ? localConfig.device : undefined;
 
-  function assertCLIOverridesDevice(expected) {
-    return function () {
-      const { type, device } = compose();
+      describe('CLI overrides', () => {
+        describe('--device-name', () => {
+          describe.each([
+            ['ios.none'],
+            ['ios.simulator'],
+          ])('given iOS (%s) device', (deviceType) => {
+            beforeEach(() => setConfig(deviceType, configType));
 
-      expect(type).toBe(expected.type);
-      expect(device).toBe(expected.device);
-    };
-  }
+            test('should override .type', () => {
+              cliConfig.deviceName = 'iPad';
+              expect(compose().device).toEqual({ type: 'iPad' });
+            });
 
-  describe('unhappy scenarios:', () => {
-    describe('aliased configuration', () => {
-      it('should throw if devices are not declared', () => {
-        localConfig.device = 'someDevice';
-        expect(compose).toThrow(errorComposer.thereAreNoDeviceConfigs('someDevice'));
+            test('should override .type and .os', () => {
+              cliConfig.deviceName = 'iPhone SE, iOS 9.3.5';
+              expect(compose().device).toEqual({ type: 'iPhone SE', os: 'iOS 9.3.5' });
+            });
+          });
+
+          describe('given android.emulator device', () => {
+            beforeEach(() => setConfig('android.emulator', configType));
+
+            test('should override .avdName', () => {
+              cliConfig.deviceName = 'Galaxy_S100';
+              expect(compose().device).toEqual({ avdName: 'Galaxy_S100' });
+            });
+          });
+
+          describe('given android.attached device', () => {
+            beforeEach(() => setConfig('android.attached', configType));
+
+            test('should override .adbName', () => {
+              cliConfig.deviceName = 'emu.*tor';
+              expect(compose().device).toEqual({ adbName: 'emu.*tor' });
+            });
+          });
+
+          describe('given android.genycloud device', () => {
+            beforeEach(() => setConfig('android.genycloud', configType));
+
+            test('should override .recipeName', () => {
+              cliConfig.deviceName = 'anotherRecipe';
+              expect(compose().device).toEqual({ recipeName: 'anotherRecipe' });
+            });
+          });
+
+          describe('given a custom device', () => {
+            beforeEach(() => setConfig('./customDriver', configType));
+
+            test('should override .device', () => {
+              cliConfig.deviceName = 'aCustomValue';
+              expect(compose().device).toEqual('aCustomValue');
+            });
+          });
+        });
+
+        describe('--device-boot-args', () => {
+          describe.each([
+            ['ios.simulator'],
+            ['android.emulator'],
+          ])('given a supported device (%j)', (deviceType) => {
+            beforeEach(() => setConfig(deviceType, configType));
+
+            it('should override .bootArgs without warnings', () => {
+              cliConfig.deviceBootArgs = '--example';
+              expect(compose()).toEqual(expect.objectContaining({
+                bootArgs: '--example'
+              }));
+
+              expect(logger.warn).not.toHaveBeenCalled();
+            });
+          });
+
+          describe.each([
+            ['ios.none'],
+            ['android.attached'],
+            ['android.genycloud'],
+            ['./customDriver'],
+          ])('given a non-supported device (%j)', (deviceType) => {
+            beforeEach(() => setConfig(deviceType, configType));
+
+            it('should print a warning and refuse to override .bootArgs', () => {
+              cliConfig.deviceBootArgs = '--example';
+              expect(compose()).not.toEqual(expect.objectContaining({
+                bootArgs: '--example'
+              }));
+
+              expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/--device-boot-args.*not supported/));
+            });
+          });
+        });
+
+        describe('--force-adb-install', () => {
+          describe.each([
+            ['android.attached'],
+            ['android.emulator'],
+            ['android.genycloud'],
+          ])('given an Android device (%j)', (deviceType) => {
+            beforeEach(() => setConfig(deviceType, configType));
+
+            it('should override .forceAdbInstall without warnings', () => {
+              cliConfig.forceAdbInstall = true;
+              expect(compose()).toEqual(expect.objectContaining({
+                forceAdbInstall: true,
+              }));
+
+              expect(logger.warn).not.toHaveBeenCalled();
+            });
+          });
+
+          describe.each([
+            ['ios.none'],
+            ['ios.simulator'],
+            ['./customDriver'],
+          ])('given a non-supported device (%j)', (deviceType) => {
+            beforeEach(() => setConfig(deviceType, configType));
+
+            it('should print a warning and refuse to override .forceAdbInstall', () => {
+              cliConfig.forceAdbInstall = true;
+              expect(compose()).not.toEqual(expect.objectContaining({
+                forceAdbInstall: true,
+              }));
+
+              expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/--force-adb-install.*not supported/));
+            });
+          });
+        });
+
+        describe('--headless', () => {
+          describe('given android.emulator device', () => {
+            beforeEach(() => setConfig('android.emulator', configType));
+
+            it('should override .headless without warnings', () => {
+              cliConfig.headless = true;
+              expect(compose()).toEqual(expect.objectContaining({
+                headless: true,
+              }));
+
+              expect(logger.warn).not.toHaveBeenCalled();
+            });
+          });
+
+          describe.each([
+            ['ios.none'],
+            ['ios.simulator'],
+            ['android.attached'],
+            ['android.genycloud'],
+            ['./customDriver'],
+          ])('given a non-supported device (%j)', (deviceType) => {
+            beforeEach(() => setConfig(deviceType, configType));
+
+            it('should print a warning and refuse to override .headless', () => {
+              cliConfig.headless = true;
+              expect(compose()).not.toEqual(expect.objectContaining({
+                headless: true,
+              }));
+
+              expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/--headless.*not supported/));
+            });
+          });
+        });
+
+        describe('--gpu', () => {
+          describe('given android.emulator device', () => {
+            beforeEach(() => setConfig('android.emulator', configType));
+
+            it('should override .gpuMode without warnings', () => {
+              cliConfig.gpu = 'auto';
+              expect(compose()).toEqual(expect.objectContaining({
+                gpuMode: 'auto',
+              }));
+
+              expect(logger.warn).not.toHaveBeenCalled();
+            });
+          });
+
+          describe.each([
+            ['ios.none'],
+            ['ios.simulator'],
+            ['android.attached'],
+            ['./customDriver'],
+          ])('given a non-supported device (%j)', (deviceType) => {
+            beforeEach(() => setConfig(deviceType, configType));
+
+            it('should print a warning and refuse to override .gpuMode', () => {
+              cliConfig.gpu = 'auto';
+              expect(compose()).not.toEqual(expect.objectContaining({
+                gpuMode: 'auto',
+              }));
+
+              expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/--gpu.*not supported/));
+            });
+          });
+        });
+
+        describe('--readonlyEmu', () => {
+          describe('given android.emulator device', () => {
+            beforeEach(() => setConfig('android.emulator', configType));
+
+            it('should override .readonly without warnings', () => {
+              cliConfig.readonlyEmu = true;
+              expect(compose()).toEqual(expect.objectContaining({
+                readonly: true
+              }));
+
+              expect(logger.warn).not.toHaveBeenCalled();
+            });
+          });
+
+          describe.each([
+            ['ios.none'],
+            ['ios.simulator'],
+            ['android.attached'],
+            ['android.genycloud'],
+            ['./customDriver'],
+          ])('given a non-supported device (%j)', (deviceType) => {
+            beforeEach(() => setConfig(deviceType, configType));
+
+            it('should print a warning and refuse to override .readonly', () => {
+              cliConfig.readonlyEmu = true;
+              expect(compose()).not.toEqual(expect.objectContaining({
+                readonly: true
+              }));
+
+              expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/--readonly-emu.*not supported/));
+            });
+          });
+        });
       });
 
-      it('should throw if device config is not found (alias)', () => {
-        localConfig.device = 'someDevice';
-        globalConfig.devices = { otherDevice: iosSimulatorWithShorthandQuery };
+      describe('Unhappy scenarios', () => {
+        describe('missing device matcher properties', () => {
+          test.each([
+            [['type', 'name', 'id'], 'ios.simulator'],
+            [['adbName'], 'android.attached'],
+            [['avdName'], 'android.emulator'],
+            [['recipeUUID', 'recipeName'], 'android.genycloud'],
+          ])('should throw for missing %s for "%s" device', (expectedProps, deviceType) => {
+            setConfig(deviceType, configType);
+            for (const key of expectedProps) {
+              delete deviceConfig.device[key];
+            }
+            deviceConfig.device.misspelled = 'value';
 
-        expect(compose).toThrow(errorComposer.cantResolveDeviceAlias('someDevice'));
+            expect(compose).toThrowError(errorComposer.missingDeviceMatcherProperties(alias(), expectedProps));
+
+            // ...and now prove the opposite:
+            deviceConfig.device[_.sample(expectedProps)] = 'someValue';
+            expect(compose).not.toThrowError();
+          });
+        });
+
+        test('should throw if a device type cannot be resolved', () => {
+          setConfig('./customDriver', configType);
+          const someError = new Error('Some error');
+          driverRegistry.resolve = () => {
+            throw someError;
+          };
+
+          expect(compose).toThrow(errorComposer.invalidDeviceType(
+            alias(),
+            deviceConfig,
+            someError
+          ));
+        });
+
+        //region separate device config validation
+        if (configType === 'plain') return;
+
+        describe('.bootArgs validation', () => {
+          test.each([
+            'ios.none',
+            'android.attached',
+            'android.genycloud',
+          ])('cannot be used for %j device', (deviceType) => {
+            setConfig(deviceType, configType);
+            deviceConfig.bootArgs = '--someArg';
+            expect(compose).toThrow(errorComposer.unsupportedDeviceProperty(alias(), 'bootArgs'));
+          });
+
+          describe.each([
+            'ios.simulator',
+            'android.emulator',
+          ])('for a supported device (%j)', (deviceType) => {
+            beforeEach(() => setConfig(deviceType, configType));
+
+            it('should throw if .bootArgs are malformed (e.g., array)', () => {
+              deviceConfig.bootArgs = ['--someArg'];
+
+              expect(compose).toThrowError(
+                errorComposer.malformedDeviceProperty(alias(), 'bootArgs')
+              );
+            });
+          });
+
+          test('should be disabled for custom devices', () => {
+            setConfig('./customDriver', configType);
+            deviceConfig.bootArgs = [0xAC, 0xDC];
+            expect(compose).not.toThrowError();
+          });
+        });
+
+        describe('.forceAdbInstall validation', () => {
+          test.each([
+            'ios.none',
+            'ios.simulator',
+          ])('cannot be used for iOS device (%j)', (deviceType) => {
+            setConfig(deviceType, configType);
+            deviceConfig.forceAdbInstall = false;
+            expect(compose).toThrow(errorComposer.unsupportedDeviceProperty(alias(), 'forceAdbInstall'));
+          });
+
+          describe.each([
+            'android.attached',
+            'android.emulator',
+            'android.genycloud',
+          ])('for Android device (%j)', (deviceType) => {
+            beforeEach(() => setConfig(deviceType, configType));
+
+            it('should throw if .forceAdbInstall is malformed (e.g., string)', () => {
+              deviceConfig.forceAdbInstall = 'yes';
+
+              expect(compose).toThrowError(
+                errorComposer.malformedDeviceProperty(alias(), 'forceAdbInstall')
+              );
+            });
+          });
+
+          test('should be disabled for custom devices', () => {
+            setConfig('./customDriver', configType);
+            deviceConfig.forceAdbInstall = /anything/;
+            expect(compose).not.toThrowError();
+          });
+        });
+
+        describe('.gpuMode validation', () => {
+          test.each([
+            'ios.none',
+            'ios.simulator',
+            'android.attached',
+            'android.genycloud',
+          ])('cannot be used for a non-emulator device (%j)', (deviceType) => {
+            setConfig(deviceType, configType);
+            deviceConfig.gpuMode = 'auto';
+            expect(compose).toThrow(errorComposer.unsupportedDeviceProperty(alias(), 'gpuMode'));
+          });
+
+          describe('given android.emulator device', () => {
+            beforeEach(() => setConfig('android.emulator', configType));
+
+            test(`should throw if value is not a string`, () => {
+              deviceConfig.gpuMode = ['auto'];
+              expect(compose).toThrowError(errorComposer.malformedDeviceProperty(alias(), 'gpuMode'));
+            });
+
+            test(`should throw if value is not in (${KNOWN_GPU_MODES})`, () => {
+              for (const gpuMode of KNOWN_GPU_MODES) {
+                deviceConfig.gpuMode = gpuMode;
+                expect(compose).not.toThrowError();
+
+                deviceConfig.gpuMode = gpuMode.slice(1);
+                expect(compose).toThrowError(errorComposer.malformedDeviceProperty(alias(), 'gpuMode'));
+              }
+            });
+          });
+
+          test('should be disabled for custom devices', () => {
+            setConfig('./customDriver', configType);
+            deviceConfig.gpuMode = class Whatever {};
+            expect(compose).not.toThrowError();
+          });
+        });
+
+        describe('.headless validation', () => {
+          test.each([
+            'ios.none',
+            'ios.simulator',
+            'android.attached',
+            'android.genycloud',
+          ])('cannot be used for a non-emulator device (%j)', (deviceType) => {
+            setConfig(deviceType, configType);
+            deviceConfig.headless = true;
+            expect(compose).toThrow(errorComposer.unsupportedDeviceProperty(alias(), 'headless'));
+          });
+
+          describe('given android.emulator device', () => {
+            beforeEach(() => setConfig('android.emulator', configType));
+
+            test(`should throw if value is not a boolean (e.g., string)`, () => {
+              deviceConfig.headless = `${Math.random() > 0.5}`; // string
+              expect(compose).toThrowError(errorComposer.malformedDeviceProperty(alias(), 'headless'));
+            });
+          });
+
+          test('should be disabled for custom devices', () => {
+            setConfig('./customDriver', configType);
+            deviceConfig.headless = NaN;
+            expect(compose).not.toThrowError();
+          });
+        });
+
+        describe('.readonly validation', () => {
+          test.each([
+            'ios.none',
+            'ios.simulator',
+            'android.attached',
+            'android.genycloud',
+          ])('cannot be used for a non-emulator device (%j)', (deviceType) => {
+            setConfig(deviceType, configType);
+            deviceConfig.readonly = true;
+            expect(compose).toThrow(errorComposer.unsupportedDeviceProperty(alias(), 'readonly'));
+          });
+
+          describe('given android.emulator device', () => {
+            beforeEach(() => setConfig('android.emulator', configType));
+
+            test(`should throw if value is not a boolean (e.g., string)`, () => {
+              deviceConfig.readonly = `${Math.random() > 0.5}`; // string
+              expect(compose).toThrowError(errorComposer.malformedDeviceProperty(alias(), 'readonly'));
+            });
+          });
+
+          test('should be disabled for custom devices', () => {
+            setConfig('./customDriver', configType);
+            deviceConfig.readonly = () => {};
+            expect(compose).not.toThrowError();
+          });
+        });
+
+        describe('.utilBinaryPaths validation', () => {
+          test.each([
+            'ios.none',
+            'ios.simulator',
+          ])('cannot be used for a non-Android device (%j)', (deviceType) => {
+            setConfig(deviceType, configType);
+            deviceConfig.utilBinaryPaths = [];
+            expect(compose).toThrow(errorComposer.unsupportedDeviceProperty(alias(), 'utilBinaryPaths'));
+          });
+
+          describe.each([
+            'android.attached',
+            'android.emulator',
+            'android.genycloud',
+          ])('for Android device (%j)', (deviceType) => {
+            beforeEach(() => setConfig(deviceType, configType));
+
+            it('should throw if .utilBinaryPaths are malformed (array of non-strings)', () => {
+              deviceConfig.utilBinaryPaths = [{ path: 'valid/path/not/in/array' }];
+
+              expect(compose).toThrowError(
+                errorComposer.malformedDeviceProperty(alias(), 'utilBinaryPaths')
+              );
+            });
+
+            it('should throw if device.utilBinaryPaths are malformed (string)', () => {
+              deviceConfig.utilBinaryPaths = 'valid/path/not/in/array';
+
+              expect(compose).toThrowError(
+                errorComposer.malformedDeviceProperty(alias(), 'utilBinaryPaths')
+              );
+            });
+          });
+
+          test('should be disabled for custom devices', () => {
+            setConfig('./customDriver', configType);
+            deviceConfig.utilBinaryPaths = 42;
+            expect(compose).not.toThrowError();
+          });
+        });
       });
-
-      it('should throw if device config is not found (inline)', () => {
-        delete localConfig.device;
-        globalConfig.devices = { otherDevice: iosSimulatorWithShorthandQuery };
-
-        expect(compose).toThrow(errorComposer.deviceConfigIsUndefined());
-      });
-
-      it('should throw if device.utilBinaryPaths are malformed (string)', () => {
-        localConfig.device = 'someDevice';
-        globalConfig.devices = {
-          [localConfig.device]: {
-            type: 'android.emulator',
-            device: { avdName: 'Pixel' },
-            utilBinaryPaths: 'valid/path/not/in/array',
-          },
-        };
-
-        expect(compose).toThrowError(
-          errorComposer.malformedUtilBinaryPaths(localConfig.device)
-        );
-      });
-    });
-
-    describe('empty device object', () => {
-      it('should throw if the inline device config has no type', () => {
-        localConfig.device = {};
-        expect(compose).toThrow(errorComposer.missingDeviceType());
-      });
-
-      it('should throw if the aliased device config has no type', () => {
-        localConfig.device = 'someDevice';
-        globalConfig.devices = { someDevice: { } };
-
-        expect(compose).toThrow(errorComposer.missingDeviceType('someDevice'));
-      });
-
-      it('should throw if the inline device config is empty', () => {
-        localConfig.type = 'android.emulator';
-        localConfig.device = {};
-
-        expect(compose).toThrow(errorComposer.missingDeviceMatcherProperties(undefined, [
-          'avdName'
-        ]));
-      });
-
-      it('should throw if the aliased device config is missing properties', () => {
-        localConfig.device = 'someDevice';
-        globalConfig.devices = {
-          someDevice: {
-            type: 'ios.simulator',
-            device: { os: 'iOS 9.3.5' }
-          },
-        };
-
-        expect(compose).toThrow(errorComposer.missingDeviceMatcherProperties('someDevice', [
-          'type',
-          'name',
-          'id',
-        ]));
-      });
-    });
-
-    it('should throw if the device config has invalid type', () => {
-      const someError = new Error('Some error');
-      driverRegistry.resolve = () => { throw someError; };
-
-      localConfig.device = { type: 'android.apk' };
-      expect(compose).toThrow(errorComposer.invalidDeviceType(
-        undefined,
-        localConfig.device,
-        someError
-      ));
-    });
-
-    describe('missing device matcher properties', () => {
-      it.each([
-        [['type', 'name', 'id'], 'ios.simulator'],
-        [['adbName'], 'android.attached'],
-        [['avdName'], 'android.emulator'],
-        [['recipeUUID', 'recipeName'], 'android.genycloud'],
-      ])('should throw for missing %j for "%s" type', (expectedProps, deviceType) => {
-        localConfig.device = {
-          type: deviceType,
-          device: {
-            misspelled: 'value'
-          }
-        };
-
-        expect(compose).toThrowError(errorComposer.missingDeviceMatcherProperties(undefined, expectedProps));
-
-        localConfig.device.device[_.sample(expectedProps)] = 'someValue';
-        expect(compose).not.toThrowError();
-      });
-    });
-
-    it('should throw if .utilBinaryPaths are malformed (array of non-strings)', () => {
-      Object.assign(localConfig, {
-        type: 'android.emulator',
-        device: { avdName: 'Pixel' },
-        utilBinaryPaths: [{ path: 'valid/path/not/in/array' }],
-      });
-
-      expect(compose).toThrowError(
-        errorComposer.malformedUtilBinaryPaths(undefined)
-      );
     });
   });
 });

--- a/detox/src/configuration/configurations.mock.js
+++ b/detox/src/configuration/configurations.mock.js
@@ -87,6 +87,14 @@ const iosSimulatorWithShorthandQuery = {
   device: 'iPhone 7 Plus, iOS 10.2'
 };
 
+const iosSimulatorWithDetailedQuery = {
+  type: 'ios.simulator',
+  device: {
+    type: 'iPhone 7 Plus',
+    os: 'iOS 10.2',
+  },
+};
+
 const validSession = {
   server: 'ws://localhost:8099',
   sessionId: 'test',
@@ -98,6 +106,11 @@ const androidEmulator = {
   'device': {
     'avdName': 'Pixel_API_28',
   },
+};
+
+const androidEmulatorWithShorthandQuery = {
+  'type': 'android.emulator',
+  'device': 'Pixel_API_28',
 };
 
 module.exports = {
@@ -116,5 +129,7 @@ module.exports = {
   apkWithBinary,
 
   iosSimulatorWithShorthandQuery,
+  iosSimulatorWithDetailedQuery,
   androidEmulator,
+  androidEmulatorWithShorthandQuery,
 };

--- a/detox/src/configuration/index.test.js
+++ b/detox/src/configuration/index.test.js
@@ -117,7 +117,9 @@ describe('composeDetoxConfig', () => {
         },
         deviceConfig: expect.objectContaining({
           type: 'ios.simulator',
-          device: 'iPhone XS',
+          device: {
+            type: 'iPhone XS',
+          },
         }),
         runnerConfig: {
           testRunner: 'mocha',

--- a/detox/src/configuration/utils/warnings.js
+++ b/detox/src/configuration/utils/warnings.js
@@ -1,0 +1,12 @@
+const DEVICE_LAUNCH_ARGS_DEPRECATION = `\
+--device-launch-args is a deprecated name of this option.
+Please change your scripts to use --device-boot-args instead.`;
+
+const DEVICE_LAUNCH_ARGS_GENERIC_DEPRECATION = `\
+--device-launch-args / $DETOX_DEVICE_LAUNCH_ARGS is a deprecated name of this option.
+Please change your scripts to use --device-boot-args / $DETOX_DEVICE_BOOT_ARGS instead.`;
+
+module.exports = {
+  DEVICE_LAUNCH_ARGS_DEPRECATION,
+  DEVICE_LAUNCH_ARGS_GENERIC_DEPRECATION,
+};

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -197,7 +197,8 @@ class Device {
       return this.deviceDriver.installApp(
         this._deviceId,
         currentApp.binaryPath,
-        currentApp.testBinaryPath
+        currentApp.testBinaryPath,
+        this._deviceConfig.forceAdbInstall
       );
     });
   }

--- a/detox/src/devices/Device.js
+++ b/detox/src/devices/Device.js
@@ -92,7 +92,7 @@ class Device {
     await this.deviceDriver.prepare();
 
     this._deviceId = await traceCall('acquireDevice', () =>
-      this.deviceDriver.acquireFreeDevice(this._deviceConfig.device));
+      this.deviceDriver.acquireFreeDevice(this._deviceConfig.device, this._deviceConfig));
 
     const appAliases = Object.keys(this._appsConfig);
     if (appAliases.length === 1) {
@@ -276,7 +276,7 @@ class Device {
   }
 
   async resetContentAndSettings() {
-    await this.deviceDriver.resetContentAndSettings(this._deviceId);
+    await this.deviceDriver.resetContentAndSettings(this._deviceId, this._deviceConfig);
   }
 
   getPlatform() {

--- a/detox/src/devices/Device.test.js
+++ b/detox/src/devices/Device.test.js
@@ -290,7 +290,7 @@ describe('Device', () => {
         expect(driverMock.driver.uninstallApp).toHaveBeenCalledWith(device.id, bundleId);
 
         await device.installApp('/tmp/app', '/tmp/app-test');
-        expect(driverMock.driver.installApp).toHaveBeenCalledWith(device.id, '/tmp/app', '/tmp/app-test');
+        expect(driverMock.driver.installApp).toHaveBeenCalledWith(device.id, '/tmp/app', '/tmp/app-test', undefined);
 
         await device.launchApp({}, bundleId);
         expect(driverMock.driver.launchApp).toHaveBeenCalledWith(device.id, bundleId, expect.anything(), undefined);
@@ -683,21 +683,26 @@ describe('Device', () => {
 
   describe('installApp()', () => {
     it(`with a custom app path should use custom app path`, async () => {
-      const device = await aValidDevice();
+      const device = await aValidDevice({
+        deviceConfig: { forceAdbInstall: true },
+      });
+
       await device.installApp('newAppPath');
-      expect(driverMock.driver.installApp).toHaveBeenCalledWith(device.id, 'newAppPath', device._deviceConfig.testBinaryPath);
+      expect(driverMock.driver.installApp).toHaveBeenCalledWith(device.id, 'newAppPath', device._deviceConfig.testBinaryPath, true);
     });
 
     it(`with a custom test app path should use custom test app path`, async () => {
-      const device = await aValidDevice();
+      const device = await aValidDevice({
+        deviceConfig: { forceAdbInstall: false },
+      });
       await device.installApp('newAppPath', 'newTestAppPath');
-      expect(driverMock.driver.installApp).toHaveBeenCalledWith(device.id, 'newAppPath', 'newTestAppPath');
+      expect(driverMock.driver.installApp).toHaveBeenCalledWith(device.id, 'newAppPath', 'newTestAppPath', false);
     });
 
     it(`with no args should use the default path given in configuration`, async () => {
       const device = await aValidDevice();
       await device.installApp();
-      expect(driverMock.driver.installApp).toHaveBeenCalledWith(device.id, device._currentApp.binaryPath, device._currentApp.testBinaryPath);
+      expect(driverMock.driver.installApp).toHaveBeenCalledWith(device.id, device._currentApp.binaryPath, device._currentApp.testBinaryPath, undefined);
     });
   });
 

--- a/detox/src/devices/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/drivers/DeviceDriverBase.js
@@ -23,64 +23,64 @@ class DeviceDriverBase {
     return {};
   }
 
-  async acquireFreeDevice(_deviceQuery) {
-    return await Promise.resolve('');
+  async acquireFreeDevice(_deviceQuery, _deviceConfig) {
+    return '';
   }
 
   async prepare() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async launchApp() {
-    return await Promise.resolve(NaN);
+    return NaN;
   }
 
   async waitForAppLaunch() {
-    return await Promise.resolve(NaN);
+    return NaN;
   }
 
   async takeScreenshot(_deviceId, _screenshotName) {
-    return await Promise.resolve('');
+    return '';
   }
 
   async sendToHome() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async setBiometricEnrollment() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async matchFace() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async unmatchFace() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async matchFinger() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async unmatchFinger() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async shake() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async installApp(_deviceId, _binaryPath, _testBinaryPath) {
-    return await Promise.resolve('');
+    return '';
   }
 
   async uninstallApp() {
-    return await Promise.resolve('');
+    return '';
   }
 
   installUtilBinaries() {
-    return Promise.resolve('');
+    return '';
   }
 
   async deliverPayload(params) {
@@ -88,19 +88,19 @@ class DeviceDriverBase {
   }
 
   async setLocation(_lat, _lon) {
-    return await Promise.resolve('');
+    return '';
   }
 
   async reverseTcpPort() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async unreverseTcpPort() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async clearKeychain(_udid) {
-    return await Promise.resolve('');
+    return '';
   }
 
   async waitUntilReady() {
@@ -108,11 +108,11 @@ class DeviceDriverBase {
   }
 
   async waitForActive() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async waitForBackground() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async reloadReactNative() {
@@ -126,35 +126,35 @@ class DeviceDriverBase {
   }
 
   async setPermissions(_deviceId, _bundleId, _permissions) {
-    return await Promise.resolve('');
+    return '';
   }
 
   async terminate(_deviceId, _bundleId) {
-    return await Promise.resolve('');
+    return '';
   }
 
   async shutdown() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async setOrientation(_deviceId, _orientation) {
-    return await Promise.resolve('');
+    return '';
   }
 
   async setURLBlacklist(_urlList) {
-    return await Promise.resolve('');
+    return '';
   }
 
   async enableSynchronization() {
-    return await Promise.resolve('');
+    return '';
   }
 
   async disableSynchronization() {
-    return await Promise.resolve('');
+    return '';
   }
 
-  async resetContentAndSettings() {
-    return await Promise.resolve('');
+  async resetContentAndSettings(_deviceId, _deviceConfig) {
+    return '';
   }
 
   createRandomDirectory() {
@@ -170,16 +170,20 @@ class DeviceDriverBase {
   }
 
   getBundleIdFromBinary(_appPath) {
+    return '';
   }
 
   validateDeviceConfig(_deviceConfig) {
   }
 
   getPlatform() {
+    return '';
   }
 
   async getUiDevice() {
-    log.warn(`getUiDevice() is an android specific function, it exposes UiAutomator's UiDevice API (https://developer.android.com/reference/android/support/test/uiautomator/UiDevice) make sure you create an android specific test for this scenario`);
+    log.warn(`getUiDevice() is an Android-specific function, it exposes UiAutomator's UiDevice API (https://developer.android.com/reference/android/support/test/uiautomator/UiDevice).`);
+    log.warn(`Make sure you create an Android-specific test for this scenario.`);
+    
     return await Promise.resolve('');
   }
 
@@ -195,7 +199,9 @@ class DeviceDriverBase {
   }
 
   async pressBack() {
-    log.warn('pressBack() is an android specific function, make sure you create an android specific test for this scenario');
+    log.warn('pressBack() is an Android-specific function.');
+    log.warn(`Make sure you create an Android-specific test for this scenario.`);
+
     return await Promise.resolve('');
   }
 

--- a/detox/src/devices/drivers/android/attached/AttachedAndroidDriver.js
+++ b/detox/src/devices/drivers/android/attached/AttachedAndroidDriver.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const DeviceRegistry = require('../../../DeviceRegistry');
 const AndroidDriver = require('../AndroidDriver');
 const FreeDeviceFinder = require('../tools/FreeDeviceFinder');
@@ -17,9 +15,11 @@ class AttachedAndroidDriver extends AndroidDriver {
     return this._name;
   }
 
-  async acquireFreeDevice(deviceQuery) {
-    const adbNamePattern = _.isPlainObject(deviceQuery) ? deviceQuery.adbName : deviceQuery;
-    const adbName = await this._deviceRegistry.allocateDevice(() => this._freeDeviceFinder.findFreeDevice(adbNamePattern));
+  async acquireFreeDevice(_deviceQuery, deviceConfig) {
+    const adbNamePattern = deviceConfig.device.adbName;
+    const adbName = await this._deviceRegistry.allocateDevice(() => {
+      return this._freeDeviceFinder.findFreeDevice(adbNamePattern);
+    });
 
     await this.adb.apiLevel(adbName);
     await this.adb.unlockScreen(adbName);

--- a/detox/src/devices/drivers/android/attached/AttachedAndroidDriver.test.js
+++ b/detox/src/devices/drivers/android/attached/AttachedAndroidDriver.test.js
@@ -23,9 +23,17 @@ describe('Attached android device driver', () => {
   beforeEach(mockBaseClassesDependencies);
   beforeEach(mockDirectDependencies);
 
-  const adbNamePattern = '9A291FFAZ005S9';
-  const deviceConfig = {
-    adbName: adbNamePattern,
+  const adbNamePattern =  '9A291FFAZ005S9';
+  const deviceConfigWithObject = {
+    device: {
+      adbName: adbNamePattern,
+    },
+  };
+
+  const deviceConfigWithString = {
+    device: {
+      adbName: adbNamePattern,
+    },
   };
 
   let emitter;
@@ -34,6 +42,7 @@ describe('Attached android device driver', () => {
   let FreeDeviceFinder;
   let freeDeviceFinderObj;
   let uut;
+
   beforeEach(() => {
     const Emitter = jest.genMockFromModule('../../../../utils/AsyncEmitter');
     emitter = new Emitter();
@@ -70,7 +79,7 @@ describe('Attached android device driver', () => {
         }
       });
 
-      await uut.acquireFreeDevice(adbNamePattern);
+      await uut.acquireFreeDevice(void 0, deviceConfigWithString);
       expect(deviceRegistry.allocateDevice).toHaveBeenCalled();
     });
 
@@ -83,7 +92,7 @@ describe('Attached android device driver', () => {
         }
       });
 
-      await uut.acquireFreeDevice(deviceConfig);
+      await uut.acquireFreeDevice(deviceConfigWithObject.device, deviceConfigWithObject);
       expect(deviceRegistry.allocateDevice).toHaveBeenCalled();
     });
 
@@ -95,7 +104,7 @@ describe('Attached android device driver', () => {
       const adbName = `${adbNamePattern}_allocated`;
       deviceRegistry.allocateDevice.mockReturnValue(adbName);
 
-      await uut.acquireFreeDevice(adbNamePattern);
+      await uut.acquireFreeDevice(void 0, deviceConfigWithString);
 
       expect(emitter.emit).toHaveBeenCalledWith('bootDevice', { coldBoot: false, deviceId: adbName, type: 'device' });
     });
@@ -104,7 +113,7 @@ describe('Attached android device driver', () => {
       const adbName = `${adbNamePattern}_allocated`;
       deviceRegistry.allocateDevice.mockReturnValue(adbName);
 
-      await uut.acquireFreeDevice(adbNamePattern);
+      await uut.acquireFreeDevice(void 0, deviceConfigWithString);
       expect(adbObj().apiLevel).toHaveBeenCalledWith(adbName);
     });
 
@@ -112,7 +121,7 @@ describe('Attached android device driver', () => {
       const adbName = `${adbNamePattern}_allocated`;
       deviceRegistry.allocateDevice.mockReturnValue(adbName);
 
-      await uut.acquireFreeDevice(adbNamePattern);
+      await uut.acquireFreeDevice(void 0, deviceConfigWithString);
       expect(adbObj().unlockScreen).toHaveBeenCalledWith(adbName);
     });
 
@@ -121,7 +130,7 @@ describe('Attached android device driver', () => {
       deviceRegistry.allocateDevice.mockReturnValue(adbName);
 
       expect(uut.name).toEqual('Unnamed Android Device');
-      await uut.acquireFreeDevice(adbNamePattern);
+      await uut.acquireFreeDevice(void 0, deviceConfigWithString);
       expect(uut.name).toEqual(adbName);
     });
   });

--- a/detox/src/devices/drivers/android/emulator/EmulatorDriver.js
+++ b/detox/src/devices/drivers/android/emulator/EmulatorDriver.js
@@ -46,18 +46,20 @@ class EmulatorDriver extends AndroidDriver {
     return this._name;
   }
 
-  async acquireFreeDevice(deviceQuery) {
-    const avdName = _.isPlainObject(deviceQuery) ? deviceQuery.avdName : deviceQuery;
+  async acquireFreeDevice(_deviceQuery, deviceConfig) {
+    const avdName = deviceConfig.device.avdName;
 
     await this._avdValidator.validate(avdName);
-    await this._fixAvdConfigIniSkinNameIfNeeded(avdName);
+    await this._fixAvdConfigIniSkinNameIfNeeded(avdName, deviceConfig.headless);
 
-    const adbName = await this._deviceAllocation.allocateDevice(avdName);
+    const adbName = await this._deviceAllocation.allocateDevice(deviceConfig);
+
     await this.adb.apiLevel(adbName);
     await this.adb.disableAndroidAnimations(adbName);
     await this.adb.unlockScreen(adbName);
 
     this._name = `${adbName} (${avdName})`;
+
     return adbName;
   }
 
@@ -74,8 +76,12 @@ class EmulatorDriver extends AndroidDriver {
     await this.appInstallHelper.install(deviceId, binaryPath, testBinaryPath);
   }
 
-  /*async*/ binaryVersion() {
-    return this._emuVersionResolver.resolve();
+  /**
+   * @param {boolean} headless
+   * @async
+   */
+  binaryVersion(headless) {
+    return this._emuVersionResolver.resolve(headless);
   }
 
   async cleanup(deviceId, bundleId) {
@@ -95,8 +101,8 @@ class EmulatorDriver extends AndroidDriver {
     await this.adb.setLocation(deviceId, lat, lon);
   }
 
-  async _fixAvdConfigIniSkinNameIfNeeded(avdName) {
-    const binaryVersion = _.get(await this.binaryVersion(), 'major');
+  async _fixAvdConfigIniSkinNameIfNeeded(avdName, headless) {
+    const binaryVersion = _.get(await this.binaryVersion(headless), 'major');
     if (!binaryVersion) {
       log.warn({ event: 'EMU_SKIN_CFG_PATCH' }, [
         'Failed to detect emulator version! (see previous logs)',

--- a/detox/src/devices/drivers/android/emulator/EmulatorDriver.js
+++ b/detox/src/devices/drivers/android/emulator/EmulatorDriver.js
@@ -5,7 +5,6 @@ const ini = require('ini');
 const _ = require('lodash');
 
 const DetoxRuntimeError = require('../../../../errors/DetoxRuntimeError');
-const argparse = require('../../../../utils/argparse');
 const environment = require('../../../../utils/environment');
 const log = require('../../../../utils/logger').child({ __filename });
 const DeviceRegistry = require('../../../DeviceRegistry');
@@ -63,17 +62,13 @@ class EmulatorDriver extends AndroidDriver {
     return adbName;
   }
 
-  async installApp(deviceId, _binaryPath, _testBinaryPath) {
-    if (argparse.getArgValue('force-adb-install') === 'true') {
-      return await super.installApp(deviceId, _binaryPath, _testBinaryPath);
+  async installApp(deviceId, binaryPath, testBinaryPath, forceAdbInstall) {
+    if (forceAdbInstall) {
+      await super.installApp(deviceId, binaryPath, testBinaryPath);
+    } else {
+      const installPaths = this._getInstallPaths(binaryPath, testBinaryPath);
+      await this.appInstallHelper.install(deviceId, installPaths.binaryPath, installPaths.testBinaryPath);
     }
-
-    const {
-      binaryPath,
-      testBinaryPath,
-    } = this._getInstallPaths(_binaryPath, _testBinaryPath);
-
-    await this.appInstallHelper.install(deviceId, binaryPath, testBinaryPath);
   }
 
   /**

--- a/detox/src/devices/drivers/android/emulator/EmulatorVersionResolver.js
+++ b/detox/src/devices/drivers/android/emulator/EmulatorVersionResolver.js
@@ -9,17 +9,17 @@ class EmulatorVersionResolver {
     this.version = undefined;
   }
 
-  async resolve() {
+  async resolve(headless) {
     if (!this.version) {
-      this.version = await this._resolve();
+      this.version = await this._resolve(headless);
     }
     return this.version;
   }
 
-  async _resolve() {
+  async _resolve(headless) {
     let rawOutput;
     try {
-      rawOutput = await this._emulatorExec.exec(new QueryVersionCommand()) || '';
+      rawOutput = await this._emulatorExec.exec(new QueryVersionCommand({ headless })) || '';
     } catch (error) {
       log.error({ event: EMU_BIN_VERSION_DETECT_EV, success: false, error }, 'Could not detect emulator binary version', error);
       return null;

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorDeviceAllocation.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorDeviceAllocation.js
@@ -19,7 +19,13 @@ class EmulatorDeviceAllocation extends AndroidDeviceAllocation {
     this._rand = rand;
   }
 
-  async allocateDevice(avdName) {
+  /**
+   * @param {Detox.DetoxAndroidEmulatorDriverConfig} deviceConfig
+   * @returns {Promise<null>}
+   */
+  async allocateDevice(deviceConfig) {
+    const { avdName } = deviceConfig.device;
+
     this._logAllocationAttempt(avdName);
     const {
       adbName,
@@ -30,7 +36,13 @@ class EmulatorDeviceAllocation extends AndroidDeviceAllocation {
     const coldBoot = !!placeholderPort;
     if (coldBoot) {
       try {
-        await this._launchEmulator(avdName, placeholderPort);
+        await this._launchEmulator(avdName, {
+          bootArgs: deviceConfig.bootArgs,
+          gpuMode: deviceConfig.gpuMode,
+          headless: deviceConfig.headless,
+          readonly: deviceConfig.readonly,
+          port: placeholderPort,
+        });
       } catch (e) {
         await this.deallocateDevice(adbName);
         throw e;
@@ -64,9 +76,9 @@ class EmulatorDeviceAllocation extends AndroidDeviceAllocation {
     };
   }
 
-  async _launchEmulator(avdName, bootPort) {
+  async _launchEmulator(avdName, options) {
     await traceCall('emulatorLaunch', () =>
-      this._emulatorLauncher.launch(avdName, { port: bootPort }));
+      this._emulatorLauncher.launch(avdName, options));
   }
 
   async _awaitEmulatorBoot(adbName) {

--- a/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.js
+++ b/detox/src/devices/drivers/android/emulator/helpers/EmulatorLauncher.js
@@ -22,7 +22,15 @@ class EmulatorLauncher extends AndroidDeviceLauncher {
     this._emulatorExec = emulatorExec;
   }
 
-  async launch(emulatorName, options = { port: undefined }) {
+  /**
+   * @param {string} emulatorName
+   * @param {string | undefined} options.bootArgs
+   * @param {string | undefined} options.gpuMode
+   * @param {boolean} options.headless
+   * @param {number | undefined} options.port
+   * @param {boolean} options.readonly
+   */
+  async launch(emulatorName, options = {}) {
     const launchCommand = new LaunchCommand(emulatorName, options);
 
     return await retry({

--- a/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.js
@@ -58,7 +58,8 @@ class GenyCloudDriver extends AndroidDriver {
     await this._validateGmsaasAuth();
   }
 
-  async acquireFreeDevice(deviceQuery) {
+  async acquireFreeDevice(_deviceQuery, deviceConfig) {
+    const deviceQuery = deviceConfig.device;
     const recipe = await this._recipeQuerying.getRecipeFromQuery(deviceQuery);
     this._assertRecipe(deviceQuery, recipe);
 

--- a/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.test.js
+++ b/detox/src/devices/drivers/android/genycloud/GenyCloudDriver.test.js
@@ -17,8 +17,10 @@ const anInstance = () => ({
   toString: () => 'mock-instance-toString()',
 });
 
-const aDeviceQuery = () => ({
-  query: 'mock',
+const aDeviceConfig = () => ({
+  device: {
+    query: 'mock',
+  },
 });
 
 describe('Genymotion-cloud driver', () => {
@@ -205,24 +207,24 @@ describe('Genymotion-cloud driver', () => {
         givenResolvedRecipeForQuery(recipe);
         givenDeviceAllocationResult(instance);
 
-        const deviceQuery = aDeviceQuery();
-        const result = await uut.acquireFreeDevice(deviceQuery);
+        const deviceConfig = aDeviceConfig();
+        const result = await uut.acquireFreeDevice(void 0, deviceConfig);
 
         expect(result).toEqual(instance);
-        expect(recipeQuerying().getRecipeFromQuery).toHaveBeenCalledWith(deviceQuery);
+        expect(recipeQuerying().getRecipeFromQuery).toHaveBeenCalledWith(deviceConfig.device);
         expect(instanceAllocation().allocateDevice).toHaveBeenCalledWith(recipe);
       });
 
       it('should throw a descriptive error recipe not found', async () => {
-        const deviceQuery = aDeviceQuery();
+        const deviceConfig = aDeviceConfig();
         givenNoRecipes();
         givenDeviceAllocationResult(anInstance());
 
         try {
-          await uut.acquireFreeDevice(deviceQuery);
+          await uut.acquireFreeDevice(void 0, deviceConfig);
         } catch (e) {
           expect(e.toString()).toContain('No Genymotion-Cloud template found to match the configured lookup query');
-          expect(e.toString()).toContain(JSON.stringify(deviceQuery));
+          expect(e.toString()).toContain(JSON.stringify(deviceConfig.device));
           expect(e.toString()).toContain('HINT: Revisit your detox configuration');
           expect(e.toString()).toContain('https://cloud.geny.io/app/shared-devices');
           return;
@@ -235,7 +237,7 @@ describe('Genymotion-cloud driver', () => {
         givenResolvedRecipeForQuery(aRecipe());
         givenDeviceAllocationResult(instance);
 
-        await uut.acquireFreeDevice(aDeviceQuery());
+        await uut.acquireFreeDevice(void 0, aDeviceConfig());
 
         expect(uut.name).toEqual('mock-instance-toString()');
       });
@@ -245,7 +247,7 @@ describe('Genymotion-cloud driver', () => {
         givenResolvedRecipeForQuery(aRecipe());
         givenDeviceAllocationResult(instance);
 
-        await uut.acquireFreeDevice(aDeviceQuery());
+        await uut.acquireFreeDevice(void 0, aDeviceConfig());
 
         expect(adbObj().apiLevel).toHaveBeenCalledWith(instance.adbName);
       });
@@ -255,7 +257,7 @@ describe('Genymotion-cloud driver', () => {
         givenResolvedRecipeForQuery(aRecipe());
         givenDeviceAllocationResult(instance);
 
-        await uut.acquireFreeDevice(aDeviceQuery());
+        await uut.acquireFreeDevice(void 0, aDeviceConfig());
 
         expect(adbObj().disableAndroidAnimations).toHaveBeenCalledWith(instance.adbName);
       });

--- a/detox/src/devices/drivers/android/genycloud/helpers/GenyRecipeQuerying.js
+++ b/detox/src/devices/drivers/android/genycloud/helpers/GenyRecipeQuerying.js
@@ -1,16 +1,12 @@
-const _ = require('lodash');
-
 class GenyRecipeQuerying {
   constructor(recipesService) {
     this.recipesService = recipesService;
   }
 
-  async getRecipeFromQuery(deviceQuery) {
-    const queryObj = _.isPlainObject(deviceQuery) ? deviceQuery : { recipeName: deviceQuery };
-    if (queryObj.recipeUUID) {
-      return this.recipesService.getRecipeByUUID(queryObj.recipeUUID);
-    }
-    return this.recipesService.getRecipeByName(queryObj.recipeName);
+  async getRecipeFromQuery({ recipeName, recipeUUID }) {
+    return recipeUUID
+      ? this.recipesService.getRecipeByUUID(recipeUUID)
+      : this.recipesService.getRecipeByName(recipeName);
   }
 }
 

--- a/detox/src/devices/drivers/android/genycloud/helpers/GenyRecipeQuerying.test.js
+++ b/detox/src/devices/drivers/android/genycloud/helpers/GenyRecipeQuerying.test.js
@@ -22,16 +22,6 @@ describe('Genymotion-cloud recipe-query helper', () => {
   const givenRecipeByNameResult = (recipe) => recipesService.getRecipeByName.mockResolvedValue(recipe);
   const givenRecipeByUUIDResult = (recipe) => recipesService.getRecipeByUUID.mockResolvedValue(recipe);
 
-  it('should query using an explicit recipe name', async () => {
-    const deviceQuery = 'recipe-mock-name';
-    const recipe = aRecipe();
-    givenRecipeByNameResult(recipe);
-
-    const result = await uut.getRecipeFromQuery(deviceQuery);
-    expect(result).toEqual(recipe);
-    expect(recipesService.getRecipeByName).toHaveBeenCalledWith(deviceQuery);
-  });
-
   it('should query based on an object containing recipe name', async () => {
     const deviceQuery = {
       recipeName: 'recipe-mock-name',

--- a/detox/src/devices/drivers/ios/SimulatorDriver.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.js
@@ -10,7 +10,6 @@ const SimulatorScreenshotPlugin = require('../../../artifacts/screenshot/Simulat
 const temporaryPath = require('../../../artifacts/utils/temporaryPath');
 const SimulatorRecordVideoPlugin = require('../../../artifacts/video/SimulatorRecordVideoPlugin');
 const DetoxRuntimeError = require('../../../errors/DetoxRuntimeError');
-const argparse = require('../../../utils/argparse');
 const environment = require('../../../utils/environment');
 const getAbsoluteBinaryPath = require('../../../utils/getAbsoluteBinaryPath');
 const log = require('../../../utils/logger').child({ __filename });
@@ -62,7 +61,8 @@ class SimulatorDriver extends IosDriver {
     await super.cleanup(deviceId, bundleId);
   }
 
-  async acquireFreeDevice(deviceQuery) {
+  async acquireFreeDevice(_deviceQuery, deviceConfig) {
+    const deviceQuery = this._adaptQuery(deviceConfig.device);
     const udid = await this.deviceRegistry.allocateDevice(async () => {
       return await this._findOrCreateDevice(deviceQuery);
     });
@@ -75,7 +75,7 @@ class SimulatorDriver extends IosDriver {
     this._name = `${udid} ${deviceComment}`;
 
     try {
-      await this._boot(udid, deviceQuery.type || deviceQuery);
+      await this._boot(udid, deviceConfig);
     } catch (e) {
       await this.deviceRegistry.disposeDevice(udid);
       throw e;
@@ -98,10 +98,9 @@ class SimulatorDriver extends IosDriver {
     }
   }
 
-  async _boot(deviceId, type) {
-    const deviceLaunchArgs = argparse.getArgValue('deviceLaunchArgs');
-    const coldBoot = await this.applesimutils.boot(deviceId, deviceLaunchArgs);
-    await this.emitter.emit('bootDevice', { coldBoot, deviceId, type });
+  async _boot(deviceId, deviceConfig) {
+    const coldBoot = await this.applesimutils.boot(deviceId, deviceConfig.bootArgs);
+    await this.emitter.emit('bootDevice', { coldBoot, deviceId, type: deviceConfig.type });
   }
 
   async installApp(deviceId, binaryPath) {
@@ -190,10 +189,10 @@ class SimulatorDriver extends IosDriver {
     await this.applesimutils.clearKeychain(deviceId);
   }
 
-  async resetContentAndSettings(deviceId) {
+  async resetContentAndSettings(deviceId, deviceConfig) {
     await this.shutdown(deviceId);
     await this.applesimutils.resetContentAndSettings(deviceId);
-    await this._boot(deviceId);
+    await this._boot(deviceId, deviceConfig);
   }
 
   getLogsPaths(deviceId) {
@@ -236,13 +235,17 @@ class SimulatorDriver extends IosDriver {
 
   /***
    * @private
-   * @param {String | Object} rawDeviceQuery
+   * @param {{
+   *   byId?: string;
+   *   byName?: string;
+   *   byType?: string;
+   *   byOS?: string;
+   * }} deviceQuery
    * @returns {Promise<String>}
    */
-  async _findOrCreateDevice(rawDeviceQuery) {
+  async _findOrCreateDevice(deviceQuery) {
     let udid;
 
-    const deviceQuery = this._adaptQuery(rawDeviceQuery);
     const { free, taken } = await this._groupDevicesByStatus(deviceQuery);
 
     if (_.isEmpty(free)) {
@@ -286,27 +289,12 @@ class SimulatorDriver extends IosDriver {
     return result;
   }
 
-  _adaptQuery(rawDeviceQuery) {
-    let byId, byName, byOS, byType;
-
-    if (_.isPlainObject(rawDeviceQuery)) {
-      byId = rawDeviceQuery.id;
-      byName = rawDeviceQuery.name;
-      byOS = rawDeviceQuery.os;
-      byType = rawDeviceQuery.type;
-    } else {
-      if (_.includes(rawDeviceQuery, ',')) {
-        [byType, byOS] = _.split(rawDeviceQuery, /\s*,\s*/);
-      } else {
-        byType = rawDeviceQuery;
-      }
-    }
-
+  _adaptQuery({ id, name, os, type }) {
     return _.omitBy({
-      byId,
-      byName,
-      byOS,
-      byType,
+      byId: id,
+      byName: name,
+      byOS: os,
+      byType: type,
     }, _.isUndefined);
   }
 
@@ -319,10 +307,8 @@ class SimulatorDriver extends IosDriver {
     ]).join(' and ');
   }
 
-  _commentDevice(rawDeviceQuery) {
-    return _.isPlainObject(rawDeviceQuery)
-      ? JSON.stringify(rawDeviceQuery)
-      : `(${rawDeviceQuery})`;
+  _commentDevice({ byId, byName, byOS, byType }) {
+    return byId || _.compact([byName, byType, byOS]).join(', ');
   }
 
   async setStatusBar(deviceId, flags) {

--- a/detox/src/devices/drivers/ios/SimulatorDriver.test.js
+++ b/detox/src/devices/drivers/ios/SimulatorDriver.test.js
@@ -129,6 +129,8 @@ describe('IOS simulator driver', () => {
       },
     });
 
+    const asConfig = (device) => ({ type: 'ios.simulator', device });
+
     let applesimutils;
 
     beforeEach(() => {
@@ -138,26 +140,8 @@ describe('IOS simulator driver', () => {
       applesimutils.list.mockImplementation(async () => require('./tools/applesimutils.mock')['--list']);
     });
 
-    it('should accept string as device type', async () => {
-      await uut.acquireFreeDevice('iPhone X');
-
-      expect(applesimutils.list).toHaveBeenCalledWith(
-        { byType: 'iPhone X' },
-        'Searching for device by type = "iPhone X" ...'
-      );
-    });
-
-    it('should accept string with comma as device type and OS version', async () => {
-      await uut.acquireFreeDevice('iPhone X, iOS 12.0');
-
-      expect(applesimutils.list).toHaveBeenCalledWith(
-        { byType: 'iPhone X', byOS: 'iOS 12.0' },
-        'Searching for device by type = "iPhone X" and by OS = "iOS 12.0" ...'
-      );
-    });
-
-    it('should accept { byId } as matcher', async () => {
-      await uut.acquireFreeDevice({ id: 'C6EC2279-A6EB-40BE-99D2-5F11949F25E5' });
+    it('should accept { id } as matcher', async () => {
+      await uut.acquireFreeDevice(void 0, asConfig({ id: 'C6EC2279-A6EB-40BE-99D2-5F11949F25E5' }));
 
       expect(applesimutils.list).toHaveBeenCalledWith(
         { byId: 'C6EC2279-A6EB-40BE-99D2-5F11949F25E5' },
@@ -165,8 +149,8 @@ describe('IOS simulator driver', () => {
       );
     });
 
-    it('should accept { byName } as matcher', async () => {
-      await uut.acquireFreeDevice({ name: 'Chika' });
+    it('should accept { name } as matcher', async () => {
+      await uut.acquireFreeDevice(void 0, asConfig({ name: 'Chika' }));
 
       expect(applesimutils.list).toHaveBeenCalledWith(
         { byName: 'Chika' },
@@ -174,8 +158,8 @@ describe('IOS simulator driver', () => {
       );
     });
 
-    it('should accept { byType } as matcher', async () => {
-      await uut.acquireFreeDevice({ type: 'iPad Air' });
+    it('should accept { type } as matcher', async () => {
+      await uut.acquireFreeDevice(void 0, asConfig({ type: 'iPad Air' }));
 
       expect(applesimutils.list).toHaveBeenCalledWith(
         { byType: 'iPad Air' },
@@ -183,8 +167,8 @@ describe('IOS simulator driver', () => {
       );
     });
 
-    it('should accept { byType, byOS } as matcher', async () => {
-      await uut.acquireFreeDevice({ type: 'iPad 2', os: 'iOS 9.3.6' });
+    it('should accept { type, os } as matcher', async () => {
+      await uut.acquireFreeDevice(void 0, asConfig({ type: 'iPad 2', os: 'iOS 9.3.6' }));
 
       expect(applesimutils.list).toHaveBeenCalledWith(
         { byType: 'iPad 2', byOS: 'iOS 9.3.6' },
@@ -201,7 +185,7 @@ describe('IOS simulator driver', () => {
       givenCreatedDeviceUDID(udidNew);
       givenUsedSimulators(udidUsed);
 
-      const result = await uut.acquireFreeDevice('iPhone Mock');
+      const result = await uut.acquireFreeDevice(void 0, asConfig('iPhone Mock'));
 
       expect(uut.applesimutils.create).toHaveBeenCalledWith(specUsed);
       expect(result).toEqual(udidNew);
@@ -214,7 +198,7 @@ describe('IOS simulator driver', () => {
       givenSystemDevices(specUsed);
       givenNoUsedSimulators();
 
-      const result = await uut.acquireFreeDevice('iPhone Mock');
+      const result = await uut.acquireFreeDevice(void 0, asConfig('iPhone Mock'));
 
       expect(result).toEqual(udid);
       expect(uut.applesimutils.create).not.toHaveBeenCalled();

--- a/detox/src/devices/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/drivers/ios/tools/AppleSimUtils.js
@@ -44,12 +44,12 @@ class AppleSimUtils {
    * @param {String} udid - device id
    * @returns {Promise<boolean>} true, if device has been booted up from the shutdown state
    */
-  async boot(udid, deviceLaunchArgs = '') {
+  async boot(udid, deviceBootArgs = '') {
     const isBooted = await this.isBooted(udid);
 
     if (!isBooted) {
       const statusLogs = { trying: `Booting device ${udid}...` };
-      await this._execSimctl({ cmd: `boot ${udid} ${deviceLaunchArgs}`, statusLogs, retries: 10 });
+      await this._execSimctl({ cmd: `boot ${udid} ${deviceBootArgs}`, statusLogs, retries: 10 });
       await this._execSimctl({ cmd: `bootstatus ${udid}`, retries: 1 });
       return true;
     }

--- a/detox/src/errors/DetoxConfigErrorComposer.js
+++ b/detox/src/errors/DetoxConfigErrorComposer.js
@@ -316,7 +316,7 @@ Please check your Detox config${this._atPath()}`,
   _invalidPropertyType(propertyName, expectedType, deviceAlias) {
     return new DetoxConfigError({
       message: `Invalid type of ${J(propertyName)} inside the device configuration.\n`
-        + ` Expected ${expectedType}.`,
+        + `Expected ${expectedType}.`,
       hint: `Check that in your Detox config${this._atPath()}`,
       debugInfo: this._focusOnDeviceConfig(deviceAlias),
       inspectOptions: { depth: 3 },

--- a/detox/src/errors/DetoxConfigErrorComposer.js
+++ b/detox/src/errors/DetoxConfigErrorComposer.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const deviceAppTypes = require('../configuration/utils/deviceAppTypes');
 
 const DetoxConfigError = require('./DetoxConfigError');
+const DetoxInternalError = require('./DetoxInternalError');
 const J = s => JSON.stringify(s);
 
 class DetoxConfigErrorComposer {
@@ -51,10 +52,21 @@ class DetoxConfigErrorComposer {
     };
   }
 
+  _getDeviceConfig(deviceAlias) {
+    let config = undefined;
+
+    this._focusOnDeviceConfig(deviceAlias, (value) => {
+      config = value;
+      return value;
+    });
+
+    return config;
+  }
+
   _focusOnDeviceConfig(deviceAlias, postProcess = _.identity) {
     const { type, device } = this._getSelectedConfiguration();
     if (!deviceAlias) {
-      if (type) {
+      if (type || !device) {
         return this._focusOnConfiguration(postProcess);
       } else {
         return this._focusOnConfiguration(c => {
@@ -93,6 +105,7 @@ class DetoxConfigErrorComposer {
     };
   }
 
+  // region setters
   setConfigurationName(configurationName) {
     this.configurationName = configurationName || '';
     return this;
@@ -112,6 +125,7 @@ class DetoxConfigErrorComposer {
     this._extends = !!value;
     return this;
   }
+  // endregion
 
   // region configuration/index
 
@@ -160,7 +174,7 @@ class DetoxConfigErrorComposer {
 
     return new DetoxConfigError({
       message: `Cannot determine which configuration to use from Detox config${this._atPath()}`,
-      hint: 'Use --configuration to choose one of the following:\n' + hintConfigurations(configurations),
+      hint: 'Use --configuration to choose one of the following:\n' + hintList(configurations),
     });
   }
 
@@ -169,7 +183,7 @@ class DetoxConfigErrorComposer {
 
     return new DetoxConfigError({
       message: `Failed to find a configuration named ${J(this.configurationName)} in Detox config${this._atPath()}`,
-      hint: 'Below are the configurations Detox was able to find:\n' + hintConfigurations(configurations),
+      hint: 'Below are the configurations Detox was able to find:\n' + hintList(configurations),
     });
   }
 
@@ -241,7 +255,7 @@ You should create a dictionary of device configurations in Detox config, e.g.:
     return new DetoxConfigError({
       message: `Failed to find a device config ${J(alias)} in the "devices" dictionary of Detox config${this._atPath()}`,
       hint: 'Below are the device configurations Detox was able to find:\n'
-        + hintConfigurations(this.contents.devices) + '\n\n'
+        + hintList(this.contents.devices) + '\n\n'
         + `Check your configuration ${J(this.configurationName)}:`,
       debugInfo: this._getSelectedConfiguration(),
       inspectOptions: { depth: 0 },
@@ -287,7 +301,7 @@ Examine your Detox config${this._atPath()}`,
     return new DetoxConfigError({
       message: `Invalid device type ${J(deviceConfig.type)} inside your configuration.`,
       hint: `Did you mean to use one of these?
-${hintConfigurations(deviceAppTypes)}
+${hintList(deviceAppTypes)}
 
 P.S. If you intended to use a third-party driver, please resolve this error:
 
@@ -299,14 +313,65 @@ Please check your Detox config${this._atPath()}`,
     });
   }
 
-  malformedUtilBinaryPaths(deviceAlias) {
+  _invalidPropertyType(propertyName, expectedType, deviceAlias) {
     return new DetoxConfigError({
-      message: `Invalid type of "utilBinaryPaths" inside the device configuration.`
-            + ` Expected an array of strings.`,
+      message: `Invalid type of ${J(propertyName)} inside the device configuration.\n`
+        + ` Expected ${expectedType}.`,
       hint: `Check that in your Detox config${this._atPath()}`,
       debugInfo: this._focusOnDeviceConfig(deviceAlias),
       inspectOptions: { depth: 3 },
     });
+  }
+
+  _unsupportedPropertyByDeviceType(propertyName, supportedDeviceTypes, deviceAlias) {
+    const { type } = this._getDeviceConfig(deviceAlias);
+
+    return new DetoxConfigError({
+      message: `The current device type ${J(type)} does not support ${J(propertyName)} property.`,
+      hint: `You can use this property only with the following device types:\n` +
+        hintList(supportedDeviceTypes) + '\n\n' +
+        `Please fix your Detox config${this._atPath()}`,
+      debugInfo: this._focusOnDeviceConfig(deviceAlias),
+      inspectOptions: { depth: 4 },
+    });
+  }
+
+  malformedDeviceProperty(deviceAlias, propertyName) {
+    switch (propertyName) {
+      case 'bootArgs':
+        return this._invalidPropertyType('bootArgs', 'a string', deviceAlias);
+      case 'utilBinaryPaths':
+        return this._invalidPropertyType('utilBinaryPaths', 'an array of strings', deviceAlias);
+      case 'forceAdbInstall':
+        return this._invalidPropertyType('forceAdbInstall', 'a boolean value', deviceAlias);
+      case 'gpuMode':
+        return this._invalidPropertyType('gpuMode', "'auto' | 'host' | 'swiftshader_indirect' | 'angle_indirect' | 'guest'", deviceAlias);
+      case 'headless':
+        return this._invalidPropertyType('headless', 'a boolean value', deviceAlias);
+      case 'readonly':
+        return this._invalidPropertyType('readonly', 'a boolean value', deviceAlias);
+      default:
+        throw new DetoxInternalError(`Composing .malformedDeviceProperty(${propertyName}) is not implemented`);
+    }
+  }
+
+  unsupportedDeviceProperty(deviceAlias, propertyName) {
+    switch (propertyName) {
+      case 'bootArgs':
+        return this._unsupportedPropertyByDeviceType('bootArgs', ['ios.simulator', 'android.emulator'], deviceAlias);
+      case 'forceAdbInstall':
+        return this._unsupportedPropertyByDeviceType('forceAdbInstall', ['android.attached', 'android.emulator', 'android.genycloud'], deviceAlias);
+      case 'gpuMode':
+        return this._unsupportedPropertyByDeviceType('gpuMode', ['android.emulator'], deviceAlias);
+      case 'headless':
+        return this._unsupportedPropertyByDeviceType('headless', ['android.emulator'], deviceAlias);
+      case 'readonly':
+        return this._unsupportedPropertyByDeviceType('readonly', ['android.emulator'], deviceAlias);
+      case 'utilBinaryPaths':
+        return this._unsupportedPropertyByDeviceType('utilBinaryPaths', ['android.attached', 'android.emulator', 'android.genycloud'], deviceAlias);
+      default:
+        throw new DetoxInternalError(`Composing .unsupportedDeviceProperty(${propertyName}) is not implemented`);
+    }
   }
 
   missingDeviceMatcherProperties(deviceAlias, expectedProperties) {
@@ -353,7 +418,7 @@ You should create a dictionary of app configurations in Detox config, e.g.:
   cantResolveAppAlias(appAlias) {
     return new DetoxConfigError({
       message: `Failed to find an app config ${J(appAlias)} in the "apps" dictionary of Detox config${this._atPath()}`,
-      hint: 'Below are the app configurations Detox was able to find:\n' + hintConfigurations(this.contents.apps) +
+      hint: 'Below are the app configurations Detox was able to find:\n' + hintList(this.contents.apps) +
         `\n\nCheck your configuration ${J(this.configurationName)}:`,
       debugInfo: this._getSelectedConfiguration(),
       inspectOptions: { depth: 1 },
@@ -571,8 +636,9 @@ Check contents of your Detox config${this._atPath()}`,
   }
 }
 
-function hintConfigurations(configurations) {
-  return _.keys(configurations).map(c => `* ${c}`).join('\n');
+function hintList(items) {
+  const values = Array.isArray(items) ? items : _.keys(items);
+  return values.map(c => `* ${c}`).join('\n');
 }
 
 module.exports = DetoxConfigErrorComposer;

--- a/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
+++ b/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
@@ -637,8 +637,9 @@ Please check your Detox config at path:
 }]
 `;
 
-exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedUtilBinaryPaths should create an error for aliased configuration 1`] = `
-[DetoxConfigError: Invalid type of "utilBinaryPaths" inside the device configuration. Expected an array of strings.
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("bootArgs") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: Invalid type of "bootArgs" inside the device configuration.
+ Expected a string.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -650,14 +651,17 @@ HINT: Check that in your Detox config at path:
       device: {
         type: 'iPhone 12'
       },
-      utilBinaryPaths: 'invalid'
+      bootArgs: [
+        '--arg'
+      ]
     }
   }
 }]
 `;
 
-exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedUtilBinaryPaths should create an error for inlined configuration 1`] = `
-[DetoxConfigError: Invalid type of "utilBinaryPaths" inside the device configuration. Expected an array of strings.
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("bootArgs") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: Invalid type of "bootArgs" inside the device configuration.
+ Expected a string.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -668,15 +672,219 @@ HINT: Check that in your Detox config at path:
       device: {
         type: 'ios.simulator',
         device: [Object],
-        utilBinaryPaths: 'invalid'
+        bootArgs: [Array]
       }
     }
   }
 }]
 `;
 
-exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedUtilBinaryPaths should create an error for plain configuration 1`] = `
-[DetoxConfigError: Invalid type of "utilBinaryPaths" inside the device configuration. Expected an array of strings.
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("forceAdbInstall") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: Invalid type of "forceAdbInstall" inside the device configuration.
+ Expected a boolean value.
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 12'
+      },
+      forceAdbInstall: 'false'
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("forceAdbInstall") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: Invalid type of "forceAdbInstall" inside the device configuration.
+ Expected a boolean value.
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'ios.simulator',
+        device: [Object],
+        forceAdbInstall: 'true'
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("gpuMode") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: Invalid type of "gpuMode" inside the device configuration.
+ Expected 'auto' | 'host' | 'swiftshader_indirect' | 'angle_indirect' | 'guest'.
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 12'
+      },
+      gpuMode: true
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("gpuMode") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: Invalid type of "gpuMode" inside the device configuration.
+ Expected 'auto' | 'host' | 'swiftshader_indirect' | 'angle_indirect' | 'guest'.
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'ios.simulator',
+        device: [Object],
+        gpuMode: 'something_odd'
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("headless") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: Invalid type of "headless" inside the device configuration.
+ Expected a boolean value.
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 12'
+      },
+      headless: 'non-boolean'
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("headless") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: Invalid type of "headless" inside the device configuration.
+ Expected a boolean value.
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'ios.simulator',
+        device: [Object],
+        headless: 'non-boolean'
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("readonly") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: Invalid type of "readonly" inside the device configuration.
+ Expected a boolean value.
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 12'
+      },
+      readonly: 'non-boolean'
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("readonly") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: Invalid type of "readonly" inside the device configuration.
+ Expected a boolean value.
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'ios.simulator',
+        device: [Object],
+        readonly: 'non-boolean'
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("utilBinaryPaths") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: Invalid type of "utilBinaryPaths" inside the device configuration.
+ Expected an array of strings.
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 12'
+      },
+      utilBinaryPaths: [
+        NaN,
+        'valid'
+      ]
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("utilBinaryPaths") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: Invalid type of "utilBinaryPaths" inside the device configuration.
+ Expected an array of strings.
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'ios.simulator',
+        device: [Object],
+        utilBinaryPaths: [Array]
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("utilBinaryPaths") should create an error for plain configuration 1`] = `
+[DetoxConfigError: Invalid type of "utilBinaryPaths" inside the device configuration.
+ Expected an array of strings.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -691,6 +899,12 @@ HINT: Check that in your Detox config at path:
     }
   }
 }]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty should throw on an unknown argument 1`] = `
+"Composing .malformedDeviceProperty(unknown) is not implemented
+Please report this issue on our GitHub tracker:
+https://github.com/wix/Detox/issues"
 `;
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .missingDeviceMatcherProperties should work with aliased configurations 1`] = `
@@ -827,6 +1041,321 @@ HINT: You should create a dictionary of device configurations in Detox config, e
   }
 }
 ]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("bootArgs") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "bootArgs" property.
+
+HINT: You can use this property only with the following device types:
+* ios.simulator
+* android.emulator
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 12'
+      },
+      bootArgs: '--no-window'
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("bootArgs") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "bootArgs" property.
+
+HINT: You can use this property only with the following device types:
+* ios.simulator
+* android.emulator
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'ios.simulator',
+        device: {
+          type: 'iPhone 12'
+        },
+        bootArgs: '--no-window'
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("forceAdbInstall") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "forceAdbInstall" property.
+
+HINT: You can use this property only with the following device types:
+* android.attached
+* android.emulator
+* android.genycloud
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 12'
+      },
+      forceAdbInstall: false
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("forceAdbInstall") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "forceAdbInstall" property.
+
+HINT: You can use this property only with the following device types:
+* android.attached
+* android.emulator
+* android.genycloud
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'ios.simulator',
+        device: {
+          type: 'iPhone 12'
+        },
+        forceAdbInstall: true
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("gpuMode") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "gpuMode" property.
+
+HINT: You can use this property only with the following device types:
+* android.emulator
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 12'
+      },
+      gpuMode: 'auto'
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("gpuMode") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "gpuMode" property.
+
+HINT: You can use this property only with the following device types:
+* android.emulator
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'ios.simulator',
+        device: {
+          type: 'iPhone 12'
+        },
+        gpuMode: 'auto'
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("headless") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "headless" property.
+
+HINT: You can use this property only with the following device types:
+* android.emulator
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 12'
+      },
+      headless: true
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("headless") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "headless" property.
+
+HINT: You can use this property only with the following device types:
+* android.emulator
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'ios.simulator',
+        device: {
+          type: 'iPhone 12'
+        },
+        headless: true
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("readonly") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "readonly" property.
+
+HINT: You can use this property only with the following device types:
+* android.emulator
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 12'
+      },
+      readonly: false
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("readonly") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "readonly" property.
+
+HINT: You can use this property only with the following device types:
+* android.emulator
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'ios.simulator',
+        device: {
+          type: 'iPhone 12'
+        },
+        readonly: false
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("utilBinaryPaths") should create an error for aliased configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "utilBinaryPaths" property.
+
+HINT: You can use this property only with the following device types:
+* android.attached
+* android.emulator
+* android.genycloud
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  devices: {
+    aDevice: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 12'
+      },
+      utilBinaryPaths: []
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("utilBinaryPaths") should create an error for inlined configuration 1`] = `
+[DetoxConfigError: The current device type "ios.simulator" does not support "utilBinaryPaths" property.
+
+HINT: You can use this property only with the following device types:
+* android.attached
+* android.emulator
+* android.genycloud
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    inlined: {
+      device: {
+        type: 'ios.simulator',
+        device: {
+          type: 'iPhone 12'
+        },
+        utilBinaryPaths: []
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("utilBinaryPaths") should create an error for plain configuration 1`] = `
+[DetoxConfigError: The current device type "android.emulator" does not support "utilBinaryPaths" property.
+
+HINT: You can use this property only with the following device types:
+* android.attached
+* android.emulator
+* android.genycloud
+
+Please fix your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    plain: {
+      type: 'android.emulator',
+      device: 'Pixel_3a_API_30_x86',
+      binaryPath: 'path/to/apk',
+      utilBinaryPaths: []
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty should throw on an unknown argument 1`] = `
+"Composing .unsupportedDeviceProperty(unknown) is not implemented
+Please report this issue on our GitHub tracker:
+https://github.com/wix/Detox/issues"
 `;
 
 exports[`DetoxConfigErrorComposer (from composeSessionConfig) .invalidDebugSynchronizationProperty should create a generic error, if the config location is not known 1`] = `

--- a/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
+++ b/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
@@ -639,7 +639,7 @@ Please check your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("bootArgs") should create an error for aliased configuration 1`] = `
 [DetoxConfigError: Invalid type of "bootArgs" inside the device configuration.
- Expected a string.
+Expected a string.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -661,7 +661,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("bootArgs") should create an error for inlined configuration 1`] = `
 [DetoxConfigError: Invalid type of "bootArgs" inside the device configuration.
- Expected a string.
+Expected a string.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -681,7 +681,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("forceAdbInstall") should create an error for aliased configuration 1`] = `
 [DetoxConfigError: Invalid type of "forceAdbInstall" inside the device configuration.
- Expected a boolean value.
+Expected a boolean value.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -701,7 +701,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("forceAdbInstall") should create an error for inlined configuration 1`] = `
 [DetoxConfigError: Invalid type of "forceAdbInstall" inside the device configuration.
- Expected a boolean value.
+Expected a boolean value.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -721,7 +721,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("gpuMode") should create an error for aliased configuration 1`] = `
 [DetoxConfigError: Invalid type of "gpuMode" inside the device configuration.
- Expected 'auto' | 'host' | 'swiftshader_indirect' | 'angle_indirect' | 'guest'.
+Expected 'auto' | 'host' | 'swiftshader_indirect' | 'angle_indirect' | 'guest'.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -741,7 +741,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("gpuMode") should create an error for inlined configuration 1`] = `
 [DetoxConfigError: Invalid type of "gpuMode" inside the device configuration.
- Expected 'auto' | 'host' | 'swiftshader_indirect' | 'angle_indirect' | 'guest'.
+Expected 'auto' | 'host' | 'swiftshader_indirect' | 'angle_indirect' | 'guest'.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -761,7 +761,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("headless") should create an error for aliased configuration 1`] = `
 [DetoxConfigError: Invalid type of "headless" inside the device configuration.
- Expected a boolean value.
+Expected a boolean value.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -781,7 +781,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("headless") should create an error for inlined configuration 1`] = `
 [DetoxConfigError: Invalid type of "headless" inside the device configuration.
- Expected a boolean value.
+Expected a boolean value.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -801,7 +801,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("readonly") should create an error for aliased configuration 1`] = `
 [DetoxConfigError: Invalid type of "readonly" inside the device configuration.
- Expected a boolean value.
+Expected a boolean value.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -821,7 +821,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("readonly") should create an error for inlined configuration 1`] = `
 [DetoxConfigError: Invalid type of "readonly" inside the device configuration.
- Expected a boolean value.
+Expected a boolean value.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -841,7 +841,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("utilBinaryPaths") should create an error for aliased configuration 1`] = `
 [DetoxConfigError: Invalid type of "utilBinaryPaths" inside the device configuration.
- Expected an array of strings.
+Expected an array of strings.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -864,7 +864,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("utilBinaryPaths") should create an error for inlined configuration 1`] = `
 [DetoxConfigError: Invalid type of "utilBinaryPaths" inside the device configuration.
- Expected an array of strings.
+Expected an array of strings.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -884,7 +884,7 @@ HINT: Check that in your Detox config at path:
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("utilBinaryPaths") should create an error for plain configuration 1`] = `
 [DetoxConfigError: Invalid type of "utilBinaryPaths" inside the device configuration.
- Expected an array of strings.
+Expected an array of strings.
 
 HINT: Check that in your Detox config at path:
 /home/detox/myproject/.detoxrc.json

--- a/detox/src/utils/argparse.js
+++ b/detox/src/utils/argparse.js
@@ -4,17 +4,18 @@ const argv = require('minimist')(process.argv.slice(2));
 const { escape } = require('./pipeCommands');
 
 function getArgValue(key, alias) {
-  let value = _getArgvValue(key, alias);
+  const value = _getArgvValue(key, alias);
+  return value === undefined ? getEnvValue(key) : value;
+}
 
-  if (value === undefined) {
-    const envKey = _.findKey(process.env, matchesKey(
-      `DETOX_${_.snakeCase(key)}`.toUpperCase()
-    ));
+function getEnvValue(key) {
+  const envKey = _.findKey(process.env, matchesKey(
+    `DETOX_${_.snakeCase(key)}`.toUpperCase()
+  ));
 
-    value = process.env[envKey];
-    if (value === 'undefined') {
-      value = undefined;
-    }
+  let value = process.env[envKey];
+  if (value === 'undefined') {
+    value = undefined;
   }
 
   return value;
@@ -82,6 +83,7 @@ function joinArgs(keyValues, options = DEFAULT_JOIN_ARGUMENTS_OPTIONS) {
 
 module.exports = {
   getArgValue,
+  getEnvValue,
   getFlag,
   joinArgs,
 };

--- a/detox/test/e2e/detox.config.js
+++ b/detox/test/e2e/detox.config.js
@@ -109,6 +109,8 @@ const config = {
 
     'android.emulator': {
       type: 'android.emulator',
+      headless: Boolean(process.env.CI),
+      readonly: true,
       device: {
         avdName: 'Pixel_3A_API_29'
       },

--- a/detox/test/integration/stub/StubDriver.js
+++ b/detox/test/integration/stub/StubDriver.js
@@ -31,7 +31,7 @@ class StubDriver extends DeviceDriverBase {
     };
   }
 
-  async acquireFreeDevice(deviceQuery) {
+  async acquireFreeDevice(_deviceQuery, _deviceConfig) {
     await sleepSomeTime();
     await this.emitter.emit('bootDevice', { coldBoot: false, deviceId: this._deviceId, type: 'stub' });
     return this._deviceId;

--- a/docs/APIRef.Configuration.md
+++ b/docs/APIRef.Configuration.md
@@ -16,7 +16,8 @@ In essence, Detox scans for the configuration to use, through multiple files. It
 Options 1-5 allow for a standalone Detox configuration in either a `json` format or using Javascript syntax.
 Option 6 means the configuration is available in `json` format inside the project's `package.json`, which is more suitable if you like having all of your project's configurations in one place.
 
-Please find the [Detox example app](/examples/demo-react-native/detox.config.js) as a working reference.
+Please find the [Detox example app](/examples/demo-react-native/detox.config.js) as a working reference. Also, look at
+[the typings file](https://github.com/wix/Detox/blob/master/detox/index.d.ts) provided by Detox.
 
 ### Extending configurations
 
@@ -150,9 +151,14 @@ A device config can have the following params:
 
 |Configuration Params|Details|
 |---|---|
-|`type`| Mandatory property to discern device types: `ios.simulator`, `android.emulator`, `android.attached`, `android.genycloud`, `ios.none`, etc. |
-|`device`| Device query, e.g. `{ "byType": "iPhone 11 Pro" }` for iOS simulator, `{ "avdName": "Pixel_2_API_29" }` for Android emulator or `{ "adbName": "<pattern>" }` for attached Android device with name matching the regex. |
-|`utilBinaryPaths`| (optional, Android only): An **array** of relative paths of _utility_ app (apk) binary-files to preinstall on the tested devices - once before the test execution begins.<br />Note: these are not effected by various install-lifecycle events, such as launching an app with `device.launchApp({delete: true})`, which reinstalls the app. A good example of why this might come in handy is [Test Butler](https://github.com/linkedin/test-butler). |
+|`type`| _**Required.** String Literal_. Mandatory property to discern device types: `ios.simulator`, `android.emulator`, `android.attached`, `android.genycloud`, `ios.none`, etc. |
+|`device`| _**Required.** Object._ Device query, e.g. `{ "byType": "iPhone 11 Pro" }` for iOS simulator, `{ "avdName": "Pixel_2_API_29" }` for Android emulator or `{ "adbName": "<pattern>" }` for attached Android device with name matching the regex. |
+|`bootArgs`| _Optional. String. Supported by `ios.simulator` and `android.emulator` only._ <br> Supply an extra **string** of arguments to `xcrun simctl boot ...` or `emulator -verbose ... @AVD_Name`.  |
+|`forceAdbInstall`| _Optional. Boolean. Supported for Android devices only._ <br> A **boolean** value, **false** by default. When set **true**, it tells `device.installApp()` to use `adb install`. Otherwise, it would use the combination of `adb push <app.apk>` and `adb shell pm install`.  |
+|`utilBinaryPaths`| _Optional. Array of strings. Supported for Android devices only._ <br> An array of relative paths of _utility_ app (apk) binary-files to preinstall on the tested devices - once before the test execution begins.<br>**Note**: these are not affected by various install-lifecycle events, such as launching an app with `device.launchApp({delete: true})`, which reinstalls the app. A good example of why this might come in handy is [Test Butler](https://github.com/linkedin/test-butler). |
+|`gpuMode`|  _Optional. String Literal (<code>auto &#124; host &#124; swiftshader_indirect &#124; angle_indirect &#124; guest</code>). Supported by `android.emulator` only._ <br> A fixed **string** , which tells [in which GPU mode](https://developer.android.com/studio/run/emulator-acceleration#command-gpu) the emulator should be booted. |
+|`headless`| _Optional. Boolean. Supported by `android.emulator` only._ <br>  _False_ by default. When set to _true_, it tells Detox to boot an Android emulator with `-no-window` option.  |
+|`readonly`| _Optional. Boolean. Supported by `android.emulator` only._ <br>  _False_ by default. When set to _true_, it forces Detox to boot even a single emulator with `-read-only` option.<br>**Note**: when used with multiple workers, this setting has no effect — emulators will be booted always with `-read-only`. |
 
 Also, in the Detox `configurations` you can use the device configs as-is, without aliasing:
 


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #1306

In this pull request, I have added the following options to the device configs:

```diff
  interface DetoxAndroidEmulatorDriverConfig extends DetoxSharedAndroidDriverConfig {
      type: 'android.emulator';
      device: string | { avdName: string };
+     bootArgs?: string;
+     gpuMode?: 'auto' | 'host' | 'swiftshader_indirect' | 'angle_indirect' | 'guest';
+     headless?: boolean;
+     readonly?: boolean;
  }

  interface DetoxSharedAndroidDriverConfig {
+     forceAdbInstall?: boolean;
      utilBinaryPaths?: string[];
  }
    
  interface DetoxIosSimulatorDriverConfig {
    type: 'ios.simulator';
    device: string | Partial<IosSimulatorQuery>;
+   bootArgs?: string;
  }
```

Also, to align the previous `--device-launch-args` and the current `bootArgs` naming, I aliased that CLI param:

```
      --device-boot-args, --device-launch-args  Custom arguments to pass (through) onto the device (emulator/simulator) binary when booted.
```

Detox will be warning that `--device-launch-args` is a deprecated name, and users should be using `--device-boot-args`.

- [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.
- [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.