### PR TITLE
Make Android unit tests run locally

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -132,7 +132,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:$_kotlinVersion"
     testImplementation 'org.apache.commons:commons-io:1.3.2'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:4.0.0'
-    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'org.robolectric:robolectric:4.4'
 }
 
 // Spek (https://spekframework.org/setup-android)

--- a/detox/android/detox/src/testFull/java/com/wix/detox/espresso/registry/IRStatusInquirerTest.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/espresso/registry/IRStatusInquirerTest.kt
@@ -14,9 +14,13 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
 import java.util.concurrent.Executors
 
 @RunWith(RobolectricTestRunner::class)
+// Fixes: Hangs in UIThread.postFirstSync inside IRStatusInquirer.getAllBusyResources when upgrading robolectric 4.3.x -> 4.4
+// See http://robolectric.org/blog/2019/06/04/paused-looper/ (coming from https://github.com/robolectric/robolectric/releases/tag/robolectric-4.4)
+@LooperMode(LooperMode.Mode.LEGACY)
 class IRStatusInquirerTest {
 
     lateinit var registry: IdlingResourceRegistry

--- a/detox/test/android/build.gradle
+++ b/detox/test/android/build.gradle
@@ -33,7 +33,7 @@ buildscript {
 
     dependencies {
         classpath "com.android.tools.build:gradle:$androidGradlePluginVersion"
-        classpath 'de.undercouch:gradle-download-task:4.0.2'
+        classpath 'de.undercouch:gradle-download-task:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         if (!rootProject.hasProperty('suppressUnitTests')) {

--- a/docs/Guide.Contributing.md
+++ b/docs/Guide.Contributing.md
@@ -180,7 +180,7 @@ launchctl setenv PATH $PATH
 Under `detox/android`:
 
 ```sh
-./gradlew test
+./gradlew testFullRelease
 ```
 
 ### Detox - Example Projects


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #<?>

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have enabled the execution of our Android unit tests locally. It was broken, returning a 501 error for any Robolectric-based test case, as the repository was accessed via `http` rather than `https`. Upgrading to a newer Robolectric fixes that, likely because it is hosted on a different artifactory.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
