### PR TITLE
fix (android): for #3440 - Missing Proguard Entry for org.apache.commons.lang3.**

### DIFF
--- a/detox/android/detox/proguard-rules-app.pro
+++ b/detox/android/detox/proguard-rules-app.pro
@@ -13,3 +13,4 @@
 -keep class kotlin.text.** { *; }
 -keep class kotlin.io.** { *; }
 -keep class okhttp3.** { *; }
+-keep class org.apache.commons.lang3.** { *; }


### PR DESCRIPTION
Missing proguard entry in Detox for lang3.stringutils break method invocation. As multiple lang3 classes are are in detox, I used **

## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #3440

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have added the missing proguard entry to get Detox working again.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [N/A] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [N/A] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
