### PR TITLE
feat(Sync Logs): unify debug-sync logs between platforms.

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/adapters/server/DetoxActionHandlers.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/adapters/server/DetoxActionHandlers.kt
@@ -120,7 +120,7 @@ class QueryStatusActionHandler(
 
     private fun formatResource(resource: IdlingResource): Map<String, Any> {
         if (resource is DescriptiveIdlingResource) {
-            return resource.getJSONDescription()
+            return resource.getDescription().json()
         }
 
         if (resource.javaClass.name.contains("LooperIdlingResource")) {
@@ -136,20 +136,24 @@ class QueryStatusActionHandler(
     }
 
     private fun formatLooperResourceFromName(resourceName: String): Map<String, Any> {
-        if (isJSCodeExecution(resourceName)) {
-            return formatLooperResource(
+        return when {
+            isJSCodeExecution(resourceName) -> {
+                formatLooperResource(
                     "\"${resourceName}\" (JS Thread)",
                     "JavaScript code"
-            )
-        } else if (isNativeCodeExecution(resourceName)) {
-            return formatLooperResource(
+                )
+            }
+            isNativeCodeExecution(resourceName) -> {
+                formatLooperResource(
                     "\"${resourceName}\" (Native Modules Thread)",
                     "native module calls"
-            )
-        } else {
-            return formatLooperResource(
+                )
+            }
+            else -> {
+                formatLooperResource(
                     "\"${resourceName}\""
-            )
+                )
+            }
         }
     }
 
@@ -157,13 +161,7 @@ class QueryStatusActionHandler(
      * @see URL https://reactnative.dev/docs/profiling
      */
     private fun isJSCodeExecution(looperName: String): Boolean {
-        val options = arrayOf(
-                "mqt_js",
-                "JSCall",
-                "Bridge.executeJSCall"
-        )
-
-        return options.any { looperName.contains(it) }
+        return looperName.contains("mqt_js")
     }
 
     private fun formatLooperResource(thread: String, executionType: String? = null): Map<String, Any> {
@@ -187,14 +185,7 @@ class QueryStatusActionHandler(
      * @see URL https://reactnative.dev/docs/profiling
      */
     private fun isNativeCodeExecution(looperName: String): Boolean {
-        val options = arrayOf(
-                "mqt_native",
-                "NativeCall",
-                "callJavaModuleMethod",
-                "onBatchComplete"
-        )
-
-        return options.any { looperName.contains(it) }
+        return looperName.contains("mqt_native")
     }
 }
 

--- a/detox/android/detox/src/full/java/com/wix/detox/adapters/server/QueryStatusActionHandler.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/adapters/server/QueryStatusActionHandler.kt
@@ -1,0 +1,96 @@
+package com.wix.detox.adapters.server
+
+import androidx.test.espresso.IdlingResource
+import com.wix.detox.TestEngineFacade
+import com.wix.detox.reactnative.idlingresources.DescriptiveIdlingResource
+
+class QueryStatusActionHandler(
+    private val outboundServerAdapter: OutboundServerAdapter,
+    private val testEngineFacade: TestEngineFacade
+)
+    : DetoxActionHandler {
+
+    override fun handle(params: String, messageId: Long) {
+        val data = mutableMapOf<String, Any?>()
+        data["status"] = formatStatus(testEngineFacade.getBusyIdlingResources())
+
+        outboundServerAdapter.sendMessage("currentStatusResult", data, messageId)
+    }
+
+    private fun formatStatus(busyResources: List<IdlingResource>): Map<String, Any> {
+        if (busyResources.isEmpty()) {
+            return mapOf("app_status" to "idle")
+        }
+
+        val status = mutableMapOf<String, Any>()
+        status["app_status"] = "busy"
+        status["busy_resources"] = busyResources.map{ formatResource(it) }
+
+        return status
+    }
+
+    private fun formatResource(resource: IdlingResource): Map<String, Any> {
+        if (resource is DescriptiveIdlingResource) {
+            return resource.getDescription().json()
+        }
+
+        if (resource.javaClass.name.contains("LooperIdlingResource")) {
+            return formatLooperResourceFromName(resource.name)
+        }
+
+        return mapOf<String, Any>(
+            "name" to "unknown",
+            "description" to mapOf<String, Any>(
+                "identifier" to resource.name
+            )
+        )
+    }
+
+    private fun formatLooperResourceFromName(resourceName: String): Map<String, Any> {
+        return when {
+            isJSCodeExecution(resourceName) -> {
+                formatLooperResource(
+                    "\"${resourceName}\" (JS Thread)",
+                    "JavaScript code"
+                )
+            }
+            isNativeCodeExecution(resourceName) -> {
+                formatLooperResource(
+                    "\"${resourceName}\" (Native Modules Thread)",
+                    "native module calls"
+                )
+            }
+            else -> {
+                formatLooperResource(
+                    "\"${resourceName}\""
+                )
+            }
+        }
+    }
+
+    /**
+     * @see URL https://reactnative.dev/docs/profiling
+     */
+    private fun isJSCodeExecution(looperName: String): Boolean {
+        return looperName.contains("mqt_js")
+    }
+
+    private fun formatLooperResource(thread: String, executionType: String? = null): Map<String, Any> {
+        return mapOf<String, Any>(
+            "name" to "looper",
+            "description" to
+                    mutableMapOf<String, Any>(
+                        "thread" to thread
+                    ).apply {
+                        if (executionType != null) put("execution_type", executionType)
+                    }
+        )
+    }
+
+    /**
+     * @see URL https://reactnative.dev/docs/profiling
+     */
+    private fun isNativeCodeExecution(looperName: String): Boolean {
+        return looperName.contains("mqt_native")
+    }
+}

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AnimatedModuleIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AnimatedModuleIdlingResource.java
@@ -1,9 +1,12 @@
 package com.wix.detox.reactnative.idlingresources;
 
+import java.util.HashMap;
+import java.util.Map;
 import android.util.Log;
 import android.view.Choreographer;
 
 import com.wix.detox.reactnative.ReactNativeInfo;
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
 
 import org.jetbrains.annotations.NotNull;
 import org.joor.Reflect;
@@ -67,6 +70,19 @@ public class AnimatedModuleIdlingResource implements DescriptiveIdlingResource, 
     @Override
     public String getDescription() {
         return "Animations running on screen";
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> getJSONDescription() {
+        final Map<String, Object> jsonDescription = new HashMap<>();
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "ui");
+
+        final Map<String, Object> description = new HashMap<>();
+        description.put("reason", "Animations running on screen");
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
+
+        return jsonDescription;
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AnimatedModuleIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AnimatedModuleIdlingResource.java
@@ -68,12 +68,6 @@ public class AnimatedModuleIdlingResource implements DescriptiveIdlingResource, 
 
     @NotNull
     @Override
-    public String getDescription() {
-        return "Animations running on screen";
-    }
-
-    @NotNull
-    @Override
     public Map<String, Object> getJSONDescription() {
         final Map<String, Object> jsonDescription = new HashMap<>();
         jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "ui");

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AnimatedModuleIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AnimatedModuleIdlingResource.java
@@ -68,15 +68,11 @@ public class AnimatedModuleIdlingResource implements DescriptiveIdlingResource, 
 
     @NotNull
     @Override
-    public Map<String, Object> getJSONDescription() {
-        final Map<String, Object> jsonDescription = new HashMap<>();
-        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "ui");
-
-        final Map<String, Object> description = new HashMap<>();
-        description.put("reason", "Animations running on screen");
-        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
-
-        return jsonDescription;
+    public IdlingResourceDescription getDescription() {
+        return new IdlingResourceDescription.Builder()
+                .name("ui")
+                .addDescription("reason", "Animations running on screen")
+                .build();
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AnimatedModuleIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AnimatedModuleIdlingResource.java
@@ -1,12 +1,9 @@
 package com.wix.detox.reactnative.idlingresources;
 
-import java.util.HashMap;
-import java.util.Map;
 import android.util.Log;
 import android.view.Choreographer;
 
 import com.wix.detox.reactnative.ReactNativeInfo;
-import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
 
 import org.jetbrains.annotations.NotNull;
 import org.joor.Reflect;

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResource.kt
@@ -8,6 +8,8 @@ import com.wix.detox.reactnative.helpers.RNHelpers
 import org.joor.Reflect
 import java.util.concurrent.Executor
 
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants
+
 private typealias SExecutorReflectedGenFnType = (executor: Executor) -> SerialExecutorReflected
 private val defaultSExecutorReflectedGenFn: SExecutorReflectedGenFnType = { executor: Executor -> SerialExecutorReflected(executor) }
 
@@ -51,6 +53,11 @@ open class AsyncStorageIdlingResource
 
     override fun getName(): String = javaClass.name
     override fun getDescription() = "Disk I/O activity"
+
+    override fun getJSONDescription(): Map<String, Any> {
+        return mapOf<String, Any>( IdlingResourceConstants.RESOURCE_NAME_KEY to "io")
+    }
+
     override fun isIdleNow(): Boolean =
         checkIdle().also { idle ->
             if (!idle) {

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResource.kt
@@ -52,7 +52,6 @@ open class AsyncStorageIdlingResource
     }
 
     override fun getName(): String = javaClass.name
-    override fun getDescription() = "Disk I/O activity"
 
     override fun getJSONDescription(): Map<String, Any> {
         return mapOf<String, Any>( IdlingResourceConstants.RESOURCE_NAME_KEY to "io")

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResource.kt
@@ -8,8 +8,6 @@ import com.wix.detox.reactnative.helpers.RNHelpers
 import org.joor.Reflect
 import java.util.concurrent.Executor
 
-import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants
-
 private typealias SExecutorReflectedGenFnType = (executor: Executor) -> SerialExecutorReflected
 private val defaultSExecutorReflectedGenFn: SExecutorReflectedGenFnType = { executor: Executor -> SerialExecutorReflected(executor) }
 
@@ -53,8 +51,8 @@ open class AsyncStorageIdlingResource
 
     override fun getName(): String = javaClass.name
 
-    override fun getJSONDescription(): Map<String, Any> {
-        return mapOf<String, Any>( IdlingResourceConstants.RESOURCE_NAME_KEY to "io")
+    override fun getDescription(): IdlingResourceDescription {
+        return IdlingResourceDescription.Builder().name("io").build()
     }
 
     override fun isIdleNow(): Boolean =

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/BridgeIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/BridgeIdlingResource.java
@@ -7,7 +7,11 @@ import com.facebook.react.bridge.ReactContext;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
 
 /**
  * Created by simonracz on 01/06/2017.
@@ -44,6 +48,19 @@ public class BridgeIdlingResource extends DetoxBaseIdlingResource implements Not
     @Override
     public String getDescription() {
         return "Activity on the React-Native bridge";
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> getJSONDescription() {
+        final Map<String, Object> jsonDescription = new HashMap<>();
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "one_time_event");
+
+        final Map<String, Object> description = new HashMap<>();
+        description.put("event", "Activity on the React-Native bridge");
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
+
+        return jsonDescription;
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/BridgeIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/BridgeIdlingResource.java
@@ -46,12 +46,6 @@ public class BridgeIdlingResource extends DetoxBaseIdlingResource implements Not
 
     @NotNull
     @Override
-    public String getDescription() {
-        return "Activity on the React-Native bridge";
-    }
-
-    @NotNull
-    @Override
     public Map<String, Object> getJSONDescription() {
         final Map<String, Object> jsonDescription = new HashMap<>();
         jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "one_time_event");

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/BridgeIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/BridgeIdlingResource.java
@@ -11,8 +11,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
-
 /**
  * Created by simonracz on 01/06/2017.
  */
@@ -46,11 +44,8 @@ public class BridgeIdlingResource extends DetoxBaseIdlingResource implements Not
 
     @NotNull
     @Override
-    public Map<String, Object> getJSONDescription() {
-        final Map<String, Object> jsonDescription = new HashMap<>();
-        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "bridge");
-
-        return jsonDescription;
+    public IdlingResourceDescription getDescription() {
+        return new IdlingResourceDescription.Builder().name("bridge").build();
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/BridgeIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/BridgeIdlingResource.java
@@ -48,11 +48,7 @@ public class BridgeIdlingResource extends DetoxBaseIdlingResource implements Not
     @Override
     public Map<String, Object> getJSONDescription() {
         final Map<String, Object> jsonDescription = new HashMap<>();
-        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "one_time_event");
-
-        final Map<String, Object> description = new HashMap<>();
-        description.put("event", "Activity on the React-Native bridge");
-        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "bridge");
 
         return jsonDescription;
     }

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/DescriptiveIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/DescriptiveIdlingResource.kt
@@ -4,4 +4,9 @@ import androidx.test.espresso.IdlingResource
 
 interface DescriptiveIdlingResource: IdlingResource {
     fun getDescription(): String
+
+    /**
+     * Returns a descriptive JSON representation of the resource.
+     */
+    fun getJSONDescription(): Map<String, Any>
 }

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/DescriptiveIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/DescriptiveIdlingResource.kt
@@ -3,8 +3,6 @@ package com.wix.detox.reactnative.idlingresources
 import androidx.test.espresso.IdlingResource
 
 interface DescriptiveIdlingResource: IdlingResource {
-    fun getDescription(): String
-
     /**
      * Returns a descriptive JSON representation of the resource.
      */

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/DescriptiveIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/DescriptiveIdlingResource.kt
@@ -4,7 +4,7 @@ import androidx.test.espresso.IdlingResource
 
 interface DescriptiveIdlingResource: IdlingResource {
     /**
-     * Returns a descriptive JSON representation of the resource.
+     * Returns a descriptive representation of the resource.
      */
-    fun getJSONDescription(): Map<String, Any>
+    fun getDescription(): IdlingResourceDescription
 }

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/IdlingResourceConstants.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/IdlingResourceConstants.kt
@@ -1,6 +1,0 @@
-package com.wix.detox.reactnative.idlingresources
-
-interface IdlingResourceConstants {
-    const val RESOURCE_NAME_KEY = "name"
-    const val RESOURCE_DESCRIPTION_KEY = "description"
-}

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/IdlingResourceConstants.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/IdlingResourceConstants.kt
@@ -1,0 +1,6 @@
+package com.wix.detox.reactnative.idlingresources
+
+interface IdlingResourceConstants {
+    const val RESOURCE_NAME_KEY = "name"
+    const val RESOURCE_DESCRIPTION_KEY = "description"
+}

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/IdlingResourceDescription.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/IdlingResourceDescription.kt
@@ -1,0 +1,20 @@
+package com.wix.detox.reactnative.idlingresources
+
+class IdlingResourceDescription private constructor(
+  private val name: String,
+  private val description: Map<String, Any>) {
+    fun json(): Map<String, Any> = mutableMapOf<String, Any>("name" to name)
+      .apply { if (description.isNotEmpty()) put("description", description) }
+
+    override fun equals(other: Any?): Boolean = other is IdlingResourceDescription &&
+        other.json() == this.json()
+
+    data class Builder(
+      var name: String = "unknown",
+      var description: MutableMap<String, Any> = mutableMapOf()) {
+
+        fun name(name: String) = apply { this.name = name }
+        fun addDescription(key: String, value: Any) = apply { this.description[key] = value }
+        fun build() = IdlingResourceDescription(name, description)
+    }
+}

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
@@ -1,5 +1,7 @@
 package com.wix.detox.reactnative.idlingresources;
 
+import java.util.HashMap;
+import java.util.Map;
 import android.util.Log;
 import android.view.Choreographer;
 
@@ -17,6 +19,8 @@ import java.util.regex.PatternSyntaxException;
 import androidx.annotation.NonNull;
 import okhttp3.Call;
 import okhttp3.Dispatcher;
+
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
 
 /**
  * Created by simonracz on 09/10/2017.
@@ -79,6 +83,19 @@ public class NetworkIdlingResource extends DetoxBaseIdlingResource implements Ch
         }
 
         return description;
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> getJSONDescription() {
+        final Map<String, Object> jsonDescription = new HashMap<>();
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "network");
+
+        final Map<String, Object> description = new HashMap<>();
+        description.put("urls", new ArrayList<String>(busyResources));
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
+
+        return jsonDescription;
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
@@ -75,18 +75,6 @@ public class NetworkIdlingResource extends DetoxBaseIdlingResource implements Ch
 
     @NotNull
     @Override
-    public String getDescription() {
-        String description = "In-flight network activity";
-
-        if (!busyResources.isEmpty()) {
-            description += "\nDetails:\n\t - " + busyResources.toString();
-        }
-
-        return description;
-    }
-
-    @NotNull
-    @Override
     public Map<String, Object> getJSONDescription() {
         final Map<String, Object> jsonDescription = new HashMap<>();
         jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "network");

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
@@ -1,7 +1,5 @@
 package com.wix.detox.reactnative.idlingresources;
 
-import java.util.HashMap;
-import java.util.Map;
 import android.util.Log;
 import android.view.Choreographer;
 
@@ -20,14 +18,10 @@ import androidx.annotation.NonNull;
 import okhttp3.Call;
 import okhttp3.Dispatcher;
 
-import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
 
 /**
  * Created by simonracz on 09/10/2017.
- */
-
-
-/**
+ *
  * Idling Resource which monitors React Native's OkHttpClient.
  * <p>
  * Must call stop() on it, before removing it from Espresso.
@@ -75,15 +69,11 @@ public class NetworkIdlingResource extends DetoxBaseIdlingResource implements Ch
 
     @NotNull
     @Override
-    public Map<String, Object> getJSONDescription() {
-        final Map<String, Object> jsonDescription = new HashMap<>();
-        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "network");
-
-        final Map<String, Object> description = new HashMap<>();
-        description.put("urls", new ArrayList<String>(busyResources));
-        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
-
-        return jsonDescription;
+    public IdlingResourceDescription getDescription() {
+        return new IdlingResourceDescription.Builder()
+                .name("network")
+                .addDescription("urls", new ArrayList<>(busyResources))
+                .build();
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
@@ -1,5 +1,7 @@
 package com.wix.detox.reactnative.idlingresources;
 
+import java.util.HashMap;
+import java.util.Map;
 import android.util.Log;
 import android.view.Choreographer;
 
@@ -8,6 +10,8 @@ import org.joor.Reflect;
 import org.joor.ReflectException;
 
 import androidx.annotation.NonNull;
+
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
 
 /**
  * Created by simonracz on 26/07/2017.
@@ -55,6 +59,19 @@ public class UIModuleIdlingResource extends DetoxBaseIdlingResource implements C
     @Override
     public String getDescription() {
         return "UI rendering activity";
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> getJSONDescription() {
+        final Map<String, Object> jsonDescription = new HashMap<>();
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "ui");
+
+        final Map<String, Object> description = new HashMap<>();
+        description.put("reason", "UI rendering activity");
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
+
+        return jsonDescription;
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
@@ -57,12 +57,6 @@ public class UIModuleIdlingResource extends DetoxBaseIdlingResource implements C
 
     @NotNull
     @Override
-    public String getDescription() {
-        return "UI rendering activity";
-    }
-
-    @NotNull
-    @Override
     public Map<String, Object> getJSONDescription() {
         final Map<String, Object> jsonDescription = new HashMap<>();
         jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "ui");

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
@@ -1,5 +1,6 @@
 package com.wix.detox.reactnative.idlingresources;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import android.util.Log;
@@ -10,8 +11,6 @@ import org.joor.Reflect;
 import org.joor.ReflectException;
 
 import androidx.annotation.NonNull;
-
-import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
 
 /**
  * Created by simonracz on 26/07/2017.
@@ -57,15 +56,11 @@ public class UIModuleIdlingResource extends DetoxBaseIdlingResource implements C
 
     @NotNull
     @Override
-    public Map<String, Object> getJSONDescription() {
-        final Map<String, Object> jsonDescription = new HashMap<>();
-        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "ui");
-
-        final Map<String, Object> description = new HashMap<>();
-        description.put("reason", "UI rendering activity");
-        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
-
-        return jsonDescription;
+    public IdlingResourceDescription getDescription() {
+        return new IdlingResourceDescription.Builder()
+                .name("ui")
+                .addDescription("reason", "UI rendering activity")
+                .build();
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResource.kt
@@ -14,7 +14,6 @@ class TimersIdlingResource @JvmOverloads constructor(
     private var callback: IdlingResource.ResourceCallback? = null
 
     override fun getName(): String = this.javaClass.name
-    override fun getDescription(): String = "Enqueued timers"
 
     override fun getJSONDescription(): Map<String, Any> {
         return mapOf<String, Any>( IdlingResourceConstants.RESOURCE_NAME_KEY to "timers")

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResource.kt
@@ -2,6 +2,8 @@ package com.wix.detox.reactnative.idlingresources.timers
 
 import android.view.Choreographer
 import androidx.test.espresso.IdlingResource
+
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants
 import com.wix.detox.reactnative.idlingresources.DetoxBaseIdlingResource
 
 class TimersIdlingResource @JvmOverloads constructor(
@@ -13,6 +15,10 @@ class TimersIdlingResource @JvmOverloads constructor(
 
     override fun getName(): String = this.javaClass.name
     override fun getDescription(): String = "Enqueued timers"
+
+    override fun getJSONDescription(): Map<String, Any> {
+        return mapOf<String, Any>( IdlingResourceConstants.RESOURCE_NAME_KEY to "timers")
+    }
 
     override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
         this.callback = callback

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResource.kt
@@ -3,8 +3,8 @@ package com.wix.detox.reactnative.idlingresources.timers
 import android.view.Choreographer
 import androidx.test.espresso.IdlingResource
 
-import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants
 import com.wix.detox.reactnative.idlingresources.DetoxBaseIdlingResource
+import com.wix.detox.reactnative.idlingresources.IdlingResourceDescription
 
 class TimersIdlingResource @JvmOverloads constructor(
         private val interrogationStrategy: IdleInterrogationStrategy,
@@ -15,8 +15,8 @@ class TimersIdlingResource @JvmOverloads constructor(
 
     override fun getName(): String = this.javaClass.name
 
-    override fun getJSONDescription(): Map<String, Any> {
-        return mapOf<String, Any>( IdlingResourceConstants.RESOURCE_NAME_KEY to "timers")
+    override fun getDescription(): IdlingResourceDescription {
+        return IdlingResourceDescription.Builder().name("timers").build();
     }
 
     override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {

--- a/detox/android/detox/src/testFull/java/com/wix/detox/adapters/server/QueryStatusActionHandlerSpec.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/adapters/server/QueryStatusActionHandlerSpec.kt
@@ -1,0 +1,131 @@
+package com.wix.detox.adapters.server
+
+import android.content.Context
+import androidx.test.espresso.IdlingResource
+import com.nhaarman.mockitokotlin2.*
+import com.wix.detox.TestEngineFacade
+import com.wix.detox.reactnative.idlingresources.DescriptiveIdlingResource
+import com.wix.detox.reactnative.idlingresources.IdlingResourceDescription
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object QueryStatusActionHandlerSpec : Spek({
+    describe("Query Status Action Handler") {
+        val params = "{\"mock\": \"params\"}"
+        val messageId = 666L
+
+        lateinit var outboundServerAdapter: OutboundServerAdapter
+        lateinit var testEngineFacade: TestEngineFacade
+
+        beforeEachTest {
+            outboundServerAdapter = mock()
+
+            testEngineFacade = mock()
+            whenever(testEngineFacade.awaitIdle()).then {
+                synchronized(testEngineFacade) {}
+            }
+            whenever(testEngineFacade.syncIdle()).then {
+                synchronized(testEngineFacade) {}
+            }
+        }
+
+        fun queryStatusHandler() = QueryStatusActionHandler(outboundServerAdapter, testEngineFacade)
+
+        it("should return idle app status") {
+            queryStatusHandler().handle(params, messageId)
+            val expectedData =  mapOf("status" to mapOf("app_status" to "idle"))
+            verify(outboundServerAdapter).sendMessage(eq("currentStatusResult"), eq(expectedData), eq(messageId))
+        }
+
+        fun createMockedDescriptiveResource(description: IdlingResourceDescription):
+                DescriptiveIdlingResource {
+            val resource: DescriptiveIdlingResource = mock()
+            whenever(resource.getDescription()).thenReturn(description)
+            return resource
+        }
+
+        it("should return busy app status with descriptive resource") {
+            val fakeDescription = IdlingResourceDescription.Builder()
+                .name("foo")
+                .addDescription("bar", "baz")
+                .addDescription("qux", "quux")
+                .build()
+
+            val busyResources: List<IdlingResource> = listOf(
+                createMockedDescriptiveResource(fakeDescription)
+            )
+            whenever(testEngineFacade.getBusyIdlingResources()).thenReturn(busyResources)
+
+            queryStatusHandler().handle(params, messageId)
+
+            val expectedBusyResourceDescription = listOf(
+                mapOf("name" to "foo", "description" to mapOf("bar" to "baz", "qux" to "quux"))
+            )
+            val expectedData =  mapOf("status" to mapOf("app_status" to "busy", "busy_resources" to expectedBusyResourceDescription))
+            verify(outboundServerAdapter).sendMessage(eq("currentStatusResult"), eq(expectedData), eq(messageId))
+        }
+
+        abstract class LooperIdlingResource: IdlingResource {}
+
+        fun createMockedLooperIdlingResource(resourceName: String): LooperIdlingResource {
+            val resource: LooperIdlingResource = mock()
+            whenever(resource.name).thenReturn(resourceName)
+            return resource
+        }
+
+        it("should return busy app status with looper resources") {
+            val busyResources: List<IdlingResource> = listOf(
+                createMockedLooperIdlingResource("mqt_js"),
+                createMockedLooperIdlingResource("mqt_native"),
+                createMockedLooperIdlingResource("unmapped")
+            )
+            whenever(testEngineFacade.getBusyIdlingResources()).thenReturn(busyResources)
+
+            queryStatusHandler().handle(params, messageId)
+
+            val expectedBusyResourceDescription = listOf(
+                mapOf(
+                    "name" to "looper",
+                    "description" to mapOf(
+                        "thread" to "\"mqt_js\" (JS Thread)",
+                        "execution_type" to "JavaScript code"
+                    )
+                ),
+                mapOf(
+                    "name" to "looper",
+                    "description" to mapOf(
+                        "thread" to "\"mqt_native\" (Native Modules Thread)",
+                        "execution_type" to "native module calls"
+                    )
+                ),
+                mapOf(
+                    "name" to "looper",
+                    "description" to mapOf("thread" to "\"unmapped\"")
+                )
+            )
+            val expectedData =  mapOf("status" to mapOf("app_status" to "busy", "busy_resources" to expectedBusyResourceDescription))
+            verify(outboundServerAdapter).sendMessage(eq("currentStatusResult"), eq(expectedData), eq(messageId))
+        }
+
+        fun createMockedIdlingResource(name: String): IdlingResource {
+            val resource: IdlingResource = mock()
+            whenever(resource.name).thenReturn(name)
+            return resource
+        }
+
+        it("should return busy app status with unknown resource") {
+            val busyResources: List<IdlingResource> = listOf(
+                createMockedIdlingResource( "quux")
+            )
+            whenever(testEngineFacade.getBusyIdlingResources()).thenReturn(busyResources)
+
+            queryStatusHandler().handle(params, messageId)
+
+            val expectedBusyResourceDescription = listOf(
+                mapOf("name" to "unknown", "description" to mapOf("identifier" to "quux"))
+            )
+            val expectedData =  mapOf("status" to mapOf("app_status" to "busy", "busy_resources" to expectedBusyResourceDescription))
+            verify(outboundServerAdapter).sendMessage(eq("currentStatusResult"), eq(expectedData), eq(messageId))
+        }
+    }
+})

--- a/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResourceSpec.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResourceSpec.kt
@@ -70,7 +70,11 @@ class AsyncStorageIdlingResourceSpec: Spek({
                 givenAnActiveTask()
                 givenNoPendingTasks()
                 assertThat(uut.isIdleNow).isFalse()
-                assertThat(uut.getJSONDescription()).isEqualTo(mapOf("name" to "io"))
+
+                val expectedDescription = IdlingResourceDescription.Builder()
+                    .name("io")
+                    .build()
+                assertThat(uut.getDescription()).isEqualTo(expectedDescription)
             }
 
             it("should be busy if executor has pending tasks") {

--- a/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResourceSpec.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResourceSpec.kt
@@ -70,6 +70,7 @@ class AsyncStorageIdlingResourceSpec: Spek({
                 givenAnActiveTask()
                 givenNoPendingTasks()
                 assertThat(uut.isIdleNow).isFalse()
+                assertThat(uut.getJSONDescription()).isEqualTo(mapOf("name" to "io"))
             }
 
             it("should be busy if executor has pending tasks") {

--- a/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/IdlingResourceDescriptionSpec.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/IdlingResourceDescriptionSpec.kt
@@ -30,5 +30,17 @@ class IdlingResourceDescriptionSpec: Spek({
             Assertions.assertThat(description.json()).isEqualTo(expectedJSON)
         }
 
+        it("should build without name") {
+            description = IdlingResourceDescription.Builder()
+                .addDescription("bar", "baz")
+                .addDescription("qux", "quux")
+                .build()
+
+            expectedJSON = mapOf(
+                "name" to "unknown",
+                "description" to mapOf("bar" to "baz", "qux" to "quux")
+            )
+            Assertions.assertThat(description.json()).isEqualTo(expectedJSON)
+        }
     }
 })

--- a/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/IdlingResourceDescriptionSpec.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/IdlingResourceDescriptionSpec.kt
@@ -1,0 +1,34 @@
+package com.wix.detox.reactnative.idlingresources
+
+import org.assertj.core.api.Assertions
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class IdlingResourceDescriptionSpec: Spek({
+    describe("Idling Resource Description Builder") {
+        lateinit var description: IdlingResourceDescription
+        lateinit var expectedJSON: Map<String, Any>
+
+        it("should build with given description") {
+            description = IdlingResourceDescription.Builder()
+                .name("foo")
+                .addDescription("bar", "baz")
+                .addDescription("qux", "quux")
+                .build()
+
+            expectedJSON = mapOf(
+                "name" to "foo",
+                "description" to mapOf("bar" to "baz", "qux" to "quux")
+            )
+            Assertions.assertThat(description.json()).isEqualTo(expectedJSON)
+        }
+
+        it("should build without description") {
+            description = IdlingResourceDescription.Builder().name("foo").build()
+
+            expectedJSON = mapOf("name" to "foo")
+            Assertions.assertThat(description.json()).isEqualTo(expectedJSON)
+        }
+
+    }
+})

--- a/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResourceSpec.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResourceSpec.kt
@@ -48,6 +48,7 @@ object TimersIdlingResourceSpec : Spek({
         it("should be busy if strategy says so") {
             givenBusyStrategy()
             Assertions.assertThat(uut().isIdleNow).isFalse()
+            Assertions.assertThat(uut().getJSONDescription()).isEqualTo(mapOf("name" to "timers"))
         }
 
         it("should transition to idle if found idle by strategy") {

--- a/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResourceSpec.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResourceSpec.kt
@@ -3,6 +3,7 @@ package com.wix.detox.reactnative.idlingresources.timers
 import android.view.Choreographer
 import androidx.test.espresso.IdlingResource
 import com.nhaarman.mockitokotlin2.*
+import com.wix.detox.reactnative.idlingresources.IdlingResourceDescription
 import org.assertj.core.api.Assertions
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -48,7 +49,11 @@ object TimersIdlingResourceSpec : Spek({
         it("should be busy if strategy says so") {
             givenBusyStrategy()
             Assertions.assertThat(uut().isIdleNow).isFalse()
-            Assertions.assertThat(uut().getJSONDescription()).isEqualTo(mapOf("name" to "timers"))
+
+            val expectedDescription = IdlingResourceDescription.Builder()
+                .name("timers")
+                .build()
+            Assertions.assertThat(uut().getDescription()).isEqualTo(expectedDescription)
         }
 
         it("should transition to idle if found idle by strategy") {

--- a/detox/ios/Detox/DetoxManager.swift
+++ b/detox/ios/Detox/DetoxManager.swift
@@ -377,8 +377,12 @@ public class DetoxManager : NSObject, WebSocketDelegate {
 			waitForRNLoad(withMessageId: messageId)
 			return
 		case "currentStatus":
-			DTXSyncManager.idleStatus { status in
-				self.webSocket.sendAction("currentStatusResult", params: ["messageId": messageId, "status": status], messageId: messageId)
+			DTXSyncManager.status { status in
+			  self.webSocket.sendAction(
+				"currentStatusResult",
+				params: ["messageId": messageId, "status": status],
+				messageId: messageId
+			  )
 			}
 			return
 		case "loginSuccess":

--- a/detox/src/client/Client.test.js
+++ b/detox/src/client/Client.test.js
@@ -242,7 +242,7 @@ describe('Client', () => {
     it('should consistently run "currentStatus" queries when it takes too long', async () => {
       await simulateInFlightAction();
 
-      mockAws.mockResponse('currentStatusResult', { status: 'zug-zug!' });
+      mockAws.mockResponse('currentStatusResult', { status: { app_status: 'idle' } });
       jest.advanceTimersByTime(validSession.debugSynchronization);
 
       expect(jest.getTimerCount()).toBe(0);
@@ -352,7 +352,7 @@ describe('Client', () => {
       ['waitForBackground', 'waitForBackgroundDone', actions.WaitForBackground],
       ['waitForActive', 'waitForActiveDone', actions.WaitForActive],
       ['waitUntilReady', 'ready', actions.Ready],
-      ['currentStatus', 'currentStatusResult', actions.CurrentStatus, {}, { status: 'App is idle' }],
+      ['currentStatus', 'currentStatusResult', actions.CurrentStatus, {}, { status: { app_status: 'idle' } }],
     ])('.%s', (methodName, expectedResponseType, Action, params, expectedResponseParams) => {
       beforeEach(async () => {
         await client.connect();

--- a/detox/src/client/actions/SyncStatusSchema.json
+++ b/detox/src/client/actions/SyncStatusSchema.json
@@ -343,6 +343,17 @@
               {
                 "properties":{
                   "name":{
+                    "const":"bridge"
+                  }
+                },
+                "required":[
+                  "name"
+                ],
+                "additionalProperties":false
+              },
+              {
+                "properties":{
+                  "name":{
                     "const":"unknown"
                   },
                   "description":{

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -1,5 +1,6 @@
 const { DetoxInternalError, DetoxRuntimeError } = require('../../errors');
 const { getDetoxLevel } = require('../../utils/logger');
+const formatJSONStatus = require('../actions/formatters/SyncStatusFormatter');
 
 class Action {
   constructor(type, params = {}) {
@@ -268,7 +269,7 @@ class CurrentStatus extends Action {
 
   async handle(response) {
     this.expectResponseOfType(response, 'currentStatusResult');
-    return response.params.status;
+    return formatJSONStatus(response.params.status);
   }
 }
 

--- a/detox/src/client/actions/formatters/SyncStatusFormatter.js
+++ b/detox/src/client/actions/formatters/SyncStatusFormatter.js
@@ -61,6 +61,7 @@ const resourceFormatters = {
   looper: looperFormatter,
   io: () => { return makeResourceTitle(`Disk I/O activity.`); },
   unknown: unknownResourceFormatter,
+  bridge: () => { return makeResourceTitle(`Activity on the React-Native bridge.`); },
 };
 
 function resourceDescriptionFromJSON(jsonDescription) {

--- a/detox/src/client/actions/formatters/SyncStatusFormatter.test.js
+++ b/detox/src/client/actions/formatters/SyncStatusFormatter.test.js
@@ -348,6 +348,19 @@ describe('Sync Status Formatter', () => {
       await expect(format(busyStatus)).toMatchSnapshot();
     });
 
+    it('should format "bridge" correctly', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'bridge'
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toMatchSnapshot();
+    });
+
     it('should format "unknown" correctly', async () => {
       let busyStatus = {
         app_status: 'busy',

--- a/detox/src/client/actions/formatters/__snapshots__/SyncStatusFormatter.test.js.snap
+++ b/detox/src/client/actions/formatters/__snapshots__/SyncStatusFormatter.test.js.snap
@@ -58,7 +58,8 @@ With reasons:
 • must have required property 'description' in path \\"#/oneOf/1/properties/busy_resources/items/anyOf/7/required\\" with params: {\\"missingProperty\\":\\"description\\"}
 • must have required property 'description' in path \\"#/oneOf/1/properties/busy_resources/items/anyOf/8/required\\" with params: {\\"missingProperty\\":\\"description\\"}
 • must be equal to constant in path \\"#/oneOf/1/properties/busy_resources/items/anyOf/9/properties/name/const\\" with params: {\\"allowedValue\\":\\"io\\"}
-• must have required property 'description' in path \\"#/oneOf/1/properties/busy_resources/items/anyOf/10/required\\" with params: {\\"missingProperty\\":\\"description\\"}
+• must be equal to constant in path \\"#/oneOf/1/properties/busy_resources/items/anyOf/10/properties/name/const\\" with params: {\\"allowedValue\\":\\"bridge\\"}
+• must have required property 'description' in path \\"#/oneOf/1/properties/busy_resources/items/anyOf/11/required\\" with params: {\\"missingProperty\\":\\"description\\"}
 • must match a schema in anyOf in path \\"#/oneOf/1/properties/busy_resources/items/anyOf\\" with params: {}
 • must match exactly one schema in oneOf in path \\"#/oneOf\\" with params: {\\"passingSchemas\\":null}
 
@@ -81,11 +82,17 @@ With reasons:
 • must have required property 'name' in path \\"#/oneOf/1/properties/busy_resources/items/anyOf/8/required\\" with params: {\\"missingProperty\\":\\"name\\"}
 • must have required property 'name' in path \\"#/oneOf/1/properties/busy_resources/items/anyOf/9/required\\" with params: {\\"missingProperty\\":\\"name\\"}
 • must have required property 'name' in path \\"#/oneOf/1/properties/busy_resources/items/anyOf/10/required\\" with params: {\\"missingProperty\\":\\"name\\"}
+• must have required property 'name' in path \\"#/oneOf/1/properties/busy_resources/items/anyOf/11/required\\" with params: {\\"missingProperty\\":\\"name\\"}
 • must match a schema in anyOf in path \\"#/oneOf/1/properties/busy_resources/items/anyOf\\" with params: {}
 • must match exactly one schema in oneOf in path \\"#/oneOf\\" with params: {\\"passingSchemas\\":null}
 
 Please report this issue on our GitHub tracker:
 https://github.com/wix/Detox/issues"
+`;
+
+exports[`Sync Status Formatter busy status should format "bridge" correctly 1`] = `
+"The app is busy with the following tasks:
+• Activity on the React-Native bridge."
 `;
 
 exports[`Sync Status Formatter busy status should format "delayed_perform_selector" correctly 1`] = `

--- a/detox/test/.gitignore
+++ b/detox/test/.gitignore
@@ -25,7 +25,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
-project.xcworkspace
+example.xcworkspace
 
 # Android/IJ
 #

--- a/detox/test/e2e/detox.config.js
+++ b/detox/test/e2e/detox.config.js
@@ -54,7 +54,7 @@ const config = {
       type: 'ios.app',
       name: 'example',
       binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/example.app',
-      build: 'set -o pipefail && xcodebuild -workspace ios/example.xcworkspace -UseNewBuildSystem=NO -scheme example_ci -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet',
+      build: 'set -o pipefail && xcodebuild -workspace ios/example.xcworkspace -UseNewBuildSystem=YES -scheme example_ci -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet',
       bundleId: 'com.wix.detox-example',
     },
 
@@ -62,7 +62,7 @@ const config = {
       type: 'ios.app',
       name: 'example',
       binaryPath: 'ios/build/Build/Products/Release-iphonesimulator/example.app',
-      build: 'set -o pipefail && export CODE_SIGNING_REQUIRED=NO && export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/example.xcworkspace -UseNewBuildSystem=NO -scheme example_ci -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet',
+      build: 'set -o pipefail && export CODE_SIGNING_REQUIRED=NO && export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/example.xcworkspace -UseNewBuildSystem=YES -scheme example_ci -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet',
     },
 
     'android.debug': {

--- a/docs/Troubleshooting.Synchronization.md
+++ b/docs/Troubleshooting.Synchronization.md
@@ -58,19 +58,18 @@ detox test --debug-synchronization 500
 Then, reproduce your issue, and you should see output similar to the following:
 
 ```plain text
-18:11:41 detox[15415] INFO:  [actions.js] The system is busy with the following tasks:
-18:11:41 
-18:11:41 Dispatch Queue
-18:11:41 ⏱ Queue: “Main Queue (<OS_dispatch_queue_main: com.apple.main-thread>)” with 1 work item
-18:11:41 
-18:11:41 Run Loop
-18:11:41 ⏱ “Main Run Loop”
-18:11:41 
-18:11:41 One-time Events
-18:11:41 ⏱ “Network Request” with object: “URL: “http://localhost:9001/delay/3000””
+detox[9733] INFO:  [APP_STATUS] The app is busy with the following tasks:
+• There are 1 work items pending on the dispatch queue: "Main Queue (<OS_dispatch_queue_main: com.apple.main-thread>)".
+• Run loop "Main Run Loop" is awake.
+• 1 enqueued native timers:
+  - Timer #1:
+    + Fire date: 2021-11-11 14:19:57 +0200.
+    + Time until fire: 0.072.
+    + Repeat interval: 0.
+    + Is recurring: NO.
 ```
 
-See [this document](https://github.com/wix/DetoxSync/blob/master/StatusDocumentation.md) for documentation of the synchronization debut output.
+See [this document](https://github.com/wix/DetoxSync/blob/master/StatusDocumentation.md) for documentation of the debug synchronization output.
 
 #### Lower-level Idling Resources Debug (iOS Only)
 


### PR DESCRIPTION
This pull request addresses the issue described here: Unify debug-sync logs between platforms #2714

As part of this change:

1. iOS: Update DetoxSync to the latest commit.
2. Android: Replace the old string sync-status with a JSON description
3. Unify debug-sync logs between the platforms, using a JSON formatter.

### Examples for _Android_ sync-status formatted messages:
```
detox[9160] INFO:  [APP_STATUS] The app seems to be idle
```
```
detox[9160] INFO:  [APP_STATUS] The app is busy with the following tasks:
• "LooperIdlingResource-2215-mqt_native_modules" (Native Modules Thread) is executing (native module calls).
• "LooperIdlingResource-2214-mqt_js" (JS Thread) is executing (JavaScript code).
• UI elements are busy:
  - Reason: UI rendering activity.
```

### Examples for _iOS_ sync-status formatted messages:

```
detox[9733] INFO:  [APP_STATUS] The app is busy with the following tasks:
• Run loop "JS Run Loop" is awake.
• There are 2 work items pending on the dispatch queue: "Main Queue (<OS_dispatch_queue_main: com.apple.main-thread>)".
• The event "Runloop Perform Block" is taking place with object: "JS Run Loop".
• The event "Runloop Perform Block" is taking place with object: "JS Run Loop".
• Run loop "Main Run Loop" is awake.
• The event "React Native (bundle load)" is taking place.
```

```
detox[9733] INFO:  [APP_STATUS] The app is busy with the following tasks:
• There are 1 work items pending on the dispatch queue: "Main Queue (<OS_dispatch_queue_main: com.apple.main-thread>)".
• Run loop "Main Run Loop" is awake.
• 1 enqueued native timers:
  - Timer #1:
    + Fire date: 2021-11-11 14:19:57 +0200.
    + Time until fire: 0.072.
    + Repeat interval: 0.
    + Is recurring: NO.
```