### PR TITLE
feat(DocSearch): integrate Detox website with Algolia DocSerach.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -56,6 +56,11 @@ const config = {
           },
         ],
       },
+      algolia: {
+        appId: 'BH4D9OD16A',
+        apiKey: 'f621c2d74268df173153c887526aebb3',
+        indexName: 'detox',
+      },
       footer: {
         style: 'dark',
         links: [

--- a/website/package.json
+++ b/website/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.9",
     "@docusaurus/preset-classic": "2.0.0-beta.9",
+    "@docusaurus/theme-search-algolia": "^2.0.0-beta.9",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",


### PR DESCRIPTION
Integrate [Detox website](https://wix.github.io/Detox/) with [Algolia DocSearch](https://docsearch.algolia.com/).

This will add a search box in our navigation bar.
![image](https://user-images.githubusercontent.com/55082339/142395644-1644c571-e6d2-41ed-9522-1123466e8c39.png)

The DocSearch is built in two parts:

- a crawler which runs on Algolia DocSearch infrastructure every 24 hours. It follows every link in Detox website and extract content from every page it traverses. It then pushes this content to an Algolia index.
- a JavaScript snippet to be inserted in Detox website that will bind this Algolia index to your search input and display its results in a dropdown UI.

I've used the App-ID, API-key and index-name as given to us by the DocSearch team.

See [DocSearch docs](https://docsearch.algolia.com/docs/what-is-docsearch/) or [Docusaurus docs (Using Algolia DocSearch)](https://docusaurus.io/docs/next/search#using-algolia-docsearch) for more information.

**@wix/detox-team let's wait with merging this PR until their crawler will index our site docs, merging this now will just add the search box with no search results.**