### PR TITLE
ci: Introduce an additional job for RN 66 compat on Android

### DIFF
--- a/.buildkite/jobs/pipeline.android_demo_app_rn_66.yml
+++ b/.buildkite/jobs/pipeline.android_demo_app_rn_66.yml
@@ -1,0 +1,12 @@
+  - label: ":android::mushroom:-RN_66_demo_project"
+    command:
+      - "nvm install"
+      - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/demo-projects.android.sh"
+    env:
+      REACT_NATIVE_VERSION: 0.66.4
+      REACT_NATIVE_COMPAT_TEST: true
+      DETOX_DISABLE_POD_INSTALL: true
+      DETOX_DISABLE_POSTINSTALL: true
+    artifact_paths:
+      - "/Users/builder/work/coverage/**/*.lcov"
+      - "/Users/builder/work/artifacts*.tar.gz"

--- a/.buildkite/pipeline_common.sh
+++ b/.buildkite/pipeline_common.sh
@@ -7,4 +7,5 @@ cat .buildkite/jobs/pipeline.ios_rn_68.yml
 cat .buildkite/jobs/pipeline.android_rn_64.yml
 cat .buildkite/jobs/pipeline.android_rn_68.yml
 cat .buildkite/jobs/pipeline.android_demo_app_rn_68.yml
+cat .buildkite/jobs/pipeline.android_demo_app_rn_66.yml
 cat .buildkite/jobs/pipeline.ios_demo_app_rn_68.yml

--- a/scripts/demo-projects.android.sh
+++ b/scripts/demo-projects.android.sh
@@ -24,6 +24,12 @@ run_f "npm run test:android-release-ci"
 DETOX_EXPOSE_GLOBALS=0 run_f "npm run test:android-release-ci"
 popd
 
+# Early completion if this is just about RN compatibility -
+# in which case, running the demo project's tests is enough.
+if [ "$REACT_NATIVE_COMPAT_TEST" = "true" ]; then
+  exit 0
+fi
+
 pushd examples/demo-react-native
 run_f "npm run test:android-release-ci"
 DETOX_EXPOSE_GLOBALS=0 run_f "npm run test:android-release-ci"

--- a/scripts/demo-projects.sh
+++ b/scripts/demo-projects.sh
@@ -3,8 +3,16 @@
 source $(dirname "$0")/logger.sh
 source $(dirname "$0")/install.sh
 
+if [ -z "$REACT_NATIVE_VERSION" ]; then
+  echo "Error: REACT_NATIVE_VERSION variable was not defined!"
+  exit 1
+fi
+
+if [ "$REACT_NATIVE_COMPAT_TEST" != "true" ]; then
+  node scripts/change_react_native_version.js "detox" ${REACT_NATIVE_VERSION} "devDependencies"
+fi
+
 # Only update the demo-react-native project; others will use this binary
 node scripts/change_react_native_version.js "examples/demo-react-native" ${REACT_NATIVE_VERSION} "dependencies"
-node scripts/change_react_native_version.js "detox" ${REACT_NATIVE_VERSION} "devDependencies"
 
 run_f "lerna bootstrap --no-ci"


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request is associated with all post-factum work done in the context of #3492.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have added a new (Android) CI job in order to regularly verify compatibility with older RN versions, of the `demo` project. An equivalent job already exists for the _main_ `test` app, although - #3492, which had to be reopened due to issues in production, has proven that this isn't enough.
There's a core difference between the `demo` and `test` projects: While the `test` app compiles Detox itself, bundled into the test .apk, the `demo` project precompiles Detox as an `.aar` and uses it. With that, the `demo` is (intentionally) much more similar to real-world users (in and out of Wix), and that can sometimes introduce specific edge-cases.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
