### PR TITLE
types: add .captureViewHierarchy typings

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -631,8 +631,8 @@ declare global {
 
             /**
              * Takes a screenshot on the device and schedules putting it in the artifacts folder upon completion of the current test.
-             * @param {string} name for the screenshot artifact
-             * @returns {Promise<string>} a temporary path to the screenshot.
+             * @param name for the screenshot artifact
+             * @returns a temporary path to the screenshot.
              * @example
              * test('Menu items should have logout', async () => {
              *   const tempPath = await device.takeScreenshot('tap on menu');
@@ -643,6 +643,24 @@ declare global {
              * });
              */
             takeScreenshot(name: string): Promise<string>;
+
+            /**
+             * (iOS only) Saves a view hierarchy snapshot (*.viewhierarchy) of the currently opened application
+             * to a temporary folder and schedules putting it to the artifacts folder upon the completion of
+             * the current test. The file can be opened later in Xcode 12.0 and above.
+             * @see https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes#:~:text=57933113
+             * @param [name="capture"] optional name for the *.viewhierarchy artifact
+             * @returns a temporary path to the captured view hierarchy snapshot.
+             * @example
+             * test('Menu items should have logout', async () => {
+             *   await device.captureViewHierarchy('myElements');
+             *   // The temporary path will remain valid until the test completion.
+             *   // Afterwards, the artifact will be moved, e.g.:
+             *   // * on success, to: <artifacts-location>/✓ Menu items should have Logout/myElements.viewhierarchy
+             *   // * on failure, to: <artifacts-location>/✗ Menu items should have Logout/myElements.viewhierarchy
+             * });
+             */
+            captureViewHierarchy(name?: string): Promise<string>;
 
             /**
              * Simulate shake (iOS Only)

--- a/detox/test/types/detox-global-tests.ts
+++ b/detox/test/types/detox-global-tests.ts
@@ -17,7 +17,14 @@ describe("Test", () => {
 
     beforeAll(async () => {
         await device.reloadReactNative();
-        await device.takeScreenshot("test screenshot");
+
+        const artifactsPaths: string[] = [
+            await device.takeScreenshot("test screenshot"),
+            await device.captureViewHierarchy(),
+            await device.captureViewHierarchy('a'),
+        ];
+
+        artifactsPaths.splice(0);
     });
 
     afterAll(async () => {

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -84,6 +84,7 @@ This is the most flexible way of editing the launch arguments. Refer to the [lau
 - [`device.resetContentAndSettings()` **iOS Only**](#deviceresetcontentandsettings-ios-only)
 - [`device.getPlatform()`](#devicegetplatform)
 - [`device.takeScreenshot([name])`](#devicetakescreenshotname)
+- [`device.captureViewHierarchy([name])`](#devicecaptureviewhierarchyname)
 - [`device.shake()` **iOS Only**](#deviceshake-ios-only)
 - [`device.setBiometricEnrollment(bool)` **iOS Only**](#devicesetbiometricenrollmentbool-ios-only)
 - [`device.matchFace()` **iOS Only**](#devicematchface-ios-only)
@@ -419,6 +420,28 @@ if (device.getPlatform() === 'ios') {
 #### `device.takeScreenshot([name])`
 
 Takes a screenshot of the device. For full details on taking screenshots with Detox, refer to the [screen-shots guide](APIRef.Screenshots.md).
+
+#### `device.captureViewHierarchy([name])`
+
+**iOS Only.** Saves a view hierarchy snapshot (`*.viewhierarchy`) of the
+currently opened application to a temporary folder and schedules putting it to
+the artifacts folder upon the completion of the current test. The file can be
+opened later in Xcode 12.0 and above.
+See [Xcode 12 Release notes: #57933113](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes#:\~:text=57933113)
+for more details.
+
+The `name` parameter is optional — by default, it equals to `capture`.
+
+```js
+test('Capture view hierarchy', async () => {
+  const temporaryArtifactPath = await device.captureViewHierarchy('myElements');
+
+  // The temporary path will remain valid until the test completion.
+  // Afterwards, the artifact will be moved, e.g.:
+  // * on success, to: <artifacts-location>/✓ Capture view hierarchy/myElements.viewhierarchy
+  // * on failure, to: <artifacts-location>/✗ Capture view hierarchy/myElements.viewhierarchy
+});
+```
 
 #### `device.shake()` **iOS Only**
 


### PR DESCRIPTION
## Description

- This pull request adds missing information about `device.captureViewHierarchy` API to the documentation and TS typings.

In this pull request, I have:

- [x] updated typings
- [x] added typing tests
- [x] updated docs


> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
