### PR TITLE
Fix classCastException in RN66 workaround

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/uimodule/DispatchCommandOperationReflected.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/uimodule/DispatchCommandOperationReflected.kt
@@ -26,9 +26,9 @@ class DispatchCommandOperationReflected(val instance: Any?) {
             0
         }
 
-    val viewCommand: String?
+    val viewCommand
         get() = try {
-            Reflect.on(instance).field(FIELD_COMMAND).get<String>()
+            Reflect.on(instance).field(FIELD_COMMAND).get<Any>()
         } catch (e: ReflectException) {
             Log.e(DetoxLog.LOG_TAG, "failed to get $FIELD_COMMAND ", e)
             null

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/uimodule/RN66Workaround.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/uimodule/RN66Workaround.kt
@@ -19,7 +19,7 @@ class RN66Workaround {
     fun isScarceUISwitchCommandStuckInQueue(uiManagerModuleReflected: UIManagerModuleReflected): Boolean {
         var isStuckSwitchOperation = false
 
-        val rnVersion = ReactNativeInfo.rnVersion();
+        val rnVersion = ReactNativeInfo.rnVersion()
 
         if (rnVersion.minor >= 66 && uiManagerModuleReflected.getUIOpsCount() >= 1) {
             val nextUIOperation = uiManagerModuleReflected.getNextUIOpReflected()


### PR DESCRIPTION
## Description
In the RN66 workaround we assume that viewCommand will return a String, but apparently it can sometimes return an Int and this leads to classCastException. In this fix I've changed it to return Any. Fixes issue #3168 