### PR TITLE
fix(ios): select key window in ios15-compatible way

### DIFF
--- a/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
@@ -371,7 +371,7 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 {
 	NSMutableDictionary* rv = [NSMutableDictionary new];
 	
-	rv[@"viewHierarchy"] = [[UIWindowScene _keyWindowScene] dtx_recursiveDescription];
+ 	rv[@"viewHierarchy"] = [[UIWindow dtx_keyWindowScene] dtx_recursiveDescription];
 	
 	NSMutableArray* windowDescriptions = [NSMutableArray new];
 	

--- a/detox/ios/Detox/Utilities/UIWindow+DetoxUtils.h
+++ b/detox/ios/Detox/Utilities/UIWindow+DetoxUtils.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, class, readonly, nullable) UIWindow* dtx_keyWindow NS_SWIFT_NAME(dtx_keyWindow);
 @property (nonatomic, strong, class, readonly) NSArray<UIWindow*>* dtx_allKeyWindowSceneWindows;
 
++ (id _Nullable)dtx_keyWindowScene;
 + (NSArray<UIWindow*>*)dtx_allWindows;
 + (NSArray<UIWindow*>*)dtx_allWindowsForScene:(nullable UIWindowScene*)scene;
 + (void)dtx_enumerateAllWindowsUsingBlock:(void (NS_NOESCAPE ^)(UIWindow* obj, NSUInteger idx, BOOL *stop))block;

--- a/detox/ios/Detox/Utilities/UIWindow+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/UIWindow+DetoxUtils.m
@@ -138,19 +138,34 @@ static NSString* _DTXNSStringFromUISceneActivationState(UISceneActivationState s
 
 + (UIWindow*)dtx_keyWindow
 {
-	return UIWindowScene._keyWindowScene._keyWindow;
+    UIWindow        *foundWindow = nil;
+    NSArray         *windows = [[UIApplication sharedApplication]windows];
+    for (UIWindow   *window in windows) {
+        if (window.isKeyWindow) {
+            foundWindow = window;
+            break;
+        }
+    }
+    return foundWindow;
+}
+
++ (UIWindowScene*)dtx_keyWindowScene
+{
+	UIWindow* keyWindow = [self dtx_keyWindow];
+	UIWindowScene* scene = keyWindow ? keyWindow.windowScene :  nil;
+	return scene;
 }
 
 + (NSArray<UIWindow *> *)dtx_allKeyWindowSceneWindows
 {
-	UIWindowScene* scene = UIWindowScene._keyWindowScene;
+	UIWindowScene* scene = [self dtx_keyWindowScene];
 	return [self dtx_allWindowsForScene:scene];
 }
 
 + (NSArray<UIWindow*>*)dtx_allWindowsForScene:(UIWindowScene*)scene
 {
 	NSMutableArray<UIWindow*>* windows = [[self dtx_allWindows] mutableCopy];
-	scene = scene ?: UIWindowScene._keyWindowScene;
+	scene = scene ?: [self dtx_keyWindowScene];
 	if(scene != nil)
 	{
 		NSPredicate* predicate = [NSPredicate predicateWithFormat:@"windowScene == %@", scene];
@@ -193,7 +208,7 @@ static NSString* _DTXNSStringFromUISceneActivationState(UISceneActivationState s
 
 + (void)dtx_enumerateKeyWindowSceneWindowsUsingBlock:(void (NS_NOESCAPE ^)(UIWindow* obj, NSUInteger idx, BOOL *stop))block
 {
-	UIWindowScene* scene = UIWindowScene._keyWindowScene;
+	UIWindowScene* scene = [self dtx_keyWindowScene];
 	[self dtx_enumerateWindowsInScene:scene usingBlock:block];
 }
 


### PR DESCRIPTION

## Description

- This pull request addresses the issue described here: #2895

In this pull request, I have followed the general outline from this stackoverflow https://stackoverflow.com/a/58447461/9910298 to find the key window (and key window's scene) in a way that works on ios15 now that they have removed the hidden ios internal that was previously used.

- I do not believe this requires any documentation or typescript change
- It may be correct to remove these internals lines now as well but I was less sure on that: https://github.com/wix/Detox/blob/25c240b157bc4bbb98e4da94c55f141594dceb51/detox/ios/Detox/AppleInternals/DTXAppleInternals.h#L51-L52

This PR serves as a possibly-working but minimal version of the patch I originally authored here https://github.com/wix/Detox/issues/2895#issuecomment-926181391 that @calebmackdavenport incorporated here #2992, but #2992 includes some whitespace changes which I don't understand and also includes a new example which (as a maintainer on other repos) I fear will slow down the PR incorporation, as demos are typically unrelated to bug fixes and add maintenance burden to a repo so slow down PR review etc

I just want to see ios15 support merged, so if Caleb saw success with the actual fix I made (that went in to 2992) and nothing else was required, then I'd love a clean PR to be merged ASAP :-) 