### PR TITLE
AppleSimUtils: replace zombie-enabled workaround with designated flag.

### DIFF
--- a/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
@@ -344,7 +344,7 @@ class AppleSimUtils {
     }
 
     const cmdArgs = quote(_.flatten(this._mergeLaunchArgs(launchArgs, languageAndLocale)));
-    let launchBin = `SIMCTL_CHILD_NSZombieEnabled=YES SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="${dylibs}" ` +
+    let launchBin = `SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=YES SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="${dylibs}" ` +
       `/usr/bin/xcrun simctl launch ${udid} ${bundleId} --args ${cmdArgs}`;
 
     const result = await exec.execWithRetriesAndLogs(launchBin, {


### PR DESCRIPTION
Enable `GULGeneratedClassDisposeDisabled` environment flag to disable GoogleUtilities' Swizzler from disposing generated classes when executing Detox tests. This flag works with [GoogleUtilities v7.7](https://github.com/google/GoogleUtilities/blob/main/CHANGELOG.md#770).

This replaces the `NSZombieEnabled` flag, which was used as a workaround.

See: https://github.com/firebase/firebase-ios-sdk/issues/9083.