### PR TITLE
Update with details of toHaveLabel inconsistency

### DIFF
--- a/docs/APIRef.Expect.md
+++ b/docs/APIRef.Expect.md
@@ -67,6 +67,8 @@ await expect(element(by.id('UniqueId204'))).toHaveText('I contain some text');
 
 Expects the element to have the specified label as its accessibility label (iOS) or content description (Android). In React Native, this corresponds to the value in the [`accessibilityLabel`](https://facebook.github.io/react-native/docs/view.html#accessibilitylabel) prop.
 
+Note that there is an inconsistency between the implementation for accessibility between android and ios. On ios if a View has no accessibilityLabel explicitly defined, then it defaults to having a concatenation of the accessibilityLabels of the child Views. On android, the same View would have no accessibilityLabel at all. See [this](https://github.com/facebook/react-native/issues/32826) issue for details.
+
 ```js
 await expect(element(by.id('UniqueId204'))).toHaveLabel('Done');
 ```


### PR DESCRIPTION
## Description
Android and Ios can behave differently with toHaveLabel, because the RN implementation of accessibilityLabel is different. On android, not setting the label explicitly will result in a View without any accessibilityLabel. On Ios, not setting the label will result in a view that has an accessibilityLabel that is a concatenation of the accessibilityLabels of the child Views. This PR updates the docs to point out this difference. 

Addresses [this](https://github.com/wix/Detox/issues/3119) issue.