### PR TITLE
fix(types): Apply Android type to multi-element case of getAttributes() return value

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1243,7 +1243,7 @@ declare global {
              *    jestExpect(attributes.width).toHaveValue(100);
              * })
              */
-             getAttributes(): Promise<IosElementAttributes | AndroidElementAttributes | { elements: IosElementAttributes[]; }>;
+            getAttributes(): Promise<IosElementAttributes | AndroidElementAttributes | { elements: (IosElementAttributes | AndroidElementAttributes)[]; }>;
         }
 
         interface WebExpect<R = Promise<void>> {

--- a/detox/test/types/detox-global-tests.ts
+++ b/detox/test/types/detox-global-tests.ts
@@ -103,10 +103,12 @@ describe("Test", () => {
         let androidAttributes: Omit<Detox.AndroidElementAttributes, keyof Detox.IosElementAttributes>;
 
         beforeEach(async () => {
-            const attributes = await element(by.id("element")).getAttributes();
+            let attributes = await element(by.id("element")).getAttributes();
             if ('elements' in attributes) {
-                commonAttributes = iosAttributes = attributes.elements[0];
-            } else if ('activationPoint' in attributes) {
+                attributes = attributes.elements[0];
+            }
+
+            if ('activationPoint' in attributes) {
                 commonAttributes = iosAttributes = attributes;
             } else {
                 commonAttributes = androidAttributes = attributes;


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request is associated with #3179

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have applied the `AndroidElementAttributes` type to `getAttributes()`' return value for the `{ element[] }` case.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
