### PR TITLE
fix: jest@28 compatibility

### DIFF
--- a/detox/runners/jest-circus/environment.js
+++ b/detox/runners/jest-circus/environment.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
-const NodeEnvironment = require('jest-environment-node');
+const maybeNodeEnvironment = require('jest-environment-node');
+const NodeEnvironment = maybeNodeEnvironment.default || maybeNodeEnvironment;
 
 const DetoxError = require('../../src/errors/DetoxError');
 const Timer = require('../../src/utils/Timer');

--- a/detox/runners/jest-circus/utils/assertJestCircus26.js
+++ b/detox/runners/jest-circus/utils/assertJestCircus26.js
@@ -3,12 +3,14 @@ const path = require('path');
 
 const DetoxRuntimeError = require('../../../src/errors/DetoxRuntimeError');
 
-function assertJestCircus26(config) {
-  if (!/jest-circus/.test(config.testRunner)) {
+function assertJestCircus26(maybeProjectConfig) {
+  const projectConfig = maybeProjectConfig.projectConfig || maybeProjectConfig;
+
+  if (!/jest-circus/.test(projectConfig.testRunner)) {
     throw new DetoxRuntimeError('Cannot run tests without "jest-circus" npm package, exiting.');
   }
 
-  const circusPackageJson = path.join(path.dirname(config.testRunner), 'package.json');
+  const circusPackageJson = path.join(path.dirname(projectConfig.testRunner), 'package.json');
   if (!fs.existsSync(circusPackageJson)) {
     throw new DetoxRuntimeError('Check that you have an installed copy of "jest-circus" npm package, exiting.');
   }
@@ -31,7 +33,7 @@ function assertJestCircus26(config) {
     );
   }
 
-  return config;
+  return projectConfig;
 }
 
 module.exports = assertJestCircus26;


### PR DESCRIPTION
## Description

Fixes two issues with the new Jest 28:

1. Handling a possible `default` export from `jest-environment-node`.
2. Handling a possible new config format: now it is not `projectConfig`, rather `{ projectConfig, globalConfig }`.3. 