### PR TITLE
update proguard rules for kotlin

### DIFF
--- a/detox/android/detox/proguard-rules-app.pro
+++ b/detox/android/detox/proguard-rules-app.pro
@@ -9,3 +9,5 @@
 -keep class com.reactnativecommunity.asyncstorage.** { *; }
 
 -keep class kotlin.jvm.** { *; }
+-keep class kotlin.collections.** { *; }
+-keep class kotlin.text.** { *; }


### PR DESCRIPTION
Fixes an issue with missing kotlin classes in release builds - https://github.com/wix/Detox/issues/3010. I was not able to reproduce this problem locally, but it looks similar to complaints made a few months ago (after which we added the jvm rule).