### PR TITLE
feat: undeprecate device.relaunchApp()

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -486,6 +486,15 @@ declare global {
              */
             launchApp(config?: DeviceLaunchAppConfig): Promise<void>;
 
+           /**
+            * Relaunch the app. Convenience method that calls {@link Device#launchApp}
+            * with { newInstance: true } override.
+            *
+            * @param config
+            * @see Device#launchApp
+            */
+            relaunchApp(config?: Omit<DeviceLaunchAppConfig, 'newInstance'>): Promise<void>;
+
             /**
              * Access the user-defined launch-arguments predefined through static scopes such as the Detox configuration file and
              * command-line arguments. This access allows - through dedicated methods, for both value-querying and

--- a/detox/src/devices/runtime/RuntimeDevice.js
+++ b/detox/src/devices/runtime/RuntimeDevice.js
@@ -116,9 +116,6 @@ class RuntimeDevice {
     return traceCall('launchApp', () => this._doLaunchApp(params, bundleId));
   }
 
-  /**
-   * @deprecated
-   */
   async relaunchApp(params = {}, bundleId) {
     if (params.newInstance === undefined) {
       params['newInstance'] = true;

--- a/detox/test/types/detox-module-tests.ts
+++ b/detox/test/types/detox-module-tests.ts
@@ -8,6 +8,45 @@ import { by, device, element, expect, waitFor } from 'detox';
 describe('Test', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
+    await device.launchApp({
+      newInstance: false,
+      permissions: {
+        location: 'always',
+        notifications: 'YES',
+        calendar: 'NO',
+        camera: 'YES',
+        contacts: 'NO',
+        health: 'YES',
+        homekit: 'NO',
+        medialibrary: 'YES',
+        microphone: 'NO',
+        motion: 'YES',
+        photos: 'NO',
+        reminders: 'YES',
+        siri: 'NO',
+        speech: 'YES',
+        faceid: 'NO',
+        userTracking: 'YES',
+      },
+      url: 'detoxtesturlscheme://such-string',
+      userNotification: {},
+      userActivity: {},
+      delete: false,
+      launchArgs: {
+        someArg: 42,
+      },
+      languageAndLocale: {
+        language: 'en',
+        locale: 'en-CA',
+      },
+    });
+
+    await device.relaunchApp();
+    await device.relaunchApp({
+      launchArgs: {
+        someArg: 42,
+      },
+    });
   });
 
   afterAll(async () => {

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -269,12 +269,12 @@ Launches the app with a URL blacklist to disable network synchronization on cert
 await device.launchApp({
   newInstance: true,
   launchArgs: { detoxURLBlacklistRegex: ' \\("http://192.168.1.253:19001/onchange","https://e.crashlytics.com/spi/v2/events"\\)' },
-}); 
+});
 ```
 
 #### `device.relaunchApp(params)`
 
-**Deprecated:** Use `device.launchApp(params)` instead. The method calls `launchApp({newInstance: true})` for backwards compatibility.
+The method calls `launchApp({newInstance: true})` as a convenience method.
 
 #### `device.terminateApp()`
 


### PR DESCRIPTION
Resolves https://github.com/wix/Detox/issues/3350

## Description

In this pull request, I have removed a deprecation notice from `device.relaunchApp` API. From now, it is considered a legit shorthand, e. g.:

```js
await device.launchApp({ newInstance: true, launchArgs: { /* ... */} });
// is the same as:
await device.relaunchApp({ launchArgs: { /* ... */ } });
```

> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
