### PR TITLE
[post-workshop] Fix and improve error messages in aapt resolution

### DIFF
--- a/detox/src/utils/environment.js
+++ b/detox/src/utils/environment.js
@@ -161,7 +161,7 @@ function throwSdkToolPathError(sdkToolPath) {
   const name = path.basename(sdkToolPath);
   const dir = path.dirname(sdkToolPath);
 
-  throwSdkIntegrityError(`There was no "${name}" executable file in directory: ${dir}/`);
+  throwSdkIntegrityError(`There was no "${name}" executable file in directory: ${dir}${path.sep}`);
 }
 
 function throwSdkIntegrityError(errMessage) {

--- a/detox/src/utils/environment.js
+++ b/detox/src/utils/environment.js
@@ -161,7 +161,7 @@ function throwSdkToolPathError(sdkToolPath) {
   const name = path.basename(sdkToolPath);
   const dir = path.dirname(sdkToolPath);
 
-  throwSdkIntegrityError(`There was no "${name}" executable file in directory: ${dir}\/`);
+  throwSdkIntegrityError(`There was no "${name}" executable file in directory: ${dir}/`);
 }
 
 function throwSdkIntegrityError(errMessage) {

--- a/detox/src/utils/environment.js
+++ b/detox/src/utils/environment.js
@@ -161,7 +161,7 @@ function throwSdkToolPathError(sdkToolPath) {
   const name = path.basename(sdkToolPath);
   const dir = path.dirname(sdkToolPath);
 
-  throwSdkIntegrityError(`There was no "${name}" executable file in directory: ${dir}${path.sep}`);
+  throwSdkIntegrityError(`There was no "${name}" executable file in directory: ${dir}`);
 }
 
 function throwSdkIntegrityError(errMessage) {

--- a/detox/src/utils/environment.js
+++ b/detox/src/utils/environment.js
@@ -78,7 +78,7 @@ function getAndroidEmulatorPath() {
     return legacyPath;
   }
 
-  throwSdkIntegrityError(sdkRoot, 'emulator/emulator');
+  throwSdkBinIntegrityError(sdkRoot, 'emulator/emulator');
 }
 
 async function getAaptPath() {
@@ -88,23 +88,33 @@ async function getAaptPath() {
   }
 
   const latestBuildTools = await getLatestBuildToolsPath(sdkRoot);
-  const defaultPath = latestBuildTools && which('aapt', latestBuildTools);
+  if (!latestBuildTools) {
+    throwSdkIntegrityError('Failed to find the "aapt" tool under the Android SDK: No build-tools are installed!');
+  }
+
+  const defaultPath = which('aapt', latestBuildTools);
   if (defaultPath) {
     return defaultPath;
   }
 
-  throwSdkIntegrityError(sdkRoot, `${latestBuildTools}/aapt`);
+  throwSdkToolPathError(`${latestBuildTools}/aapt`);
 }
 
 async function getLatestBuildToolsPath(sdkRoot) {
-  if (!sdkRoot) return '';
+  if (!sdkRoot) {
+    return '';
+  }
 
   const buildToolsDir = path.join(sdkRoot, 'build-tools');
-  if (!fs.existsSync(buildToolsDir)) return '';
+  if (!fs.existsSync(buildToolsDir)) {
+    return '';
+  }
 
   const buildToolsVersions = await fsext.getDirectories(buildToolsDir);
   const latestBuildToolsVersion = _.last(buildToolsVersions);
-  if (!latestBuildToolsVersion) return '';
+  if (!latestBuildToolsVersion) {
+    return '';
+  }
 
   return path.join(buildToolsDir, latestBuildToolsVersion);
 }
@@ -120,7 +130,7 @@ function getAdbPath() {
     return defaultPath;
   }
 
-  throwSdkIntegrityError(sdkRoot, 'platform-tools/adb');
+  throwSdkBinIntegrityError(sdkRoot, 'platform-tools/adb');
 }
 
 function getGmsaasPath() {
@@ -142,15 +152,20 @@ function throwMissingAvdError(avdName, avdPath, avdIniPath) {
   );
 }
 
-function throwSdkIntegrityError(sdkRoot, relativeExecutablePath) {
-  const executablePath = path.join(sdkRoot, relativeExecutablePath);
-  const name = path.basename(executablePath);
-  const dir = path.dirname(executablePath);
+function throwSdkBinIntegrityError(sdkRoot, relativeBinPath) {
+  const executablePath = path.join(sdkRoot, relativeBinPath);
+  throwSdkToolPathError(executablePath);
+}
 
-  throw new DetoxRuntimeError(
-    `There was no "${name}" executable file in directory: ${dir}.\n` +
-    `Check integrity of your Android SDK.`
-  );
+function throwSdkToolPathError(sdkToolPath) {
+  const name = path.basename(sdkToolPath);
+  const dir = path.dirname(sdkToolPath);
+
+  throwSdkIntegrityError(`There was no "${name}" executable file in directory: ${dir}\/`);
+}
+
+function throwSdkIntegrityError(errMessage) {
+  throw new DetoxRuntimeError(`${errMessage}\nCheck the integrity of your Android SDK.`);
 }
 
 function throwMissingGmsaasError() {

--- a/detox/src/utils/environment.test.js
+++ b/detox/src/utils/environment.test.js
@@ -207,7 +207,7 @@ describe('Environment', () => {
           const expectedErrPath = path.join(tempSdkPath, validBuildToolsPath);
 
           await genExec(`${validBuildToolsPath}/not-aapt`);
-          await expect(Environment.getAaptPath()).rejects.toThrow(new RegExp(`There was no "aapt" .*file in directory: ${expectedErrPath}${path.sep}`));
+          await expect(Environment.getAaptPath()).rejects.toThrow(new RegExp(`There was no "aapt" .*file in directory: ${expectedErrPath}`));
         });
 
         it('should throw error if there are no inner <sdk-version> directories where aapt could reside', async () => {
@@ -236,7 +236,7 @@ describe('Environment', () => {
         it('should throw error if adb is not found in platform-tools/', async () => {
           const expectedErrPath = path.join(tempSdkPath, 'platform-tools');
 
-          expect(() => Environment.getAdbPath()).toThrow(new RegExp(`There was no "adb" .*file in directory: ${expectedErrPath}${path.sep}`));
+          expect(() => Environment.getAdbPath()).toThrow(new RegExp(`There was no "adb" .*file in directory: ${expectedErrPath}`));
         });
       });
 

--- a/detox/src/utils/environment.test.js
+++ b/detox/src/utils/environment.test.js
@@ -207,7 +207,7 @@ describe('Environment', () => {
           const expectedErrPath = path.join(tempSdkPath, validBuildToolsPath);
 
           await genExec(`${validBuildToolsPath}/not-aapt`);
-          await expect(Environment.getAaptPath()).rejects.toThrow(new RegExp(`There was no "aapt" .*file in directory: ${expectedErrPath}`));
+          await expect(Environment.getAaptPath()).rejects.toThrow(`There was no "aapt" executable file in directory: ${expectedErrPath}`);
         });
 
         it('should throw error if there are no inner <sdk-version> directories where aapt could reside', async () => {
@@ -236,7 +236,7 @@ describe('Environment', () => {
         it('should throw error if adb is not found in platform-tools/', async () => {
           const expectedErrPath = path.join(tempSdkPath, 'platform-tools');
 
-          expect(() => Environment.getAdbPath()).toThrow(new RegExp(`There was no "adb" .*file in directory: ${expectedErrPath}`));
+          expect(() => Environment.getAdbPath()).toThrow(`There was no "adb" executable file in directory: ${expectedErrPath}`);
         });
       });
 

--- a/detox/src/utils/environment.test.js
+++ b/detox/src/utils/environment.test.js
@@ -204,10 +204,10 @@ describe('Environment', () => {
 
         it('should throw error if aapt is missing inside (a valid) build-tools/<sdk-version> directory', async () => {
           const validBuildToolsPath = 'build-tools/20.0.0';
-          const expectedErrPath = `${tempSdkPath}/${validBuildToolsPath}`;
+          const expectedErrPath = path.join(tempSdkPath, validBuildToolsPath);
 
           await genExec(`${validBuildToolsPath}/not-aapt`);
-          await expect(Environment.getAaptPath()).rejects.toThrow(new RegExp(`There was no "aapt" .*file in directory: ${expectedErrPath}/`));
+          await expect(Environment.getAaptPath()).rejects.toThrow(new RegExp(`There was no "aapt" .*file in directory: ${expectedErrPath}${path.sep}`));
         });
 
         it('should throw error if there are no inner <sdk-version> directories where aapt could reside', async () => {
@@ -234,9 +234,9 @@ describe('Environment', () => {
         });
 
         it('should throw error if adb is not found in platform-tools/', async () => {
-          const expectedErrPath = `${tempSdkPath}/platform-tools`;
+          const expectedErrPath = path.join(tempSdkPath, 'platform-tools');
 
-          expect(() => Environment.getAdbPath()).toThrow(new RegExp(`There was no "adb" .*file in directory: ${expectedErrPath}/`));
+          expect(() => Environment.getAdbPath()).toThrow(new RegExp(`There was no "adb" .*file in directory: ${expectedErrPath}${path.sep}`));
         });
       });
 

--- a/detox/src/utils/environment.test.js
+++ b/detox/src/utils/environment.test.js
@@ -207,7 +207,7 @@ describe('Environment', () => {
           const expectedErrPath = `${tempSdkPath}/${validBuildToolsPath}`;
 
           await genExec(`${validBuildToolsPath}/not-aapt`);
-          await expect(Environment.getAaptPath()).rejects.toThrow(new RegExp(`There was no "aapt" .*file in directory: ${expectedErrPath}\/`));
+          await expect(Environment.getAaptPath()).rejects.toThrow(new RegExp(`There was no "aapt" .*file in directory: ${expectedErrPath}/`));
         });
 
         it('should throw error if there are no inner <sdk-version> directories where aapt could reside', async () => {
@@ -236,7 +236,7 @@ describe('Environment', () => {
         it('should throw error if adb is not found in platform-tools/', async () => {
           const expectedErrPath = `${tempSdkPath}/platform-tools`;
 
-          expect(() => Environment.getAdbPath()).toThrow(new RegExp(`There was no "adb" .*file in directory: ${expectedErrPath}\/`));
+          expect(() => Environment.getAdbPath()).toThrow(new RegExp(`There was no "adb" .*file in directory: ${expectedErrPath}/`));
         });
       });
 

--- a/detox/src/utils/environment.test.js
+++ b/detox/src/utils/environment.test.js
@@ -202,9 +202,17 @@ describe('Environment', () => {
           expect(await Environment.getAaptPath()).toMatch(/.build-tools.20.0.0.aapt/);
         });
 
-        it('should throw error if aapt is not found inside build-tools/<someDir>', async () => {
-          await genExec('build-tools/aapt');
-          await expect(Environment.getAaptPath()).rejects.toThrow(/There was no.*file in directory:/);
+        it('should throw error if aapt is missing inside (a valid) build-tools/<sdk-version> directory', async () => {
+          const validBuildToolsPath = 'build-tools/20.0.0';
+          const expectedErrPath = `${tempSdkPath}/${validBuildToolsPath}`;
+
+          await genExec(`${validBuildToolsPath}/not-aapt`);
+          await expect(Environment.getAaptPath()).rejects.toThrow(new RegExp(`There was no "aapt" .*file in directory: ${expectedErrPath}\/`));
+        });
+
+        it('should throw error if there are no inner <sdk-version> directories where aapt could reside', async () => {
+          await genExec('build-tools/dummy');
+          await expect(Environment.getAaptPath()).rejects.toThrow('Failed to find the "aapt" tool under the Android SDK: No build-tools are installed!');
         });
       });
 
@@ -226,7 +234,9 @@ describe('Environment', () => {
         });
 
         it('should throw error if adb is not found in platform-tools/', async () => {
-          await expect(Environment.getAaptPath()).rejects.toThrow(/There was no.*file in directory:/);
+          const expectedErrPath = `${tempSdkPath}/platform-tools`;
+
+          expect(() => Environment.getAdbPath()).toThrow(new RegExp(`There was no "adb" .*file in directory: ${expectedErrPath}\/`));
         });
       });
 


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #<?>

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have fixed error messages coming from failed `aapt` resolutions, of the following form:

```
12:05:47.946 detox[12345] ERROR: There was no "aapt" executable file in directory /Users/d4vidi/Library/Android/sdk/Users/d4vidi/Library/Android/sdk/build-tools/32.0.0.
Check integrity of your Android SDK.
```

As one can easily notice - the SDK path is duplicated!

Also, error was not descriptive enough for the (realistic?) case where the are no build-tools effectively installed under `build-tools/` (e.g. under `build-tools/32.0.0/`).

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
