### PR TITLE
Revert "UIView+DetoxUtils: put thread to sleep."

### DIFF
--- a/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
@@ -349,11 +349,6 @@ DTX_DIRECT_MEMBERS
 #pragma mark - Check Hitability
 
 - (BOOL)dtx_isHittable {
-  // TODO: This workaround should be removed (`sleepForTimeInterval`).
-  // It was added because DetoxSync appears to ignore UI view controller transitions to be completed
-  // before the next action is taking place.
-  [NSThread sleepForTimeInterval:0.5];
-
   CGPoint point = [self findVisiblePoint];
   return [self dtx_isHittableAtPoint:point error:nil];
 }


### PR DESCRIPTION
This PR reverts the commit [UIView+DetoxUtils: put thread to sleep before checking view hitability.](https://github.com/wix/Detox/pull/3145/commits/668965dfeb22cffefec125196be91d353b80a7db).
It was added temporally for test purposes, and merged by mistake here: https://github.com/wix/Detox/pull/3145.