### PR TITLE
Add `deprecated` information to TypeScript types

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -994,6 +994,7 @@ declare global {
              * Simulate tap at a specific point on an element.
              * Note: The point coordinates are relative to the matched element and the element size could changes on different devices or even when changing the device font size.
              * @example await element(by.id('tappable')).tapAtPoint({ x:5, y:10 });
+             * @deprecated Use `.tap()` instead.
              */
             tapAtPoint(point: { x: number; y: number }): Promise<void>;
 
@@ -1108,7 +1109,7 @@ declare global {
              * @example
              * await expect(element(by.id('PinchableScrollView'))).toBeVisible();
              * await element(by.id('PinchableScrollView')).pinchWithAngle('outward', 'slow', 0);
-             * @deprecated Should use pinch instead
+             * @deprecated Use `.pinch()` instead.
              */
             pinchWithAngle(direction: PinchDirection, speed: Speed, angle: number): Promise<void>;
 

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -868,6 +868,7 @@ declare global {
             /**
              * Expect the view to not be visible.
              * @example await expect(element(by.id('UniqueId205'))).toBeNotVisible();
+             * @deprecated Use `.not.toBeVisible()` instead.
              */
             toBeNotVisible(): R;
 
@@ -880,6 +881,7 @@ declare global {
             /**
              * Expect the view to not exist in the UI hierarchy.
              * @example await expect(element(by.id('RandomJunk959'))).toNotExist();
+             * @deprecated Use `.not.toExist()` instead.
              */
             toNotExist(): R;
 
@@ -892,6 +894,7 @@ declare global {
             /**
              * Expect the view not to be focused.
              * @example await expect(element(by.id('passwordInput'))).toBeNotFocused();
+             * @deprecated Use `.not.toBeFocused()` instead.
              */
             toBeNotFocused(): R;
 


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #2973

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have updated TS types for project to make it visible when writing code, that deprecated methods are deprecated.

VSCode will mark these methods like that:

![Screenshot 2021-09-10 at 13 19 22](https://user-images.githubusercontent.com/6529801/132845768-15d33679-603f-4cdd-b5ba-065b929da321.png)


<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
