### PR TITLE
Use root locale when changing case in java

### DIFF
--- a/detox/android/detox/src/main/java/org/joor/Reflect.java
+++ b/detox/android/detox/src/main/java/org/joor/Reflect.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -633,10 +634,10 @@ public class Reflect {
             return "";
         }
         else if (length == 1) {
-            return string.toLowerCase();
+            return string.toLowerCase(Locale.ROOT);
         }
         else {
-            return string.substring(0, 1).toLowerCase() + string.substring(1);
+            return string.substring(0, 1).toLowerCase(Locale.ROOT) + string.substring(1);
         }
     }
 


### PR DESCRIPTION
## Description

Not setting locale for language/country neutral operation may cause bug depending on the default locale.
See https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#ROOT

Note: I am just searching for `toLowerCase()` and `toUppercase()` in my project's dependencies and send the same PR, in order to potentially raise the awareness. Although I've seen the lack of explicit locale has caused issues for us, I am not sure if wix/Detox is actually affected. 

Example related issue: https://github.com/joltup/rn-fetch-blob/issues/573


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
