### PR TITLE
Fixed codegen

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-node": "^6.0.1",
     "jest": "^27.0.0",
     "jest-environment-node": "^27.0.0",
+    "react-native-codegen": "^0.0.8",
     "mocha": ">=6.0.0",
     "mockdate": "^2.0.1",
     "prettier": "1.7.0",

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -37,6 +37,7 @@
     "react-native-webview": "11.4.4"
   },
   "devDependencies": {
+    "react-native-codegen": "^0.0.8",
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
     "@types/node": "^14.14.20",


### PR DESCRIPTION
The codegen in react-native-codegen 0.0.6 broke (the default for react-native 0.64).
I fixed it by resolving to a higher version. (0.0.8^)
This affect the ios example project under the test folder and broke it's build