### PR TITLE
fix: more reliable uninstall for multiple apps

### DIFF
--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -251,6 +251,10 @@ class Detox {
     for (const appName of appNames) {
       await this.device.selectApp(appName);
       await this.device.uninstallApp();
+    }
+
+    for (const appName of appNames) {
+      await this.device.selectApp(appName);
       await this.device.installApp();
     }
 

--- a/detox/src/Detox.test.js
+++ b/detox/src/Detox.test.js
@@ -244,10 +244,12 @@ describe('Detox', () => {
         expect(runtimeDevice.uninstallApp).toHaveBeenCalledTimes(2);
         expect(runtimeDevice.installApp).toHaveBeenCalledTimes(2);
 
-        expect(runtimeDevice.selectApp).toHaveBeenCalledTimes(3);
+        expect(runtimeDevice.selectApp).toHaveBeenCalledTimes(5);
         expect(runtimeDevice.selectApp.mock.calls[0]).toEqual(['default']);
         expect(runtimeDevice.selectApp.mock.calls[1]).toEqual(['extraApp']);
-        expect(runtimeDevice.selectApp.mock.calls[2]).toEqual([null]);
+        expect(runtimeDevice.selectApp.mock.calls[2]).toEqual(['default']);
+        expect(runtimeDevice.selectApp.mock.calls[3]).toEqual(['extraApp']);
+        expect(runtimeDevice.selectApp.mock.calls[4]).toEqual([null]);
       });
     });
 


### PR DESCRIPTION
## Description

When the applications from the same publisher can share the stored credentials with each other, it turns out that in order to delete the credentials from the simulator you have to uninstall ALL the applications before you start installing them back again.

That's why I have to change subtly the strategy of reinstall here.