### PR TITLE
tests: expect `getAttributes()` to return a checkbox value.

### DIFF
--- a/detox/test/e2e/33.attributes.test.js
+++ b/detox/test/e2e/33.attributes.test.js
@@ -128,9 +128,9 @@ describe('Attributes', () => {
   describe('of a checkbox', () => {
     beforeAll(useMatcher(by.id('checkboxId')));
 
-    it(':ios: should not have any .value (because it is not implemented)', async () => {
-      expect(await currentElement.getAttributes()).not.toMatchObject({
-        value: expect.anything(),
+    it(':ios: should have a string .value', async () => {
+      expect(await currentElement.getAttributes()).toMatchObject({
+        value: expect.stringContaining('off'),
       });
     });
 

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.12.0",
-    "@react-native-community/checkbox": "^0.5.7",
+    "@react-native-community/checkbox": "^0.5.11",
     "@react-native-community/geolocation": "^2.0.2",
     "@react-native-picker/picker": "^2.1.0",
     "moment": "^2.24.0",


### PR DESCRIPTION
Since [accessibilityValue](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/1619583-accessibilityvalue) of checkbox is now exposed (see: https://github.com/react-native-checkbox/react-native-checkbox/releases/tag/v0.5.11), change the relevant e2e test to expect a checkbox `value` when calling `getAttributes`.