### PR TITLE
internal: allow to mutate retries count via argv

### DIFF
--- a/detox/src/configuration/index.js
+++ b/detox/src/configuration/index.js
@@ -95,7 +95,7 @@ async function composeDetoxConfig({
     cliConfig,
   });
 
-  const result = Object.freeze({
+  const result = {
     appsConfig,
     artifactsConfig,
     behaviorConfig,
@@ -105,10 +105,10 @@ async function composeDetoxConfig({
     errorComposer,
     runnerConfig,
     sessionConfig,
-  });
+  };
 
   for (const fn of hooks.UNSAFE_configReady) {
-    await fn(result);
+    await fn({ ...result, argv });
   }
 
   return result;


### PR DESCRIPTION
## Description

Unblocks issue ~no. 105 in DWP~ classified. 😎🤣 

As it turned out, we can't mutate `retries` count on CI because it is a CLI tool option, not an option of Detox.

To do that, we need access to `argv` itself. 🤷‍♂️ 