### PR TITLE
docs: test runners clarification

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT_ANDROID.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT_ANDROID.yml
@@ -42,7 +42,7 @@ body:
     id: environment
     attributes:
       label: In what environment did this happen?
-      description: "Note: the test-runner is set in your detox configuration file (e.g. package.json, detox.config)."
+      description: "Note: the test runner is Jest by default, unless overridden via testRunner property in your detox configuration file (e.g. package.json, detox.config)."
       value: "Detox version:
       \nReact Native version:
       \nNode version:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT_IOS.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT_IOS.yml
@@ -42,7 +42,7 @@ body:
     id: environment
     attributes:
       label: In what environment did this happen?
-      description: "Note: the test-runner is set in your detox configuration file (e.g. package.json, detox.config)."
+      description: "Note: the test runner is Jest by default, unless overridden via testRunner property in your detox configuration file (e.g. package.json, detox.config)."
       value: "Detox version:
       \nReact Native version:
       \nNode version:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT_OTHER.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT_OTHER.yml
@@ -37,11 +37,11 @@ body:
     id: environment
     attributes:
       label: In what environment did this happen?
-      description: "Note: the test-runner is set in your detox configuration file (e.g. package.json, detox.config)."
+      description: "Note: the test runner is Jest by default, unless overridden via testRunner property in your detox configuration file (e.g. package.json, detox.config)."
       value: "Detox version:
       \nReact Native version:
       \nNode version:
-      \nTest-runner (select one): jest-circus / jest+jasmine / mocha / other"
+      \nTest-runner (select one): jest / other"
   - type: textarea
     id: detox-logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/HELP_WITH_USING_DETOX.yml
+++ b/.github/ISSUE_TEMPLATE/HELP_WITH_USING_DETOX.yml
@@ -16,7 +16,7 @@ body:
     id: environment
     attributes:
       label: Your environment
-      description: "Note: the test-runner is set in your detox configuration file (e.g. package.json, detox.config)."
+      description: "Note: the test runner is set in your detox configuration file (e.g. package.json, detox.config)."
       value: "Detox version:
       \nReact Native version:
       \nNode version:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ The most difficult part of automated testing on mobile is the tip of the testing
 - **Runs on Devices** (not yet supported on iOS): Gain confidence to ship by testing your app on a device/simulator just like a real user.
 - **Automatically Synchronized:** Stops flakiness at the core by monitoring asynchronous operations in your app.
 - **Made For CI:** Execute your E2E tests on CI platforms like Travis without grief.
-- **Test Runner Independent:** Use Jest, Mocha, AVA, or any other JavaScript test runner you like (spoiler: we have our favorite).
 - **Debuggable:** Modern `async`-`await` API allows breakpoints in asynchronous tests to work as expected.
 
 ## Supported Versions

--- a/detox/local-cli/utils/testCommandArgs.js
+++ b/detox/local-cli/utils/testCommandArgs.js
@@ -145,7 +145,7 @@ module.exports = {
     boolean: true,
     default: true,
     group: 'Execution:',
-    describe: `Use Detox' custom console-logging implementation, for logging Detox (non-device) logs. Disabling will fallback to node.js / test-runner's implementation (e.g. Jest / Mocha).`,
+    describe: `Use Detox' custom console-logging implementation, for logging Detox (non-device) logs. Disabling will fallback to node.js / test runner's implementation (e.g. Jest).`,
   },
   'force-adb-install': {
     boolean: true,

--- a/docs/APIRef.DetoxCLI.md
+++ b/docs/APIRef.DetoxCLI.md
@@ -20,7 +20,7 @@ npm install -g detox-cli
 ### Usage
 
 ```sh
-detox <command> [options] 
+detox <command> [options]
 ```
 
 ### Commands
@@ -98,7 +98,7 @@ Initiating your test suite[^1].
 | --device-launch-args                          | A list of passthrough-arguments to use when (if) devices (Android emulator / iOS simulator) are launched by Detox.<br />**Note: the value must be specified after an equal sign (`=`) and inside quotes.** Usage example:<br />`--device-launch-args="-http-proxy http://1.1.1.1:8000 -no-snapshot-load"` |
 | --app-launch-args                             | Custom arguments to pass (through) onto the app every time it is launched. The same **note** applies here, as for **--device-launch-args**.<br />See [launch arguments guide](APIRef.LaunchArgs.md) for complete info.                                                                                    |
 | --no-color                                    | Disable colors in log output                                                                                                                                                                                                                                                                              |
-| --use-custom-logger                           | Use Detox' custom console-logging implementation, for logging Detox (non-device) logs. Disabling will fallback to node.js / test-runner’s implementation (e.g. Jest / Mocha).<br />_Default: true_                                                                                                        |
+| --use-custom-logger                           | Use Detox' custom console-logging implementation, for logging Detox (non-device) logs. Disabling will fallback to node.js / test runner’s implementation (e.g. Jest).<br />_Default: true_                                                                                                        |
 | --force-adb-install                           | Due to problems with the `adb install` command on Android, Detox resorts to a different scheme for installing APKs. Setting true will disable that and force usage of `adb install`, instead.<br/>This flag is temporary until the Detox way proves stable.<br/>_Default: false_                          |
 | --inspect-brk                                 | Uses [node’s --inspect-brk](https://nodejs.org/en/docs/guides/debugging-getting-started/#enable-inspector) flag to let users debug the test runner <br />_Default: false_                                                                                                                                 |
 | --help                                        | Show help                                                                                                                                                                                                                                                                                                 |

--- a/docs/Guide.ParallelTestExecution.md
+++ b/docs/Guide.ParallelTestExecution.md
@@ -7,9 +7,9 @@ sidebar_label: Parallel Test Execution
 
 ## Parallel Test Execution
 
-Detox can leverage multi worker support of JS test runners ([Jest](http://jestjs.io/docs/en/cli#maxworkers-num), [AVA](https://github.com/avajs/ava#process-isolation), etc.).
+Detox can leverage multi worker support of JS test runners ([Jest](http://jestjs.io/docs/en/cli#maxworkers-num),  etc.).
 
-By default `detox test` will run the test runner with one worker (it will pass `--maxWorkers=1` to Jest CLI, Mocha is unaffected). Worker count can be controlled by adding `--workers n` to `detox test`, read more in [`detox-cli` section](APIRef.DetoxCLI.md#test).
+By default `detox test` will run the test runner with one worker. Worker count can be controlled by adding `--workers n` to `detox test`, read more in [`detox-cli` section](APIRef.DetoxCLI.md#test).
 
 ### Device Creation
 

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -160,7 +160,7 @@ dependencies {
 ```groovy
 android {
   // ...
-  
+
   defaultConfig {
       // ...
       testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
@@ -219,7 +219,7 @@ _In the app’s `AndroidManifest.xml`_
 
 ```xml
 <manifest>
-  <application 
+  <application
         ...
         android:networkSecurityConfig="@xml/network_security_config">
   </application>
@@ -288,7 +288,7 @@ If, when [setting up your work environment](Introduction.AndroidDevEnv.md), you�
 Setting Test Butler up for working with Detox is a bit different than explained in their guides. The process, as a whole, is twofold:
 
 1. Preinstalling the test-butler-app APK onto the test device.
-1. Integrating the test-butler-lib into your own test APK, and initializing it in a custom test-runner (as explained).
+1. Integrating the test-butler-lib into your own test APK, and initializing it in a custom test runner (as explained).
 
 The library part can be easily achieved as explained there (i.e. by using Gradle’s `androidTestImplementation`). Same goes for initialization. As for the APK, the suggested usage of Gradle’s `androidTestUtil` is scarce when running with Detox (i.e. non-native instrumentation tests). Here’s what to do instead.
 
@@ -369,7 +369,7 @@ In your app’s `buildscript` (i.e. `android/app/build.gradle`) add this to the 
 ```groovy
 android {
   // ...
-  
+
   defaultConfig {
       // ...
       testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type

--- a/docs/Introduction.GettingStarted.md
+++ b/docs/Introduction.GettingStarted.md
@@ -83,7 +83,7 @@ Follow [our comprehensive guide for Jest](Guide.Jest.md).
 
 ### Apply Detox Configuration
 
-If you’ve completed the test-runner setup successfully using `detox init`, you should have a `.detoxrc.json` file containing a skeletal configuration for Detox to use. This configuration is only half-baked and needs to be set up properly. You now need to either create or edit that file, and apply the actual configuration suitable for your specific project.
+If you’ve completed the test runner setup successfully using `detox init`, you should have a `.detoxrc.json` file containing a skeletal configuration for Detox to use. This configuration is only half-baked and needs to be set up properly. You now need to either create or edit that file, and apply the actual configuration suitable for your specific project.
 
 Detox scans for a configuration through multiple files. It starts from the current working directory, and runs over the following options, in this order:
 

--- a/website/versioned_docs/version-19.x/APIRef.DetoxCLI.md
+++ b/website/versioned_docs/version-19.x/APIRef.DetoxCLI.md
@@ -20,7 +20,7 @@ npm install -g detox-cli
 ### Usage
 
 ```sh
-detox <command> [options] 
+detox <command> [options]
 ```
 
 ### Commands
@@ -99,7 +99,7 @@ Initiating your test suite[^1].
 | --device-launch-args                          | A list of passthrough-arguments to use when (if) devices (Android emulator / iOS simulator) are launched by Detox.<br />**Note: the value must be specified after an equal sign (`=`) and inside quotes.** Usage example:<br />`--device-launch-args="-http-proxy http://1.1.1.1:8000 -no-snapshot-load"` |
 | --app-launch-args                             | Custom arguments to pass (through) onto the app every time it is launched. The same **note** applies here, as for **--device-launch-args**.<br />See [launch arguments guide](APIRef.LaunchArgs.md) for complete info.                                                                                    |
 | --no-color                                    | Disable colors in log output                                                                                                                                                                                                                                                                              |
-| --use-custom-logger                           | Use Detox' custom console-logging implementation, for logging Detox (non-device) logs. Disabling will fallback to node.js / test-runner’s implementation (e.g. Jest / Mocha).<br />_Default: true_                                                                                                        |
+| --use-custom-logger                           | Use Detox' custom console-logging implementation, for logging Detox (non-device) logs. Disabling will fallback to node.js / test-runner’s implementation (e.g. Jest).<br />_Default: true_                                                                                                        |
 | --force-adb-install                           | Due to problems with the `adb install` command on Android, Detox resorts to a different scheme for installing APKs. Setting true will disable that and force usage of `adb install`, instead.<br/>This flag is temporary until the Detox way proves stable.<br/>_Default: false_                          |
 | --inspect-brk                                 | Uses [node’s --inspect-brk](https://nodejs.org/en/docs/guides/debugging-getting-started/#enable-inspector) flag to let users debug the jest/mocha test runner <br />_Default: false_                                                                                                                      |
 | --help                                        | Show help                                                                                                                                                                                                                                                                                                 |


### PR DESCRIPTION
## Description

Replaces `test-runner` property notice from YAML templates and Markdown docs with an up-to-date information:

1. Jest test runner is the default and it is implied.
2. Instead of undocumented `test-runner` syntax, we now suggest the correct and documented `testRunner` property as a source of truth.

Last but not least, `testRunner` property still remains supported by Detox for custom commands (e.g. `nyc jest`) and (possibly) other runners.