### PR TITLE
fix(iOS, Podfile): check RN version before calling workaround.

### DIFF
--- a/detox/test/ios/Podfile
+++ b/detox/test/ios/Podfile
@@ -29,5 +29,8 @@ end
 
 post_install do |installer|
   react_native_post_install(installer)
-  __apply_Xcode_12_5_M1_post_install_workaround(installer)
+  # See https://github.com/wix/Detox/pull/3035#discussion_r774747705
+  if ENV["REACT_NATIVE_VERSION"] && ENV["REACT_NATIVE_VERSION"].match(/0.6[6,7].*/)
+    __apply_Xcode_12_5_M1_post_install_workaround(installer)
+  end
 end


### PR DESCRIPTION
Wrapping RN v0.66 - v0.67 workaround with a check whether the RN version is 0.66 or 0.67, to avoid failures on CI when building Detox with RN v0.64. This workaround will be removed at RN v0.68.

Otherwise, we'll get `undefined method` error on RN v0.64:
```
Generating Pods project
--
  | [!] An error occurred while processing the post-install hook of the Podfile.
  |  
  | undefined method `__apply_Xcode_12_5_M1_post_install_workaround' for #<Pod::Podfile:0x00007f7f5bd58f68>
  |  
  | /Users/builder/work/detox/test/ios/Podfile:32:in `block (2 levels) in from_ruby'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-core-1.10.2/lib/cocoapods-core/podfile.rb:179:in `post_install!'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/installer.rb:897:in `run_podfile_post_install_hook'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/installer.rb:885:in `block in run_podfile_post_install_hooks'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/user_interface.rb:145:in `message'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/installer.rb:884:in `run_podfile_post_install_hooks'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/installer.rb:329:in `block (2 levels) in create_and_save_projects'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/installer/xcode/pods_project_generator/pods_project_writer.rb:61:in `write!'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/installer.rb:328:in `block in create_and_save_projects'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/user_interface.rb:64:in `section'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/installer.rb:307:in `create_and_save_projects'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/installer.rb:299:in `generate_pods_project'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/installer.rb:178:in `integrate'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/installer.rb:166:in `install!'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/command/install.rb:52:in `run'
  | /Library/Ruby/Gems/2.6.0/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/lib/cocoapods/command.rb:52:in `run'
  | /Library/Ruby/Gems/2.6.0/gems/cocoapods-1.10.2/bin/pod:55:in `<top (required)>'
  | /usr/local/bin/pod:23:in `load'
  | /usr/local/bin/pod:23:in `<main>'
```

The error was detected by @igorgn, in which also verified that this commit fixes the bug.