### PR TITLE
fix(iOS): move Headers build phase before Compile Sources.

### DIFF
--- a/detox/ios/Detox.xcodeproj/project.pbxproj
+++ b/detox/ios/Detox.xcodeproj/project.pbxproj
@@ -667,9 +667,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3947679F1DBF985400D72256 /* Build configuration list for PBXNativeTarget "Detox" */;
 			buildPhases = (
+				394767941DBF985400D72256 /* Headers */,
 				394767921DBF985400D72256 /* Sources */,
 				394767931DBF985400D72256 /* Frameworks */,
-				394767941DBF985400D72256 /* Headers */,
 				394767951DBF985400D72256 /* Resources */,
 				39C3C34B1DBF9A05008177E1 /* CopyFiles */,
 			);


### PR DESCRIPTION
## Description

Resolves this comment: https://github.com/wix/Detox/issues/3319#issuecomment-1094890944

XCode keeps complaining:

> Cycle inside Detox; building could produce unreliable results. This usually can be resolved by moving the target's Headers build phase before Compile Sources.

I've done what XCode asks - the error goes away.
