### PR TITLE
Add appcompat dependency to docs

### DIFF
--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -160,7 +160,7 @@ also ensure that this line appears in `dependencies`:
 ```groovy
 dependencies {
     // ...
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0' // (check what the latest version is!)
 }
 ```
 

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -152,6 +152,14 @@ In your app’s `buildscript` (i.e. `android/app/build.gradle`) add this in `dep
 dependencies {
     // ...
     androidTestImplementation('com.wix:detox:+')
+}
+```
+
+also ensure that this line appears in `dependencies`:
+
+```groovy
+dependencies {
+    // ...
     implementation 'androidx.appcompat:appcompat:1.1.0'
 }
 ```

--- a/docs/Introduction.Android.md
+++ b/docs/Introduction.Android.md
@@ -152,6 +152,7 @@ In your app’s `buildscript` (i.e. `android/app/build.gradle`) add this in `dep
 dependencies {
     // ...
     androidTestImplementation('com.wix:detox:+')
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 }
 ```
 

--- a/docs/Troubleshooting.BuildingTheApp.md
+++ b/docs/Troubleshooting.BuildingTheApp.md
@@ -13,9 +13,9 @@ For troubleshooting of other issue, refer to our [troubleshooting index](Trouble
 
 ## Android
 
-### Problem: AAPT
+### Problem: AAPT - resource linking failure
 
-For build errors involving AAPT such as this one:
+For build errors involving AAPT resource linking failure, such as this one:
 
 ```text
 Execution failed for task ':app:processReleaseAndroidTestResources'.

--- a/docs/Troubleshooting.BuildingTheApp.md
+++ b/docs/Troubleshooting.BuildingTheApp.md
@@ -29,7 +29,7 @@ Ensure that the following line appears in your app's `buildscript` (`android/app
 ```groovy
 dependencies {
     // ...
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0' // (check what the latest version is!)
 }
 ```
 

--- a/docs/Troubleshooting.BuildingTheApp.md
+++ b/docs/Troubleshooting.BuildingTheApp.md
@@ -13,7 +13,27 @@ For troubleshooting of other issue, refer to our [troubleshooting index](Trouble
 
 ## Android
 
-### Problem: minSdkVersion mistmatch
+### Problem: AAPT
+
+For build errors involving AAPT such as this one:
+
+```text
+Execution failed for task ':app:processReleaseAndroidTestResources'.
+> A failure occurred while executing com.android.build.gradle.internal.res.LinkApplicationAndroidResourcesTask$TaskAction
+   > Android resource linking failed
+     ERROR:: AAPT: error: resource style/Widget.AppCompat.TextView ...
+```
+
+Ensure that the following line appears in your app's `buildscript` (`android/app/build.gradle`) in the `dependencies` section:
+
+```groovy
+dependencies {
+    // ...
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+}
+```
+
+### Problem: minSdkVersion mismatch
 
 For Gradle errors involving `minSdkVersion` mismatches resembling this one:
 


### PR DESCRIPTION
## Description
When a project is setup through react-native init, the following appcompat dependency is not added. 

    implementation 'androidx.appcompat:appcompat:1.1.0'

This later causes the following error when building Detox in release mode:

    Execution failed for task ':app:processReleaseAndroidTestResources'.
    > A failure occurred while executing com.android.build.gradle.internal.res.LinkApplicationAndroidResourcesTask$TaskAction
       > Android resource linking failed
         ERROR:: AAPT: error: resource style/Widget.AppCompat.TextView ...


In this pull request I have updated the docs with the solution for this issue.
