### PR TITLE
Fix kotlin proguard configuration

### DIFF
--- a/detox/android/detox/proguard-rules-app.pro
+++ b/detox/android/detox/proguard-rules-app.pro
@@ -11,3 +11,4 @@
 -keep class kotlin.jvm.** { *; }
 -keep class kotlin.collections.** { *; }
 -keep class kotlin.text.** { *; }
+-keep class kotlin.io.** { *; }

--- a/detox/test/android/app/proguard-rules.pro
+++ b/detox/test/android/app/proguard-rules.pro
@@ -26,4 +26,3 @@
 -keepclassmembers class * {
     @com.facebook.jni.annotations.DoNotStrip *;
 }
--keep class kotlin.** { *; }


### PR DESCRIPTION
Missing kotlin.io in proguard is causing a failure of notification tests on release builds