### PR TITLE
Update support docs to java11 and min version 64

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Detox is built from the ground up to support React Native projects as well as pu
 
 The following React Native versions have been tested:
 
-| iOS                                                                                            | Android                                                                                                                                                                                                                                        |
-|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ≤0.66.x                                                                                        | ≥0.64, ≤0.66 - <ul> <li>Visibility edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/23870) </li><li>Switch edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/32594) </li></ul> |
+| iOS                                                                                            | Android                                                                                                            |
+|------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| ≤0.66.x                                                                                        | ≥0.64, ≤0.66 - Visibility edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/23870) \* |
 
 Future versions are most likely supported, but have not been tested yet. Please open issues if you find specific issues with newer React Native versions.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following React Native versions have been tested:
 
 | iOS                                                                                            | Android                                                                                                                                                                                                                                        |
 |------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ≤0.66.x                                                                                        | ≥0.64, ≤0.66 - <ul> <li>Visibility edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/23870) </li><li>Switch edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/23870) </li></ul> |
+| ≤0.66.x                                                                                        | ≥0.64, ≤0.66 - <ul> <li>Visibility edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/23870) </li><li>Switch edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/32594) </li></ul> |
 
 Future versions are most likely supported, but have not been tested yet. Please open issues if you find specific issues with newer React Native versions.
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Detox is built from the ground up to support React Native projects as well as pu
 
 The following React Native versions have been tested:
 
-| iOS     | Android                                                                                                           |
-|---------|-------------------------------------------------------------------------------------------------------------------|
-| ≤0.66.x | ≥0.59, ≤0.66 - Visibility edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/23870)\* |
+| iOS                                                                                            | Android                                                                                                                                                                                                                                        |
+|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ≤0.66.x                                                                                        | ≥0.64, ≤0.66 - <ul> <li>Visibility edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/23870) </li><li>Switch edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/23870) </li></ul> |
 
 Future versions are most likely supported, but have not been tested yet. Please open issues if you find specific issues with newer React Native versions.
 

--- a/docs/Introduction.AndroidDevEnv.md
+++ b/docs/Introduction.AndroidDevEnv.md
@@ -15,7 +15,7 @@ Note that running automated UI tests is _not the same_ as developing Android app
 
 This is the most basic step in the process, as without a proper Java SDK installed, nothing Android-ish works -- at least not from command-line, which is mandatory for executing `Detox`.
 
-_The bottom line is that **Android needs Java 1.8 installed**._
+_The bottom line is that **Android needs Java 11 installed**._
 
 To check for your real java-executable’s version, in a command-line console, run:
 
@@ -26,15 +26,15 @@ java -version
 What needs to be verified is that `java` is in-path and that the output contains something as this:
 
 ```sh
-java version "1.8.0_121"
+java version "11.0.11"
 ...
 ```
 
-Namely, that the version is `1.8.x_abc`.
+Namely, that the version is `11.0.11`.
 
 > Note: Do not be confused by the Java version potentially used by your browsers, etc. For `Detox`, what the command-line sees is what matters.
 
-On macOS, in particular, java comes from both the OS _and_ possibly other installers such as `homebrew`, so you are more likely to go into a mess: see [this Stack Overflow post](https://stackoverflow.com/questions/24342886/how-to-install-java-8-on-mac).
+On macOS, in particular, java comes from both the OS _and_ possibly other installers such as `homebrew`, so you are more likely to go into a mess: see [this Stack Overflow post](https://stackoverflow.com/questions/52524112/how-do-i-install-java-on-mac-osx-allowing-version-switching/52524114#52524114).
 
 ---
 

--- a/docs/Introduction.AndroidDevEnv.md
+++ b/docs/Introduction.AndroidDevEnv.md
@@ -15,7 +15,7 @@ Note that running automated UI tests is _not the same_ as developing Android app
 
 This is the most basic step in the process, as without a proper Java SDK installed, nothing Android-ish works -- at least not from command-line, which is mandatory for executing `Detox`.
 
-_The bottom line is that **Android needs Java installed**. If you want to run with React Native 66 and Android 12 then it needs to be at least Java 11, otherwise you should have at least Java 8._
+_The bottom line is that **Android needs Java installed**. If you want to run with React Native 66 and Android 12 then it needs to be at least Java 11, otherwise you should have Java 8._
 
 To check for your real java-executable’s version, in a command-line console, run:
 

--- a/docs/Introduction.AndroidDevEnv.md
+++ b/docs/Introduction.AndroidDevEnv.md
@@ -23,7 +23,7 @@ To check for your real java-executable’s version, in a command-line console, r
 java -version
 ```
 
-What needs to be verified is that `java` is in-path and that the output contains something as this:
+What needs to be verified is that `java` is in-path and that the output contains something like this:
 
 ```sh
 java version "11.0.11"

--- a/docs/Introduction.AndroidDevEnv.md
+++ b/docs/Introduction.AndroidDevEnv.md
@@ -15,7 +15,7 @@ Note that running automated UI tests is _not the same_ as developing Android app
 
 This is the most basic step in the process, as without a proper Java SDK installed, nothing Android-ish works -- at least not from command-line, which is mandatory for executing `Detox`.
 
-_The bottom line is that **Android needs Java 11 installed**._
+_The bottom line is that **Android needs Java installed**. If you want to run with React Native 66 and Android 12 then it needs to be at least Java 11, otherwise you should have at least Java 8._
 
 To check for your real java-executable’s version, in a command-line console, run:
 
@@ -26,11 +26,11 @@ java -version
 What needs to be verified is that `java` is in-path and that the output contains something like this:
 
 ```sh
-java version "11.0.11"
+java version "11.x.x"
 ...
 ```
 
-Namely, that the version is `11.0.11`.
+Namely, that the version is `11.x.x`.
 
 > Note: Do not be confused by the Java version potentially used by your browsers, etc. For `Detox`, what the command-line sees is what matters.
 


### PR DESCRIPTION
## Description
Update documentation to reflect that we now use java11 and that the minimum RN version has changed to 0.64
