### PR TITLE
internal(artifacts): enable external tracking

### DIFF
--- a/detox/src/artifacts/ArtifactsManager.js
+++ b/detox/src/artifacts/ArtifactsManager.js
@@ -1,3 +1,4 @@
+const EventEmitter = require('events');
 const path = require('path');
 const util = require('util');
 
@@ -9,8 +10,10 @@ const log = require('../utils/logger').child({ __filename });
 
 const FileArtifact = require('./templates/artifact/FileArtifact');
 
-class ArtifactsManager {
+class ArtifactsManager extends EventEmitter {
   constructor({ pathBuilder, plugins }) {
+    super();
+
     this._pluginConfigs = plugins;
     this._idlePromise = Promise.resolve();
     this._idleCallbackRequests = [];
@@ -32,8 +35,13 @@ class ArtifactsManager {
         return artifactPath;
       },
 
-      trackArtifact: _.noop,
-      untrackArtifact: _.noop,
+      trackArtifact: (artifact) => {
+        this.emit('trackArtifact', artifact);
+      },
+
+      untrackArtifact: (artifact) => {
+        this.emit('untrackArtifact', artifact);
+      },
 
       requestIdleCallback: (callback) => {
         this._idleCallbackRequests.push({

--- a/detox/src/artifacts/ArtifactsManager.test.js
+++ b/detox/src/artifacts/ArtifactsManager.test.js
@@ -204,6 +204,26 @@ describe('ArtifactsManager', () => {
       });
     });
 
+    describe('.trackArtifact()', () => {
+      it('should emit "trackArtifact" event from the artifacts manaager', () => {
+        const artifact = {};
+        const listener = jest.fn();
+        artifactsManager.on('trackArtifact', listener);
+        artifactsApi.trackArtifact(artifact);
+        expect(listener).toHaveBeenCalledWith(artifact);
+      });
+    });
+
+    describe('.untrackArtifact()', () => {
+      it('should emit "untrackArtifact" event from the artifacts manaager', () => {
+        const artifact = {};
+        const listener = jest.fn();
+        artifactsManager.on('untrackArtifact', listener);
+        artifactsApi.untrackArtifact(artifact);
+        expect(listener).toHaveBeenCalledWith(artifact);
+      });
+    });
+
     describe('hooks', () => {
       describe('error handling', () => {
         function itShouldCatchErrorsOnPhase(hookName, argFactory) {


### PR DESCRIPTION
## Description

Allows for external entities to monitor new artifacts provided a private access to `detoxInstance._artifactsManager`:

```js
detoxInstance._artifactsManager.on('trackArtifact', (artifact) => {
  // ...
});
```
Needed to try out an experimental Detox + Allure integration.

![image](https://user-images.githubusercontent.com/1962469/155345523-71e95dab-7d0e-4a78-88ba-cadc8ad10e33.png)
