### PR TITLE
build: limit peerDependencies to jest@27 max

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "detox",
   "description": "E2E tests and automation for mobile",
-  "version": "19.6.6",
+  "version": "19.6.7-build.limit-jest-27.0",
   "bin": {
     "detox": "local-cli/cli.js"
   },

--- a/detox/package.json
+++ b/detox/package.json
@@ -81,8 +81,8 @@
     "yargs-unparser": "^2.0.0"
   },
   "peerDependencies": {
-    "jest-circus": "26.0.x - 26.4.x || >=26.5.2",
-    "jest-environment-node": ">=25.0.0",
+    "jest-circus": "26.0.x - 26.4.x || >=26.5.2 <28.0.0",
+    "jest-environment-node": ">=25.0.0 <28.0.0",
     "mocha": ">=6.0.0"
   },
   "engines": {

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-test",
-  "version": "19.6.6",
+  "version": "19.6.7-build.limit-jest-27.0",
   "private": true,
   "engines": {
     "node": ">=8.3.0"
@@ -49,7 +49,7 @@
     "@types/react-native": "^0.64.19",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
-    "detox": "^19.6.6",
+    "detox": "^19.6.7-build.limit-jest-27.0",
     "eslint": "^7.32.0",
     "eslint-plugin-unicorn": "^39.0.0",
     "express": "^4.15.3",

--- a/examples/demo-native-android/package.json
+++ b/examples/demo-native-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-demo-native-android",
-  "version": "19.6.6",
+  "version": "19.6.7-build.limit-jest-27.0",
   "private": true,
   "scripts": {
     "packager": "react-native start",
@@ -8,7 +8,7 @@
     "e2e": "mocha e2e --opts ./e2e/mocha.opts"
   },
   "devDependencies": {
-    "detox": "^19.6.6",
+    "detox": "^19.6.7-build.limit-jest-27.0",
     "mocha": "^6.1.3"
   },
   "detox": {}

--- a/examples/demo-native-ios/package.json
+++ b/examples/demo-native-ios/package.json
@@ -1,9 +1,9 @@
 {
   "name": "detox-demo-native-ios",
-  "version": "19.6.6",
+  "version": "19.6.7-build.limit-jest-27.0",
   "private": true,
   "devDependencies": {
-    "detox": "^19.6.6",
+    "detox": "^19.6.7-build.limit-jest-27.0",
     "mocha": "^6.1.3"
   },
   "detox": {

--- a/examples/demo-plugin/package.json
+++ b/examples/demo-plugin/package.json
@@ -1,12 +1,12 @@
 {
   "name": "demo-plugin",
-  "version": "19.6.6",
+  "version": "19.6.7-build.limit-jest-27.0",
   "private": true,
   "scripts": {
     "test:plugin": "detox test --configuration plugin -l verbose"
   },
   "devDependencies": {
-    "detox": "^19.6.6",
+    "detox": "^19.6.7-build.limit-jest-27.0",
     "jest": "^27.0.0"
   },
   "detox": {

--- a/examples/demo-react-native-detox-instruments/package.json
+++ b/examples/demo-react-native-detox-instruments/package.json
@@ -1,10 +1,10 @@
 {
   "name": "demo-react-native-detox-instruments",
-  "version": "19.6.6",
+  "version": "19.6.7-build.limit-jest-27.0",
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "detox": "^19.6.6",
+    "detox": "^19.6.7-build.limit-jest-27.0",
     "mocha": "6.x.x"
   },
   "detox": {

--- a/examples/demo-react-native-jest/package.json
+++ b/examples/demo-react-native-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-react-native-jest",
-  "version": "19.6.6",
+  "version": "19.6.7-build.limit-jest-27.0",
   "private": true,
   "scripts": {
     "test:ios-release": "detox test --configuration ios.sim.release -l verbose",
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",
-    "detox": "^19.6.6",
+    "detox": "^19.6.7-build.limit-jest-27.0",
     "jest": "^27.0.0",
     "sanitize-filename": "^1.6.1",
     "ts-jest": "^27.0.0",

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "19.6.6",
+  "version": "19.6.7-build.limit-jest-27.0",
   "private": true,
   "scripts": {
     "start": "react-native start",
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^8.2.0",
-    "detox": "^19.6.6",
+    "detox": "^19.6.7-build.limit-jest-27.0",
     "mocha": "^6.1.3",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
     "generation",
     "."
   ],
-  "version": "19.6.6",
+  "version": "19.6.7-build.limit-jest-27.0",
   "npmClient": "npm",
   "command": {
     "publish": {

--- a/package.json
+++ b/package.json
@@ -54,5 +54,5 @@
     "shell-utils": "1.x.x",
     "unified": "^10.1.0"
   },
-  "version": "19.6.6"
+  "version": "19.6.7-build.limit-jest-27.0"
 }


### PR DESCRIPTION
## Description

It turns out that in the recent `npm` package manager versions (8.x) the fact of having `peerDependencies` can dramatically change the installation outcome. Hence, I am considering limiting the supported Jest versions to 26..27.

Detox 20 will have support for 27..28, respectively.

@d4vidi WDYT?

P. S. In fact, I myself am not 100% sure what the most correct solution is.