### PR TITLE
External contributors bypass

### DIFF
--- a/.buildkite/pipeline_common.sh
+++ b/.buildkite/pipeline_common.sh
@@ -2,6 +2,13 @@
 
 echo "steps:"
 
+ORIGINAL_REPO=$(echo $BUILDKITE_REPO | sed 's/.*github.com\///')
+echo $ORIGINAL_REPO
+PR_REPO=$(echo $BUILDKITE_PULL_REQUEST_REPO | sed 's/.*github.com\///')
+echo $PR_REPO
+
+[[ $ORIGINAL_REPO != $PR_REPO ]] && echo '  - block: ":rocket: Release!"'
+
 cat .buildkite/jobs/pipeline.ios_rn_64.yml
 cat .buildkite/jobs/pipeline.ios_rn_67.yml
 cat .buildkite/jobs/pipeline.android_rn_64.yml

--- a/.buildkite/pipeline_common.sh
+++ b/.buildkite/pipeline_common.sh
@@ -4,7 +4,7 @@ ORIGINAL_REPO=$(echo "$BUILDKITE_REPO" | sed 's/.*github.com\///')
 PR_REPO=$(echo $BUILDKITE_PULL_REQUEST_REPO | sed 's/.*github.com\///')
 
 echo "steps:"
-[[ $ORIGINAL_REPO != $PR_REPO ]] && echo '  - block: ":rocket: Release!"'
+[[ $PR_REPO != '' ]] && [[ $ORIGINAL_REPO != $PR_REPO ]] && echo '  - block: ":rocket: Release!"'
 
 cat .buildkite/jobs/pipeline.ios_rn_64.yml
 cat .buildkite/jobs/pipeline.ios_rn_67.yml

--- a/.buildkite/pipeline_common.sh
+++ b/.buildkite/pipeline_common.sh
@@ -1,12 +1,9 @@
 #!/bin/bash -e
 
-echo "steps:"
-
-ORIGINAL_REPO=$(echo $BUILDKITE_REPO | sed 's/.*github.com\///')
-echo $ORIGINAL_REPO
+ORIGINAL_REPO=$(echo "$BUILDKITE_REPO" | sed 's/.*github.com\///')
 PR_REPO=$(echo $BUILDKITE_PULL_REQUEST_REPO | sed 's/.*github.com\///')
-echo $PR_REPO
 
+echo "steps:"
 [[ $ORIGINAL_REPO != $PR_REPO ]] && echo '  - block: ":rocket: Release!"'
 
 cat .buildkite/jobs/pipeline.ios_rn_64.yml

--- a/.buildkite/pipeline_common.sh
+++ b/.buildkite/pipeline_common.sh
@@ -4,7 +4,7 @@ ORIGINAL_REPO=$(echo "$BUILDKITE_REPO" | sed 's/.*github.com\///')
 PR_REPO=$(echo $BUILDKITE_PULL_REQUEST_REPO | sed 's/.*github.com\///')
 
 echo "steps:"
-[[ $PR_REPO != '' ]] && [[ $ORIGINAL_REPO != $PR_REPO ]] && echo '  - block: ":rocket: Release!"'
+[[ $PR_REPO != '' ]] && [[ $ORIGINAL_REPO != $PR_REPO ]] && echo '  - block: ":git: Allow PR build"'
 
 cat .buildkite/jobs/pipeline.ios_rn_64.yml
 cat .buildkite/jobs/pipeline.ios_rn_67.yml


### PR DESCRIPTION
## Description
This should put a block on any PR, which is opened from forked repositories (i.e external contributors), which should be then manually unlocked by someone from Detox team
<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #<?>

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have …

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
