### PR TITLE
fix(iOS): fix visibility expectation error message.

### DIFF
--- a/detox/ios/Detox/Policy/DetoxPolicy.h
+++ b/detox/ios/Detox/Policy/DetoxPolicy.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (class, nonatomic, readonly) NSUInteger defaultPercentThresholdForVisibility;
 @property (class, nonatomic, readonly) NSUInteger consecutiveTouchPointsWithSameContentOffsetThreshold;
 
-+ (NSString*)percentDescriptionForValue:(CGFloat)value;
++ (NSString*)percentDescriptionForPercent:(CGFloat)percent;
 
 @end
 

--- a/detox/ios/Detox/Policy/DetoxPolicy.m
+++ b/detox/ios/Detox/Policy/DetoxPolicy.m
@@ -22,16 +22,8 @@
 	return 12;
 }
 
-+ (NSString*)percentDescriptionForValue:(CGFloat)value {
-	static NSNumberFormatter* formatter;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		formatter = [NSNumberFormatter new];
-		formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
-		formatter.numberStyle = NSNumberFormatterPercentStyle;
-	});
-	
-	return [formatter stringFromNumber:@(value)];
++ (NSString*)percentDescriptionForPercent:(CGFloat)percent {
+	return [NSString stringWithFormat:@"%g%%", percent];
 }
 
 @end

--- a/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
+++ b/detox/ios/Detox/Utilities/UIView+DetoxUtils.m
@@ -216,7 +216,7 @@ DTX_DIRECT_MEMBERS
 	
 	if (isRegionObscured) {
 		*explanation = [NSString stringWithFormat:@"View does not pass visibility percent "
-						"threshold (%@)", [DetoxPolicy percentDescriptionForValue:percent]];
+						"threshold (%@)", [DetoxPolicy percentDescriptionForPercent:percent]];
 	}
 	
 	return isRegionObscured;
@@ -284,7 +284,7 @@ DTX_DIRECT_MEMBERS
 		auto errorDescription = [NSString stringWithFormat:@"View is clipped by one or more of its "
 								 "superviews' bounds and does not pass visibility percent "
 								 "threshold (%@)",
-								 [DetoxPolicy percentDescriptionForValue:percent]];
+								 [DetoxPolicy percentDescriptionForPercent:percent]];
 		
 		auto userInfo = @{ NSLocalizedDescriptionKey: APPLY_PREFIX(errorDescription) };
 		
@@ -298,7 +298,7 @@ DTX_DIRECT_MEMBERS
 						   inWindowBounds:windowToUse.bounds percent:percent]) {
 		auto errorDescription = [NSString stringWithFormat:@"View is obscured by its window bounds "
 								 "and does not pass visibility percent threshold (%@)",
-								 [DetoxPolicy percentDescriptionForValue:percent]];
+								 [DetoxPolicy percentDescriptionForPercent:percent]];
 		
 		auto userInfo = @{ NSLocalizedDescriptionKey: APPLY_PREFIX(errorDescription) };
 		

--- a/detox/test/e2e/32.visibility-debug-artifacts.test.js
+++ b/detox/test/e2e/32.visibility-debug-artifacts.test.js
@@ -13,7 +13,7 @@ describe(':ios: Visibility Debug Artifacts', () => {
   it('should not be able to tap an overlayed button', async () => {
     await expectToThrow(
       () => element(by.text('Button 1')).tap(),
-      `View does not pass visibility percent threshold`,
+      `View does not pass visibility percent threshold (100%)`,
     );
   });
 


### PR DESCRIPTION
Fix visibility error message to show a valid percentage description.

Before this fix, `15` percent value was printed as `1,500%`, instead as `15%`, since `NSNumberFormatterPercentStyle` expects the value to be the percent divided by 100.

[From NSNumberFormatterPercentStyle docs](https://developer.apple.com/documentation/foundation/nsnumberformatterstyle/nsnumberformatterpercentstyle):
> For example, in the en_US locale, the number 0.123 is represented as 12%.

Since we are already using a percent value, we don't need a string formatter for the representation.