### PR TITLE
Improve atIndex matching message for Android

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/matcher/ViewAtIndexMatcher.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/matcher/ViewAtIndexMatcher.kt
@@ -21,6 +21,6 @@ class ViewAtIndexMatcher(private val index: Int, private val innerMatcher: Match
     }
 
     override fun describeTo(description: Description) {
-        description.appendText("matches " + index + "th view.")
+        description.appendText("View at index #$index, of those matching MATCHER$innerMatcher")
     }
 }

--- a/detox/android/detox/src/testFull/java/com/wix/detox/espresso/matcher/ViewAtIndexMatcherSpec.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/espresso/matcher/ViewAtIndexMatcherSpec.kt
@@ -1,0 +1,38 @@
+package com.wix.detox.espresso.matcher
+
+import android.view.View
+import com.nhaarman.mockitokotlin2.*
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.mockito.Matchers
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object ViewAtIndexMatcherSpec: Spek({
+    describe("atIndex view-matcher") {
+
+        lateinit var innerMatcher: Matcher<View>
+        lateinit var description: Description
+        beforeEachTest {
+            innerMatcher = mock()
+            whenever(innerMatcher.toString()).thenReturn("(innerMatcher description)")
+
+            description = mock()
+        }
+
+        describe("describeTo") {
+            it("should append a valid description for index 0") {
+                val uut = ViewAtIndexMatcher(0, innerMatcher)
+                uut.describeTo(description)
+                verify(description).appendText("View at index #0, of those matching MATCHER(innerMatcher description)")
+            }
+            
+            it("should append a valid description for index≥0") {
+                val uut = ViewAtIndexMatcher(7, innerMatcher)
+                uut.describeTo(description)
+                com.nhaarman.mockitokotlin2.
+                verify(description).appendText(Matchers.contains("View at index #7"))
+            }
+        }
+    }
+});

--- a/detox/test/e2e/02.matchers.test.js
+++ b/detox/test/e2e/02.matchers.test.js
@@ -1,3 +1,5 @@
+const { expectToThrow } = require('./utils/custom-expects');
+
 describe('Matchers', () => {
   beforeEach(async () => {
     await device.reloadReactNative();
@@ -19,17 +21,15 @@ describe('Matchers', () => {
     await expect(element(by.text('First button pressed!!!'))).toBeVisible();
   });
 
-  it(':ios: should fail matching out of bounds index with a suitable error', async () => {
-    try {
-      await element(by.text('Index')).atIndex(123456).tap();
-    } catch(e) {
-      if(e.message.includes("Index 123456 beyond bounds") == false)
-      {
-        let err = Error();
-        err.message = "Unexpected error message";
-        throw err;
-      }
-    }
+  it('should give a clear error when index-matching fails (i.e. index out of bounds)', async () => {
+    const expectedMessage = device.getPlatform() === 'android'
+      ? 'View at index #3, of those matching MATCHER'
+      : 'Index 3 beyond bounds [0 .. 2] for “MATCHER';
+
+    await expectToThrow(
+      () => element(by.text('Index')).atIndex(3).tap(),
+      expectedMessage,
+    );
   });
 
   it('should be able to swipe elements matched by index', async () => {


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request fixes #2430.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have improved the error message generated whenever `atIndex` fails (index out of bounds), and improved the testing around it (added coverage for Android).

It boils down to this, instead of the original message (as described in #2430):

![image](https://user-images.githubusercontent.com/9818880/142908416-2d01fbbf-b632-46de-ae4e-cf724cd06799.png)


<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
