### PR TITLE
refactor: throw DetoxRuntimeError if an invocation fails

### DIFF
--- a/detox/src/client/__snapshots__/Client.test.js.snap
+++ b/detox/src/client/__snapshots__/Client.test.js.snap
@@ -6,29 +6,34 @@ exports[`Client .execute() should throw "testFailed" error even if it has no a v
 
 exports[`Client .execute() should throw "testFailed" error with view hierarchy (on --loglevel debug) 1`] = `
 "Test Failed: this is an error
+
 View Hierarchy:
 mock-hierarchy"
 `;
 
 exports[`Client .execute() should throw "testFailed" error with view hierarchy (on --loglevel trace) 1`] = `
 "Test Failed: this is an error
+
 View Hierarchy:
 mock-hierarchy"
 `;
 
 exports[`Client .execute() should throw "testFailed" error without view hierarchy but with a hint (on --loglevel error) 1`] = `
 "Test Failed: this is an error
-TIP: To print view hierarchy on failed actions/matches, use log-level verbose or higher."
+
+HINT: To print view hierarchy on failed actions/matches, use log-level verbose or higher."
 `;
 
 exports[`Client .execute() should throw "testFailed" error without view hierarchy but with a hint (on --loglevel info) 1`] = `
 "Test Failed: this is an error
-TIP: To print view hierarchy on failed actions/matches, use log-level verbose or higher."
+
+HINT: To print view hierarchy on failed actions/matches, use log-level verbose or higher."
 `;
 
 exports[`Client .execute() should throw "testFailed" error without view hierarchy but with a hint (on --loglevel warn) 1`] = `
 "Test Failed: this is an error
-TIP: To print view hierarchy on failed actions/matches, use log-level verbose or higher."
+
+HINT: To print view hierarchy on failed actions/matches, use log-level verbose or higher."
 `;
 
 exports[`Client .execute() should throw even if a non-error object is thrown 1`] = `"non-error"`;

--- a/detox/src/errors/DetoxRuntimeError.js
+++ b/detox/src/errors/DetoxRuntimeError.js
@@ -5,10 +5,10 @@ const DetoxError = require('./DetoxError');
 /**
  * @typedef DetoxRuntimeErrorOptions
  * @property message { String }
- * @property hint { String }
- * @property debugInfo { String }
- * @property noStack { Boolean }
- * @property inspectOptions { Object }
+ * @property [hint] { String }
+ * @property [debugInfo] { String }
+ * @property [noStack] { Boolean }
+ * @property [inspectOptions] { Object }
  */
 
 class DetoxRuntimeError extends DetoxError {


### PR DESCRIPTION
## Description

This should allow us to easily distinguish between Detox-generated errors vs something else.

At the moment, we don't – `invoke` errors get wrapped into regular `Error` objects for no good reason.