### PR TITLE
fix: prevent a retry loop from hanging up the test runners

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@types/child-process-promise": "^2.2.1",
+    "@types/node": "^12.20.37",
     "@types/ws": "^7.4.0",
     "eslint": "^4.11.0",
     "eslint-plugin-import": "^2.23.3",

--- a/detox/src/devices/allocation/drivers/android/emulator/EmulatorLauncher.js
+++ b/detox/src/devices/allocation/drivers/android/emulator/EmulatorLauncher.js
@@ -67,7 +67,7 @@ class EmulatorLauncher extends DeviceLauncher {
   }
 
   async _waitForBootToComplete(adbName) {
-    await retry({ retries: 240, interval: 2500 }, async () => {
+    await retry({ retries: 240, interval: 2500, unref: true }, async () => {
       const isBootComplete = await this._adb.isBootComplete(adbName);
 
       if (!isBootComplete) {

--- a/detox/src/devices/allocation/drivers/android/emulator/EmulatorLauncher.js
+++ b/detox/src/devices/allocation/drivers/android/emulator/EmulatorLauncher.js
@@ -67,7 +67,7 @@ class EmulatorLauncher extends DeviceLauncher {
   }
 
   async _waitForBootToComplete(adbName) {
-    await retry({ retries: 240, interval: 2500, unref: true }, async () => {
+    await retry({ retries: 240, interval: 2500, shouldUnref: true }, async () => {
       const isBootComplete = await this._adb.isBootComplete(adbName);
 
       if (!isBootComplete) {

--- a/detox/src/utils/retry.js
+++ b/detox/src/utils/retry.js
@@ -1,5 +1,6 @@
 const sleep = require('./sleep');
 
+const DEFAULT_UNREF = false;
 const DEFAULT_INITIAL_SLEEP = 0;
 const DEFAULT_RETRIES = 9;
 const DEFAULT_INTERVAL = 500;
@@ -23,12 +24,13 @@ async function retry(optionsOrFunc, func) {
     backoff = DEFAULT_BACKOFF_MODE,
     conditionFn = DEFAULT_CONDITION_FN,
     initialSleep = DEFAULT_INITIAL_SLEEP,
+    unref = DEFAULT_UNREF,
   } = options;
 
   const backoffFn = backoffModes[backoff]();
 
   if (initialSleep) {
-    await sleep(initialSleep);
+    await sleep(initialSleep, { unref });
   }
 
   // eslint-disable-next-line no-constant-condition
@@ -41,7 +43,7 @@ async function retry(optionsOrFunc, func) {
       if (!conditionFn(e) || (totalTries > retries)) {
         throw e;
       }
-      await sleep(backoffFn({ interval, totalTries }));
+      await sleep(backoffFn({ interval, totalTries }), { unref });
     }
   }
 }

--- a/detox/src/utils/retry.js
+++ b/detox/src/utils/retry.js
@@ -1,6 +1,5 @@
 const sleep = require('./sleep');
 
-const DEFAULT_UNREF = false;
 const DEFAULT_INITIAL_SLEEP = 0;
 const DEFAULT_RETRIES = 9;
 const DEFAULT_INTERVAL = 500;
@@ -24,13 +23,14 @@ async function retry(optionsOrFunc, func) {
     backoff = DEFAULT_BACKOFF_MODE,
     conditionFn = DEFAULT_CONDITION_FN,
     initialSleep = DEFAULT_INITIAL_SLEEP,
-    unref = DEFAULT_UNREF,
+    shouldUnref,
   } = options;
 
   const backoffFn = backoffModes[backoff]();
+  const sleepOptions = shouldUnref ? { shouldUnref } : undefined;
 
   if (initialSleep) {
-    await sleep(initialSleep, { unref });
+    await sleep(initialSleep, sleepOptions);
   }
 
   // eslint-disable-next-line no-constant-condition
@@ -43,7 +43,7 @@ async function retry(optionsOrFunc, func) {
       if (!conditionFn(e) || (totalTries > retries)) {
         throw e;
       }
-      await sleep(backoffFn({ interval, totalTries }), { unref });
+      await sleep(backoffFn({ interval, totalTries }), sleepOptions);
     }
   }
 }

--- a/detox/src/utils/retry.test.js
+++ b/detox/src/utils/retry.test.js
@@ -41,7 +41,27 @@ describe('retry', () => {
 
     expect(mockFn).toHaveBeenCalledTimes(1);
     expect(sleep).toHaveBeenCalledTimes(1);
-    expect(sleep).toHaveBeenCalledWith(1234);
+    expect(sleep).toHaveBeenCalledWith(1234, { unref: false });
+  });
+
+  it('should call sleep() with { unref: true } if set', async () => {
+    const mockFn = mockFailingTwiceUserFn();
+
+    try {
+      await retry({
+        initialSleep: 1000,
+        retries: 2,
+        interval: 0,
+        unref: true,
+      }, mockFn);
+    } catch (e) {
+      fail('expected retry not to fail');
+    }
+
+    expect(mockFn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledWith(1000, { unref: true });
+    expect(sleep).toHaveBeenCalledWith(0, { unref: true });
   });
 
   it('should retry multiple times', async () => {
@@ -79,8 +99,8 @@ describe('retry', () => {
     } catch (error) {}
 
     expect(sleep).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenCalledWith(baseInterval);
-    expect(sleep).toHaveBeenCalledWith(baseInterval * 2);
+    expect(sleep).toHaveBeenCalledWith(baseInterval, { unref: false });
+    expect(sleep).toHaveBeenCalledWith(baseInterval * 2, { unref: false });
   });
 
   it('should allow for a constant sleep interval instead of an increasing one by setting backoff="none"', async () => {
@@ -98,8 +118,8 @@ describe('retry', () => {
     } catch (error) {}
 
     expect(sleep).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenNthCalledWith(1, baseInterval);
-    expect(sleep).toHaveBeenNthCalledWith(2, baseInterval);
+    expect(sleep).toHaveBeenNthCalledWith(1, baseInterval, { unref: false });
+    expect(sleep).toHaveBeenNthCalledWith(2, baseInterval, { unref: false });
   });
 
   it('should allow for the default linear backoff when set explicitly as "linear"', async () => {
@@ -117,8 +137,8 @@ describe('retry', () => {
     } catch (error) {}
 
     expect(sleep).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenCalledWith(baseInterval);
-    expect(sleep).toHaveBeenCalledWith(baseInterval * 2);
+    expect(sleep).toHaveBeenCalledWith(baseInterval, { unref: false });
+    expect(sleep).toHaveBeenCalledWith(baseInterval * 2, { unref: false });
   });
 
   it('should adhere to a custom condition', async () => {
@@ -146,6 +166,6 @@ describe('retry', () => {
     } catch (error) {}
 
     expect(mockFn).toHaveBeenCalledTimes(defaultRetries + 1);
-    expect(sleep).toHaveBeenCalledWith(defaultInterval);
+    expect(sleep).toHaveBeenCalledWith(defaultInterval, { unref: false });
   });
 });

--- a/detox/src/utils/retry.test.js
+++ b/detox/src/utils/retry.test.js
@@ -41,10 +41,10 @@ describe('retry', () => {
 
     expect(mockFn).toHaveBeenCalledTimes(1);
     expect(sleep).toHaveBeenCalledTimes(1);
-    expect(sleep).toHaveBeenCalledWith(1234, { unref: false });
+    expect(sleep).toHaveBeenCalledWith(1234, undefined);
   });
 
-  it('should call sleep() with { unref: true } if set', async () => {
+  it('should call sleep() with { shouldUnref: true } if set', async () => {
     const mockFn = mockFailingTwiceUserFn();
 
     try {
@@ -52,7 +52,7 @@ describe('retry', () => {
         initialSleep: 1000,
         retries: 2,
         interval: 0,
-        unref: true,
+        shouldUnref: true,
       }, mockFn);
     } catch (e) {
       fail('expected retry not to fail');
@@ -60,8 +60,8 @@ describe('retry', () => {
 
     expect(mockFn).toHaveBeenCalledTimes(3);
     expect(sleep).toHaveBeenCalledTimes(3);
-    expect(sleep).toHaveBeenCalledWith(1000, { unref: true });
-    expect(sleep).toHaveBeenCalledWith(0, { unref: true });
+    expect(sleep).toHaveBeenCalledWith(1000, { shouldUnref: true });
+    expect(sleep).toHaveBeenCalledWith(0, { shouldUnref: true });
   });
 
   it('should retry multiple times', async () => {
@@ -99,8 +99,8 @@ describe('retry', () => {
     } catch (error) {}
 
     expect(sleep).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenCalledWith(baseInterval, { unref: false });
-    expect(sleep).toHaveBeenCalledWith(baseInterval * 2, { unref: false });
+    expect(sleep).toHaveBeenCalledWith(baseInterval, undefined);
+    expect(sleep).toHaveBeenCalledWith(baseInterval * 2, undefined);
   });
 
   it('should allow for a constant sleep interval instead of an increasing one by setting backoff="none"', async () => {
@@ -118,8 +118,8 @@ describe('retry', () => {
     } catch (error) {}
 
     expect(sleep).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenNthCalledWith(1, baseInterval, { unref: false });
-    expect(sleep).toHaveBeenNthCalledWith(2, baseInterval, { unref: false });
+    expect(sleep).toHaveBeenNthCalledWith(1, baseInterval, undefined);
+    expect(sleep).toHaveBeenNthCalledWith(2, baseInterval, undefined);
   });
 
   it('should allow for the default linear backoff when set explicitly as "linear"', async () => {
@@ -137,8 +137,8 @@ describe('retry', () => {
     } catch (error) {}
 
     expect(sleep).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenCalledWith(baseInterval, { unref: false });
-    expect(sleep).toHaveBeenCalledWith(baseInterval * 2, { unref: false });
+    expect(sleep).toHaveBeenCalledWith(baseInterval, undefined);
+    expect(sleep).toHaveBeenCalledWith(baseInterval * 2, undefined);
   });
 
   it('should adhere to a custom condition', async () => {
@@ -166,6 +166,6 @@ describe('retry', () => {
     } catch (error) {}
 
     expect(mockFn).toHaveBeenCalledTimes(defaultRetries + 1);
-    expect(sleep).toHaveBeenCalledWith(defaultInterval, { unref: false });
+    expect(sleep).toHaveBeenCalledWith(defaultInterval, undefined);
   });
 });

--- a/detox/src/utils/sleep.js
+++ b/detox/src/utils/sleep.js
@@ -1,9 +1,7 @@
-const defaultOptions = { unref: false };
-
-async function sleep(ms, options = defaultOptions) {
+async function sleep(ms, { shouldUnref = false } = {}) {
   return new Promise(resolve => {
     const handle = setTimeout(resolve, ms);
-    if (options.unref) {
+    if (shouldUnref) {
       handle.unref();
     }
   });

--- a/detox/src/utils/sleep.js
+++ b/detox/src/utils/sleep.js
@@ -1,5 +1,12 @@
-async function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+const defaultOptions = { unref: false };
+
+async function sleep(ms, options = defaultOptions) {
+  return new Promise(resolve => {
+    const handle = setTimeout(resolve, ms);
+    if (options.unref) {
+      handle.unref();
+    }
+  });
 }
 
 module.exports = sleep;

--- a/detox/src/utils/sleep.test.js
+++ b/detox/src/utils/sleep.test.js
@@ -17,8 +17,8 @@ describe('sleep', () => {
     expect(setTimeoutMock.mock.results[0].value.unref).not.toHaveBeenCalled();
   });
 
-  it('should call .unref() when given options = { unref: true }', async () => {
-    await sleep(0, { unref: true });
+  it('should call .unref() when given options = { shouldUnref: true }', async () => {
+    await sleep(0, { shouldUnref: true });
     expect(setTimeoutMock.mock.results[0].value.unref).toHaveBeenCalled();
   });
 });

--- a/detox/src/utils/sleep.test.js
+++ b/detox/src/utils/sleep.test.js
@@ -1,0 +1,24 @@
+describe('sleep', () => {
+  let sleep;
+  let setTimeoutMock;
+
+  beforeEach(() => {
+    setTimeoutMock = jest.spyOn(global, 'setTimeout')
+      .mockImplementation((callback) => {
+        callback();
+        return ({ unref: jest.fn() });
+      });
+
+    sleep = require('./sleep');
+  });
+
+  it('should not call .unref() by default', async () => {
+    await sleep(0);
+    expect(setTimeoutMock.mock.results[0].value.unref).not.toHaveBeenCalled();
+  });
+
+  it('should call .unref() when given options = { unref: true }', async () => {
+    await sleep(0, { unref: true });
+    expect(setTimeoutMock.mock.results[0].value.unref).toHaveBeenCalled();
+  });
+});

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
-    "@types/node": "^14.14.20",
+    "@types/node": "^12.20.37",
     "detox": "^19.1.0",
     "dtslint": "^4.0.6",
     "express": "^4.15.3",


### PR DESCRIPTION
## Description
- This pull request resolves #2481

In this pull request, I have:

* added `shouldUnref` option to `sleep` utility
* added `shouldUnref ` option to `retry` utility
* added `shouldUnref: true` to the `retry()` call for Android emulator
* updated unit tests
* checked manually the end result.

To simulate the hanging emulator I monkey-patched `detox/src/devices/common/drivers/android/exec/BinaryExec.js` and forced it to use this script:

```bash title='emulator'
#!/usr/bin/env bash

while read -r line;
do
   echo "$line" ;
done
```

### Before

![Screenshot 2021-11-29 at 17 39 43](https://user-images.githubusercontent.com/1962469/143904117-78afd7bd-7250-44d2-b7a7-12f5f99fd016.png)

### After

![Screenshot 2021-11-29 at 17 40 09](https://user-images.githubusercontent.com/1962469/143904125-01720fe4-beff-4647-9596-9e2c660ef6c1.png)