### PR TITLE
fix(ios): inject web() stub function properly

### DIFF
--- a/detox/src/ios/expectTwo.js
+++ b/detox/src/ios/expectTwo.js
@@ -636,6 +636,7 @@ class IosExpect {
     this.expect = this.expect.bind(this);
     this.waitFor = this.waitFor.bind(this);
     this.by = new By();
+    this.web = this.web.bind(this);
     this.web.element = this.web;
   }
 

--- a/detox/test/e2e/29.webview.test.js
+++ b/detox/test/e2e/29.webview.test.js
@@ -1,4 +1,11 @@
+const jestExpect = require('expect');
 const MOCK_TEXT = 'Mock Text';
+
+describe(':ios: WebView', () => {
+  it('should throw a runtime error on attempt to use', () => {
+    jestExpect(() => web(by.id('webview_1'))).toThrowError(/Detox does not support .* on iOS/);
+  });
+});
 
 describe(':android: WebView', () => {
   let webview_1;


### PR DESCRIPTION
## Description

Fixes the issue:

```
web
^^^ --- trying to access the global variable injected by Detox
```

where previously it has been throwing an error immediately:

```
Detox instance has not been initialized·
HINT: Make sure to call detox.init() before your test begins
```

while the expected behavior would be:

```js
web; // does not throw
web(); // calling the function throws: Detox does not support web(), web.element() on iOS
```