### PR TITLE
feat(config): remove legacy dash props

### DIFF
--- a/detox/src/configuration/composeRunnerConfig.js
+++ b/detox/src/configuration/composeRunnerConfig.js
@@ -4,8 +4,8 @@
  * @param {Detox.DetoxConfigurationOverrides} localConfig
  */
 function composeRunnerConfig({ globalConfig, cliConfig }) {
-  const testRunner = globalConfig.testRunner || globalConfig['test-runner'] || 'jest';
-  const customRunnerConfig = cliConfig.runnerConfig || globalConfig.runnerConfig || globalConfig['runner-config'];
+  const testRunner = globalConfig.testRunner || 'jest';
+  const customRunnerConfig = cliConfig.runnerConfig || globalConfig.runnerConfig;
 
   return {
     testRunner,

--- a/detox/src/configuration/composeRunnerConfig.test.js
+++ b/detox/src/configuration/composeRunnerConfig.test.js
@@ -18,11 +18,6 @@ describe('composeRunnerConfig', () => {
     expect(composeRunnerConfig().testRunner).toBe('nyc jest');
   });
 
-  it('should take .test-runner from globalConfig', () => {
-    globalConfig['test-runner'] = 'nyc jest';
-    expect(composeRunnerConfig().testRunner).toBe('nyc jest');
-  });
-
   it('should set .testRunner to "jest" by default', () => {
     expect(composeRunnerConfig().testRunner).toBe('jest');
   });
@@ -36,13 +31,6 @@ describe('composeRunnerConfig', () => {
 
   it('should take .runnerConfig from config if it is not defined via CLI', () => {
     globalConfig.runnerConfig = 'from/config.json';
-    delete cliConfig.runnerConfig;
-
-    expect(composeRunnerConfig().runnerConfig).toBe('from/config.json');
-  });
-
-  it('should take .runner-config from config if it is not defined via CLI', () => {
-    globalConfig['runner-config'] = 'from/config.json';
     delete cliConfig.runnerConfig;
 
     expect(composeRunnerConfig().runnerConfig).toBe('from/config.json');


### PR DESCRIPTION
Resolves https://github.com/wix/Detox/issues/3355

## Description

Removes old and **undocumented** global configuration properties: `test-runner` and `runner-config`.

Instead, their camelCase alternatives should be used: `testRunner` and `runnerConfig`.