### PR TITLE
fix(ios): remove Xcode 12.5 + M1 workaround call.

### DIFF
--- a/detox/test/ios/Podfile
+++ b/detox/test/ios/Podfile
@@ -29,5 +29,4 @@ end
 
 post_install do |installer|
   react_native_post_install(installer)
-  __apply_Xcode_12_5_M1_post_install_workaround(installer)
 end


### PR DESCRIPTION
We are not using M1s, so I believe that we don't need the workaround (?)