### PR TITLE
docs(Introduction.iOS): add `build` and `binaryPath` to the example.

### DIFF
--- a/docs/Introduction.iOS.md
+++ b/docs/Introduction.iOS.md
@@ -27,9 +27,10 @@ Whether you’ve selected to apply the configuration in a  `.detoxrc.json` or bu
   },
   "apps": {
     "ios.release": {
+      "name": "YourProject",
       "type": "ios.app",
-      "binaryPath": <path to .app bundle>,
-      "build": <xcodebuild command>
+      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/YourProject.app",
+      "build": "xcodebuild -project ios/YourProject.xcodeproj -scheme YourProject -sdk iphonesimulator -derivedDataPath ios/build"
     }
   },
   "configurations": {
@@ -41,10 +42,14 @@ Whether you’ve selected to apply the configuration in a  `.detoxrc.json` or bu
 }
 ```
 
+:::info
+
 For a comprehensive explanation of Detox configuration, see our [dedicated API-reference guide](APIRef.Configuration.md).
+
+:::
 
 In the above configuration example, make sure to provide the correct information for your project/app. Under the key `"binaryPath"`, you should provide the path of the .app bundle to use. Normally, this is the path where the `"build”` command would output this bundle. Under the key `"build"`, specify the `xcodebuild` command for your project.
 
-Also make sure the simulator model specified under the key `device.type` (e.g. `iPhone 12 Pro Max` above) is actually available on your machine (it was installed by Xcode). Check this by typing `applesimutils --list` in Terminal to display all available simulators.
+Also, make sure the simulator model specified under the key `device.type` (e.g. `iPhone 12 Pro Max` above) is actually available on your machine (it was installed by Xcode). Check this by typing `applesimutils --list` in Terminal to display all available simulators.
 
 For a complete, working example, refer to the [Detox example project configuration](https://github.com/wix/Detox/blob/master/detox/test/package.json).


### PR DESCRIPTION
Add a `xcodebuild` command example and `binaryPath` example to the provided configuration example. No reason to have a placeholder if that's an example (and not a template), and the configuration keys are explain immediately after.

In response to this issue: https://github.com/wix/Detox/issues/3107.