### PR TITLE
docs: Fix AndroidDevEnv lint errors

### DIFF
--- a/docs/Introduction.AndroidDevEnv.md
+++ b/docs/Introduction.AndroidDevEnv.md
@@ -29,7 +29,9 @@ What needs to be verified is that `java` is in-path and that the output contains
 java version "11.x.x"
 ...
 ```
+
 or, if you have [openjdk](https://techoral.com/blog/openjdk-developers-guide.html) installed:
+
 ```sh
 openjdk version "11.0.2" 2019-01-1
 ...
@@ -47,7 +49,7 @@ If otherwise the version is simply wrong, try these course of actions:
 
 - On MacOS, in particular, Java comes from both the OS _and_ possibly other installers such as `homebrew`. That can really get things tangled up. To mitigate:
   - Use one of the options suggested in this [Stack Overflow post](https://stackoverflow.com/questions/52524112/how-do-i-install-java-on-mac-osx-allowing-version-switching/52524114#52524114).
-  - Install OpenJDK 11 on top of the existing versions ([how to check?](https://medium.com/notes-for-geeks/java-home-and-java-home-on-macos-f246cab643bd)): https://techoral.com/blog/java/install-openjdk-11-on-mac.html. Consider employing the `JAVA_HOME` variable to get things to work right. _Note: This is more suitable if your environment is fairly clean, and does not contain versions from 3rd-party installers (e.g. `homebrew`)._
+  - Install OpenJDK 11 on top of the existing versions ([how to check?](https://medium.com/notes-for-geeks/java-home-and-java-home-on-macos-f246cab643bd)): <https://techoral.com/blog/java/install-openjdk-11-on-mac.html>. Consider employing the `JAVA_HOME` variable to get things to work right. _Note: This is more suitable if your environment is fairly clean, and does not contain versions from 3rd-party installers (e.g. `homebrew`)._
 - Use these refs, which might be useful:
   - <https://java.com/en/download/faq/java_mac.xml#version>
   - <https://www.java.com/en/download/help/version_manual.xml>


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #<?>

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have addresses some markdown linter errors:

```
docs/Introduction.AndroidDevEnv.md:31 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
docs/Introduction.AndroidDevEnv.md:33 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```sh"]
docs/Introduction.AndroidDevEnv.md:50:157 MD034/no-bare-urls Bare URL used [Context: "https://techoral.com/blog/java..."]
```

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
