### PR TITLE
fix: race condition in DetoxServer class

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -62,7 +62,6 @@
     "find-up": "^4.1.0",
     "fs-extra": "^4.0.2",
     "funpermaproxy": "^1.0.1",
-    "get-port": "^2.1.0",
     "ini": "^1.3.4",
     "lodash": "^4.17.5",
     "minimist": "^1.2.0",

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -2,7 +2,6 @@
 const { URL } = require('url');
 const util = require('util');
 
-const getPort = require('get-port');
 const _ = require('lodash');
 
 const lifecycleSymbols = require('../runners/integration').lifecycle;
@@ -146,17 +145,20 @@ class Detox {
   async _doInit() {
     const behaviorConfig = this._behaviorConfig.init;
     const sessionConfig = this._sessionConfig;
-    if (!sessionConfig.server) {
-      sessionConfig.server = `ws://localhost:${await getPort()}`;
-    }
 
     if (sessionConfig.autoStart) {
       this._server = new DetoxServer({
-        port: new URL(sessionConfig.server).port,
+        port: sessionConfig.server
+          ? new URL(sessionConfig.server).port
+          : 0,
         standalone: false,
       });
 
       await this._server.open();
+
+      if (!sessionConfig.server) {
+        sessionConfig.server = `ws://localhost:${this._server.port}`;
+      }
     }
 
     this._client = new Client(sessionConfig);

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -12,7 +12,11 @@ jest.mock('get-port');
 
 jest.mock('./server/DetoxServer', () => {
   const FakeServer = jest.genMockFromModule('./server/DetoxServer');
-  return jest.fn().mockImplementation(() => new FakeServer());
+  return jest.fn().mockImplementation(() => {
+    const server =  new FakeServer();
+    server.port = 12345;
+    return server;
+  });
 });
 
 describe('Detox', () => {
@@ -82,8 +86,6 @@ describe('Detox', () => {
       },
     });
 
-    require('get-port').mockResolvedValue(12345);
-
     logger = require('./utils/logger');
     invoke = require('./invoke');
     Client = require('./client/Client');
@@ -119,7 +121,7 @@ describe('Detox', () => {
 
       it('should create a DetoxServer automatically', () =>
         expect(DetoxServer).toHaveBeenCalledWith({
-          port: '12345',
+          port: 0,
           standalone: false,
         }));
 

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -8,7 +8,6 @@ jest.mock('./utils/AsyncEmitter');
 jest.mock('./invoke');
 jest.mock('./utils/wrapWithStackTraceCutter');
 jest.mock('./environmentFactory');
-jest.mock('get-port');
 
 jest.mock('./server/DetoxServer', () => {
   const FakeServer = jest.genMockFromModule('./server/DetoxServer');

--- a/detox/src/configuration/composeSessionConfig.js
+++ b/detox/src/configuration/composeSessionConfig.js
@@ -42,13 +42,19 @@ async function composeSessionConfig(options) {
     session.debugSynchronization = +cliConfig.debugSynchronization;
   }
 
-  return {
+  const result = {
     autoStart: !session.server,
     sessionId: uuid.UUID(),
     debugSynchronization: 10000,
 
     ...session,
   };
+
+  if (!result.server && !result.autoStart) {
+    throw errorComposer.cannotSkipAutostartWithMissingServer();
+  }
+
+  return result;
 }
 
 module.exports = composeSessionConfig;

--- a/detox/src/configuration/composeSessionConfig.test.js
+++ b/detox/src/configuration/composeSessionConfig.test.js
@@ -120,8 +120,8 @@ describe('composeSessionConfig', () => {
         globalConfig.session = { autoStart: false };
       });
 
-      it('should override the value', async () => {
-        expect(await compose()).toMatchObject({ autoStart: false });
+      it('should throw an error if the server is not defined', async () => {
+        await expect(compose).rejects.toThrowError(errorComposer.cannotSkipAutostartWithMissingServer());
       });
     });
 

--- a/detox/src/errors/DetoxConfigErrorComposer.js
+++ b/detox/src/errors/DetoxConfigErrorComposer.js
@@ -622,6 +622,18 @@ Examine your Detox config${this._atPath()}`,
     });
   }
 
+  cannotSkipAutostartWithMissingServer() {
+    return new DetoxConfigError({
+      message: `Cannot have both an undefined session.server URL and session.autoStart set to false`,
+      hint: `Check that in your Detox config${this._atPath()}`,
+      inspectOptions: { depth: 3 },
+      debugInfo: _.omitBy({
+        session: _.get(this.contents, ['session']),
+        ...this._focusOnConfiguration(c => _.pick(c, ['session'])),
+      }, _.isEmpty),
+    });
+  }
+
   // endregion
 
   missingBuildScript(appConfig) {

--- a/detox/src/errors/DetoxConfigErrorComposer.test.js
+++ b/detox/src/errors/DetoxConfigErrorComposer.test.js
@@ -712,6 +712,47 @@ describe('DetoxConfigErrorComposer', () => {
         expect(build()).toMatchSnapshot();
       });
     });
+
+    describe('.cannotSkipAutostartWithMissingServer', () => {
+      beforeEach(() => {
+        build = () => builder.cannotSkipAutostartWithMissingServer();
+        builder.setConfigurationName('android.release');
+        builder.setDetoxConfig({
+          configurations: {
+            'android.release': {
+              type: 'android.emulator',
+              device: {
+                avdName: 'Pixel_2_API_29',
+              },
+              session: {
+                autoStart: false,
+              },
+            }
+          }
+        });
+      });
+
+      it('should create a generic error, if the config location is not known', () => {
+        expect(build()).toMatchSnapshot();
+      });
+
+      it('should create an error with a hint, if the config location is known', () => {
+        builder.setDetoxConfigPath('/home/detox/myproject/.detoxrc.json');
+        expect(build()).toMatchSnapshot();
+      });
+
+      it('should point to global session if there is one', () => {
+        builder.setDetoxConfig({
+          session: {
+            autoStart: false
+          },
+          configurations: {},
+        });
+
+        builder.setDetoxConfigPath('/home/detox/myproject/.detoxrc.json');
+        expect(build()).toMatchSnapshot();
+      });
+    });
   });
 
   describe('(from local-cli/build)', () => {

--- a/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
+++ b/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
@@ -1358,6 +1358,53 @@ Please report this issue on our GitHub tracker:
 https://github.com/wix/Detox/issues"
 `;
 
+exports[`DetoxConfigErrorComposer (from composeSessionConfig) .cannotSkipAutostartWithMissingServer should create a generic error, if the config location is not known 1`] = `
+[DetoxConfigError: Cannot have both an undefined session.server URL and session.autoStart set to false
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    'android.release': {
+      session: {
+        autoStart: false
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeSessionConfig) .cannotSkipAutostartWithMissingServer should create an error with a hint, if the config location is known 1`] = `
+[DetoxConfigError: Cannot have both an undefined session.server URL and session.autoStart set to false
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  configurations: {
+    'android.release': {
+      session: {
+        autoStart: false
+      }
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from composeSessionConfig) .cannotSkipAutostartWithMissingServer should point to global session if there is one 1`] = `
+[DetoxConfigError: Cannot have both an undefined session.server URL and session.autoStart set to false
+
+HINT: Check that in your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  session: {
+    autoStart: false
+  }
+}]
+`;
+
 exports[`DetoxConfigErrorComposer (from composeSessionConfig) .invalidDebugSynchronizationProperty should create a generic error, if the config location is not known 1`] = `
 [DetoxConfigError: session.debugSynchronization should be a positive number
 

--- a/detox/src/server/DetoxServer.js
+++ b/detox/src/server/DetoxServer.js
@@ -2,7 +2,7 @@
 const _ = require('lodash');
 const WebSocket = require('ws');
 
-const DetoxRuntimeError = require('../errors/DetoxRuntimeError');
+const { DetoxInternalError, DetoxRuntimeError } = require('../errors');
 const Deferred = require('../utils/Deferred');
 const log = require('../utils/logger').child({ __filename });
 
@@ -28,11 +28,19 @@ class DetoxServer {
     this._closing = null;
   }
 
+  get port() {
+    if (!this._wss) {
+      throw new DetoxInternalError('Cannot get a port of a closed WebSocket server');
+    }
+
+    return this._wss.address().port;
+  }
+
   async open() {
     await this._startListening();
 
     const level = this._options.standalone ? 'info' : 'debug';
-    log[level]({ event: 'WSS_CREATE' }, `Detox server listening on localhost:${this._options.port}...`);
+    log[level]({ event: 'WSS_CREATE' }, `Detox server listening on localhost:${this.port}...`);
   }
 
   async close() {


### PR DESCRIPTION
## Description

Related to https://github.com/wix/Detox/pull/3174

Hopefully, this is an ultimate fix that will never ever cause the further reproduction of that bug.

Solution: using `port: 0` to make sure `wss` server allocates the port dynamically and setting the resulting value post-factum to the client config.