### PR TITLE
Apply time prefix to plain (terminal) logs

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -56,9 +56,10 @@
   "dependencies": {
     "ajv": "^8.6.3",
     "bunyan": "^1.8.12",
-    "bunyan-debug-stream": "^1.1.0",
+    "bunyan-debug-stream": "^2.0.1",
     "chalk": "^2.4.2",
     "child-process-promise": "^2.2.0",
+    "dateformat": "4.5.1",
     "find-up": "^4.1.0",
     "fs-extra": "^4.0.2",
     "funpermaproxy": "^1.0.1",

--- a/detox/package.json
+++ b/detox/package.json
@@ -59,7 +59,6 @@
     "bunyan-debug-stream": "^2.0.1",
     "chalk": "^2.4.2",
     "child-process-promise": "^2.2.0",
-    "dateformat": "4.5.1",
     "find-up": "^4.1.0",
     "fs-extra": "^4.0.2",
     "funpermaproxy": "^1.0.1",

--- a/detox/src/utils/dateUtils.js
+++ b/detox/src/utils/dateUtils.js
@@ -1,0 +1,15 @@
+// This is technically a super-lightweight lib to format date/time (which
+// seems to be an issue in JS...). In case more advanced techniques are ever
+// needed, dateFormat v4.5.1 may come in handy as a drop-in replacement.
+
+function shortFormat(date) {
+  const HH = date.getHours().toString().padStart(2, '0');
+  const MM = date.getMinutes().toString().padStart(2, '0');
+  const ss = date.getSeconds().toString().padStart(2, '0');
+  const milli = date.getMilliseconds().toString().padStart(3, '0');
+  return `${HH}:${MM}:${ss}.${milli}`;
+}
+
+module.exports = {
+  shortFormat,
+};

--- a/detox/src/utils/dateUtils.test.js
+++ b/detox/src/utils/dateUtils.test.js
@@ -1,0 +1,23 @@
+describe('Date/time utils', () => {
+  let dateUtils;
+  beforeEach(() => {
+    dateUtils = require('./dateUtils');
+  });
+
+  describe('"short" formatter', () => {
+    it('should return an HH:MM:SS.l format', () => {
+      const moonLanding = new Date('July 20, 69 20:17:59.123');
+      expect(dateUtils.shortFormat(moonLanding)).toEqual('20:17:59.123');
+    });
+
+    it('should 1-pad all-around', () => {
+      const date = new Date('January 1, 2000 1:2:3.004');
+      expect(dateUtils.shortFormat(date)).toEqual('01:02:03.004');
+    });
+
+    it('should 2- or 3-pad all-around', () => {
+      const date = new Date('January 1, 2000 0:0:0');
+      expect(dateUtils.shortFormat(date)).toEqual('00:00:00.000');
+    });
+  });
+});

--- a/detox/src/utils/logger.js
+++ b/detox/src/utils/logger.js
@@ -1,7 +1,5 @@
 // @ts-nocheck
 
-const dateFormat = require('dateformat');
-
 const path = require('path');
 
 const bunyan = require('bunyan');
@@ -13,9 +11,7 @@ const temporaryPath = require('../artifacts/utils/temporaryPath');
 
 const argparse = require('./argparse');
 const customConsoleLogger = require('./customConsoleLogger');
-
-const LOG_DATE_FORMAT = "HH:MM:ss.l";
-const shortDateFormatter = (date) => dateFormat(date, LOG_DATE_FORMAT);
+const { shortFormat: shortDateFormat } = require('./dateUtils');
 
 function adaptLogLevelName(level) {
   switch (level) {
@@ -91,7 +87,7 @@ function createPlainBunyanStream({ logPath, level, showDate = true }) {
 function init() {
   const levelFromArg = argparse.getArgValue('loglevel', 'l');
   const level = adaptLogLevelName(levelFromArg);
-  const debugStream = createPlainBunyanStream({ level, showDate: shortDateFormatter });
+  const debugStream = createPlainBunyanStream({ level, showDate: shortDateFormat });
   const bunyanStreams = [debugStream];
 
   let jsonFileStreamPath, plainFileStreamPath;

--- a/detox/src/utils/logger.js
+++ b/detox/src/utils/logger.js
@@ -1,4 +1,7 @@
 // @ts-nocheck
+
+const dateFormat = require('dateformat');
+
 const path = require('path');
 
 const bunyan = require('bunyan');
@@ -10,6 +13,9 @@ const temporaryPath = require('../artifacts/utils/temporaryPath');
 
 const argparse = require('./argparse');
 const customConsoleLogger = require('./customConsoleLogger');
+
+const LOG_DATE_FORMAT = "HH:MM:ss.l";
+const shortDateFormatter = (date) => dateFormat(date, LOG_DATE_FORMAT);
 
 function adaptLogLevelName(level) {
   switch (level) {
@@ -36,9 +42,9 @@ function tryOverrideConsole(logger, global) {
   }
 }
 
-function createPlainBunyanStream({ logPath, level }) {
+function createPlainBunyanStream({ logPath, level, showDate = true }) {
   const options = {
-    showDate: false,
+    showDate: showDate,
     showLoggerName: true,
     showPid: true,
     showMetadata: false,
@@ -85,7 +91,8 @@ function createPlainBunyanStream({ logPath, level }) {
 function init() {
   const levelFromArg = argparse.getArgValue('loglevel', 'l');
   const level = adaptLogLevelName(levelFromArg);
-  const bunyanStreams = [createPlainBunyanStream({ level })];
+  const debugStream = createPlainBunyanStream({ level, showDate: shortDateFormatter });
+  const bunyanStreams = [debugStream];
 
   let jsonFileStreamPath, plainFileStreamPath;
   if (!global.DETOX_CLI && !global.IS_RUNNING_DETOX_UNIT_TESTS) {


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request resolves #3157.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have enabled a custom (short) timestamp prefix to terminal logs. Other log outputs should have remained intact.

Before:

```
detox[35368] INFO:  [test.js] DETOX_CONFIGURATION="android.emu.release" DETOX_LOGLEVEL="verbose" DETOX_REPORT_SPECS=true DETOX_START_TIMESTAMP=1644339539856 DETOX_USE_CUSTOM_LOGGER=true nyc jest --config e2e/config.js --testNamePattern '^((?!:ios:).)*$' e2e/01.sanity.test.js
detox[35370] DEBUG: [WSS_CREATE] Detox server listening on localhost:54581...
detox[35370] DEBUG: [WSS_CONNECTION, #54582] registered a new connection.
detox[35370] DEBUG: [EXEC_CMD, #0] "/Users/amitd/Library/Android/sdk/emulator/emulator" -list-avds --verbose
detox[35370] DEBUG: [EXEC_CMD, #1] "/Users/amitd/Library/Android/sdk/emulator/emulator" -version
detox[35370] DEBUG: [EMU_BIN_VERSION_DETECT] Detected emulator binary version { major: 30, minor: 5, patch: 4, toString: [Function: toString] }
detox[35370] DEBUG: [ALLOCATE_DEVICE] Trying to allocate a device based on "Pixel_3A_API_29"
detox[35370] DEBUG: [EXEC_CMD, #2] "/Users/amitd/Library/Android/sdk/platform-tools/adb"  devices
detox[35370] DEBUG: [EXEC_SUCCESS, #2] List of devices attached
```

After:

```
18:58:59.862 detox[35368] INFO:  [test.js] DETOX_CONFIGURATION="android.emu.release" DETOX_LOGLEVEL="verbose" DETOX_REPORT_SPECS=true DETOX_START_TIMESTAMP=1644339539856 DETOX_USE_CUSTOM_LOGGER=true nyc jest --config e2e/config.js --testNamePattern '^((?!:ios:).)*$' e2e/01.sanity.test.js
18:59:02.434 detox[35370] DEBUG: [WSS_CREATE] Detox server listening on localhost:54581...
18:59:02.446 detox[35370] DEBUG: [WSS_CONNECTION, #54582] registered a new connection.
18:59:02.561 detox[35370] DEBUG: [EXEC_CMD, #0] "/Users/amitd/Library/Android/sdk/emulator/emulator" -list-avds --verbose
18:59:02.593 detox[35370] DEBUG: [EXEC_CMD, #1] "/Users/amitd/Library/Android/sdk/emulator/emulator" -version
18:59:02.856 detox[35370] DEBUG: [EMU_BIN_VERSION_DETECT] Detected emulator binary version { major: 30, minor: 5, patch: 4, toString: [Function: toString] }
18:59:02.857 detox[35370] DEBUG: [ALLOCATE_DEVICE] Trying to allocate a device based on "Pixel_3A_API_29"
18:59:02.860 detox[35370] DEBUG: [EXEC_CMD, #2] "/Users/amitd/Library/Android/sdk/platform-tools/adb"  devices
18:59:02.876 detox[35370] DEBUG: [EXEC_SUCCESS, #2] List of devices attached
```

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
