### PR TITLE
Update Guide.RunningOnCI for React Native usage with Release configuration

### DIFF
--- a/docs/Guide.RunningOnCI.md
+++ b/docs/Guide.RunningOnCI.md
@@ -48,6 +48,10 @@ We will need to create a [release device configuration for Detox](APIRef.Configu
 
 > TIP: Notice that the name `example` above should be replaced with your actual project name.
 
+> **Tip:** You may need to add build config `ENABLE_TESTABILITY=YES` to `xcodebuild` to keep symbols not being striped when you are using React Native.
+> Detox tests app with DetoxSync which dynamic loads React Native symbols to hook RN, so we need to keep these symbols visible.
+> Full build command will looks like: `xcodebuild -project ios/example.xcodeproj -scheme example -configuration Release -sdk iphonesimulator -derivedDataPath ios/build ENABLE_TESTABILITY=YES`
+
 ### Step 2: Add `build` and `test` Commands to Your CI Script
 
 Assuming your CI is executing some sort of shell script, add the following commands that should run inside the project root:


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request is for document enhancement.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I added a tip for CI testing guide.

When using Detox with React Native, DetoxSync dynamic loads React Native symbols to hook it.
But in Release configuration, xcode strips symbols by default, this will cause dlsym() get null pointer and when DetoxSync executes the code, boooom, say hi to SIGSEGV. [code](https://github.com/wix/DetoxSync/blob/master/DetoxSync/DetoxSync/ReactNativeSupport/DTXReactNativeSupport.m#L117)

To solve this problem in easy (but not suitable for production environment) way is to add build config `ENABLE_TESTABILITY=YES` to `xcodebuild` to keep symbols not being striped when using React Native.
