### PR TITLE
fix(types): optional longPress duration

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -992,10 +992,10 @@ declare global {
 
             /**
              * Simulate long press on an element
-             * @param duration (iOS only) press duration time, in milliseconds. Optional (default is 1000ms).
+             * @param duration (iOS only) custom press duration time, in milliseconds. Optional (default is 1000ms).
              * @example await element(by.id('tappable')).longPress();
              */
-            longPress(duration: number): Promise<void>;
+            longPress(duration?: number): Promise<void>;
 
             /**
              * Simulate long press on an element and then drag it to the position of the target element. (iOS Only)

--- a/detox/test/types/detox-global-tests.ts
+++ b/detox/test/types/detox-global-tests.ts
@@ -32,6 +32,8 @@ describe("Test", () => {
     test("Test", async () => {
         await element(by.id("element")).replaceText("text");
         await element(by.id("element")).tap();
+        await element(by.id("element")).longPress();
+        await element(by.id("element")).longPress(1000);
         await element(by.id("element")).scroll(50, "down");
         await element(by.id("scrollView")).scrollTo("bottom");
         await expect(element(by.id("element")).atIndex(0)).toNotExist();


### PR DESCRIPTION
## Description

- This pull request addresses a regression introduced by #2977

In this pull request, I made the `duration` parameter optional, as it has been before.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
