### PR TITLE
fix(jest-circus): proper handling of init errors

### DIFF
--- a/detox/runners/jest-circus/listeners/DetoxInitErrorListener.js
+++ b/detox/runners/jest-circus/listeners/DetoxInitErrorListener.js
@@ -1,19 +1,23 @@
 const _ = require('lodash');
 
 class DetoxInitErrorListener {
-  setup(event, { unhandledErrors, rootDescribeBlock }) {
-    if (unhandledErrors.length > 0) {
-      rootDescribeBlock.mode = 'skip';
+  add_hook(event, { unhandledErrors, currentDescribeBlock, rootDescribeBlock }) {
+    if (_.isEmpty(unhandledErrors)) {
+      return;
+    }
+
+    if (currentDescribeBlock !== rootDescribeBlock || currentDescribeBlock.hooks.length > 1) {
+      _.last(currentDescribeBlock.hooks).fn = async () => {};
     }
   }
 
-  add_test(event, { currentDescribeBlock, rootDescribeBlock }) {
-    if (currentDescribeBlock === rootDescribeBlock && rootDescribeBlock.mode === 'skip') {
+  add_test(event, { unhandledErrors, currentDescribeBlock }) {
+    if (!_.isEmpty(unhandledErrors)) {
       const currentTest = _.last(currentDescribeBlock.children);
+      const dummyError = new Error('Environment setup failed. See the detailed error below.');
+      delete dummyError.stack;
 
-      if (currentTest) {
-        currentTest.mode = 'skip';
-      }
+      currentTest.errors.push(dummyError);
     }
   }
 }

--- a/detox/src/utils/Timer.js
+++ b/detox/src/utils/Timer.js
@@ -27,6 +27,7 @@ class Timer {
 
   async run(action) {
     const error = new DetoxRuntimeError();
+    delete error.stack;
 
     return Promise.race([
       this._timeoutDeferred.promise.then(() => {


### PR DESCRIPTION
## Description

Previously, if there was an error in the Detox setup phase (e.g. port allocation collision or device not booting), the entire suite with all the tests was marked as skipped. The motivation was to reduce the output for such tests.

But as it seems, it doe not play well with Jest reporters — such tests are considered skipped indeed, nevertheless, and if a suite fails on such an early error — it is not going to be retried via Detox CLI mechanism.

So, the suggested solution is to duplicate the unhandled error to each test and to noop the registered hooks (to prevent their accidental execution — yes, unfortunately, that happens).

### Before

![Screen Shot 2022-02-08 at 14 10 08](https://user-images.githubusercontent.com/1962469/152984420-5725a5ab-f31b-44ca-95ba-fa8eccd476b8.png)

### After

![Screen Shot 2022-02-08 at 19 09 30](https://user-images.githubusercontent.com/1962469/153038996-156f506b-5455-414f-9268-e050c225d517.png)



