### PR TITLE
test(types): skipLibCheck=true during type testing

### DIFF
--- a/detox/test/tsconfig.json
+++ b/detox/test/tsconfig.json
@@ -6,6 +6,7 @@
     "allowJs": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "skipLibCheck": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "moduleResolution": "node",


### PR DESCRIPTION
## Description

This allows the library to type-check across a wide 3rd-party version skew
without needing to add resolutions{} pin blocks to package.json

Related #3035 - I saw CI failures there

Note that this is an area of controversy in the typescript ecosystem. As proponents of strong type-checking we all want to check as much as possible.

However, 3rd party library compatibility causes type-checking problems quite frequently. So frequently that the main react-native template had to add this enabled, and only turned it off by effectively committing themselves to a future process of build breaks and resolution pin updates, examine this diff:

https://github.com/react-native-community/react-native-template-typescript/commit/7a2c4161f214fbafac725c82686e76790da689f3

For a library like Detox where typing is not a core feature (it's important, but Detox's core feature is *testing* not typing), I don't think 3rd party type checking provides value personally.

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
