### PR TITLE
fix(iOS): ignore `simctl terminate` error when app is not running.

### DIFF
--- a/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
@@ -233,7 +233,11 @@ class AppleSimUtils {
     };
 
     try {
-      await this._execSimctl({ cmd: `terminate ${udid} ${bundleId}`, statusLogs });
+      await this._execSimctl({
+        cmd: `terminate ${udid} ${bundleId}`,
+        statusLogs: statusLogs,
+        silent: true
+      });
     } catch (err) {
       // Since we have no convenient way to check whether the app is currently running or not, we might execute this
       // command (terminate) even if the app is not currently running, or even installed.


### PR DESCRIPTION
Since we have no convenient way to check whether the app is currently running or not, we might execute this command (terminate) even if the app is not currently running, or even installed.

We have encountered some case where the following error is thrown in a case where the app did not run (@burya4ok):
```
An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=3):
Application termination failed.
FBSSystemService reported failure without an error, possibly because the app is not currently running.
```

This workaround is done to ignore the error above, as we do not care if the app was running before, we just want to make sure it isn't now.

---
**Note for reviewer:** I also considered the alternative of checking `_isAppRunning` in `RuntimeDevice.js` before terminating the app on a new launch (`_doLaunchApp`), but this check is based on having the prior information mapped on `_processes`, which is not something we can rely on all cases (for instance, app can be launched manually, or from a previous run of Detox).