### PR TITLE
feat(config): drop support for the all-in-one configuration format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,10 @@ trim_trailing_whitespace = true
 indent_size = 2
 tab_width = 2
 
+[detox/index.d.ts]
+indent_size = 4
+tab_width = 4
+
 [{*.cjs,*.js}]
 indent_size = 2
 tab_width = 2

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -77,9 +77,14 @@ describe('Detox', () => {
       override: {
         configurations: {
           test: {
-            type: 'fake.device',
-            binaryPath: '/tmp/fake/path',
-            device: 'a device',
+            device: {
+              type: 'fake.device',
+              device: 'a device',
+            },
+            app: {
+              type: 'fake.app',
+              binaryPath: '/tmp/fake/path',
+            },
           },
         },
       },

--- a/detox/src/configuration/__mocks__/configuration/oldschema/package.json
+++ b/detox/src/configuration/__mocks__/configuration/oldschema/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "oldschema",
+  "version": "1.0.0",
+  "dependencies": {
+  },
+  "detox": {
+    "configurations": {
+      "single": {
+        "type": "ios.simulator",
+        "device": "iPhone 12",
+        "binaryPath": "/some/path/to.app"
+      }
+    }
+  }
+}

--- a/detox/src/configuration/__mocks__/configuration/packagejson/package.json
+++ b/detox/src/configuration/__mocks__/configuration/packagejson/package.json
@@ -8,8 +8,11 @@
     },
     "configurations": {
       "simple": {
-        "type": "android.attached",
-        "device": "Hello from package.json"
+        "device": {
+          "type": "android.attached",
+          "device": "Hello from package.json"
+        },
+        "apps": []
       }
     }
   }

--- a/detox/src/configuration/__mocks__/configuration/priority/.detoxrc.js
+++ b/detox/src/configuration/__mocks__/configuration/priority/.detoxrc.js
@@ -1,8 +1,11 @@
 module.exports = {
     configurations: {
         simple: {
+          device: {
             type: "android.attached",
             device: "Hello from .detoxrc",
+          },
+          apps: [],
         },
     },
 };

--- a/detox/src/configuration/__mocks__/configuration/priority/detox-config.json
+++ b/detox/src/configuration/__mocks__/configuration/priority/detox-config.json
@@ -1,8 +1,11 @@
 {
     "configurations": {
         "simple": {
+          "device": {
             "type": "android.attached",
             "device": "Hello from detox-config.json"
+          },
+          "apps": []
         }
     }
 }

--- a/detox/src/configuration/__mocks__/configuration/priority/package.json
+++ b/detox/src/configuration/__mocks__/configuration/priority/package.json
@@ -1,10 +1,13 @@
 {
-    "detox": {
-        "configurations": {
-            "simple": {
-                "type": "android.attached",
-                "device": "Hello from package.json"
-            }
-        }
+  "detox": {
+    "configurations": {
+      "simple": {
+        "device": {
+          "type": "android.attached",
+          "device": "Hello from detox-config.json"
+        },
+        "apps": []
+      }
     }
+  }
 }

--- a/detox/src/configuration/composeAppsConfig.test.js
+++ b/detox/src/configuration/composeAppsConfig.test.js
@@ -48,101 +48,6 @@ describe('composeAppsConfig', () => {
     cliConfig,
   });
 
-  describe('given a plain configuration', () => {
-    beforeEach(() => {
-      localConfig = {
-        type: 'ios.simulator',
-        device: 'Phone',
-        binaryPath: 'path/to/app',
-        bundleId: 'com.example.app',
-        build: 'echo OK',
-        launchArgs: {
-          hello: 'world',
-        }
-      };
-    });
-
-    it.each([
-      ['ios.simulator', 'ios.app'],
-      ['android.attached', 'android.apk'],
-      ['android.emulator', 'android.apk'],
-      ['android.genycloud', 'android.apk'],
-    ])('should infer type and app properties for %j', (deviceType, appType) => {
-      deviceConfig.type = deviceType;
-      expect(compose()).toEqual({
-        default: {
-          ...localConfig,
-          type: appType,
-          device: undefined,
-        },
-      });
-    });
-
-    it('should take it as-is for unknown device type', () => {
-      deviceConfig.type = './customDriver';
-      localConfig = { ...deviceConfig };
-      expect(compose()).toEqual({
-        default: localConfig
-      });
-    });
-
-    it('should ignore mistyped Android properties for iOS app', () => {
-      deviceConfig.type = 'ios.simulator';
-      localConfig.testBinaryPath = 'somePath';
-
-      const appConfig = compose().default;
-      expect(appConfig.testBinaryPath).toBe(undefined);
-    });
-
-    it('should include Android properties for Android app', () => {
-      deviceConfig.type = 'android.emulator';
-      localConfig.testBinaryPath = 'somePath';
-
-      const appConfig = compose().default;
-      expect(appConfig.testBinaryPath).toBe('somePath');
-    });
-
-    it.each([
-      ['ios.simulator'],
-      ['android.attached'],
-      ['android.emulator'],
-      ['android.genycloud'],
-    ])('should ignore non-recognized properties for %j', (deviceType) => {
-      deviceConfig.type = deviceType;
-      localConfig.testBinaryPath2 = 'somePath';
-      expect(compose().default.testBinaryPath2).toBe(undefined);
-    });
-
-    describe('.launchArgs', () => {
-      it('when it it is a string, should throw', () => {
-        localConfig.launchArgs = '-detoxAppArgument NO';
-        expect(compose).toThrowError(errorComposer.malformedAppLaunchArgs(['configurations', configurationName]));
-      });
-
-      it('when it is an object with nullish properties, it should omit them', () => {
-        localConfig.launchArgs.nully = null;
-        localConfig.launchArgs.undefiny = undefined;
-        localConfig.launchArgs.aString = 'proveYourself';
-        localConfig.launchArgs.anObject = { a: 1 };
-        localConfig.launchArgs.anInteger = 2;
-
-        expect(compose().default.launchArgs).toEqual({
-          hello: 'world',
-          aString: 'proveYourself',
-          anInteger: 2,
-          anObject: { a: 1 },
-        });
-      });
-    });
-
-    describe('given an unknown device type', () => {
-      it('should transfer the config as-is, for backward compatibility', () => {
-        deviceConfig.type = './myDriver';
-        expect(compose()).toEqual({ default: localConfig });
-      });
-    });
-  });
-
   describe('given a configuration with single app', () => {
     beforeEach(() => {
       deviceConfig.type = 'ios.simulator';
@@ -235,37 +140,29 @@ describe('composeAppsConfig', () => {
     });
   });
 
-  describe('unhappy scenarios:', () => {
-    describe('plain configuration:', () => {
-      beforeEach(() => {
-        localConfig = {
-          type: 'ios.simulator',
-          device: 'Phone',
-          binaryPath: 'path/to/app',
-          bundleId: 'com.example.app',
-          build: 'echo OK',
-          launchArgs: {
-            hello: 'world',
-          }
-        };
-      });
-
-      it('should throw if the config has .app property defined', () => {
-        localConfig.app = 'myapp';
-        expect(compose).toThrowError(errorComposer.oldSchemaHasAppAndApps());
-      });
-
-      it('should throw if the config has .apps property defined', () => {
-        localConfig.apps = ['myapp'];
-        expect(compose).toThrowError(errorComposer.oldSchemaHasAppAndApps());
-      });
+  describe('given a configuration with no apps', () => {
+    beforeEach(() => {
+      delete localConfig.app;
+      delete localConfig.apps;
     });
 
+    describe('when the device is powered by a custom driver', () => {
+      beforeEach(() => {
+        deviceConfig.type = './stub/driver';
+      });
+
+      it('should return an empty app config', () => {
+        expect(compose()).toEqual({});
+      });
+    });
+  });
+
+  describe('unhappy scenarios:', () => {
     describe('aliased configuration:', () => {
       beforeEach(() => {
         globalConfig.apps = {
-          example1: appWithAbsoluteBinaryPath,
-          example2: appWithRelativeBinaryPath,
+          example1: { ...appWithAbsoluteBinaryPath },
+          example2: { ...appWithRelativeBinaryPath },
         };
 
         delete localConfig.type;
@@ -273,8 +170,9 @@ describe('composeAppsConfig', () => {
 
       test.each([
         ['ios.simulator'],
+        ['android.attached'],
         ['android.emulator'],
-        ['./stub/driver'],
+        ['android.genycloud'],
       ])('no app/apps is defined when device is %s', (deviceType) => {
         delete localConfig.app;
         delete localConfig.apps;
@@ -357,6 +255,22 @@ describe('composeAppsConfig', () => {
         localConfig.app = 'example1';
 
         expect(compose).toThrowError(errorComposer.missingAppBinaryPath(
+          ['apps', 'example1']
+        ));
+      });
+
+      test.each([
+        ['ios.app', 'ios.simulator'],
+        ['android.apk', 'android.attached'],
+        ['android.apk', 'android.emulator'],
+        ['android.apk', 'android.genycloud'],
+      ])('known app (device type = %s) has malformed launchArgs', (appType, deviceType) => {
+        globalConfig.apps.example1.launchArgs = '-hello -world';
+        globalConfig.apps.example1.type = appType;
+        deviceConfig.type = deviceType;
+        localConfig.app = 'example1';
+
+        expect(compose).toThrowError(errorComposer.malformedAppLaunchArgs(
           ['apps', 'example1']
         ));
       });

--- a/detox/src/configuration/composeArtifactsConfig.js
+++ b/detox/src/configuration/composeArtifactsConfig.js
@@ -15,7 +15,7 @@ const resolveModuleFromPath = require('../utils/resolveModuleFromPath');
  * @param {*} cliConfig
  * @param {string} configurationName
  * @param {Detox.DetoxConfig} globalConfig
- * @param {Detox.DetoxConfigurationOverrides} localConfig
+ * @param {Detox.DetoxConfiguration} localConfig
  */
 function composeArtifactsConfig({
   cliConfig,

--- a/detox/src/configuration/composeBehaviorConfig.js
+++ b/detox/src/configuration/composeBehaviorConfig.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 /**
  * @param {*} cliConfig
  * @param {Detox.DetoxConfig} globalConfig
- * @param {Detox.DetoxConfigurationOverrides} localConfig
+ * @param {Detox.DetoxConfiguration} localConfig
  */
 function composeBehaviorConfig({
   cliConfig,

--- a/detox/src/configuration/composeDeviceConfig.js
+++ b/detox/src/configuration/composeDeviceConfig.js
@@ -12,13 +12,8 @@ const log = require('../utils/logger').child({ __filename });
  * @returns {Detox.DetoxDeviceConfig}
  */
 function composeDeviceConfig(opts) {
-  const { localConfig, cliConfig } = opts;
-
-  const deviceConfig = localConfig.type
-    ? composeDeviceConfigFromPlain(opts)
-    : composeDeviceConfigFromAliased(opts);
-
-  applyCLIOverrides(deviceConfig, cliConfig);
+  const deviceConfig = composeDeviceConfigFromAliased(opts);
+  applyCLIOverrides(deviceConfig, opts.cliConfig);
   deviceConfig.device = unpackDeviceQuery(deviceConfig);
 
   return deviceConfig;
@@ -27,29 +22,7 @@ function composeDeviceConfig(opts) {
 /**
  * @param {DetoxConfigErrorComposer} opts.errorComposer
  * @param {Detox.DetoxConfig} opts.globalConfig
- * @param {Detox.DetoxPlainConfiguration} opts.localConfig
- * @returns {Detox.DetoxDeviceConfig}
- */
-function composeDeviceConfigFromPlain(opts) {
-  const { errorComposer, localConfig } = opts;
-
-  const type = localConfig.type;
-  const device = localConfig.device || localConfig.name;
-  const utilBinaryPaths = localConfig.utilBinaryPaths;
-
-  const deviceConfig = type in EXPECTED_DEVICE_MATCHER_PROPS
-    ? _.omitBy({ type, device, utilBinaryPaths }, _.isUndefined)
-    : { ...localConfig };
-
-  validateDeviceConfig({ deviceConfig, errorComposer });
-
-  return deviceConfig;
-}
-
-/**
- * @param {DetoxConfigErrorComposer} opts.errorComposer
- * @param {Detox.DetoxConfig} opts.globalConfig
- * @param {Detox.DetoxAliasedConfiguration} opts.localConfig
+ * @param {Detox.DetoxConfiguration} opts.localConfig
  * @returns {Detox.DetoxDeviceConfig}
  */
 function composeDeviceConfigFromAliased(opts) {

--- a/detox/src/configuration/composeRunnerConfig.js
+++ b/detox/src/configuration/composeRunnerConfig.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 /**
  * @param {Detox.DetoxConfig} globalConfig
- * @param {Detox.DetoxConfigurationOverrides} localConfig
+ * @param {Detox.DetoxConfiguration} localConfig
  */
 function composeRunnerConfig({ globalConfig, cliConfig }) {
   const testRunner = globalConfig.testRunner || 'jest';

--- a/detox/src/configuration/composeSessionConfig.js
+++ b/detox/src/configuration/composeSessionConfig.js
@@ -5,7 +5,7 @@ const uuid = require('../utils/uuid');
  * @param {{
  *  cliConfig: Record<string, any>;
  *  globalConfig: Detox.DetoxConfig;
- *  localConfig: Detox.DetoxConfigurationOverrides;
+ *  localConfig: Detox.DetoxConfiguration;
  *  errorComposer: import('../errors/DetoxConfigErrorComposer');
  * }} options
  */

--- a/detox/src/configuration/index.js
+++ b/detox/src/configuration/index.js
@@ -20,9 +20,9 @@ const hooks = {
 async function composeDetoxConfig({
   cwd = process.cwd(),
   argv = undefined,
+  errorComposer = new DetoxConfigErrorComposer(),
   override,
 }) {
-  const errorComposer = new DetoxConfigErrorComposer();
   const cliConfig = collectCliConfig({ argv });
   const findupResult = await loadExternalConfig({
     errorComposer,
@@ -56,6 +56,10 @@ async function composeDetoxConfig({
   });
 
   const localConfig = configurations[configurationName];
+
+  if (localConfig['type']) {
+    throw errorComposer.configurationShouldNotUseLegacyFormat();
+  }
 
   const deviceConfig = composeDeviceConfig({
     errorComposer,

--- a/detox/src/configuration/index.test.js
+++ b/detox/src/configuration/index.test.js
@@ -43,6 +43,18 @@ describe('composeDetoxConfig', () => {
       })).rejects.toThrowError(errorComposer.noConfigurationSpecified());
     });
 
+    it('should throw an error if the local config has the old schema', async () => {
+      try {
+        await configuration.composeDetoxConfig({
+          cwd: path.join(__dirname, '__mocks__/configuration/oldschema'),
+          errorComposer,
+        });
+      } catch (e) {
+        // NOTE: we want errorComposer to be mutated, that's why we assert inside try-catch
+        expect(e).toEqual(errorComposer.configurationShouldNotUseLegacyFormat());
+      }
+    });
+
     it('should return a complete Detox config merged with the file configuration', async () => {
       const config = await configuration.composeDetoxConfig({
         cwd: path.join(__dirname, '__mocks__/configuration/packagejson'),
@@ -68,9 +80,14 @@ describe('composeDetoxConfig', () => {
           },
           configurations: {
             another: {
-              type: 'ios.simulator',
-              device: 'iPhone X',
-              binaryPath: 'path/to/app',
+              device: {
+                type: 'ios.simulator',
+                device: 'iPhone X'
+              },
+              app: {
+                type: 'ios.app',
+                binaryPath: 'path/to/app',
+              },
             },
           },
         }

--- a/detox/src/errors/DetoxConfigErrorComposer.js
+++ b/detox/src/errors/DetoxConfigErrorComposer.js
@@ -25,16 +25,6 @@ class DetoxConfigErrorComposer {
   _atPath() {
     return this.filepath ? ` at path:\n${this.filepath}` : '.';
   }
-
-  _inTheAppConfig() {
-    const { type } = this._getSelectedConfiguration();
-    if (type) {
-      return `in configuration ${J(this.configurationName)}`;
-    }
-
-    return `in the app config`;
-  }
-
   _getSelectedConfiguration() {
     return _.get(this.contents, ['configurations', this.configurationName]);
   }
@@ -64,9 +54,10 @@ class DetoxConfigErrorComposer {
   }
 
   _focusOnDeviceConfig(deviceAlias, postProcess = _.identity) {
-    const { type, device } = this._getSelectedConfiguration();
+    const { device } = this._getSelectedConfiguration();
     if (!deviceAlias) {
-      if (type || !device) {
+      // istanbul ignore next
+      if (!device) {
         return this._focusOnConfiguration(postProcess);
       } else {
         return this._focusOnConfiguration(c => {
@@ -92,8 +83,7 @@ class DetoxConfigErrorComposer {
     if (alias) {
       return this.contents.devices[alias];
     } else {
-      const config = this._getSelectedConfiguration();
-      return config.type ? config : config.device;
+      return this._getSelectedConfiguration().device;
     }
   }
 
@@ -222,6 +212,61 @@ Examine your Detox config${this._atPath()}`,
         }
       },
       inspectOptions: { depth: 1 }
+    });
+  }
+
+  configurationShouldNotUseLegacyFormat() {
+    const name = this.configurationName;
+    const localConfig = this._getSelectedConfiguration();
+    /* istanbul ignore next */
+    const deviceType = localConfig.type || '';
+    const isAndroid = deviceType.startsWith('android.');
+    const isIOS = deviceType.startsWith('ios.');
+    const appName = 'myApp' + (isIOS ? '.ios' : '') + (isAndroid ? '.android' : '');
+    const deviceName = isIOS ? 'simulator' : isAndroid ? 'emulator' : 'myDevice';
+    const appType = isIOS ? 'ios.app' : isAndroid ? 'android.apk' : '<optional property>';
+    const binaryPath = isIOS || isAndroid ? localConfig.binaryPath : (localConfig.binaryPath || '<optional property>');
+    const deviceQuery = isIOS || isAndroid ? localConfig.device : (localConfig.device || '<optional property>');
+
+    return new DetoxConfigError({
+      message: `The ${J(name)} configuration utilizes a deprecated all-in-one schema, that is not supported ` +
+        `by the current version of Detox.`,
+      hint: `Remove the "type" property. A valid configuration is expected to have both the "device" and "app" aliases ` +
+        `pointing to the corresponding keys in the 'devices' and 'apps' config sections. For example:\n
+{
+  "apps": {
+*-->${J(appName)}: {
+|     "type": ${J(appType)},
+|     "binaryPath": ${J(binaryPath)},
+|   },
+| },
+| "devices": {
+|*->${J(deviceName)}: {
+||    "type": ${J(deviceType)},
+||    "device": ${J(deviceQuery)}
+||  },
+||},
+||"configurations": {
+||  ${J(name)}: {
+||    /* REMOVE (!) "type": ${J(deviceType)} */
+|*--- "device": ${J(deviceName)},
+*---- "app": ${J(appName)},
+      ...
+    }
+  }
+}
+Examine your Detox config${this._atPath()}`,
+      debugInfo: {
+        apps: this.contents.apps
+          ? _.mapValues(this.contents.apps, _.constant({}))
+          : undefined,
+        devices: this.contents.devices
+          ? _.mapValues(this.contents.devices, _.constant({}))
+          : undefined,
+
+        ...this._focusOnConfiguration(),
+      },
+      inspectOptions: { depth: 2 }
     });
   }
 
@@ -456,7 +501,7 @@ Examine your Detox config${this._atPath()}`,
 
   malformedAppLaunchArgs(appPath) {
     return new DetoxConfigError({
-      message: `Invalid type of "launchArgs" property ${this._inTheAppConfig()}.\nExpected an object:`,
+      message: `Invalid type of "launchArgs" property in the app config.\nExpected an object:`,
       debugInfo: this._focusOnAppConfig(appPath),
       inspectOptions: { depth: 4 },
     });
@@ -464,7 +509,7 @@ Examine your Detox config${this._atPath()}`,
 
   missingAppBinaryPath(appPath) {
     return new DetoxConfigError({
-      message: `Missing "binaryPath" property ${this._inTheAppConfig()}.\nExpected a string:`,
+      message: `Missing "binaryPath" property in the app config.\nExpected a string:`,
       debugInfo: this._focusOnAppConfig(appPath, this._ensureProperty('binaryPath')),
       inspectOptions: { depth: 4 },
     });
@@ -535,18 +580,6 @@ Examine your Detox config${this._atPath()}`,
 Examine your Detox config${this._atPath()}`,
       debugInfo: this._focusOnConfiguration(),
       inspectOptions: { depth: 0 }
-    });
-  }
-
-  oldSchemaHasAppAndApps() {
-    return new DetoxConfigError({
-      message: `Your configuration ${J(this.configurationName)} appears to be in a legacy format, which can’t contain "app" or "apps".`,
-      hint: `Remove "type" property from configuration and use "device" property instead:\n` +
-        `a) "device": { "type": ${J(this._getSelectedConfiguration().type)}, ... }\n` +
-        `b) "device": "<alias-to-device>" // you should add that device configuration to "devices" with the same key` +
-        `\n\nCheck your Detox config${this._atPath()}`,
-      debugInfo: this._focusOnConfiguration(this._ensureProperty('type', 'device')),
-      inspectOptions: { depth: 2 },
     });
   }
 

--- a/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
+++ b/detox/src/errors/__snapshots__/DetoxConfigErrorComposer.test.js.snap
@@ -267,22 +267,6 @@ Expected an object:
 }]
 `;
 
-exports[`DetoxConfigErrorComposer (from composeAppsConfig) .malformedAppLaunchArgs should work with plain configurations 1`] = `
-[DetoxConfigError: Invalid type of "launchArgs" property in configuration "plain".
-Expected an object:
-
-{
-  configurations: {
-    plain: {
-      type: 'android.emulator',
-      device: 'Pixel_3a_API_30_x86',
-      binaryPath: 'path/to/apk',
-      launchArgs: 'invalid'
-    }
-  }
-}]
-`;
-
 exports[`DetoxConfigErrorComposer (from composeAppsConfig) .missingAppBinaryPath should create an error for aliased configuration 1`] = `
 [DetoxConfigError: Missing "binaryPath" property in the app config.
 Expected a string:
@@ -323,21 +307,6 @@ Expected a string:
       apps: [
         undefined
       ]
-    }
-  }
-}]
-`;
-
-exports[`DetoxConfigErrorComposer (from composeAppsConfig) .missingAppBinaryPath should create an error for plain configuration 1`] = `
-[DetoxConfigError: Missing "binaryPath" property in configuration "plain".
-Expected a string:
-
-{
-  configurations: {
-    plain: {
-      type: 'android.emulator',
-      device: 'Pixel_3a_API_30_x86',
-      binaryPath: undefined
     }
   }
 }]
@@ -495,28 +464,6 @@ Examine your Detox config at path:
 /home/detox/myproject/.detoxrc.json]
 `;
 
-exports[`DetoxConfigErrorComposer (from composeAppsConfig) .oldSchemaHasAppAndApps should create an error for ambigous old/new configuration if it has .apps 1`] = `
-[DetoxConfigError: Your configuration "plain" appears to be in a legacy format, which can’t contain "app" or "apps".
-
-HINT: Remove "type" property from configuration and use "device" property instead:
-a) "device": { "type": "android.emulator", ... }
-b) "device": "<alias-to-device>" // you should add that device configuration to "devices" with the same key
-
-Check your Detox config at path:
-/home/detox/myproject/.detoxrc.json
-
-{
-  configurations: {
-    plain: {
-      type: 'android.emulator',
-      device: 'Pixel_3a_API_30_x86',
-      binaryPath: 'path/to/apk',
-      app: 'my-app'
-    }
-  }
-}]
-`;
-
 exports[`DetoxConfigErrorComposer (from composeAppsConfig) .thereAreNoAppConfigs should create an error for aliased configuration 1`] = `
 [DetoxConfigError: Cannot use app alias "someApp" since there is no "apps" config in Detox config at path:
 /home/detox/myproject/.detoxrc.json
@@ -555,7 +502,7 @@ Check your configuration "aliased":
 `;
 
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .deviceConfigIsUndefined should produce a helpful error 1`] = `
-[DetoxConfigError: Missing "device" property in the selected configuration "plain":
+[DetoxConfigError: Missing "device" property in the selected configuration "aliased":
 
 HINT: It should be an alias to the device config, or the device config itself, e.g.:
 {
@@ -567,7 +514,7 @@ HINT: It should be an alias to the device config, or the device config itself, e
 |   }
 | },
 | "configurations": {
-|   "plain": {
+|   "aliased": {
 *---- "device": "myDevice", // or { type: 'ios.simulator', ... }
       ...
     },
@@ -880,25 +827,6 @@ HINT: Check that in your Detox config at path:
 }]
 `;
 
-exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty ("utilBinaryPaths") should create an error for plain configuration 1`] = `
-[DetoxConfigError: Invalid type of "utilBinaryPaths" inside the device configuration.
-Expected an array of strings.
-
-HINT: Check that in your Detox config at path:
-/home/detox/myproject/.detoxrc.json
-
-{
-  configurations: {
-    plain: {
-      type: 'android.emulator',
-      device: 'Pixel_3a_API_30_x86',
-      binaryPath: 'path/to/apk',
-      utilBinaryPaths: 'invalid'
-    }
-  }
-}]
-`;
-
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .malformedDeviceProperty should throw on an unknown argument 1`] = `
 "Composing .malformedDeviceProperty(unknown) is not implemented
 Please report this issue on our GitHub tracker:
@@ -952,30 +880,6 @@ Check that in your Detox config at path:
           type: 'iPhone 12'
         }
       }
-    }
-  }
-}]
-`;
-
-exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .missingDeviceMatcherProperties should work with plain configurations 1`] = `
-[DetoxConfigError: Invalid or empty "device" matcher inside the device config.
-
-HINT: It should have the device query to run on, e.g.:
-
-{
-  "type": "android.emulator",
-  "device": { "foo": ... }
-      // or { "bar": ... }
-}
-Check that in your Detox config at path:
-/home/detox/myproject/.detoxrc.json
-
-{
-  configurations: {
-    plain: {
-      type: 'android.emulator',
-      device: 'Pixel_3a_API_30_x86',
-      binaryPath: 'path/to/apk'
     }
   }
 }]
@@ -1327,29 +1231,6 @@ Please fix your Detox config at path:
 }]
 `;
 
-exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty ("utilBinaryPaths") should create an error for plain configuration 1`] = `
-[DetoxConfigError: The current device type "android.emulator" does not support "utilBinaryPaths" property.
-
-HINT: You can use this property only with the following device types:
-* android.attached
-* android.emulator
-* android.genycloud
-
-Please fix your Detox config at path:
-/home/detox/myproject/.detoxrc.json
-
-{
-  configurations: {
-    plain: {
-      type: 'android.emulator',
-      device: 'Pixel_3a_API_30_x86',
-      binaryPath: 'path/to/apk',
-      utilBinaryPaths: []
-    }
-  }
-}]
-`;
-
 exports[`DetoxConfigErrorComposer (from composeDeviceConfig) .unsupportedDeviceProperty should throw on an unknown argument 1`] = `
 "Composing .unsupportedDeviceProperty(unknown) is not implemented
 Please report this issue on our GitHub tracker:
@@ -1536,7 +1417,6 @@ exports[`DetoxConfigErrorComposer (from configuration/index) .cantChooseConfigur
 /etc/detox/config.js
 
 HINT: Use --configuration to choose one of the following:
-* plain
 * aliased
 * inlined
 * inlinedMulti]
@@ -1573,10 +1453,239 @@ Examine your Detox config at path:
 {
   configurations: {
     empty: {},
-    plain: [Object],
     aliased: [Object],
     inlined: [Object],
     inlinedMulti: [Object]
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from configuration/index) .configurationShouldNotUseLegacyFormat for "android.emulator" device type should create a helpful error 1`] = `
+[DetoxConfigError: The "legacy" configuration utilizes a deprecated all-in-one schema, that is not supported by the current version of Detox.
+
+HINT: Remove the "type" property. A valid configuration is expected to have both the "device" and "app" aliases pointing to the corresponding keys in the 'devices' and 'apps' config sections. For example:
+
+{
+  "apps": {
+*-->"myApp.android": {
+|     "type": "android.apk",
+|     "binaryPath": "/path/android.emulator.app",
+|   },
+| },
+| "devices": {
+|*->"emulator": {
+||    "type": "android.emulator",
+||    "device": "some-query(android.emulator)"
+||  },
+||},
+||"configurations": {
+||  "legacy": {
+||    /* REMOVE (!) "type": "android.emulator" */
+|*--- "device": "emulator",
+*---- "app": "myApp.android",
+      ...
+    }
+  }
+}
+Examine your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  apps: {
+    someApp: {}
+  },
+  devices: {
+    aDevice: {}
+  },
+  configurations: {
+    legacy: {
+      type: 'android.emulator',
+      device: 'some-query(android.emulator)',
+      binaryPath: '/path/android.emulator.app'
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from configuration/index) .configurationShouldNotUseLegacyFormat for "android.genycloud" device type should create a helpful error 1`] = `
+[DetoxConfigError: The "legacy" configuration utilizes a deprecated all-in-one schema, that is not supported by the current version of Detox.
+
+HINT: Remove the "type" property. A valid configuration is expected to have both the "device" and "app" aliases pointing to the corresponding keys in the 'devices' and 'apps' config sections. For example:
+
+{
+  "apps": {
+*-->"myApp.android": {
+|     "type": "android.apk",
+|     "binaryPath": "/path/android.genycloud.app",
+|   },
+| },
+| "devices": {
+|*->"emulator": {
+||    "type": "android.genycloud",
+||    "device": "some-query(android.genycloud)"
+||  },
+||},
+||"configurations": {
+||  "legacy": {
+||    /* REMOVE (!) "type": "android.genycloud" */
+|*--- "device": "emulator",
+*---- "app": "myApp.android",
+      ...
+    }
+  }
+}
+Examine your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  apps: {
+    someApp: {}
+  },
+  devices: {
+    aDevice: {}
+  },
+  configurations: {
+    legacy: {
+      type: 'android.genycloud',
+      device: 'some-query(android.genycloud)',
+      binaryPath: '/path/android.genycloud.app'
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from configuration/index) .configurationShouldNotUseLegacyFormat for "ios.simulator" device type should create a helpful error 1`] = `
+[DetoxConfigError: The "legacy" configuration utilizes a deprecated all-in-one schema, that is not supported by the current version of Detox.
+
+HINT: Remove the "type" property. A valid configuration is expected to have both the "device" and "app" aliases pointing to the corresponding keys in the 'devices' and 'apps' config sections. For example:
+
+{
+  "apps": {
+*-->"myApp.ios": {
+|     "type": "ios.app",
+|     "binaryPath": "/path/ios.simulator.app",
+|   },
+| },
+| "devices": {
+|*->"simulator": {
+||    "type": "ios.simulator",
+||    "device": "some-query(ios.simulator)"
+||  },
+||},
+||"configurations": {
+||  "legacy": {
+||    /* REMOVE (!) "type": "ios.simulator" */
+|*--- "device": "simulator",
+*---- "app": "myApp.ios",
+      ...
+    }
+  }
+}
+Examine your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  apps: {
+    someApp: {}
+  },
+  devices: {
+    aDevice: {}
+  },
+  configurations: {
+    legacy: {
+      type: 'ios.simulator',
+      device: 'some-query(ios.simulator)',
+      binaryPath: '/path/ios.simulator.app'
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from configuration/index) .configurationShouldNotUseLegacyFormat for custom driver type should create a helpful error 1`] = `
+[DetoxConfigError: The "legacy" configuration utilizes a deprecated all-in-one schema, that is not supported by the current version of Detox.
+
+HINT: Remove the "type" property. A valid configuration is expected to have both the "device" and "app" aliases pointing to the corresponding keys in the 'devices' and 'apps' config sections. For example:
+
+{
+  "apps": {
+*-->"myApp": {
+|     "type": "<optional property>",
+|     "binaryPath": "<optional property>",
+|   },
+| },
+| "devices": {
+|*->"myDevice": {
+||    "type": "./custom-driver",
+||    "device": "<optional property>"
+||  },
+||},
+||"configurations": {
+||  "legacy": {
+||    /* REMOVE (!) "type": "./custom-driver" */
+|*--- "device": "myDevice",
+*---- "app": "myApp",
+      ...
+    }
+  }
+}
+Examine your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  apps: {
+    someApp: {}
+  },
+  devices: {
+    aDevice: {}
+  },
+  configurations: {
+    legacy: {
+      type: './custom-driver',
+      webUrl: 'https://example.com'
+    }
+  }
+}]
+`;
+
+exports[`DetoxConfigErrorComposer (from configuration/index) .configurationShouldNotUseLegacyFormat for missing global .apps and .devices should create a helpful error 1`] = `
+[DetoxConfigError: The "legacy" configuration utilizes a deprecated all-in-one schema, that is not supported by the current version of Detox.
+
+HINT: Remove the "type" property. A valid configuration is expected to have both the "device" and "app" aliases pointing to the corresponding keys in the 'devices' and 'apps' config sections. For example:
+
+{
+  "apps": {
+*-->"myApp.ios": {
+|     "type": "ios.app",
+|     "binaryPath": "/some/path",
+|   },
+| },
+| "devices": {
+|*->"simulator": {
+||    "type": "ios.simulator",
+||    "device": "iPhone 12"
+||  },
+||},
+||"configurations": {
+||  "legacy": {
+||    /* REMOVE (!) "type": "ios.simulator" */
+|*--- "device": "simulator",
+*---- "app": "myApp.ios",
+      ...
+    }
+  }
+}
+Examine your Detox config at path:
+/home/detox/myproject/.detoxrc.json
+
+{
+  apps: undefined,
+  devices: undefined,
+  configurations: {
+    legacy: {
+      type: 'ios.simulator',
+      device: 'iPhone 12',
+      binaryPath: '/some/path'
+    }
   }
 }]
 `;
@@ -1627,7 +1736,6 @@ exports[`DetoxConfigErrorComposer (from configuration/index) .noConfigurationWit
 /home/detox/myproject/.detoxrc.json
 
 HINT: Below are the configurations Detox was able to find:
-* plain
 * aliased
 * inlined
 * inlinedMulti]

--- a/detox/test/e2e/detox.config.js
+++ b/detox/test/e2e/detox.config.js
@@ -200,10 +200,12 @@ const config = {
       apps: ['android.release', 'android.release.withArgs'],
     },
     'stub': {
-      type: './integration/stub',
-      name: 'integration-stub',
       device: {
+        type: './integration/stub',
         integ: 'stub'
+      },
+      app: {
+        name: 'example'
       }
     }
   }

--- a/docs/Guide.ThirdPartyDrivers.md
+++ b/docs/Guide.ThirdPartyDrivers.md
@@ -15,7 +15,10 @@ For example, the following configuration uses the "ios.simulator" driver.
   "ios.sim": {
     "type": "ios.simulator",
     "device": "...",
-    "binaryPath": "bin/YourApp.app"
+    "app": {
+      "type": "ios.app",
+      "binaryPath": "bin/YourApp.app"
+    }
   }
 }
 ```
@@ -37,7 +40,9 @@ Overall the setup for any third party driver is fairly simple.
    ```diff
    +  "thirdparty.driver.config": {
    +    "type": "detox-driver-package",
-   +    "binaryPath": "bin/YourApp.app",
+   +    "app": {
+   +      "binaryPath": "bin/YourApp.app",
+   +    }
    +  }
    ```
 

--- a/examples/demo-plugin/package.json
+++ b/examples/demo-plugin/package.json
@@ -13,12 +13,16 @@
     "test-runner": "jest",
     "configurations": {
       "plugin": {
-        "binaryPath": "my/random/path",
         "device": {
-          "foo": "bar"
+          "type": "./driver",
+          "binaryPath": "my/random/path",
+          "device": {
+            "foo": "bar"
+          }
         },
-        "name": "plugin-example",
-        "type": "./driver"
+        "app": {
+          "name": "plugin-example"
+        }
       }
     }
   }


### PR DESCRIPTION
BREAKING: please migrate to the new `{ apps, devices, configurations }` schema that Detox has been already using for more than a year.

## Description

1. Enforces the migration to the modern normalized Detox config schema:

<table>
<tr>
  <th>Legacy schema</th>
  <th>Modern schema</th>
</tr>
<tr>
  <td>
  
  ```json
  {
    "configurations": {
      "legacy.ios.debug": {
        "type": "ios.simulator",
        "device": "iPhone 12",
        "binaryPath": "/some/path/debug.app"
      },
      "legacy.ios.release": {
        "type": "ios.simulator",
        "device": "iPhone 12",
        "binaryPath": "/some/path/release.app"
      }
    }
  }
  ```
  </td>
  <td>

  ```json
  {
    "apps": {
      "ios.debug": {
        "type": "ios.app",
        "binaryPath": "/some/path/debug.app"
      },
      "ios.release": {
        "type": "ios.app",
        "binaryPath": "/some/path/release.app"
      }
    },
    "devices": {
      "iphone": {
        "type": "ios.simulator",
        "device": { "type": "iPhone 12" }
      }
    },
    "configurations": {
      "legacy.ios.debug": {
        "device": "iphone",
        "app": "ios.debug"
      },
      "legacy.ios.release": {
        "device": "iphone",
        "app": "ios.release"
      }
    }
  }
  ```
  </td>
</tr>
</table>

2. If the user wishes to run a configuration based on the old schema, Detox will throw an error like this:

```plain text
DetoxConfigError: Configuration "legacy" uses a deprecated all-in-one schema,
which is not supported by Detox.

HINT: Remove "type" property. A valid configuration should have "device" and "app"
properties defined, e.g.:

{
  "apps": {
*-->"myApp.ios": {
|     "type": "ios.app",
|     "binaryPath": "/some/path/debug.app",
|   },
| },
| "devices": {
|*->"simulator": {
||    "type": "ios.simulator",
||    "device": "iPhone 12"
||  },
||},
||"configurations": {
||  "legacy.ios.debug": {
||    /* REMOVE (!) "type": "ios.simulator" */
|*--- "device": "simulator",
*---- "app": "myApp.ios",
      ...
    }
  }
}
Examine your Detox config at path:
/home/detox/myproject/.detoxrc.json

{
  apps: undefined,
  devices: undefined,
  configurations: {
    legacy: {
      type: 'ios.simulator',
      device: 'iPhone 12',
      binaryPath: '/some/path'
    }
  }
}]

```

> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
