### PR TITLE
build(publishNewVersion): fix get new version.

### DIFF
--- a/scripts/utils/publishNewVersion.js
+++ b/scripts/utils/publishNewVersion.js
@@ -1,7 +1,16 @@
 /* tslint:disable: no-console */
 const exec = require('shell-utils').exec;
 
-const {log, logSection, getReleaseNpmTag, getReleaseVersionType, isDryRun, isSkipNpm} = require('./releaseArgs');
+const {
+  log,
+  logSection,
+  getReleaseNpmTag,
+  getReleaseVersionType,
+  getVersionSafe,
+  isDryRun,
+  isSkipNpm
+} = require('./releaseArgs');
+
 const {removeDocsForVersion, buildDocsForVersion} = require('./releaseDocumentation');
 
 function publishNewVersion() {
@@ -14,7 +23,7 @@ function publishNewVersion() {
 
   publishToNpm(releaseTag);
 
-  const newVersion = require('package.json').version;
+  const newVersion = getVersionSafe();
   log(`    new published version on tag ${releaseTag}: ${newVersion}`);
 
   if (releaseTag === 'latest') {


### PR DESCRIPTION
Getting the new version from our `package.json` was already implemented as `getVersionSafe()`.
Also, the previous import of `package.json` threw an error ([here](https://buildkite.com/wix-mobile-oss/detox/builds/532#1ae7ca83-1b4f-4fd7-89bc-b0dc8e4f3109/117-519)).