### PR TITLE
fix(Android): replace error log with throw.

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/adapters/server/WebSocketClient.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/adapters/server/WebSocketClient.java
@@ -2,6 +2,8 @@ package com.wix.detox.adapters.server;
 
 import android.util.Log;
 
+import com.wix.detox.common.DetoxErrors;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -84,7 +86,7 @@ public class WebSocketClient {
                 wsEventsHandler.onAction(type, params.toString(), messageId);
             }
         } catch (JSONException e) {
-            Log.e(LOG_TAG, "Detox Error: receiveAction decode - " + e.toString());
+            throw new DetoxErrors.DetoxIllegalArgumentException(e);
         }
     }
 

--- a/detox/android/detox/src/main/java/com/wix/detox/common/DetoxErrors.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/common/DetoxErrors.java
@@ -30,5 +30,9 @@ public interface DetoxErrors {
         public DetoxIllegalArgumentException(String message) {
             super(message);
         }
+
+        public DetoxIllegalArgumentException(Throwable cause) {
+            super(cause);
+        }
     }
 }


### PR DESCRIPTION
Replace non-informative error-log with illegal argument exception throwing.

Error is currently logged as:
```
DetoxWSClient: Detox Error: receiveAction decode - org.json.JSONException: No value for params
```
Instead of showing the full stack trace.