### PR TITLE
fix(android, api31): use api31 compatible transitive androidx deps

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -83,15 +83,15 @@ dependencies {
 // All are aligned with this release: https://developer.android.com/jetpack/androidx/releases/test#1.2.0
 dependencies {
 
-    // Versions are in-sync with the 'androidx-test-1.2.0' release/tag of the android-test github repo,
-    // used by the Detox generator. See https://github.com/android/android-test/releases/tag/androidx-test-1.2.0
+    // Versions are in-sync with the 'androidx-test-1.4.0' release/tag of the android-test github repo,
+    // used by the Detox generator. See https://github.com/android/android-test/releases/tag/androidx-test-1.4.0
     // Important: Should remain so when generator tag is replaced!
-    api('androidx.test.espresso:espresso-core:3.3.0') { // Needed all across Detox but also makes Espresso seamlessly provided to Detox users with hybrid apps/E2E-tests.
+    api('androidx.test.espresso:espresso-core:3.4.0') { // Needed all across Detox but also makes Espresso seamlessly provided to Detox users with hybrid apps/E2E-tests.
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
-    api 'androidx.test.espresso:espresso-web:3.3.0' // Web-View testing
-    api 'androidx.test:rules:1.2.0' // Needed because of ActivityTestRule. Needed by users *and* internally used by Detox.
-    api 'androidx.test.ext:junit:1.1.1' // Needed so as to seamlessly provide AndroidJUnit4 to Detox users. Depends on junit core.
+    api 'androidx.test.espresso:espresso-web:3.4.0' // Web-View testing
+    api 'androidx.test:rules:1.4.0' // Needed because of ActivityTestRule. Needed by users *and* internally used by Detox.
+    api 'androidx.test.ext:junit:1.1.3' // Needed so as to seamlessly provide AndroidJUnit4 to Detox users. Depends on junit core.
 
     // Version is the latest; Cannot sync with the Github repo (e.g. android/android-test) because the androidx
     // packaging version of associated classes is simply not there...

--- a/detox/test/android/build.gradle
+++ b/detox/test/android/build.gradle
@@ -4,9 +4,7 @@ buildscript {
     def androidGradlePluginVersion =
             rnInfo.isRN64OrHigher
                 ? '4.1.0'
-                : rnInfo.isRN62OrHigher
-                    ? '3.5.3'
-                    : '3.4.2'
+                : '3.6.4'
     println "[$project] Resorted to Android Gradle-plugin version $androidGradlePluginVersion"
 
     ext {


### PR DESCRIPTION
## Description

This PR enables apps using Detox to raise targetSdkVersion to 31

The activities exported by the libraries in the updated dependency
versions correctly specify "android:exported" attributes, so apps
that use Detox may successfully bump their targetSdkVersion to 31

Related #2899 - Detox already ran on Android12 but apps using Detox could not target API31
Related #3033 - CI failures without JDK11 and is updating lots of things at once, this is focused

#3033 is useful but looks like it will take a while, this unblocks Detox-using apps right now