### PR TITLE
fix: Exec Android UT for RN≥66 on CI

### DIFF
--- a/scripts/ci.android.sh
+++ b/scripts/ci.android.sh
@@ -10,12 +10,12 @@ run_f "npm run integration"
 popd
 
 currentRnVersion=$(echo "${REACT_NATIVE_VERSION}" | cut -d "." -f2);
-if [[ -z ${SKIP_UNIT_TESTS} && $currentRnVersion -ge 66 ]]; then
+if [[ $currentRnVersion -ge 66 ]]; then
   pushd detox/android
   run_f "./gradlew testFullRelease"
   popd
 else
-  echo "SKIP_UNIT_TESTS is set: Skipping Android unit tests"
+  echo "Skipping Android unit tests (react-native version ${currentRnVersion} is not ≥66)"
 fi
 
 mkdir -p coverage


### PR DESCRIPTION
## Description

Following our Buildkite migration, our Android unit tests execution has been rendered missing from the CI scripts.

In this pull request, I have resumed it. I'm not confident that they will indeed run successfully on our agents, but we will get that fixed as well by running, then rinse&repeat-ing.

@igorgn 