### PR TITLE
fix(android): crash message handling on client.waitUntilAppIsReady

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/DetoxCrashHandler.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/DetoxCrashHandler.kt
@@ -6,7 +6,7 @@ import com.wix.detox.adapters.server.OutboundServerAdapter
 class DetoxCrashHandler(private val outboundServerAdapter: OutboundServerAdapter) {
     fun attach() {
         Thread.setDefaultUncaughtExceptionHandler { thread, exception ->
-            Log.e(LOG_TAG, "Crash detected!!! thread=${thread.name} (${thread.id})")
+            Log.e(LOG_TAG, "Crash detected!!! thread=${thread.name} (${thread.id})", exception)
 
             val crashInfo = mapOf("errorDetails" to "@Thread ${thread.name}(${thread.id}):\n${Log.getStackTraceString(exception)}\nCheck device logs for full details!")
             outboundServerAdapter.sendMessage(ACTION_NAME, crashInfo, MESSAGE_ID)

--- a/detox/android/detox/src/full/java/com/wix/detox/TestEngineFacade.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/TestEngineFacade.kt
@@ -10,7 +10,7 @@ import com.wix.detox.reactnative.ReactNativeExtension
 
 class TestEngineFacade {
     fun awaitIdle(): Unit? = Espresso.onIdle() {
-        Log.i(LOG_TAG, "Wait is over: app is now idle!")
+        Log.i(LOG_TAG, "Wait is over: App is now idle!")
         null
     }
     fun syncIdle() = UiAutomatorHelper.espressoSync() // TODO Check whether this can be replaced with #awaitIdle()

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -34,6 +34,7 @@ class Client {
     this._slowInvocationStatusHandle = null;
     this._whenAppIsConnected = this._invalidState('before connecting to the app');
     this._whenAppIsReady = this._whenAppIsConnected;
+    this._whenAppDisconnected = Deferred.resolved();
     this._isCleaningUp = false;
     this._pendingAppCrash = null;
     this._appTerminationHandle = null;
@@ -201,6 +202,11 @@ class Client {
     }
   }
 
+  /** @async */
+  waitUntilDisconnected() {
+    return this._whenAppDisconnected.promise;
+  }
+
   async waitForBackground() {
     await this.sendAction(new actions.WaitForBackground());
   }
@@ -301,6 +307,8 @@ class Client {
     } else {
       this._whenAppIsConnected = Deferred.resolved();
     }
+
+    this._whenAppDisconnected = new Deferred();
   }
 
   _onAppReady() {
@@ -338,10 +346,15 @@ class Client {
     this._whenAppIsReady = this._whenAppIsConnected;
 
     if (this._pendingAppCrash) {
+      this._whenAppDisconnected.reject(this._pendingAppCrash);
       this._asyncWebSocket.rejectAll(this._pendingAppCrash);
       this._pendingAppCrash = null;
     } else if (this._asyncWebSocket.hasPendingActions()) {
-      this._asyncWebSocket.rejectAll(new DetoxRuntimeError('The app has unexpectedly disconnected from Detox server.'));
+      const error = new DetoxRuntimeError('The app has unexpectedly disconnected from Detox server.');
+      this._asyncWebSocket.rejectAll(error);
+      this._whenAppDisconnected.resolve();
+    } else {
+      this._whenAppDisconnected.resolve();
     }
   }
 

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -328,6 +328,10 @@ class Client {
   }
 
   _onBeforeAppCrash({ params }) {
+    if (this._pendingAppCrash) {
+      return;
+    }
+
     this._pendingAppCrash = new DetoxRuntimeError({
       message: 'The app has crashed, see the details below:',
       debugInfo: params.errorDetails,

--- a/detox/src/devices/runtime/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/runtime/drivers/android/AndroidDriver.js
@@ -153,7 +153,9 @@ class AndroidDriver extends DeviceDriverBase {
           this.instrumentation.waitForCrash()
         ]);
       } catch (e) {
+        console.warn('An error occurred while waiting for the app to become ready. Waiting for disconnection... Error:\n', e);
         await this.client.waitUntilDisconnected();
+        console.warn('...app disconnected.');
         throw e;
       } finally {
         this.instrumentation.abortWaitForCrash();

--- a/detox/src/devices/runtime/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/runtime/drivers/android/AndroidDriver.js
@@ -148,7 +148,13 @@ class AndroidDriver extends DeviceDriverBase {
 
   async waitUntilReady() {
       try {
-        await Promise.race([super.waitUntilReady(), this.instrumentation.waitForCrash()]);
+        await Promise.race([
+          super.waitUntilReady(),
+          this.instrumentation.waitForCrash()
+        ]);
+      } catch (e) {
+        await this.client.waitUntilDisconnected();
+        throw e;
       } finally {
         this.instrumentation.abortWaitForCrash();
       }

--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -94,10 +94,10 @@ dependencies {
     implementation project(':react-native-webview')
     implementation project(':react-native-community-checkbox')
     implementation project(':react-native-community-geolocation')
+    implementation project(':react-native-launch-arguments')
 
     androidTestImplementation(project(path: ':detox'))
     androidTestImplementation 'com.linkedin.testbutler:test-butler-library:2.2.1'
-
 }
 
 // Apply Hermes as our JS engine

--- a/detox/test/android/app/src/main/java/com/example/DetoxRNHost.java
+++ b/detox/test/android/app/src/main/java/com/example/DetoxRNHost.java
@@ -10,6 +10,7 @@ import com.reactnativecommunity.checkbox.ReactCheckBoxPackage;
 import com.reactnativecommunity.geolocation.GeolocationPackage;
 import com.reactnativecommunity.slider.ReactSliderPackage;
 import com.reactnativecommunity.webview.RNCWebViewPackage;
+import com.reactnativelauncharguments.LaunchArgumentsPackage;
 
 import java.util.Arrays;
 import java.util.List;
@@ -39,7 +40,8 @@ class DetoxRNHost extends ReactNativeHost {
               new RNCWebViewPackage(),
               new NativeModulePackage(),
               new AsyncStoragePackage(),
-              new ReactCheckBoxPackage()
+              new ReactCheckBoxPackage(),
+              new LaunchArgumentsPackage()
       );
    }
 }

--- a/detox/test/android/settings.gradle
+++ b/detox/test/android/settings.gradle
@@ -23,3 +23,6 @@ project(':react-native-community-geolocation').projectDir = new File(rootProject
 
 include ':@react-native-community_slider'
 project(':@react-native-community_slider').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/slider/android')
+
+include ':react-native-launch-arguments'
+project(':react-native-launch-arguments').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-launch-arguments/android')

--- a/detox/test/e2e/19.crash-handling.test.js
+++ b/detox/test/e2e/19.crash-handling.test.js
@@ -26,7 +26,7 @@ describe('Crash Handling', () => {
     await expect(element(by.text('Sanity'))).toBeVisible();
   });
 
-  it('Should throw a detailed error upon early app crash by Detox', async () => {
+  it('Should throw a detailed error upon early app crash', async () => {
     const error = await expectToThrow(
       () => relaunchAppWithArgs({ simulateEarlyCrash: true }),
       'The app has crashed');
@@ -34,10 +34,12 @@ describe('Crash Handling', () => {
     // It's important that the native-error message (containing the native stack-trace) would also
     // be included in the error's stack property, in order for Jest (specifically) to properly output all
     // of that into the shell, as we expect it to.
-    jestExpect(error.stack).toEqual(jestExpect.stringContaining('Simulating early crash'));
+    jestExpect(error.stack).toContain('Simulating early crash');
 
     if (device.getPlatform() === 'android') {
-      jestExpect(error.stack).toEqual(jestExpect.stringContaining('\tat java.lang.Thread.run'));
+      jestExpect(error.stack).toContain('\tat java.lang.Thread.run');
+    } else {
+      jestExpect(error.stack).toContain('\t0   CoreFoundation');
     }
   });
 
@@ -54,8 +56,8 @@ describe('Crash Handling', () => {
     // It's important that the native-error message (containing the native stack-trace) would also
     // be included in the error's stack property, in order for Jest (specifically) to properly output all
     // of that into the shell, as we expect it to.
-    jestExpect(error.stack).toEqual(jestExpect.stringContaining('Native stacktrace dump:\njava.lang.RuntimeException:'));
-    jestExpect(error.stack).toEqual(jestExpect.stringContaining('\tat android.app'));
-    jestExpect(error.stack).toEqual(jestExpect.stringContaining('Caused by: java.lang.IllegalStateException: This is an intentional crash!'));
+    jestExpect(error.stack).toContain('Native stacktrace dump:\njava.lang.RuntimeException:');
+    jestExpect(error.stack).toContain('\tat android.app');
+    jestExpect(error.stack).toContain('Caused by: java.lang.IllegalStateException: This is an intentional crash!');
   }, 60000);
 });

--- a/detox/test/e2e/19.crash-handling.test.js
+++ b/detox/test/e2e/19.crash-handling.test.js
@@ -34,8 +34,11 @@ describe('Crash Handling', () => {
     // It's important that the native-error message (containing the native stack-trace) would also
     // be included in the error's stack property, in order for Jest (specifically) to properly output all
     // of that into the shell, as we expect it to.
-    jestExpect(error.stack).toEqual(jestExpect.stringContaining('Error: Simulating early crash'));
-    jestExpect(error.stack).toEqual(jestExpect.stringContaining('\tat java.lang.Thread.run'));
+    jestExpect(error.stack).toEqual(jestExpect.stringContaining('Simulating early crash'));
+
+    if (device.getPlatform() === 'android') {
+      jestExpect(error.stack).toEqual(jestExpect.stringContaining('\tat java.lang.Thread.run'));
+    }
   });
 
   it(':android: should throw error upon invoke crash', async () => {

--- a/detox/test/e2e/19.crash-handling.test.js
+++ b/detox/test/e2e/19.crash-handling.test.js
@@ -26,7 +26,7 @@ describe('Crash Handling', () => {
     await expect(element(by.text('Sanity'))).toBeVisible();
   });
 
-  it('Should throw error upon app early crash by Detox', async () => {
+  it('Should throw a detailed error upon early app crash by Detox', async () => {
     const error = await expectToThrow(
       () => relaunchAppWithArgs({ simulateEarlyCrash: true }),
       'The app has crashed');
@@ -39,14 +39,14 @@ describe('Crash Handling', () => {
   });
 
   it(':android: should throw error upon invoke crash', async () => {
-    await device.reloadReactNative();
+    await device.launchApp({ newInstance: true });
     await expectToThrow(() => element(by.text('UI Crash')).tap(), 'Test Failed: Simulated crash (native)');
   });
 
-  it(':android: Should throw error upon app bootstrap crash', async () => {
-    const _relaunchApp = () => relaunchAppWithArgs({ detoxAndroidCrashingActivity: true });
-
-    const error = await expectToThrow(_relaunchApp, 'Failed to run application on the device');
+  it(':android: Should throw a detailed error upon app bootstrap crash', async () => {
+    const error = await expectToThrow(
+      () => relaunchAppWithArgs({ detoxAndroidCrashingActivity: true }),
+      'Failed to run application on the device');
 
     // It's important that the native-error message (containing the native stack-trace) would also
     // be included in the error's stack property, in order for Jest (specifically) to properly output all

--- a/detox/test/e2e/19.crash-handling.test.js
+++ b/detox/test/e2e/19.crash-handling.test.js
@@ -26,6 +26,13 @@ describe('Crash Handling', () => {
     await expect(element(by.text('Sanity'))).toBeVisible();
   });
 
+  it('Should throw error upon early app crash', async () => {
+    await expectToThrow(() => device.launchApp({
+      newInstance: true,
+      launchArgs: { simulateEarlyCrash: true }
+    }), 'The app has crashed');
+  });
+
   it(':android: should throw error upon invoke crash', async () => {
     await device.reloadReactNative();
     await expectToThrow(() => element(by.text('UI Crash')).tap(), 'Test Failed: Simulated crash (native)');

--- a/detox/test/index.android.js
+++ b/detox/test/index.android.js
@@ -1,3 +1,4 @@
+import {LaunchArguments} from 'react-native-launch-arguments';
 import example from './src/app';
 // import MessageQueue from 'react-native/Libraries/BatchedBridge/MessageQueue'
 // MessageQueue.spy(true);
@@ -8,6 +9,10 @@ import {
 
 class exampleAndroid extends example {
 
+}
+
+if (LaunchArguments.value().simulateEarlyCrash) {
+  throw new Error('Simulating early crash');
 }
 
 AppRegistry.registerComponent('example', () => exampleAndroid);

--- a/detox/test/index.android.js
+++ b/detox/test/index.android.js
@@ -1,9 +1,49 @@
-import example from './src/app';
-
+import { LaunchArguments } from 'react-native-launch-arguments';
 import {
   AppRegistry,
 } from 'react-native';
 
-class exampleAndroid extends example {}
+import example from './src/app';
+
+class exampleAndroid extends example {
+  async componentDidMount() {
+    await super.componentDidMount();
+
+    this._registerEarlyCrashIfNeeded();
+  }
+
+  _registerEarlyCrashIfNeeded() {
+    if (LaunchArguments.value().simulateEarlyCrash) {
+      console.warn('simulateEarlyCrash=true detected: Will crash in a few seconds from now (all-the-while keeping the app busy)...');
+      this._setupBusyFutureCrash();
+    }
+  }
+
+  /**
+   * What we're aiming at here is to have the app crash while Detox is waiting for it to become *ready* (i.e. idle)
+   * for the first time, because this is a soft-spot, as we know. If we crash immediately, it might be too soon (i.e. before 'isReady'
+   * is sent & received). We therefore wait a few seconds, and only then crash, provided that in a 99% chance we'll be past
+   * the isReady request. We also want to keep things busy (i.e. make sure a 'ready' isn't responded), so we use short *timeouts*
+   * rather than setInterval() and >1500ms intervals.
+   */
+  _setupBusyFutureCrash() {
+    const INTERVAL = 1000;
+    const ITERATIONS = 8;
+
+    let count = 0;
+
+    const handler = () => {
+      count++;
+
+      if (count === ITERATIONS) {
+        console.warn('simulateEarlyCrash=true', 'Simulating a crash now!');
+        throw new Error('Simulating early crash');
+      }
+      setTimeout(handler, INTERVAL)
+    };
+
+    setTimeout(handler, INTERVAL);
+  }
+}
 
 AppRegistry.registerComponent('example', () => exampleAndroid);

--- a/detox/test/index.android.js
+++ b/detox/test/index.android.js
@@ -1,18 +1,9 @@
-import {LaunchArguments} from 'react-native-launch-arguments';
 import example from './src/app';
-// import MessageQueue from 'react-native/Libraries/BatchedBridge/MessageQueue'
-// MessageQueue.spy(true);
 
 import {
   AppRegistry,
 } from 'react-native';
 
-class exampleAndroid extends example {
-
-}
-
-if (LaunchArguments.value().simulateEarlyCrash) {
-  throw new Error('Simulating early crash');
-}
+class exampleAndroid extends example {}
 
 AppRegistry.registerComponent('example', () => exampleAndroid);

--- a/detox/test/index.ios.js
+++ b/detox/test/index.ios.js
@@ -1,19 +1,10 @@
-import {LaunchArguments} from 'react-native-launch-arguments';
 import example from './src/app';
 
 import {
-  AppRegistry
+  AppRegistry,
 } from 'react-native';
 
-class exampleIos extends example {
-  async componentDidMount() {
-    super.componentDidMount();
-  }
-}
-
-if (LaunchArguments.value().simulateEarlyCrash) {
-  throw new Error('Simulating early crash');
-}
+class exampleIos extends example {}
 
 console.disableYellowBox = true;
 AppRegistry.registerComponent('example', () => exampleIos);

--- a/detox/test/index.ios.js
+++ b/detox/test/index.ios.js
@@ -1,3 +1,4 @@
+import {LaunchArguments} from 'react-native-launch-arguments';
 import example from './src/app';
 
 import {
@@ -8,6 +9,10 @@ class exampleIos extends example {
   async componentDidMount() {
     super.componentDidMount();
   }
+}
+
+if (LaunchArguments.value().simulateEarlyCrash) {
+  throw new Error('Simulating early crash');
 }
 
 console.disableYellowBox = true;

--- a/detox/test/index.ios.js
+++ b/detox/test/index.ios.js
@@ -1,3 +1,4 @@
+import {LaunchArguments} from 'react-native-launch-arguments';
 import example from './src/app';
 
 import {
@@ -5,6 +6,10 @@ import {
 } from 'react-native';
 
 class exampleIos extends example {}
+
+if (LaunchArguments.value().simulateEarlyCrash) {
+  throw new Error('Simulating early crash');
+}
 
 console.disableYellowBox = true;
 AppRegistry.registerComponent('example', () => exampleIos);

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -39,6 +39,7 @@
     "react": "17.0.2",
     "react-native": "0.68.2",
     "react-native-gradle-plugin": "^0.0.7",
+    "react-native-launch-arguments": "^3.1.0",
     "react-native-webview": "^11.18.1"
   },
   "devDependencies": {

--- a/detox/test/src/app.js
+++ b/detox/test/src/app.js
@@ -7,7 +7,6 @@ import {
   Platform,
   NativeModules,
 } from 'react-native';
-import { LaunchArguments } from 'react-native-launch-arguments';
 import * as Screens from './Screens';
 
 const isAndroid = Platform.OS === 'android';
@@ -37,8 +36,6 @@ export default class example extends Component {
       console.log('App@didMount: Found pending URL', url);
       this.setState({url: url});
     }
-
-    registerEarlyCrashIfNeeded();
   }
 
   renderButton(title, onPressCallback) {
@@ -185,37 +182,4 @@ export default class example extends Component {
     console.log('App@handleOpenURL:', params);
     this.setState({url: params.url});
   }
-}
-
-function registerEarlyCrashIfNeeded() {
-  if (LaunchArguments.value().simulateEarlyCrash) {
-    console.warn('simulateEarlyCrash=true detected: Will crash in a few seconds from now (all-the-while keeping the app busy)...');
-    setupBusyFutureCrash();
-  }
-}
-
-/**
- * What we're aiming at here is to have the app crash while Detox is waiting for it to become *ready* (i.e. idle)
- * for the first time, because this is a soft-spot, as we know. If we crash immediately, it might be too soon (i.e. before 'isReady'
- * is sent & received). We therefore wait a few seconds, and only then crash, provided that in a 99% chance we'll be past
- * the isReady request. We also want to keep things busy (i.e. make sure a 'ready' isn't responded), so we use short *timeouts*
- * rather than setInterval() and >1500ms intervals.
- */
-function setupBusyFutureCrash() {
-  const INTERVAL = 1000;
-  const ITERATIONS = 8;
-
-  let count = 0;
-
-  const handler = () => {
-    count++;
-
-    if (count === ITERATIONS) {
-      console.warn('simulateEarlyCrash=true', 'Simulating a crash now!');
-      throw new Error('Simulating early crash');
-    }
-    setTimeout(handler, INTERVAL)
-  };
-
-  setTimeout(handler, INTERVAL);
 }

--- a/detox/test/src/app.js
+++ b/detox/test/src/app.js
@@ -7,6 +7,7 @@ import {
   Platform,
   NativeModules,
 } from 'react-native';
+import { LaunchArguments } from 'react-native-launch-arguments';
 import * as Screens from './Screens';
 
 const isAndroid = Platform.OS === 'android';
@@ -36,6 +37,8 @@ export default class example extends Component {
       console.log('App@didMount: Found pending URL', url);
       this.setState({url: url});
     }
+
+    registerEarlyCrashIfNeeded();
   }
 
   renderButton(title, onPressCallback) {
@@ -182,4 +185,37 @@ export default class example extends Component {
     console.log('App@handleOpenURL:', params);
     this.setState({url: params.url});
   }
+}
+
+function registerEarlyCrashIfNeeded() {
+  if (LaunchArguments.value().simulateEarlyCrash) {
+    console.warn('simulateEarlyCrash=true detected: Will crash in a few seconds from now (all-the-while keeping the app busy)...');
+    setupBusyFutureCrash();
+  }
+}
+
+/**
+ * What we're aiming at here is to have the app crash while Detox is waiting for it to become *ready* (i.e. idle)
+ * for the first time, because this is a soft-spot, as we know. If we crash immediately, it might be too soon (i.e. before 'isReady'
+ * is sent & received). We therefore wait a few seconds, and only then crash, provided that in a 99% chance we'll be past
+ * the isReady request. We also want to keep things busy (i.e. make sure a 'ready' isn't responded), so we use short *timeouts*
+ * rather than setInterval() and >1500ms intervals.
+ */
+function setupBusyFutureCrash() {
+  const INTERVAL = 1000;
+  const ITERATIONS = 8;
+
+  let count = 0;
+
+  const handler = () => {
+    count++;
+
+    if (count === ITERATIONS) {
+      console.warn('simulateEarlyCrash=true', 'Simulating a crash now!');
+      throw new Error('Simulating early crash');
+    }
+    setTimeout(handler, INTERVAL)
+  };
+
+  setTimeout(handler, INTERVAL);
 }


### PR DESCRIPTION
## Description

Resolves #3500.

## Notes

Adds a 3rd party dependency to read launch arguments (because seemingly we have it implemented only for Android):

```diff
+ "react-native-launch-arguments": "^3.1.0",
```

🤷‍♂️ 

![image](https://user-images.githubusercontent.com/1962469/180039244-e9a58ce5-dbde-41ed-9335-1be7c5c4fb38.png)
