### PR TITLE
Debug Sync Logs: unify debug-sync logs between the platforms.

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AnimatedModuleIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AnimatedModuleIdlingResource.java
@@ -1,9 +1,12 @@
 package com.wix.detox.reactnative.idlingresources;
 
+import java.util.HashMap;
+import java.util.Map;
 import android.util.Log;
 import android.view.Choreographer;
 
 import com.wix.detox.reactnative.ReactNativeInfo;
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
 
 import org.jetbrains.annotations.NotNull;
 import org.joor.Reflect;
@@ -65,8 +68,15 @@ public class AnimatedModuleIdlingResource implements DescriptiveIdlingResource, 
 
     @NotNull
     @Override
-    public String getDescription() {
-        return "Animations running on screen";
+    public Map<String, Object> getJSONDescription() {
+        final Map<String, Object> jsonDescription = new HashMap<>();
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "ui");
+
+        final Map<String, Object> description = new HashMap<>();
+        description.put("reason", "Animations running on screen");
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
+
+        return jsonDescription;
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/AsyncStorageIdlingResource.kt
@@ -8,6 +8,8 @@ import com.wix.detox.reactnative.helpers.RNHelpers
 import org.joor.Reflect
 import java.util.concurrent.Executor
 
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants
+
 private typealias SExecutorReflectedGenFnType = (executor: Executor) -> SerialExecutorReflected
 private val defaultSExecutorReflectedGenFn: SExecutorReflectedGenFnType = { executor: Executor -> SerialExecutorReflected(executor) }
 
@@ -50,7 +52,11 @@ open class AsyncStorageIdlingResource
     }
 
     override fun getName(): String = javaClass.name
-    override fun getDescription() = "Disk I/O activity"
+
+    override fun getJSONDescription(): Map<String, Any> {
+        return mapOf<String, Any>( IdlingResourceConstants.RESOURCE_NAME_KEY to "io")
+    }
+
     override fun isIdleNow(): Boolean =
         checkIdle().also { idle ->
             if (!idle) {

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/BridgeIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/BridgeIdlingResource.java
@@ -7,7 +7,11 @@ import com.facebook.react.bridge.ReactContext;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
 
 /**
  * Created by simonracz on 01/06/2017.
@@ -42,8 +46,15 @@ public class BridgeIdlingResource extends DetoxBaseIdlingResource implements Not
 
     @NotNull
     @Override
-    public String getDescription() {
-        return "Activity on the React-Native bridge";
+    public Map<String, Object> getJSONDescription() {
+        final Map<String, Object> jsonDescription = new HashMap<>();
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "one_time_event");
+
+        final Map<String, Object> description = new HashMap<>();
+        description.put("event", "Activity on the React-Native bridge");
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
+
+        return jsonDescription;
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/DescriptiveIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/DescriptiveIdlingResource.kt
@@ -3,5 +3,8 @@ package com.wix.detox.reactnative.idlingresources
 import androidx.test.espresso.IdlingResource
 
 interface DescriptiveIdlingResource: IdlingResource {
-    fun getDescription(): String
+    /**
+     * Returns a descriptive JSON representation of the resource.
+     */
+    fun getJSONDescription(): Map<String, Any>
 }

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/IdlingResourceConstants.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/IdlingResourceConstants.kt
@@ -1,0 +1,6 @@
+package com.wix.detox.reactnative.idlingresources
+
+object IdlingResourceConstants {
+    const val RESOURCE_NAME_KEY = "name"
+    const val RESOURCE_DESCRIPTION_KEY = "description"
+}

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
@@ -1,5 +1,7 @@
 package com.wix.detox.reactnative.idlingresources;
 
+import java.util.HashMap;
+import java.util.Map;
 import android.util.Log;
 import android.view.Choreographer;
 
@@ -17,6 +19,8 @@ import java.util.regex.PatternSyntaxException;
 import androidx.annotation.NonNull;
 import okhttp3.Call;
 import okhttp3.Dispatcher;
+
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
 
 /**
  * Created by simonracz on 09/10/2017.
@@ -71,14 +75,15 @@ public class NetworkIdlingResource extends DetoxBaseIdlingResource implements Ch
 
     @NotNull
     @Override
-    public String getDescription() {
-        String description = "In-flight network activity";
+    public Map<String, Object> getJSONDescription() {
+        final Map<String, Object> jsonDescription = new HashMap<>();
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "network");
 
-        if (!busyResources.isEmpty()) {
-            description += "\nDetails:\n\t - " + busyResources.toString();
-        }
+        final Map<String, Object> description = new HashMap<>();
+        description.put("urls", new ArrayList<String>(busyResources));
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
 
-        return description;
+        return jsonDescription;
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
@@ -1,5 +1,7 @@
 package com.wix.detox.reactnative.idlingresources;
 
+import java.util.HashMap;
+import java.util.Map;
 import android.util.Log;
 import android.view.Choreographer;
 
@@ -8,6 +10,8 @@ import org.joor.Reflect;
 import org.joor.ReflectException;
 
 import androidx.annotation.NonNull;
+
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants;
 
 /**
  * Created by simonracz on 26/07/2017.
@@ -53,8 +57,15 @@ public class UIModuleIdlingResource extends DetoxBaseIdlingResource implements C
 
     @NotNull
     @Override
-    public String getDescription() {
-        return "UI rendering activity";
+    public Map<String, Object> getJSONDescription() {
+        final Map<String, Object> jsonDescription = new HashMap<>();
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_NAME_KEY, "ui");
+
+        final Map<String, Object> description = new HashMap<>();
+        description.put("reason", "UI rendering activity");
+        jsonDescription.put(IdlingResourceConstants.RESOURCE_DESCRIPTION_KEY, description);
+
+        return jsonDescription;
     }
 
     @Override

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResource.kt
@@ -2,6 +2,8 @@ package com.wix.detox.reactnative.idlingresources.timers
 
 import android.view.Choreographer
 import androidx.test.espresso.IdlingResource
+
+import com.wix.detox.reactnative.idlingresources.IdlingResourceConstants
 import com.wix.detox.reactnative.idlingresources.DetoxBaseIdlingResource
 
 class TimersIdlingResource @JvmOverloads constructor(
@@ -12,7 +14,10 @@ class TimersIdlingResource @JvmOverloads constructor(
     private var callback: IdlingResource.ResourceCallback? = null
 
     override fun getName(): String = this.javaClass.name
-    override fun getDescription(): String = "Enqueued timers"
+
+    override fun getJSONDescription(): Map<String, Any> {
+        return mapOf<String, Any>( IdlingResourceConstants.RESOURCE_NAME_KEY to "timers")
+    }
 
     override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
         this.callback = callback

--- a/detox/ios/Detox/DetoxManager.swift
+++ b/detox/ios/Detox/DetoxManager.swift
@@ -377,8 +377,12 @@ public class DetoxManager : NSObject, WebSocketDelegate {
 			waitForRNLoad(withMessageId: messageId)
 			return
 		case "currentStatus":
-			DTXSyncManager.idleStatus { status in
-				self.webSocket.sendAction("currentStatusResult", params: ["messageId": messageId, "status": status], messageId: messageId)
+			DTXSyncManager.status { status in
+			  self.webSocket.sendAction(
+				"currentStatusResult",
+				params: ["messageId": messageId, "status": status],
+				messageId: messageId
+			  )
 			}
 			return
 		case "loginSuccess":

--- a/detox/package.json
+++ b/detox/package.json
@@ -72,7 +72,8 @@
     "which": "^1.3.1",
     "ws": "^7.0.0",
     "yargs": "^16.0.3",
-    "yargs-unparser": "^2.0.0"
+    "yargs-unparser": "^2.0.0",
+    "ajv": "^8.6.3"
   },
   "peerDependencies": {
     "jest-circus": "26.0.x - 26.4.x || >=26.5.2",

--- a/detox/src/client/actions/SyncStatusFormatter.js
+++ b/detox/src/client/actions/SyncStatusFormatter.js
@@ -1,0 +1,277 @@
+const Ajv = require('ajv');
+
+const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
+
+class SyncStatusFormatter {
+  static formatJSONStatus(jsonStatus) {
+    if (!SyncStatusFormatter.isValidJSONStatus(jsonStatus)) {
+      throw new DetoxRuntimeError(`Given sync status is not compatible with the status schema, ` +
+        `given status: ${JSON.stringify(jsonStatus)}`);
+    }
+
+    if (SyncStatusFormatter.isAppIdle(jsonStatus)) {
+      return 'The app seems to be idle';
+    }
+
+    if (jsonStatus.busy_resources === undefined) {
+      throw new DetoxRuntimeError(`Given sync status is invalid, app is busy but busy-resources are not defined`);
+    }
+    const resourcesDescriptions = SyncStatusFormatter.resourcesDescriptionsFromJSON(jsonStatus.busy_resources);
+    return `The app is busy with the following tasks:\n${resourcesDescriptions.join('\n')}`;
+  }
+
+  static isValidJSONStatus(jsonStatus) {
+    const ajv = new Ajv();
+    const isValidStatus = ajv.compile(SyncStatusFormatter.jsonStatusSchema());
+    return isValidStatus(jsonStatus);
+  }
+
+  static jsonStatusSchema() {
+    return {
+      type: 'object',
+      properties: {
+        app_status: { 'enum': ['busy', 'idle'] },
+        busy_resources: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              name: { 'type': 'string' },
+              description: {
+                type: 'object',
+                additionalProperties: true
+              }
+            },
+            required: ['name'],
+            additionalProperties: false
+          }
+        }
+      },
+      required: ['app_status'],
+      additionalProperties: false
+    };
+  }
+
+  static isAppIdle(jsonStatus) {
+    return jsonStatus.app_status === 'idle' ||
+      (jsonStatus.busy_resources !== undefined && !jsonStatus.busy_resources.length);
+  }
+
+  static resourcesDescriptionsFromJSON(jsonDescriptions) {
+    let descriptions = [];
+    for (const jsonDescription of jsonDescriptions) {
+      const description = SyncStatusFormatter.resourceDescriptionFromJSON(jsonDescription);
+      descriptions.push(description);
+    }
+
+    return descriptions;
+  }
+
+  static resourceDescriptionFromJSON(jsonDescription) {
+    const resourceName = jsonDescription.name;
+    const properties = jsonDescription.description;
+
+    switch (resourceName) {
+      case 'delayed_perform_selector':
+        return SyncStatusFormatter.delayedPerformSelectorResourceDescriptionFromProperties(properties);
+
+      case 'dispatch_queue':
+        return SyncStatusFormatter.dispatchQueueResourceDescriptionFromProperties(properties);
+
+      case 'run_loop':
+        return SyncStatusFormatter.runLoopResourceDescriptionFromProperties(properties);
+
+      case 'one_time_events':
+        return SyncStatusFormatter.oneTimeEventDescriptionFromProperties(properties);
+
+      case 'timers':
+        return SyncStatusFormatter.timersResourceDescriptionFromProperties(properties);
+
+      case 'ui':
+        return SyncStatusFormatter.uiResourceDescriptionFromProperties(properties);
+
+      case 'js_timers':
+        return SyncStatusFormatter.jsTimersResourceDescriptionFromProperties(properties);
+
+      case 'network':
+        return SyncStatusFormatter.networkResourceDescriptionFromProperties(properties);
+
+      case 'looper':
+        return SyncStatusFormatter.looperResourceDescriptionFromProperties(properties);
+
+      case 'io':
+        return SyncStatusFormatter.resourceTitle(`Disk I/O activity.`);
+
+      case 'unknown':
+        return SyncStatusFormatter.unknownResourceDescriptionFromProperties(properties);
+
+      default:
+        throw new DetoxRuntimeError(`Given sync status is invalid, cannot find resource name: \`${resourceName}\``);
+    }
+  }
+
+  static delayedPerformSelectorResourceDescriptionFromProperties(properties) {
+    const pendingSelectors = SyncStatusFormatter.getPropertyFromObject('pending_selectors', properties);
+    return SyncStatusFormatter.resourceTitle(`There are ${pendingSelectors} pending delayed selectors to be ` +
+      `performed.`);
+  }
+
+  static getPropertyFromObject(propertyName, object) {
+    const property = object[propertyName];
+    if (property === undefined) {
+      throw new DetoxRuntimeError(`Given sync status is invalid. Cannot find \`${propertyName}\` property for ` +
+        `resource description`);
+    }
+
+    return property;
+  }
+
+  static resourceTitle(string) {
+    return `• ${string}`;
+  }
+
+  static dispatchQueueResourceDescriptionFromProperties(properties) {
+    const workItemsCount = SyncStatusFormatter.getPropertyFromObject('works_count', properties);
+    const queue = SyncStatusFormatter.getPropertyFromObject('queue', properties);
+    return SyncStatusFormatter.resourceTitle(`There are ${workItemsCount} work items pending on the ` +
+      `dispatch queue: "${queue}".`);
+  }
+
+  static runLoopResourceDescriptionFromProperties(properties) {
+    const runLoopName = SyncStatusFormatter.getPropertyFromObject('name', properties);
+    return SyncStatusFormatter.resourceTitle(`Run loop "${runLoopName}" is awake.`);
+  }
+
+  static oneTimeEventDescriptionFromProperties(properties) {
+    const eventName = SyncStatusFormatter.getPropertyFromObject('event', properties);
+    const objectName = properties['object'];
+
+    return SyncStatusFormatter.resourceTitle(`The event "${eventName}" is taking place` +
+      `${(objectName === null) ? `.` : ` with object: "${objectName}".`}`);
+  }
+
+  static timersResourceDescriptionFromProperties(properties) {
+    if (properties === undefined) {
+      return SyncStatusFormatter.resourceTitle(`There are enqueued timers.`);
+    }
+
+    const timers = SyncStatusFormatter.getPropertyFromObject('timers', properties);
+
+    let timerCount = 0;
+    let timersDescriptions = [];
+    for (const timer of timers) {
+      timerCount++;
+      timersDescriptions.push(SyncStatusFormatter.timerDescriptionFromTimer(timer, timerCount));
+    }
+
+    return `${SyncStatusFormatter.resourceTitle(`${timerCount} enqueued native timers:`)}` +
+      `\n${timersDescriptions.join('\n')}`;
+  }
+
+  static timerDescriptionFromTimer(timer, timerCount) {
+    const fireDate = SyncStatusFormatter.getPropertyFromObject('fire_date', timer);
+    const timeUntilFire = SyncStatusFormatter.getPropertyFromObject('time_until_fire', timer);
+    const repeatInterval = SyncStatusFormatter.getPropertyFromObject('repeat_interval', timer);
+    const isRecurring = SyncStatusFormatter.getPropertyFromObject('is_recurring', timer);
+    return `${SyncStatusFormatter.resourceSubTitle(`Timer #${timerCount}:`)}\n` +
+      `${SyncStatusFormatter.resourceSubSubTitle(`Fire date: ${fireDate}`)}.\n` +
+      `${SyncStatusFormatter.resourceSubSubTitle(`Time until fire: ${timeUntilFire.toFixed(3)}`)}.\n` +
+      `${SyncStatusFormatter.resourceSubSubTitle(`Repeat interval: ${repeatInterval}`)}.\n` +
+      `${SyncStatusFormatter.resourceSubSubTitle(`Is recurring: ${isRecurring === true ? `YES` : `NO`}`)}.`;
+  }
+
+  static resourceSubTitle(string) {
+    return `  - ${string}`;
+  }
+
+  static resourceSubSubTitle(string) {
+    return `    + ${string}`;
+  }
+
+  static uiResourceDescriptionFromProperties(properties) {
+    let countersDescriptions = [];
+    for (const [key, value] of Object.entries(properties)) {
+      const counterName = SyncStatusFormatter.uiResourceCounterNameMapping()[key];
+      if (counterName === undefined) {
+        throw new DetoxRuntimeError(`Given sync status is invalid. Cannot find \`${key}\` property for UI ` +
+          `resource description`);
+      }
+
+      countersDescriptions.push(SyncStatusFormatter.resourceSubTitle(`${counterName}: ${value}`));
+    }
+
+    return `${SyncStatusFormatter.resourceTitle(`UI elements are busy:`)}\n${countersDescriptions.join('.\n')}.`;
+  }
+
+  static uiResourceCounterNameMapping() {
+    return {
+      'layer_animation_pending_count':  `Layer animations pending`,
+      'layer_needs_display_count': `Layers needs display`,
+      'layer_needs_layout_count': `Layers needs layout`,
+      'layer_pending_animation_count': `Layers pending animations`,
+      'view_animation_pending_count': `View animations pending`,
+      'view_controller_will_appear_count': `View controllers will appear`,
+      'view_controller_will_disappear_count': `View controllers will disappear`,
+      'view_needs_display_count': `View needs display`,
+      'view_needs_layout_count': `View needs layout`,
+      'reason': `Reason`
+    };
+  }
+
+  static jsTimersResourceDescriptionFromProperties(properties) {
+    const timers = SyncStatusFormatter.getPropertyFromObject('timers', properties);
+
+    let timerCount = 0;
+    let timersDescriptions = [];
+    for (const timer of timers) {
+      timerCount++;
+      timersDescriptions.push(SyncStatusFormatter.jsTimerDescriptionFromTimer(timer, timerCount));
+    }
+
+    return `${SyncStatusFormatter.resourceTitle(`${timerCount} enqueued JavaScript timers:`)}` +
+      `\n${timersDescriptions.join('\n')}`;
+  }
+
+  static jsTimerDescriptionFromTimer(timer, timerCount) {
+    const timerID = SyncStatusFormatter.getPropertyFromObject('timer_id', timer);
+    const duration = SyncStatusFormatter.getPropertyFromObject('duration', timer);
+    const isRecurring = SyncStatusFormatter.getPropertyFromObject('is_recurring', timer);
+    return `${SyncStatusFormatter.resourceSubTitle(`Timer #${timerCount}:`)}\n` +
+      `${SyncStatusFormatter.resourceSubSubTitle(`JS timer ID: ${timerID}`)}.\n` +
+      `${SyncStatusFormatter.resourceSubSubTitle(`Duration: ${duration}`)}.\n` +
+      `${SyncStatusFormatter.resourceSubSubTitle(`Is recurring: ${isRecurring === true ? `YES` : `NO`}`)}.`;
+  }
+
+  static networkResourceDescriptionFromProperties(properties) {
+    const urls = SyncStatusFormatter.getPropertyFromObject('urls', properties);
+
+    let urlCount = 0;
+    let urlsDescriptions = [];
+    for (const url of urls) {
+      urlCount++;
+      urlsDescriptions.push(SyncStatusFormatter.urlDescriptionFromURL(url, urlCount));
+    }
+
+    return `${SyncStatusFormatter.resourceTitle(`${urlCount} network requests with URLs:`)}` +
+      `\n${urlsDescriptions.join('\n')}`;
+  }
+
+  static urlDescriptionFromURL(url, urlCount) {
+    return SyncStatusFormatter.resourceSubTitle(`URL #${urlCount}: ${url}.`);
+  }
+
+  static looperResourceDescriptionFromProperties(properties) {
+    const thread = SyncStatusFormatter.getPropertyFromObject('thread', properties);
+    const executionType = properties['execution_type'];
+
+    return SyncStatusFormatter.resourceTitle(`${thread} is executing` +
+      `${executionType !== undefined ? ` (${executionType}).` : `.`}`);
+  }
+
+  static unknownResourceDescriptionFromProperties(properties) {
+    const identifier = SyncStatusFormatter.getPropertyFromObject('identifier', properties);
+    return SyncStatusFormatter.resourceTitle(`Resource "${identifier}" is busy.`);
+  }
+}
+
+module.exports = SyncStatusFormatter;

--- a/detox/src/client/actions/SyncStatusFormatter.test.js
+++ b/detox/src/client/actions/SyncStatusFormatter.test.js
@@ -1,0 +1,379 @@
+const format = require('./SyncStatusFormatter').formatJSONStatus;
+
+describe('Sync Status Formatter', () => {
+  describe('assertions', () => {
+    test('should throw error when `app_status` is missing', async () => {
+      let invalidStatus = {
+        busy_resource: []
+      };
+
+      await expect(() => { format(invalidStatus); }).toThrowError(`Given sync status is not compatible with ` +
+        `the status schema, given status: ${JSON.stringify(invalidStatus)}`);
+    });
+
+    test('should throw error when `app_status` is invalid', async () => {
+      let invalidStatus = {
+        app_status: 'foo'
+      };
+
+      await expect(() => { format(invalidStatus); }).toThrowError(`Given sync status is not compatible with ` +
+        `the status schema, given status: ${JSON.stringify(invalidStatus)}`);
+    });
+
+    test('should throw error when `app_status` is `busy` but `busy_resources` is missing', async () => {
+      let invalidStatus = {
+        app_status: 'busy'
+      };
+
+      await expect(() => { format(invalidStatus); }).toThrowError(`Given sync status is invalid, app is busy ` +
+        `but busy-resources are not defined`);
+    });
+
+    test('should throw error when resource `name` is missing', async () => {
+      let invalidStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            description: {
+              foo: 'bar'
+            }
+          }
+        ]
+      };
+
+      await expect(() => { format(invalidStatus); }).toThrowError(`Given sync status is not compatible with ` +
+        `the status schema, given status: ${JSON.stringify(invalidStatus)}`);
+    });
+
+    test('should throw error when a busy resource is invalid', async () => {
+      let invalidStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'foo'
+          }
+        ]
+      };
+
+      await expect(() => { format(invalidStatus); }).toThrowError(`Given sync status is invalid, cannot find ` +
+        `resource name: \`foo\``);
+    });
+  });
+
+  test('should format idle status correctly', async () => {
+    let idleStatus = {
+      app_status: 'idle'
+    };
+
+    await expect(format(idleStatus)).toEqual(`The app seems to be idle`);
+  });
+
+  describe('busy status', () => {
+    test('should format "delayed_perform_selector" correctly', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'delayed_perform_selector',
+            description: {
+              pending_selectors: 123
+            }
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• There are 123 pending delayed selectors to be performed.`);
+    });
+
+    test('should format "dispatch_queue" correctly', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'dispatch_queue',
+            description: {
+              queue: 'foo',
+              works_count: 123
+            }
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• There are 123 work items pending on the dispatch queue: "foo".`);
+    });
+
+    test('should format "run_loop" correctly', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'run_loop',
+            description: {
+              name: 'foo'
+            }
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• Run loop "foo" is awake.`);
+    });
+
+    test('should format "one_time_events" correctly', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'one_time_events',
+            description: {
+              event: 'foo',
+              object: 'bar'
+            }
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• The event "foo" is taking place with object: "bar".`);
+    });
+
+    test('should format "timers" correctly when there is no description', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'timers'
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• There are enqueued timers.`);
+    });
+
+    test('should format "timers" correctly when there are timers in description', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'timers',
+            description: {
+              timers: [
+                {
+                  fire_date: "foo",
+                  time_until_fire: 0.468978,
+                  repeat_interval: 1,
+                  is_recurring: true
+                },
+                {
+                  fire_date: "bar",
+                  time_until_fire: 0.98798,
+                  repeat_interval: 0,
+                  is_recurring: false
+                }
+              ]
+            }
+          }
+
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• 2 enqueued native timers:\n` +
+        `  - Timer #1:\n` +
+        `    + Fire date: foo.\n    + Time until fire: 0.469.\n    + Repeat interval: 1.\n    + Is recurring: YES.\n` +
+        `  - Timer #2:\n` +
+        `    + Fire date: bar.\n    + Time until fire: 0.988.\n    + Repeat interval: 0.\n    + Is recurring: NO.`);
+    });
+
+    test('should format "ui" correctly #1', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'ui',
+            description: {
+              layer_animation_pending_count: 3,
+              layer_needs_display_count: 5,
+              layer_needs_layout_count: 1,
+              layer_pending_animation_count: 12
+            }
+          }
+
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• UI elements are busy:\n` +
+        `  - Layer animations pending: 3.\n` +
+        `  - Layers needs display: 5.\n` +
+        `  - Layers needs layout: 1.\n` +
+        `  - Layers pending animations: 12.`);
+    });
+
+    test('should format "ui" correctly #2', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'ui',
+            description: {
+              view_animation_pending_count: 3,
+              view_controller_will_appear_count: 5,
+              view_controller_will_disappear_count: 1,
+              view_needs_display_count: 12,
+              view_needs_layout_count: 15
+            }
+          }
+
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• UI elements are busy:\n` +
+        `  - View animations pending: 3.\n` +
+        `  - View controllers will appear: 5.\n` +
+        `  - View controllers will disappear: 1.\n` +
+        `  - View needs display: 12.\n` +
+        `  - View needs layout: 15.`);
+    });
+
+    test('should format "ui" correctly #3', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'ui',
+            description: {
+              reason: 'foo'
+            }
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• UI elements are busy:\n  - Reason: foo.`);
+    });
+
+    test('should format "network" correctly', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'network',
+            description: {
+              urls: [
+                'foo://bar.baz',
+                'qux://quux.quuz'
+              ]
+            }
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• 2 network requests with URLs:\n  - URL #1: foo://bar.baz.\n  - URL #2: qux://quux.quuz.`);
+    });
+
+    test('should format "js_timers" corrrectly', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'js_timers',
+            description: {
+              timers: [
+                {
+                  timer_id: 4,
+                  duration: 1,
+                  is_recurring: false
+                },
+                {
+                  timer_id: 12,
+                  duration: 2,
+                  is_recurring: true
+                }
+              ]
+            }
+          }
+
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• 2 enqueued JavaScript timers:\n` +
+        `  - Timer #1:\n` +
+        `    + JS timer ID: 4.\n    + Duration: 1.\n    + Is recurring: NO.\n` +
+        `  - Timer #2:\n` +
+        `    + JS timer ID: 12.\n    + Duration: 2.\n    + Is recurring: YES.`);
+    });
+
+    test('should format "looper" correctly #1', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'looper',
+            description: {
+              thread: 'Foo Looper',
+              execution_type: 'baz execution'
+            }
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• Foo Looper is executing (baz execution).`);
+    });
+
+    test('should format "looper" correctly', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'looper',
+            description: {
+              thread: 'Foo Looper'
+            }
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• Foo Looper is executing.`);
+    });
+
+    test('should format "io" correctly', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'io'
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• Disk I/O activity.`);
+    });
+
+    test('should format "unknown" correctly', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'unknown',
+            description: {
+              identifier: 'foo.bar#baz'
+            }
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toEqual(`The app is busy with the following tasks:\n` +
+        `• Resource "foo.bar#baz" is busy.`);
+    });
+  });
+});

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -1,3 +1,4 @@
+const SyncStatusFormatter = require('../../client/actions/SyncStatusFormatter');
 const DetoxInternalError = require('../../errors/DetoxInternalError');
 const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
 const { getDetoxLevel } = require('../../utils/logger');
@@ -158,7 +159,7 @@ class CurrentStatus extends Action {
 
   async handle(response) {
     this.expectResponseOfType(response, 'currentStatusResult');
-    return response.params.status;
+    return SyncStatusFormatter.formatJSONStatus(response.params.status);
   }
 }
 


### PR DESCRIPTION
This pull request addresses the issue described here: [Unify debug-sync logs between platforms #2714 ](https://github.com/wix/Detox/issues/2714)

This PR depends on https://github.com/wix/Detox/pull/3063 and https://github.com/wix/Detox/pull/3064 to get merged before.

---

### Examples for _Android_ sync-status formatted messages:
```
detox[9160] INFO:  [APP_STATUS] The app seems to be idle
```
```
detox[9160] INFO:  [APP_STATUS] The app is busy with the following tasks:
• "LooperIdlingResource-2215-mqt_native_modules" (Native Modules Thread) is executing (native module calls).
• "LooperIdlingResource-2214-mqt_js" (JS Thread) is executing (JavaScript code).
• UI elements are busy:
  - Reason: UI rendering activity.
```

### Examples for _iOS_ sync-status formatted messages:

```
detox[9733] INFO:  [APP_STATUS] The app is busy with the following tasks:
• Run loop "JS Run Loop" is awake.
• There are 2 work items pending on the dispatch queue: "Main Queue (<OS_dispatch_queue_main: com.apple.main-thread>)".
• The event "Runloop Perform Block" is taking place with object: "JS Run Loop".
• The event "Runloop Perform Block" is taking place with object: "JS Run Loop".
• Run loop "Main Run Loop" is awake.
• The event "React Native (bundle load)" is taking place.
```

```
detox[9733] INFO:  [APP_STATUS] The app is busy with the following tasks:
• There are 1 work items pending on the dispatch queue: "Main Queue (<OS_dispatch_queue_main: com.apple.main-thread>)".
• Run loop "Main Run Loop" is awake.
• 1 enqueued native timers:
  - Timer #1:
    + Fire date: 2021-11-11 14:19:57 +0200.
    + Time until fire: 0.072.
    + Repeat interval: 0.
    + Is recurring: NO.
```