### PR TITLE
feat(config): drop default "e2e" value for specs

### DIFF
--- a/detox/local-cli/templates/jest.js
+++ b/detox/local-cli/templates/jest.js
@@ -4,7 +4,7 @@ const runnerConfig = `{
     "maxWorkers": 1,
     "testEnvironment": "./environment",
     "testTimeout": 120000,
-    "testRegex": "\\\\.e2e\\\\.js$",
+    "testMatch": ["<rootDir>/e2e/*.e2e.js"],
     "reporters": ["detox/runners/jest-circus/reporter"],
     "verbose": true
 }

--- a/detox/local-cli/test.js
+++ b/detox/local-cli/test.js
@@ -162,7 +162,7 @@ function prepareMochaArgs({ cliConfig, runnerArgs, runnerConfig, platform }) {
       DETOX_APP_LAUNCH_ARGS: cliConfig.appLaunchArgs,
       DETOX_DEVICE_BOOT_ARGS: cliConfig.deviceBootArgs,
     }, _.isUndefined),
-    specs: _.isEmpty(specs) ? [runnerConfig.specs] : specs,
+    specs: _.isEmpty(specs) && runnerConfig.specs ? [runnerConfig.specs] : specs,
   };
 }
 
@@ -214,7 +214,7 @@ async function prepareJestArgs({ cliConfig, deviceConfig, runnerArgs, runnerConf
       DETOX_USE_CUSTOM_LOGGER: cliConfig.useCustomLogger,
     }, _.isUndefined),
 
-    specs: _.isEmpty(specs) ? [runnerConfig.specs] : specs,
+    specs: _.isEmpty(specs) && runnerConfig.specs ? [runnerConfig.specs] : specs,
   };
 }
 
@@ -235,7 +235,7 @@ function launchTestRunner({ argv, env, specs }) {
     command,
     quote(unparse(_.omitBy(restArgv, _.isUndefined))),
     specs.join(' ')
-  ].join(' ');
+  ].filter(Boolean).join(' ');
 
   log.info(printEnvironmentVariables(env) + fullCommand);
 

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -68,7 +68,6 @@ describe('CLI', () => {
 
       test('should default to mocha', () => expect(cliCall().command).toMatch(/^mocha/));
       test('should default to --opts e2e/mocha.opts', () => expect(cliCall().command).toMatch(/--opts e2e\/mocha.opts/));
-      test('should default to "e2e" test folder', () => expect(cliCall().command).toMatch(/ e2e$/));
       test('should pass --use-custom-logger true', () => expect(cliCall().command).toMatch(/--use-custom-logger true/));
       test('should not override process.env', () => expect(cliCall().env).toStrictEqual({}));
       test('should produce a default command (integration test)', () => {
@@ -80,7 +79,7 @@ describe('CLI', () => {
           `--use-custom-logger`, `true`
         ].join(' ');
 
-        expect(cliCall().command).toBe(`mocha ${args} e2e`);
+        expect(cliCall().command).toBe(`mocha ${args}`);
       });
     });
 
@@ -288,7 +287,7 @@ describe('CLI', () => {
 
       test('should produce a default command (integration test, ios)', () => {
         const args = `--config e2e/config.json --testNamePattern ${quote('^((?!:android:).)*$')} --maxWorkers 1`;
-        expect(cliCall().command).toBe(`jest ${args} e2e`);
+        expect(cliCall().command).toBe(`jest ${args}`);
       });
 
       test('should put default environment variables (integration test, ios)', () => {
@@ -309,7 +308,7 @@ describe('CLI', () => {
 
       test('should produce a default command (integration test)', () => {
         const args = `--config e2e/config.json --testNamePattern ${quote('^((?!:ios:).)*$')} --maxWorkers 1`;
-        expect(cliCall().command).toBe(`jest ${args} e2e`);
+        expect(cliCall().command).toBe(`jest ${args}`);
       });
 
       test('should put default environment variables (integration test)', () => {
@@ -390,7 +389,6 @@ describe('CLI', () => {
       cp.execSync.mockImplementation(() => { throw new Error; });
 
       await run(`-R 2`).catch(_.noop);
-      expect(cliCall(0).command).toMatch(/ e2e$/);
       expect(cliCall(0).env).not.toHaveProperty('DETOX_RERUN_INDEX');
 
       expect(cliCall(1).command).toMatch(/ e2e\/failing1.test.js e2e\/failing2.test.js$/);
@@ -701,7 +699,7 @@ describe('CLI', () => {
     test(`should deduce wrapped ${testRunner} CLI`, async () => {
       detoxConfig.testRunner = `nyc ${testRunner}`;
       await run();
-      expect(cliCall().command).toMatch(RegExp(`nyc ${testRunner} .* e2e$`));
+      expect(cliCall().command).toMatch(RegExp(`nyc ${testRunner} `));
     });
 
     describe.each([['ios.simulator'], ['android.emulator']])('for %s', (deviceType) => {

--- a/detox/src/configuration/composeRunnerConfig.js
+++ b/detox/src/configuration/composeRunnerConfig.js
@@ -11,7 +11,7 @@ function composeRunnerConfig({ globalConfig, cliConfig }) {
   return {
     testRunner,
     runnerConfig: customRunnerConfig || defaultRunnerConfig,
-    specs: globalConfig.specs || 'e2e',
+    specs: globalConfig.specs || '',
     skipLegacyWorkersInjection: Boolean(globalConfig.skipLegacyWorkersInjection),
   };
 }

--- a/detox/src/configuration/composeRunnerConfig.test.js
+++ b/detox/src/configuration/composeRunnerConfig.test.js
@@ -63,9 +63,9 @@ describe('composeRunnerConfig', () => {
     expect(composeRunnerConfig().specs).toBe('e2e/suite1');
   });
 
-  it('should set .specs to default e2e/ value', () => {
+  it('should treat undefined .specs as an empty string', () => {
     delete globalConfig.specs;
-    expect(composeRunnerConfig().specs).toBe('e2e');
+    expect(composeRunnerConfig().specs).toBe('');
   });
 
 });


### PR DESCRIPTION
BREAKING CHANGE: Detox won't be appending "e2e" glob to the test runner
if it is not explicitly configured to do so via "specs" property in the
config.

## Description

This is a planned deprecation.

The motivation is to fix issues such as:

* https://github.com/wix/Detox/issues/3076
* https://github.com/wix/Detox/issues/2901
