### PR TITLE
fix(Android): Make RN instance listener work in RN≤68

### DIFF
--- a/detox/android/detox/src/full/java/com/facebook/react/ReactInstanceEventListener.java
+++ b/detox/android/detox/src/full/java/com/facebook/react/ReactInstanceEventListener.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react;
+
+import com.facebook.react.bridge.ReactContext;
+
+/**
+ * New Listener interface for react instance events. {@Link
+ * ReactInstanceManager.ReactInstanceEventListener will be deprecated.}
+ */
+public interface ReactInstanceEventListener {
+
+  /**
+   * Called when the react context is initialized (all modules registered). Always called on the UI
+   * thread.
+   */
+  void onReactContextInitialized(ReactContext context);
+}


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #XXX

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have fixed a crash in registering an RN instance loading listener, in RN≤68 (following the release of the Detox `.aar` based on .68). See this [diff](https://github.com/facebook/react-native/compare/v0.67.4..v0.68.0#diff-2f01f0cd7ff8c9ea58f12ef0eff5fa8250cad144dd5490598d80d8e9e743458aR1009) --

`ReactInstanceManager.java`
![image](https://user-images.githubusercontent.com/9818880/181022953-01f6adbf-6ea9-4f9c-8c08-150660259f34.png)


The root of the problem is that at runtime, this error is thrown:

```
@Thread detox.primary(242):
java.lang.NoClassDefFoundError: Failed resolution of: Lcom\/facebook\/react\/ReactInstanceEventListener;
	at com.wix.detox.reactnative.ReactNativeLoadingMonitor$subscribeToNewRNContextUpdates$1.run(ReactNativeLoadingMonitor.kt:38)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:458)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at android.app.Instrumentation$SyncRunnable.run(Instrumentation.java:2163)
	at android.os.Handler.handleCallback(Handler.java:873)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loop(Looper.java:193)
	at android.app.ActivityThread.main(ActivityThread.java:6669)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)

Caused by: java.lang.ClassNotFoundException: Didn't find class "com.facebook.react.ReactInstanceEventListener" on path: DexPathList[[zip file "\/system\/framework\/android.test.mock.jar", zip file "\/system\/framework\/android.test.runner.jar", zip file "\/system\/framework\/org.apache.http.legacy.boot.jar", zip file "\/data\/app\/com.wix.android.dev.test-D2Zml-DbA4lQ_6WW1QstWA==\/base.apk", zip file "\/data\/app\/com.wix.android.dev-HQEvUrD-gPoOypzJvITMiw==\/base.apk"],nativeLibraryDirectories=[\/data\/app\/com.wix.android.dev.test-D2Zml-DbA4lQ_6WW1QstWA==\/lib\/x86, \/data\/app\/com.wix.android.dev-HQEvUrD-gPoOypzJvITMiw==\/lib\/x86, \/data\/app\/com.wix.android.dev.test-D2Zml-DbA4lQ_6WW1QstWA==\/base.apk!\/lib\/x86, \/data\/app\/com.wix.android.dev-HQEvUrD-gPoOypzJvITMiw==\/base.apk!\/lib\/x86, \/system\/lib, \/system\/vendor\/lib]]
	at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:134)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:379)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:312)
	... 11 more
```

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
