### PR TITLE
fix(iOS,Podfile): fix workaround condition.

### DIFF
--- a/detox/test/ios/Podfile
+++ b/detox/test/ios/Podfile
@@ -30,7 +30,7 @@ end
 post_install do |installer|
   react_native_post_install(installer)
   # See https://github.com/wix/Detox/pull/3035#discussion_r774747705
-  if ENV["REACT_NATIVE_VERSION"] && ENV["REACT_NATIVE_VERSION"].match(/0.6[6,7].*/)
+  if !ENV["REACT_NATIVE_VERSION"] || ENV["REACT_NATIVE_VERSION"].match(/0.6[6,7].*/)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
   end
 end


### PR DESCRIPTION
If the React Native version is not defined using the env-arg, we are not overriding the version (currently, we use v0.66).