### PR TITLE
feat(iOS): replace fbsimctl with AppleSimUtils for `setLocation`.

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -600,13 +600,9 @@ declare global {
 
             /**
              * Sets the simulator/emulator location to the given latitude and longitude.
-             *
-             * <p/>On iOS `setLocation` is dependent on [fbsimctl](https://github.com/facebook/idb/tree/4b7929480c3c0f158f33f78a5b802c1d0e7030d2/fbsimctl)
-             * which [is now deprecated](https://github.com/wix/Detox/issues/1371).
-             * If `fbsimctl` is not installed, the command will fail, asking for it to be installed.
-             *
-             * <p/>On Android `setLocation` will work with both Android Emulator (bundled with Android development tools) and Genymotion.
-             * The correct permissions must be set in your app manifest.
+             * - On iOS, `setLocation` is dependent on AppleSimulatorUtils, that has `--setLocation` support.
+             * - On Android, `setLocation` will work with both Android Emulator (bundled with Android development tools) and Genymotion.
+             *   The correct permissions must be set in your app manifest.
              *
              * @example await device.setLocation(32.0853, 34.7818);
              */

--- a/detox/test/e2e/drivers/location-driver.js
+++ b/detox/test/e2e/drivers/location-driver.js
@@ -1,0 +1,41 @@
+const driver = {
+  openScreen: async () => await element(by.text("Location")).tap(),
+  tapOnGetLocation: async () => await element(by.id('getLocationButton')).tap(),
+  errorElement: element(by.id('error')),
+  latitude: {
+    element: element(by.id('latitude')),
+    waitUntilVisible: async () => {
+      await waitFor(driver.latitude.element).toBeVisible().withTimeout(5500);
+    },
+    expectValue: async (latitude) => {
+      await expect(driver.latitude.element).toHaveText(`Latitude: ${latitude}`);
+    }
+  },
+  longitude: {
+    element: element(by.id('longitude')),
+    waitUntilVisible: async () => {
+      await waitFor(driver.longitude.element).toBeVisible().withTimeout(5500);
+    },
+    expectValue: async (longitude) => {
+      await expect(driver.longitude.element).toHaveText(`Longitude: ${longitude}`);
+    }
+  },
+  expectLocationToBeAvailable: async () => {
+    await driver.openScreen();
+
+    const latitude = -80.125;
+    const longitude = 66.5;
+    await device.setLocation(latitude, longitude);
+
+    await driver.tapOnGetLocation();
+
+    await driver.latitude.waitUntilVisible();
+    await driver.longitude.waitUntilVisible();
+    await driver.latitude.expectValue(latitude);
+    await driver.longitude.expectValue(longitude);
+  }
+};
+
+module.exports = {
+  locationScreenDriver: driver,
+};

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.17.3",
     "@react-native-community/checkbox": "^0.5.11",
-    "@react-native-community/geolocation": "^2.0.2",
+    "@react-native-community/geolocation": "^2.1.0",
     "@react-native-community/slider": "^4.2.1",
     "@react-native-picker/picker": "^2.1.0",
     "moment": "^2.24.0",

--- a/detox/test/src/Screens/LocationScreen.js
+++ b/detox/test/src/Screens/LocationScreen.js
@@ -29,14 +29,14 @@ export default class LocationScreen extends Component {
     this.state = {
       locationRequested: false,
       coordinates: null,
-      error: '',
+      error: null,
     }
   }
 
   onLocationReceived = (position) => {
     this.setState({
       coordinates: position.coords,
-      error: '',
+      error: null,
     });
   };
 
@@ -62,7 +62,7 @@ export default class LocationScreen extends Component {
     if (!this.state.locationRequested) {
       return (
         <Frame>
-          <Button testID="getLocationButton" title="Get location" onPress={this.requestLocation} />
+          <Button testID='getLocationButton' title='Get location' onPress={this.requestLocation} />
         </Frame>
       );
     }
@@ -70,8 +70,8 @@ export default class LocationScreen extends Component {
     if (this.state.coordinates) {
       return (
         <Frame>
-          <Label testID="latitude">Latitude: {this.state.coordinates.latitude}</Label>
-          <Label testID="longitude">Longitude: {this.state.coordinates.longitude}</Label>
+          <Label testID='latitude'>Latitude: {this.state.coordinates.latitude}</Label>
+          <Label testID='longitude'>Longitude: {this.state.coordinates.longitude}</Label>
         </Frame>
       );
     }
@@ -79,14 +79,14 @@ export default class LocationScreen extends Component {
     if (this.state.error) {
       return (
         <Frame>
-          <Label testID="error">{this.state.error}</Label>
+          <Label testID='error'>{this.state.error}</Label>
         </Frame>
       );
     }
 
     return (
       <Frame>
-        <Label testID="loading">Locating...</Label>
+        <Label testID='loading'>Locating...</Label>
       </Frame>
     );
   }

--- a/docs/APIRef.DeviceObjectAPI.md
+++ b/docs/APIRef.DeviceObjectAPI.md
@@ -358,9 +358,12 @@ Check out Detox’s [own test suite.](https://github.com/wix/Detox/tree/a9a09246
 
 Sets the simulator/emulator location to the given latitude and longitude.
 
-> On iOS `setLocation` is dependent on [`fbsimctl`](https://github.com/facebook/idb/tree/4b7929480c3c0f158f33f78a5b802c1d0e7030d2/fbsimctl) which [is now deprecated](https://github.com/wix/Detox/issues/1371). If `fbsimctl` is not installed, the command will fail, asking for it to be installed.
->
-> On Android `setLocation` will work with both Android Emulator (bundled with Android development tools) and Genymotion. The correct permissions must be set in your app manifest.
+:::note
+
+- On iOS, `setLocation` is dependent on [wix/AppleSimulatorUtils](https://github.com/wix/AppleSimulatorUtils), that has `--setLocation` support.
+- On Android, `setLocation` will work with both Android Emulator (bundled with Android development tools) and Genymotion. The correct permissions must be set in your app manifest.
+
+:::
 
 ```js
 await device.setLocation(32.0853, 34.7818);


### PR DESCRIPTION
Replace deprecated fbsimctl with AppleSimulatorUtils for `setLocation` API.

AppleSimUtils `setLocation` is now working as expected thanks to a workaround introduced in [version 0.9.6](https://github.com/wix/AppleSimulatorUtils/releases/tag/0.9.6) and another fix from [version 0.9.7](https://github.com/wix/AppleSimulatorUtils/releases/tag/0.9.7).

`setLocation` API (of ASU) requires from the Simulator app to run on non-headless mode (the Simulator app must be opened).
