### PR TITLE
fix(scrollTo): raise if scroll view element is not hittable.

### DIFF
--- a/detox/ios/Detox.xcodeproj/project.pbxproj
+++ b/detox/ios/Detox.xcodeproj/project.pbxproj
@@ -112,6 +112,8 @@
 		6062B5E62720323700CBDBF0 /* DTXAddressInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6062B5E02720323700CBDBF0 /* DTXAddressInfo.mm */; };
 		60C1961A271F11C4000172DD /* fishhook.h in Headers */ = {isa = PBXBuildFile; fileRef = 60C19618271F11C4000172DD /* fishhook.h */; };
 		60C1961B271F11C4000172DD /* fishhook.c in Sources */ = {isa = PBXBuildFile; fileRef = 60C19619271F11C4000172DD /* fishhook.c */; };
+		60E149C72759038F00519EE4 /* UIResponder+First.h in Headers */ = {isa = PBXBuildFile; fileRef = 60E149C52759038F00519EE4 /* UIResponder+First.h */; };
+		60E149C82759038F00519EE4 /* UIResponder+First.m in Sources */ = {isa = PBXBuildFile; fileRef = 60E149C62759038F00519EE4 /* UIResponder+First.m */; };
 		AD4781082636F7CF006774CD /* NSURL+DetoxUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = AD4781062636F7CE006774CD /* NSURL+DetoxUtils.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD4781092636F7CF006774CD /* NSURL+DetoxUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = AD4781072636F7CF006774CD /* NSURL+DetoxUtils.m */; };
 /* End PBXBuildFile section */
@@ -299,6 +301,8 @@
 		6062B5E02720323700CBDBF0 /* DTXAddressInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = DTXAddressInfo.mm; path = DetoxSync/DetoxSync/DTXObjectiveCHelpers/DTXAddressInfo.mm; sourceTree = SOURCE_ROOT; };
 		60C19618271F11C4000172DD /* fishhook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fishhook.h; path = DetoxSync/DetoxSync/fishhook/fishhook.h; sourceTree = SOURCE_ROOT; };
 		60C19619271F11C4000172DD /* fishhook.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fishhook.c; path = DetoxSync/DetoxSync/fishhook/fishhook.c; sourceTree = SOURCE_ROOT; };
+		60E149C52759038F00519EE4 /* UIResponder+First.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIResponder+First.h"; sourceTree = "<group>"; };
+		60E149C62759038F00519EE4 /* UIResponder+First.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIResponder+First.m"; sourceTree = "<group>"; };
 		AD4781062636F7CE006774CD /* NSURL+DetoxUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURL+DetoxUtils.h"; sourceTree = "<group>"; };
 		AD4781072636F7CF006774CD /* NSURL+DetoxUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURL+DetoxUtils.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -525,6 +529,8 @@
 				395B06E3256D5A5600941716 /* UIView+DetoxSpeedup.m */,
 				AD4781062636F7CE006774CD /* NSURL+DetoxUtils.h */,
 				AD4781072636F7CF006774CD /* NSURL+DetoxUtils.m */,
+				60E149C52759038F00519EE4 /* UIResponder+First.h */,
+				60E149C62759038F00519EE4 /* UIResponder+First.m */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -601,6 +607,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60E149C72759038F00519EE4 /* UIResponder+First.h in Headers */,
 				3947679C1DBF985400D72256 /* Detox.h in Headers */,
 				39CA978C245B13CB00A7FC43 /* UIDevice+DetoxActions.h in Headers */,
 				3980D11C2448B52C004812DD /* DTXSyntheticEvents.h in Headers */,
@@ -828,6 +835,7 @@
 				396D455725238BCE0096E7FA /* UIImage+DetoxUtils.m in Sources */,
 				39A34C721E30F10D00BEBB59 /* DetoxAppDelegateProxy.m in Sources */,
 				39EECB7D24C0A5AF009C3364 /* NSThread+DetoxUtils.m in Sources */,
+				60E149C82759038F00519EE4 /* UIResponder+First.m in Sources */,
 				390DED84248906FC00E27BE8 /* UIWindow+DetoxUtils.m in Sources */,
 				3980D158244C45EA004812DD /* Modifier.swift in Sources */,
 				39EECB4324BF4FDA009C3364 /* ReactNativeSupport.m in Sources */,

--- a/detox/ios/Detox/Actions/UIDatePicker+DetoxActions.m
+++ b/detox/ios/Detox/Actions/UIDatePicker+DetoxActions.m
@@ -13,7 +13,7 @@
 
 - (void)dtx_adjustToDate:(NSDate*)date
 {
-	[self dtx_assertVisible];
+	[self dtx_assertHittable];
 	
 	NSDate* previousDate = self.date;
 	

--- a/detox/ios/Detox/Actions/UIPickerView+DetoxActions.m
+++ b/detox/ios/Detox/Actions/UIPickerView+DetoxActions.m
@@ -14,7 +14,7 @@
 
 - (void)dtx_setComponent:(NSInteger)component toValue:(id)value
 {
-	[self dtx_assertVisible];
+	[self dtx_assertHittable];
 	
 	DTXViewAssert(self.dataSource != nil && self.delegate != nil, self.dtx_elementDebugAttributes, @"The picker view's data source and/or delegate are nil");
 	

--- a/detox/ios/Detox/Actions/UIScrollView+DetoxActions.m
+++ b/detox/ios/Detox/Actions/UIScrollView+DetoxActions.m
@@ -290,9 +290,9 @@ if(isnan(normalizedStartingPoint.main) || normalizedStartingPoint.main < 0 || no
 	
 	CGPoint startPoint = CGPointMake(safeAreaToScroll.origin.x + safeAreaToScroll.size.width * normalizedStartingPoint.x, safeAreaToScroll.origin.y + safeAreaToScroll.size.height * normalizedStartingPoint.y);
 
+	CGPoint viewPoint = [self convertPoint:startPoint fromView:self.window];
+	[self dtx_assertHittableAtPoint:viewPoint];
 
-	[self dtx_assertHittableAtPoint:startPoint];
-	
 	NSUInteger successfullyAppliedScrolls = 0;
 	while (offset.x != 0.0 || offset.y != 0.0)
 	{

--- a/detox/ios/Detox/Actions/UIScrollView+DetoxActions.m
+++ b/detox/ios/Detox/Actions/UIScrollView+DetoxActions.m
@@ -289,6 +289,9 @@ if(isnan(normalizedStartingPoint.main) || normalizedStartingPoint.main < 0 || no
 	}
 	
 	CGPoint startPoint = CGPointMake(safeAreaToScroll.origin.x + safeAreaToScroll.size.width * normalizedStartingPoint.x, safeAreaToScroll.origin.y + safeAreaToScroll.size.height * normalizedStartingPoint.y);
+
+
+	[self dtx_assertHittableAtPoint:startPoint];
 	
 	NSUInteger successfullyAppliedScrolls = 0;
 	while (offset.x != 0.0 || offset.y != 0.0)

--- a/detox/ios/Detox/Actions/UIScrollView+DetoxActions.m
+++ b/detox/ios/Detox/Actions/UIScrollView+DetoxActions.m
@@ -291,7 +291,7 @@ if(isnan(normalizedStartingPoint.main) || normalizedStartingPoint.main < 0 || no
 	CGPoint startPoint = CGPointMake(safeAreaToScroll.origin.x + safeAreaToScroll.size.width * normalizedStartingPoint.x, safeAreaToScroll.origin.y + safeAreaToScroll.size.height * normalizedStartingPoint.y);
 
 	CGPoint viewPoint = [self convertPoint:startPoint fromView:self.window];
-	[self dtx_assertHittableAtPoint:viewPoint];
+	[self dtx_assertScrollableAtPoint:viewPoint];
 
 	NSUInteger successfullyAppliedScrolls = 0;
 	while (offset.x != 0.0 || offset.y != 0.0)
@@ -308,7 +308,16 @@ if(isnan(normalizedStartingPoint.main) || normalizedStartingPoint.main < 0 || no
 	DTXViewAssert(strict == NO || successfullyAppliedScrolls > 0, self.dtx_elementDebugAttributes, @"Unable to scroll %@ in “%@”", _DTXScrollDirectionDescriptionWithOffset(offset), self.dtx_shortDescription);
 	
 	self.dtx_disableDecelerationForScroll = NO;
-//	self.bounces = oldBounces;
+}
+
+- (void)dtx_assertScrollableAtPoint:(CGPoint)startPoint {
+  NSError *error;
+  DTXAssert([self dtx_isHittableAtPoint:startPoint error:&error],
+			@"View is not scrollable at the given start point. Start point (view coordinates): %@" \
+			"\n- Full error: %@\n----\nMore about scroll action API here: " \
+			"https://wix.github.io/Detox/docs/api/actions-on-element/" \
+			"#scrolloffset-direction-startpositionx-startpositiony",
+			NSStringFromCGPoint(startPoint), error.localizedDescription);
 }
 
 @end

--- a/detox/ios/Detox/Invocation/Element.swift
+++ b/detox/ios/Detox/Invocation/Element.swift
@@ -213,13 +213,7 @@ class Element : NSObject {
 	}
 	
 	func isHittable() throws -> Bool {
-		var error: NSError? = nil
-		let rv = view.dtx_isHittable(at: view.dtx_accessibilityActivationPointInViewCoordinateSpace, error: &error)
-		if let error = error {
-			throw error
-		}
-		
-		return rv
+		return view.dtx_isHittable
 	}
 	
 	func takeScreenshot(fileName: String?) -> [String : Any] {

--- a/detox/ios/Detox/Policy/DetoxPolicy.h
+++ b/detox/ios/Detox/Policy/DetoxPolicy.h
@@ -16,8 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (class, nonatomic, readonly) NSUInteger defaultPercentThresholdForVisibility;
 @property (class, nonatomic, readonly) NSUInteger consecutiveTouchPointsWithSameContentOffsetThreshold;
 
-+ (NSString*)percentDescriptionForValue:(CGFloat)value;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/detox/ios/Detox/Policy/DetoxPolicy.m
+++ b/detox/ios/Detox/Policy/DetoxPolicy.m
@@ -22,16 +22,4 @@
 	return 12;
 }
 
-+ (NSString*)percentDescriptionForValue:(CGFloat)value {
-	static NSNumberFormatter* formatter;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		formatter = [NSNumberFormatter new];
-		formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
-		formatter.numberStyle = NSNumberFormatterPercentStyle;
-	});
-	
-	return [formatter stringFromNumber:@(value)];
-}
-
 @end

--- a/detox/ios/Detox/Utilities/NSObject+DetoxUtils.h
+++ b/detox/ios/Detox/Utilities/NSObject+DetoxUtils.h
@@ -42,6 +42,8 @@ static double LNLinearInterpolate(CGFloat from, CGFloat to, CGFloat p)
 - (BOOL)dtx_isFocused;
 
 @property (nonatomic, readonly) BOOL dtx_isHittable;
+- (BOOL)dtx_isHittableAtPoint:(CGPoint)viewPoint
+						error:(NSError* __strong __nullable * __nullable)error;
 - (void)dtx_assertHittable;
 - (void)dtx_assertHittableAtPoint:(CGPoint)point;
 

--- a/detox/ios/Detox/Utilities/NSObject+DetoxUtils.h
+++ b/detox/ios/Detox/Utilities/NSObject+DetoxUtils.h
@@ -35,7 +35,7 @@ static double LNLinearInterpolate(CGFloat from, CGFloat to, CGFloat p)
 - (BOOL)dtx_isVisible;
 - (void)dtx_assertVisibleWithPercent:(nullable NSNumber *)percent;
 - (BOOL)dtx_isVisibleAtRect:(CGRect)rect percent:(nullable NSNumber *)percent
-					  error:(NSError* __strong * __nullable)error;
+					  error:(NSError* __strong __nullable * __nullable)error;
 - (void)dtx_assertVisible;
 - (void)dtx_assertVisibleAtRect:(CGRect)rect percent:(nullable NSNumber *)percent;
 

--- a/detox/ios/Detox/Utilities/NSObject+DetoxUtils.h
+++ b/detox/ios/Detox/Utilities/NSObject+DetoxUtils.h
@@ -33,6 +33,7 @@ static double LNLinearInterpolate(CGFloat from, CGFloat to, CGFloat p)
 @property (nonatomic, readonly) CGRect dtx_visibleBounds;
 
 - (BOOL)dtx_isVisible;
+- (void)dtx_assertVisibleWithPercent:(nullable NSNumber *)percent;
 - (BOOL)dtx_isVisibleAtRect:(CGRect)rect percent:(nullable NSNumber *)percent
 					  error:(NSError* __strong * __nullable)error;
 - (void)dtx_assertVisible;
@@ -41,8 +42,6 @@ static double LNLinearInterpolate(CGFloat from, CGFloat to, CGFloat p)
 - (BOOL)dtx_isFocused;
 
 @property (nonatomic, readonly) BOOL dtx_isHittable;
-- (BOOL)dtx_isHittableAtPoint:(CGPoint)point;
-- (BOOL)dtx_isHittableAtPoint:(CGPoint)point error:(NSError* __strong * __nullable)error;
 - (void)dtx_assertHittable;
 - (void)dtx_assertHittableAtPoint:(CGPoint)point;
 

--- a/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
@@ -141,15 +141,19 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 }
 
 - (BOOL)dtx_isVisibleAtRect:(CGRect)rect percent:(nullable NSNumber *)percent
-					  error:(NSError *__strong  _Nullable *)error {
+					  error:(NSError* __strong  _Nullable *)error {
 	return [self.dtx_view dtx_isVisibleAtRect:rect percent:percent error:error];
 }
 
 - (void)dtx_assertVisible {
-	[self dtx_assertVisibleAtRect:self.dtx_bounds percent:nil];
+	[self dtx_assertVisibleWithPercent:nil];
 }
 
-- (void)dtx_assertVisibleAtRect:(CGRect)rect percent:(NSNumber *)percent {
+- (void)dtx_assertVisibleWithPercent:(nullable NSNumber *)percent {
+  [self dtx_assertVisibleAtRect:self.dtx_bounds percent:percent];
+}
+
+- (void)dtx_assertVisibleAtRect:(CGRect)rect percent:(nullable NSNumber *)percent {
 	[self.dtx_view dtx_assertVisibleAtRect:rect percent:percent];
 }
 
@@ -165,25 +169,9 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 	return YES;
 }
 
-- (BOOL)dtx_isHittableAtPoint:(CGPoint)point
-{
-	return YES;
-}
+- (void)dtx_assertHittable {}
 
-- (BOOL)dtx_isHittableAtPoint:(CGPoint)point error:(NSError* __strong * __nullable)error
-{
-	return YES;
-}
-
-- (void)dtx_assertHittable
-{
-	
-}
-
-- (void)dtx_assertHittableAtPoint:(CGPoint)point
-{
-	
-}
+- (void)dtx_assertHittableAtPoint:(CGPoint)point {}
 
 - (NSString *)dtx_text
 {

--- a/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
@@ -41,7 +41,7 @@ static NSDictionary* DTXPointToDictionary(CGPoint point)
 DTX_ALWAYS_INLINE
 static NSString* DTXPointToString(CGPoint point)
 {
-	return [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:DTXPointToDictionary(point) options:0 error:NULL] encoding:NSUTF8StringEncoding];
+	return [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:DTXPointToDictionary(point) options:0 error:nil] encoding:NSUTF8StringEncoding];
 }
 
 @interface NSObject ()
@@ -137,11 +137,11 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 }
 
 - (BOOL)dtx_isVisible {
-	return [self dtx_isVisibleAtRect:self.dtx_bounds percent:nil error:NULL];
+	return [self dtx_isVisibleAtRect:self.dtx_bounds percent:nil error:nil];
 }
 
 - (BOOL)dtx_isVisibleAtRect:(CGRect)rect percent:(nullable NSNumber *)percent
-					  error:(NSError* __strong  _Nullable *)error {
+					  error:(NSError* __strong * __nullable)error {
 	return [self.dtx_view dtx_isVisibleAtRect:rect percent:percent error:error];
 }
 
@@ -255,7 +255,7 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 		{
 			return;
 		}
-		
+
 		if([key isEqualToString:@"dtx_text"])
 		{
 			rv[@"text"] = obj;
@@ -367,9 +367,9 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 	return rv;
 }
 
-- (NSDictionary<NSString *,id> *)dtx_elementDebugAttributes
+- (NSDictionary<NSString *, id> *)dtx_elementDebugAttributes
 {
-	NSMutableDictionary* rv = [NSMutableDictionary new];
+	NSMutableDictionary<NSString *, id> *rv = [NSMutableDictionary new];
 	[rv addEntriesFromDictionary:NSObject.dtx_genericElementDebugAttributes];
 	
 	rv[@"elementAttributes"] = [self dtx_attributes];

--- a/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
@@ -169,6 +169,11 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 	return YES;
 }
 
+- (BOOL)dtx_isHittableAtPoint:(CGPoint)viewPoint
+						error:(NSError* __strong __nullable * __nullable)error {
+  return YES;
+}
+
 - (void)dtx_assertHittable {}
 
 - (void)dtx_assertHittableAtPoint:(CGPoint)point {}

--- a/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/NSObject+DetoxUtils.m
@@ -141,7 +141,7 @@ BOOL __DTXPointEqualToPoint(CGPoint a, CGPoint b)
 }
 
 - (BOOL)dtx_isVisibleAtRect:(CGRect)rect percent:(nullable NSNumber *)percent
-					  error:(NSError* __strong * __nullable)error {
+					  error:(NSError* __strong __nullable * __nullable)error {
 	return [self.dtx_view dtx_isVisibleAtRect:rect percent:percent error:error];
 }
 

--- a/detox/ios/Detox/Utilities/UIResponder+First.h
+++ b/detox/ios/Detox/Utilities/UIResponder+First.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UIResponder (First)
 
+/// Finds the first reponder.
+/// @see https://stackoverflow.com/a/21330810/11686340
 + (instancetype)dtx_first;
 
 @end

--- a/detox/ios/Detox/Utilities/UIResponder+First.h
+++ b/detox/ios/Detox/Utilities/UIResponder+First.h
@@ -1,0 +1,19 @@
+//
+//  UIResponder+First.h
+//  Detox
+//
+//  Created by Asaf Korem on 02/12/2021.
+//  Copyright © 2021 Wix. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIResponder (First)
+
++ (instancetype)dtx_first;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/detox/ios/Detox/Utilities/UIResponder+First.m
+++ b/detox/ios/Detox/Utilities/UIResponder+First.m
@@ -1,0 +1,26 @@
+//
+//  UIResponder+First.m
+//  Detox
+//
+//  Created by Asaf Korem on 02/12/2021.
+//  Copyright © 2021 Wix. All rights reserved.
+//
+
+#import "UIResponder+First.h"
+
+static __weak UIResponder *_dtx_first;
+
+@implementation UIResponder (First)
+
++ (instancetype)dtx_first {
+  _dtx_first = nil;
+  [[UIApplication sharedApplication] sendAction:@selector(responderAction:) to:nil from:nil
+									   forEvent:nil];
+  return _dtx_first;
+}
+
+- (void)responderAction:(id)sender {
+  _dtx_first = self;
+}
+
+@end

--- a/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
@@ -13,6 +13,7 @@
 #import "UIView+Drawing.h"
 #import "DetoxPolicy.h"
 #import "NSURL+DetoxUtils.h"
+#import "UIResponder+First.h"
 
 @interface DTXTouchVisualizerWindow : UIWindow @end
 
@@ -382,6 +383,11 @@ DTX_DIRECT_MEMBERS
 
   if ([self isDescendantOfView:visibleContainer]) {
 	return [self canHitFromView:self atAbsPoint:absPoint error:error];
+  }
+
+  UIView *firstResponderInputView = UIResponder.dtx_first.inputView;
+  if ([self isDescendantOfView:firstResponderInputView]) {
+	return [self canHitFromView:firstResponderInputView atAbsPoint:absPoint error:error];
   }
 
   return [self canHitFromView:visibleContainer atAbsPoint:absPoint error:error];

--- a/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
@@ -403,7 +403,6 @@ DTX_DIRECT_MEMBERS
   return CGRectIntersection(self.bounds, CGRectMake(point.x - 0.5, point.y - 0.5, 1, 1));
 }
 
-
 - (BOOL)canHitFromView:(UIView *)originView atAbsPoint:(CGPoint)point
 				 error:(NSError* __strong *)error {
   CGPoint absOrigin = [originView calcAbsOrigin];

--- a/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
@@ -216,7 +216,7 @@ DTX_DIRECT_MEMBERS
 	
 	if (isRegionObscured) {
 		*explanation = [NSString stringWithFormat:@"View does not pass visibility percent "
-						"threshold (%@)", [DetoxPolicy percentDescriptionForValue:percent]];
+						"threshold (%lu)", (unsigned long)percent];
 	}
 	
 	return isRegionObscured;
@@ -283,8 +283,7 @@ DTX_DIRECT_MEMBERS
 														   percent:percent]) {
 		auto errorDescription = [NSString stringWithFormat:@"View is clipped by one or more of its "
 								 "superviews' bounds and does not pass visibility percent "
-								 "threshold (%@)",
-								 [DetoxPolicy percentDescriptionForValue:percent]];
+								 "threshold (%lu)", (unsigned long)percent];
 		
 		auto userInfo = @{ NSLocalizedDescriptionKey: APPLY_PREFIX(errorDescription) };
 		
@@ -297,8 +296,7 @@ DTX_DIRECT_MEMBERS
 	if ([self _dtx_isTestedRegionObscured:testedRegionInWindowCoords
 						   inWindowBounds:windowToUse.bounds percent:percent]) {
 		auto errorDescription = [NSString stringWithFormat:@"View is obscured by its window bounds "
-								 "and does not pass visibility percent threshold (%@)",
-								 [DetoxPolicy percentDescriptionForValue:percent]];
+								 "and does not pass visibility percent threshold (%lu)", (unsigned long)percent];
 		
 		auto userInfo = @{ NSLocalizedDescriptionKey: APPLY_PREFIX(errorDescription) };
 		

--- a/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
@@ -225,7 +225,7 @@ DTX_DIRECT_MEMBERS
 }
 
 - (BOOL)_dtx_testVisibilityInRect:(CGRect)rect percent:(NSUInteger)percent
-							error:(NSError* __strong * __nullable)error {
+							error:(NSError* __strong __nullable * __nullable)error {
 	NSString* prefix = [NSString stringWithFormat:@"View “%@” is not visible:", self.dtx_shortDescription];
 	
 	if(UIApplication.sharedApplication._isSpringBoardShowingAnAlert)
@@ -314,7 +314,7 @@ DTX_DIRECT_MEMBERS
 }
 
 - (BOOL)dtx_isVisibleAtRect:(CGRect)rect percent:(nullable NSNumber *)percent
-					  error:(NSError* __strong * __nullable)error {
+					  error:(NSError* __strong __nullable * __nullable)error {
 	NSUInteger percentValue = percent ? percent.unsignedIntegerValue :
 		DetoxPolicy.defaultPercentThresholdForVisibility;
 	return [self _dtx_testVisibilityInRect:rect percent:percentValue error:error];
@@ -410,14 +410,14 @@ DTX_DIRECT_MEMBERS
 }
 
 - (BOOL)_isVisibleAroundPoint:(CGPoint)point visibleBounds:(CGRect)visibleBounds
-						error:(NSError* __strong * __nullable)error {
+						error:(NSError* __strong __nullable * __nullable)error {
   CGRect intersection = CGRectIntersection(
       visibleBounds, CGRectMake(point.x - 0.5, point.y - 0.5, 1, 1));
   return [self _dtx_testVisibilityInRect:intersection percent:100 error:error];
 }
 
 - (BOOL)_canHitFromView:(UIView *)originView atAbsPoint:(CGPoint)point
-			  	  error:(NSError* __strong * __nullable)error {
+			  	  error:(NSError* __strong __nullable * __nullable)error {
   CGPoint absOrigin = [originView calcAbsOrigin];
   CGPoint relativePoint = CGPointMake(point.x - absOrigin.x, point.y - absOrigin.y);
 

--- a/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
@@ -114,7 +114,7 @@ DTX_DIRECT_MEMBERS
 }
 
 - (BOOL)dtx_isVisibleAtRect:(CGRect)rect percent:(nullable NSNumber *)percent {
-	return [self dtx_isVisibleAtRect:rect percent:percent error:NULL];
+	return [self dtx_isVisibleAtRect:rect percent:percent error:nil];
 }
 
 - (UIImage*)dtx_imageFromView
@@ -363,7 +363,8 @@ DTX_DIRECT_MEMBERS
 					 visibleBounds.origin.y + visibleBounds.size.height / 2);
 }
 
-- (BOOL)dtx_isHittableAtPoint:(CGPoint)viewPoint error:(NSError* __strong *)error {
+- (BOOL)dtx_isHittableAtPoint:(CGPoint)viewPoint
+						error:(NSError* __strong __nullable * __nullable)error {
   if (viewPoint.x == NAN || viewPoint.y == NAN) {
 	if (error) {
 	  *error = [NSError

--- a/detox/ios/Detox/Utilities/UIWindow+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/UIWindow+DetoxUtils.m
@@ -136,17 +136,14 @@ static NSString* _DTXNSStringFromUISceneActivationState(UISceneActivationState s
 
 @implementation UIWindow (DetoxUtils)
 
-+ (UIWindow*)dtx_keyWindow
-{
-    UIWindow *foundWindow = nil;
-    NSArray *windows = [[UIApplication sharedApplication]windows];
-    for (UIWindow *window in windows) {
-        if (window.isKeyWindow) {
-            foundWindow = window;
-            break;
-        }
-    }
-    return foundWindow;
++ (UIWindow*)dtx_keyWindow {
+  NSArray *windows = [[UIApplication sharedApplication]windows];
+  for (UIWindow *window in windows) {
+	  if (window.isKeyWindow) {
+		  return window;
+	  }
+  }
+  return nil;
 }
 
 + (id)dtx_keyWindowScene

--- a/detox/package.json
+++ b/detox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "detox",
   "description": "E2E tests and automation for mobile",
-  "version": "19.2.0",
+  "version": "19.3.0-smoke.0",
   "bin": {
     "detox": "local-cli/cli.js"
   },

--- a/detox/test/e2e/03.actions-scroll.test.js
+++ b/detox/test/e2e/03.actions-scroll.test.js
@@ -109,7 +109,7 @@ describe('Actions - Scroll', () => {
     await expect(element(by.text('HText1'))).toBeVisible(1);
 
     try {
-      await element(by.id('ScrollViewH')).scrollTo('right');
+      await element(by.id('ScrollViewH')).scroll(200, 'right');
     } catch {}
 
     await expect(element(by.text('HText1'))).toBeVisible(1);
@@ -120,7 +120,7 @@ describe('Actions - Scroll', () => {
     await expect(element(by.text('Text1'))).toBeVisible(1);
 
     try {
-      await element(by.id('ScrollView161')).scrollTo('down');
+      await element(by.id('ScrollView161')).scroll(200, 'down');
     } catch {}
 
     await expect(element(by.text('Text1'))).toBeVisible(1);

--- a/detox/test/e2e/03.actions-scroll.test.js
+++ b/detox/test/e2e/03.actions-scroll.test.js
@@ -103,4 +103,26 @@ describe('Actions - Scroll', () => {
     await element(by.id('ScrollView161')).scrollToIndex(7);
     await expect(element(by.text('Text8'))).toBeVisible();
   });
+
+  it('should not scroll horizontally when scroll view is covered', async () => {
+    await element(by.id('toggleScrollOverlays')).tap();
+    await expect(element(by.text('HText1'))).toBeVisible(1);
+
+    try {
+      await element(by.id('ScrollViewH')).scrollTo('right');
+    } catch {}
+
+    await expect(element(by.text('HText1'))).toBeVisible(1);
+  });
+
+  it('should not scroll vertically when scroll view is covered', async () => {
+    await element(by.id('toggleScrollOverlays')).tap();
+    await expect(element(by.text('Text1'))).toBeVisible(1);
+
+    try {
+      await element(by.id('ScrollView161')).scrollTo('down');
+    } catch {}
+
+    await expect(element(by.text('Text1'))).toBeVisible(1);
+  });
 });

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -167,7 +167,10 @@ describe('Actions', () => {
     await element(by.id('toggleScrollOverlays')).tap();
 
     await element(by.id('ScrollView161')).swipe('up', 'slow', NaN, 0.9, 0.95);
-    await expect(element(by.text('Text1'))).not.toBeVisible(1);
+    if (device.getPlatform() === 'ios') {
+      // TODO: investigate why this assertion fails on Android
+      await expect(element(by.text('Text1'))).not.toBeVisible(1);
+    }
 
     await element(by.id('ScrollView161')).swipe('down', 'fast', NaN, 0.1, 0.05);
     await expect(element(by.text('Text1'))).toBeVisible(1);

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -155,19 +155,32 @@ describe('Actions', () => {
 
   it('should swipe horizontally', async () => {
     await expect(element(by.text('HText1'))).toBeVisible();
+
     await element(by.id('ScrollViewH')).swipe('left');
     await expect(element(by.text('HText1'))).not.toBeVisible();
+
     await element(by.id('ScrollViewH')).swipe('right');
     await expect(element(by.text('HText1'))).toBeVisible();
   });
 
-  it('should swipe by offset from specified positions', async () => {
+  it('should swipe vertically by offset from specified positions', async () => {
     await element(by.id('toggleScrollOverlays')).tap();
 
     await element(by.id('ScrollView161')).swipe('up', 'slow', NaN, 0.9, 0.95);
+    await expect(element(by.text('Text1'))).not.toBeVisible(1);
+
     await element(by.id('ScrollView161')).swipe('down', 'fast', NaN, 0.1, 0.05);
+    await expect(element(by.text('Text1'))).toBeVisible(1);
+  });
+
+  it('should swipe horizontally by offset from specified positions ', async () => {
+    await element(by.id('toggleScrollOverlays')).tap();
+
     await element(by.id('ScrollViewH')).swipe('left', 'slow', 0.25, 0.85, 0.75);
+    await expect(element(by.text('HText1'))).not.toBeVisible(1);
+
     await element(by.id('ScrollViewH')).swipe('right', 'fast', 0.25, 0.15, 0.25);
+    await expect(element(by.text('HText1'))).toBeVisible(1);
   });
 
   it('should not wait for long timeout (>1.5s)', async () => {

--- a/detox/test/e2e/03.actions.test.js
+++ b/detox/test/e2e/03.actions.test.js
@@ -145,7 +145,7 @@ describe('Actions', () => {
     await element(by.id('ScrollView161')).swipe('up');
 
     if (device.getPlatform() === 'ios') {
-      // TODO: investigate why this assertion fails on Android
+      // This won't work in Android, see related issue: https://github.com/facebook/react-native/issues/23870
       await expect(element(by.text('Text1'))).not.toBeVisible();
     }
 
@@ -168,7 +168,7 @@ describe('Actions', () => {
 
     await element(by.id('ScrollView161')).swipe('up', 'slow', NaN, 0.9, 0.95);
     if (device.getPlatform() === 'ios') {
-      // TODO: investigate why this assertion fails on Android
+      // This won't work in Android, see related issue: https://github.com/facebook/react-native/issues/23870
       await expect(element(by.text('Text1'))).not.toBeVisible(1);
     }
 

--- a/detox/test/e2e/33.attributes.test.js
+++ b/detox/test/e2e/33.attributes.test.js
@@ -204,8 +204,8 @@ describe('Attributes', () => {
 
         const innerViews = attributesArray.filter(a => a.identifier);
         expect(innerViews.length).toBe(2);
-        expect(innerViews[0]).toMatchObject({ ...viewShape, hittable: true });
-        expect(innerViews[1]).toMatchObject({ ...viewShape, hittable: false });
+        expect(innerViews[0]).toMatchObject({ ...viewShape });
+        expect(innerViews[1]).toMatchObject({ ...viewShape });
       });
     });
 

--- a/detox/test/e2e/34.visibility.test.js
+++ b/detox/test/e2e/34.visibility.test.js
@@ -1,13 +1,10 @@
 describe('visibility expectation', () => {
+  let halfVisibleElement;
+
   beforeEach(async () => {
     await device.reloadReactNative();
     await element(by.text('Visibility Expectation')).tap();
-  });
-
-  let halfVisibleElement;
-
-  beforeEach(() => {
-    halfVisibleElement = element(by.id('halfVisible'));
+    halfVisibleElement = await element(by.id('halfVisible'));
   });
 
   it(`should be truthy when at least 50% visibility is required`, async () => {

--- a/detox/test/e2e/35.overlay.test.js
+++ b/detox/test/e2e/35.overlay.test.js
@@ -1,0 +1,37 @@
+const { expectToThrow } = require('./utils/custom-expects');
+
+describe(':ios: Overlay', () => {
+  let showOverlayButton;
+  let verticalScrollView;
+
+  beforeEach(async () => {
+    await device.reloadReactNative();
+    await device.launchApp({newInstance: true});
+
+    await element(by.text('Overlay')).tap();
+
+    showOverlayButton = await element(by.id('ShowOverlayButton'));
+    await expect(showOverlayButton).toBeVisible();
+
+    verticalScrollView = await element(by.id('VerticalScrollView'));
+  });
+
+  describe('button', () => {
+    it('should not be hittable when overlay is shown', async () => {
+      await showOverlayButton.tap();
+      await expectToThrow(() => showOverlayButton.tap());
+    });
+  });
+
+  describe('scroll view', () => {
+    it('should be scrollable when overlay is not shown', async () => {
+      await verticalScrollView.scrollTo('bottom');
+      await expect(showOverlayButton).not.toBeVisible();
+    });
+
+    it('should not be scrollable when overlay is shown', async () => {
+      await showOverlayButton.tap();
+      await expectToThrow(() => verticalScrollView.scrollTo('bottom'));
+    });
+  });
+});

--- a/detox/test/ios/example/NativeModule.m
+++ b/detox/test/ios/example/NativeModule.m
@@ -87,4 +87,18 @@ RCT_EXPORT_METHOD(sendNotification:(NSString*)notification name:(NSString*)name)
 	});
 }
 
+RCT_EXPORT_METHOD(presentOverlayWindow) {
+    static UIWindow *overlayWindow;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        CGRect screenBounds = UIScreen.mainScreen.bounds;
+        overlayWindow = [[UIWindow alloc] initWithFrame:screenBounds];
+
+        [overlayWindow setWindowLevel:UIWindowLevelStatusBar];
+        [overlayWindow setHidden:NO];
+
+        [overlayWindow makeKeyAndVisible];
+    });
+}
+
 @end

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-test",
-  "version": "19.2.0",
+  "version": "19.3.0-smoke.0",
   "private": true,
   "engines": {
     "node": ">=8.3.0"
@@ -40,7 +40,7 @@
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
     "@types/node": "^12.20.37",
-    "detox": "^19.2.0",
+    "detox": "^19.3.0-smoke.0",
     "dtslint": "^4.0.6",
     "express": "^4.15.3",
     "glob": "^7.2.0",

--- a/detox/test/src/Screens/OverlayScreen.js
+++ b/detox/test/src/Screens/OverlayScreen.js
@@ -1,0 +1,59 @@
+import React, { Component } from 'react';
+import { View, ScrollView, TouchableOpacity, StyleSheet, Text, NativeModules, Dimensions } from 'react-native';
+
+const { NativeModule } = NativeModules;
+
+export default class OverlayScreen extends Component {
+  render() {
+    return (
+      <ScrollView style={styles.container} testID='VerticalScrollView'>
+        <TouchableOpacity onPress={() => NativeModule.presentOverlayWindow()} style={styles.button} testID='ShowOverlayButton'>
+          <Text style={styles.text}>Show Overlay</Text>
+        </TouchableOpacity>
+
+        <View style={styles.item}><Text style={styles.itemText}>Text1</Text></View>
+        <View style={styles.item}><Text style={styles.itemText}>Text2</Text></View>
+        <View style={styles.item}><Text style={styles.itemText}>Text3</Text></View>
+        <View style={styles.item}><Text style={styles.itemText}>Text4</Text></View>
+        <View style={styles.item}><Text style={styles.itemText}>Text5</Text></View>
+        <View style={styles.item}><Text style={styles.itemText}>Text6</Text></View>
+        <View style={styles.item}><Text style={styles.itemText}>Text7</Text></View>
+        <View style={styles.item}><Text style={styles.itemText}>Text8</Text></View>
+        <View style={styles.item}><Text style={styles.itemText}>Text9</Text></View>
+        <View style={styles.item}><Text style={styles.itemText}>Text10</Text></View>
+      </ScrollView>
+    );
+  }
+}
+
+const { height } = Dimensions.get('window');
+const itemHeight = height / 10 + 50;
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  button: {
+    backgroundColor: '#ffd9d9',
+    height: itemHeight,
+    justifyContent: "center",
+    alignItems: "center",
+    margin: 10
+  },
+  text: {
+    fontSize: 18,
+    color: '#000000',
+    textAlign: 'center'
+  },
+  item: {
+    height: itemHeight,
+    backgroundColor: '#d9d9ff',
+    justifyContent: "center",
+    alignItems: "center",
+    margin: 10
+  },
+  itemText: {
+    fontSize: 18,
+    color: '#525252',
+    textAlign: 'center'
+  }
+});

--- a/detox/test/src/Screens/index.js
+++ b/detox/test/src/Screens/index.js
@@ -21,6 +21,7 @@ import LaunchArgsScreen from './LaunchArgsScreen';
 import LaunchNotificationScreen from './LaunchNotificationScreen';
 import PickerViewScreen from './PickerViewScreen';
 import DeviceScreen from './DeviceScreen';
+import OverlayScreen from './OverlayScreen';
 import ElementScreenshotScreen from './ElementScreenshotScreen';
 import VirtualizedListStressScreen from './VirtualizedListStressScreen';
 import WebViewScreen from './WebViewScreen';
@@ -52,6 +53,7 @@ export {
   LaunchArgsScreen,
   LaunchNotificationScreen,
   DeviceScreen,
+  OverlayScreen,
   ElementScreenshotScreen,
   WebViewScreen,
   VirtualizedListStressScreen,

--- a/detox/test/src/app.js
+++ b/detox/test/src/app.js
@@ -105,7 +105,7 @@ class example extends Component {
         {this.renderScreenButton('Matchers', Screens.MatchersScreen)}
         {this.renderScreenButton('Actions', Screens.ActionsScreen)}
         {this.renderScreenButton('Visibility Expectation', Screens.VisibilityExpectationScreen)}
-        {!isAndroid && this.renderScreenButton('Visibility Debug Artifacts', Screens.VisibilityScreen)}
+        {isIos && this.renderScreenButton('Visibility Debug Artifacts', Screens.VisibilityScreen)}
         {this.renderScreenButton('Integrative Actions', Screens.IntegActionsScreen)}
         {this.renderScreenButton('FS Scroll Actions', Screens.ScrollActionsScreen)}
         {this.renderScreenButton('Assertions', Screens.AssertionsScreen)}
@@ -118,9 +118,10 @@ class example extends Component {
         {this.renderScreenButton('Network', Screens.NetworkScreen)}
         {this.renderAnimationScreenButtons()}
         {this.renderScreenButton('Device', Screens.DeviceScreen)}
+        {isIos && this.renderScreenButton('Overlay', Screens.OverlayScreen)}
         {this.renderScreenButton('Location', Screens.LocationScreen)}
-        {!isAndroid && this.renderScreenButton('DatePicker', Screens.DatePickerScreen)}
-        {!isAndroid && this.renderScreenButton('Picker', Screens.PickerViewScreen)}
+        {isIos && this.renderScreenButton('DatePicker', Screens.DatePickerScreen)}
+        {isIos && this.renderScreenButton('Picker', Screens.PickerViewScreen)}
         {isAndroid && this.renderScreenButton('WebView', Screens.WebViewScreen)}
         {this.renderScreenButton('Attributes', Screens.AttributesScreen)}
 

--- a/examples/demo-native-android/package.json
+++ b/examples/demo-native-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-demo-native-android",
-  "version": "19.2.0",
+  "version": "19.3.0-smoke.0",
   "private": true,
   "scripts": {
     "packager": "react-native start",
@@ -8,7 +8,7 @@
     "e2e": "mocha e2e --opts ./e2e/mocha.opts"
   },
   "devDependencies": {
-    "detox": "^19.2.0",
+    "detox": "^19.3.0-smoke.0",
     "mocha": "^6.1.3"
   },
   "detox": {}

--- a/examples/demo-native-ios/package.json
+++ b/examples/demo-native-ios/package.json
@@ -1,9 +1,9 @@
 {
   "name": "detox-demo-native-ios",
-  "version": "19.2.0",
+  "version": "19.3.0-smoke.0",
   "private": true,
   "devDependencies": {
-    "detox": "^19.2.0",
+    "detox": "^19.3.0-smoke.0",
     "mocha": "^6.1.3"
   },
   "detox": {

--- a/examples/demo-react-native-detox-instruments/package.json
+++ b/examples/demo-react-native-detox-instruments/package.json
@@ -1,10 +1,10 @@
 {
   "name": "demo-react-native-detox-instruments",
-  "version": "19.2.0",
+  "version": "19.3.0-smoke.0",
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "detox": "^19.2.0",
+    "detox": "^19.3.0-smoke.0",
     "mocha": "6.x.x"
   },
   "detox": {

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-react-native-jest",
-  "version": "19.2.0",
+  "version": "19.3.0-smoke.0",
   "private": true,
   "scripts": {
     "test:ios-release": "detox test --configuration ios.sim.release -l verbose",
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",
-    "detox": "^19.2.0",
+    "detox": "^19.3.0-smoke.0",
     "jest": "^27.0.0",
     "sanitize-filename": "^1.6.1",
     "ts-jest": "^27.0.0",

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "19.2.0",
+  "version": "19.3.0-smoke.0",
   "private": true,
   "scripts": {
     "start": "react-native start",
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^8.2.0",
-    "detox": "^19.2.0",
+    "detox": "^19.3.0-smoke.0",
     "mocha": "^6.1.3",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
     "generation",
     "."
   ],
-  "version": "19.2.0",
+  "version": "19.3.0-smoke.0",
   "npmClient": "npm",
   "command": {
     "publish": {

--- a/package.json
+++ b/package.json
@@ -54,5 +54,5 @@
     "shell-utils": "1.x.x",
     "unified": "^10.1.0"
   },
-  "version": "19.2.0"
+  "version": "19.3.0-smoke.0"
 }


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

This pull request addresses the issue described here: #2834.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have reproduced the bug from the issue, by adding more tests to the test-app. Apparently, only the `scrollTo` didn't work as expected because we don't assert if the called element is hidden by another view or window.

This fixes the bug as we did in all other UI interaction actions (taps, long-presses, date-picking), by raising an assertion when the view is not hittable.

Similar failed tests could be achieved by hiding the scroll view with another view, but I still decided to implement them with `UIWindow` ("overlay") since it is not tested anywhere in our test suite, and that's an iOS-specific behaviour (in Android we touch the visible screen, and not the window behind the element).

Also, in addition to this fix, I rewrote the mechanism of assertions before interacting with a view (for any UI gesture).