### PR TITLE
ci: stabilize artifacts upload

### DIFF
--- a/.buildkite/jobs/pipeline.android_demo_app_rn_67.yml
+++ b/.buildkite/jobs/pipeline.android_demo_app_rn_67.yml
@@ -2,7 +2,6 @@
     command:
       - "nvm install"
       - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/demo-projects.android.sh"
-      - "./scripts/upload_artifact.sh"
     env:
       REACT_NATIVE_VERSION: 0.67.2
       DETOX_DISABLE_POD_INSTALL: true

--- a/.buildkite/jobs/pipeline.android_rn_64.yml
+++ b/.buildkite/jobs/pipeline.android_rn_64.yml
@@ -2,7 +2,6 @@
     command:
       - "nvm install"
       - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/ci.android.sh"
-      - "./scripts/upload_artifact.sh"
     env:
       REACT_NATIVE_VERSION: 0.64.1
       DETOX_DISABLE_POD_INSTALL: true

--- a/.buildkite/jobs/pipeline.android_rn_67.yml
+++ b/.buildkite/jobs/pipeline.android_rn_67.yml
@@ -2,7 +2,6 @@
     command:
       - "nvm install"
       - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/ci.android.sh"
-      - "./scripts/upload_artifact.sh"
     env:
       REACT_NATIVE_VERSION: 0.67.2
       DETOX_DISABLE_POD_INSTALL: true

--- a/.buildkite/jobs/pipeline.ios_demo_app_rn_67.yml
+++ b/.buildkite/jobs/pipeline.ios_demo_app_rn_67.yml
@@ -2,7 +2,6 @@
     command:
       - "nvm install"
       - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/demo-projects.ios.sh"
-      - "./scripts/upload_artifact.sh"
     env:
       REACT_NATIVE_VERSION: 0.67.2
     artifact_paths:

--- a/.buildkite/jobs/pipeline.ios_rn_64.yml
+++ b/.buildkite/jobs/pipeline.ios_rn_64.yml
@@ -2,7 +2,6 @@
     command:
       - "nvm install"
       - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/ci.ios.sh"
-      - "./scripts/upload_artifact.sh"
     env:
       REACT_NATIVE_VERSION: 0.64.1
     artifact_paths:

--- a/.buildkite/jobs/pipeline.ios_rn_67.yml
+++ b/.buildkite/jobs/pipeline.ios_rn_67.yml
@@ -2,7 +2,6 @@
     command:
       - "nvm install"
       - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/ci.ios.sh"
-      - "./scripts/upload_artifact.sh"
     env:
       REACT_NATIVE_VERSION: 0.67.2
     artifact_paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
     - ./scripts/install.ios.sh
     script:
     - ./scripts/ci.ios.sh
-    - ./scripts/upload_artifact.sh
   - language: objective-c
     os: osx
     osx_image: xcode10.2
@@ -24,7 +23,6 @@ matrix:
     - ./scripts/install.ios.sh
     script:
     - ./scripts/ci.ios.sh
-    - ./scripts/upload_artifact.sh
   - language: android
     env:
     - REACT_NATIVE_VERSION=0.59.4

--- a/scripts/ci.android.sh
+++ b/scripts/ci.android.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -ex
 
+UPLOAD_ARTIFACT="$(pwd)/scripts/upload_artifact.sh"
+trap "$UPLOAD_ARTIFACT" EXIT
+
 # Approve unapproved SDK licenses
 yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
 

--- a/scripts/ci.ios.sh
+++ b/scripts/ci.ios.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -ex
 
+UPLOAD_ARTIFACT="$(pwd)/scripts/upload_artifact.sh"
+trap "$UPLOAD_ARTIFACT" EXIT
+
 source $(dirname "$0")/ci.sh 'noGenerate'
 
 mkdir -p coverage

--- a/scripts/demo-projects.android.sh
+++ b/scripts/demo-projects.android.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+UPLOAD_ARTIFACT="$(pwd)/scripts/upload_artifact.sh"
+trap "$UPLOAD_ARTIFACT" EXIT
+
 # Approve unapproved SDK licenses
 yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
 

--- a/scripts/demo-projects.ios.sh
+++ b/scripts/demo-projects.ios.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+UPLOAD_ARTIFACT="$(pwd)/scripts/upload_artifact.sh"
+trap "$UPLOAD_ARTIFACT" EXIT
+
 source $(dirname "$0")/demo-projects.sh
 
 pushd detox

--- a/scripts/upload_artifact.sh
+++ b/scripts/upload_artifact.sh
@@ -18,6 +18,7 @@ upload_artifacts() {
   fi
 }
 
+cd "$(dirname "$0")/.."
 upload_artifacts "detox/test/artifacts" "detoxtest"
 upload_artifacts "examples/demo-react-native/artifacts" "rnexample"
 upload_artifacts "examples/demo-react-native-jest/artifacts" "rnexamplejest"


### PR DESCRIPTION
## Description

1. Allows executing a single CI script for every occasion without need to run `upload_artifact.sh` separately: 
- `scripts/ci.android.sh`
- `scripts/ci.ios.sh`
- `scripts/demo-projects.android.sh`
- `scripts/demo-projects.ios.sh`
2. Adds executing `scripts/upload_artifact.sh` as a `trap`, so it behaves in a guaranteed way as `try ... finally ...` logic. 

## Motivation

The failed builds do not contain artifacts, see:

https://buildkite.com/wix-mobile-oss/detox/builds/915#01821590-cf8d-4791-ab6e-f06511aab75d

![image](https://user-images.githubusercontent.com/1962469/179749560-ea99b447-4f8a-4944-82d8-0fa7cbe659ca.png)

which fails the purpose of the artifacts. 😬

So, let's fix it. 😃 
