### PR TITLE
fix(genycloud): update Genymotion SaaS URLs

### DIFF
--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
@@ -63,7 +63,7 @@ class GenyAllocDriver extends AllocationDriverBase {
     if (!recipe) {
       throw new DetoxRuntimeError({
         message: `No Genymotion-Cloud template found to match the configured lookup query: ${JSON.stringify(deviceQuery)}`,
-        hint: `Revisit your detox configuration. Genymotion templates list is available at: https://cloud.geny.io/app/shared-devices`,
+        hint: `Revisit your detox configuration. Genymotion templates list is available at: https://cloud.geny.io/recipes#custom`,
       });
     }
   }

--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.test.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.test.js
@@ -88,7 +88,7 @@ describe('Allocation driver for Genymotion cloud emulators', () => {
         expect(e.toString()).toContain('No Genymotion-Cloud template found to match the configured lookup query');
         expect(e.toString()).toContain(JSON.stringify(deviceConfig.device));
         expect(e.toString()).toContain('HINT: Revisit your detox configuration');
-        expect(e.toString()).toContain('https://cloud.geny.io/app/shared-devices');
+        expect(e.toString()).toContain('https://cloud.geny.io/recipes#custom');
         return;
       }
       throw new Error('Expected an error');

--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyInstanceAllocationHelper.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyInstanceAllocationHelper.js
@@ -58,7 +58,7 @@ class GenyInstanceAllocationHelper extends DeviceAllocationHelper {
   }
 
   _logAllocationResult(deviceQuery, deviceHandle) {
-    logger.info({ event: ALLOCATE_DEVICE_LOG_EVT }, `Allocating Genymotion-Cloud instance ${deviceHandle.name} for testing. To access it via a browser, go to: https://cloud.geny.io/app/instance/${deviceHandle.uuid}`);
+    logger.info({ event: ALLOCATE_DEVICE_LOG_EVT }, `Allocating Genymotion-Cloud instance ${deviceHandle.name} for testing. To access it via a browser, go to: https://cloud.geny.io/instance/${deviceHandle.uuid}`);
   }
 }
 

--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyInstanceAllocationHelper.test.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyInstanceAllocationHelper.test.js
@@ -95,7 +95,7 @@ describe('Genymotion-Cloud instance allocation helper', () => {
 
       await uut.allocateDevice(aRecipe());
 
-      expect(logger.info).toHaveBeenCalledWith({ event: 'ALLOCATE_DEVICE' }, `Allocating Genymotion-Cloud instance ${instance.name} for testing. To access it via a browser, go to: https://cloud.geny.io/app/instance/${instance.uuid}`);
+      expect(logger.info).toHaveBeenCalledWith({ event: 'ALLOCATE_DEVICE' }, `Allocating Genymotion-Cloud instance ${instance.name} for testing. To access it via a browser, go to: https://cloud.geny.io/instance/${instance.uuid}`);
     });
   });
 

--- a/detox/src/devices/lifecycle/GenyGlobalLifecycleHandler.js
+++ b/detox/src/devices/lifecycle/GenyGlobalLifecycleHandler.js
@@ -52,7 +52,7 @@ function reportGlobalCleanupSummary(deletionLeaks) {
     deletionLeaks.forEach(({ uuid, name, error }) => {
       logger.warn(cleanupLogData, [
         `Instance ${name} (${uuid})${error ? `: ${error}` : ''}`,
-        `    Kill it by visiting https://cloud.geny.io/app/instance/${uuid}, or by running:`,
+        `    Kill it by visiting https://cloud.geny.io/instance/${uuid}, or by running:`,
         `    gmsaas instances stop ${uuid}`,
       ].join('\n'));
     });


### PR DESCRIPTION
## Description

:wave: Hi, I'm Gilles, Genymotion SaaS frontend developer.

1. there is no issue on your side, only on Genymotion SaaS, where old links to instances do not redirect to new URL at the moment. Will be fixed soon.
 Do you want me to open an issue on your repository anyway?
 
 2. Since January 25th, Genymotion SaaS interface has been updated.
  This update changed many URLs including direct links to instances and
  recipes.
  The new webapp provides automatic redirect from legacy URLs to the new
  ones but will only support it temporarily.
      
    This PR updates links to Genymotion SaaS instances and recipes.
  
    See: https://cloud.geny.io/update/22-01_1

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
