### PR TITLE
iOS(AppleSimUtils): enable NSZombies on app launch.

### DIFF
--- a/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
@@ -343,7 +343,7 @@ class AppleSimUtils {
     }
 
     const cmdArgs = quote(_.flatten(this._mergeLaunchArgs(launchArgs, languageAndLocale)));
-    let launchBin = `SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="${dylibs}" ` +
+    let launchBin = `SIMCTL_CHILD_NSZombieEnabled=YES SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="${dylibs}" ` +
       `/usr/bin/xcrun simctl launch ${udid} ${bundleId} --args ${cmdArgs}`;
 
     const result = await exec.execWithRetriesAndLogs(launchBin, {


### PR DESCRIPTION
This workaround solves the issue described here:
- https://github.com/firebase/firebase-ios-sdk/issues/9083

And some of the crashes that was mentioned here:
- https://github.com/wix/Detox/issues/3000
- https://github.com/wix/Detox/issues/3123
- https://github.com/wix/Detox/issues/2641
- https://github.com/wix/Detox/issues/2802