### PR TITLE
fix(Genycloud): Force-enable WiFi on instances by default

### DIFF
--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
@@ -40,6 +40,7 @@ class GenyAllocDriver extends AllocationDriverBase {
     const { adbName } = instance;
 
     await this._adb.disableAndroidAnimations(adbName);
+    await this._adb.setWiFiToggle(adbName, true);
     await this._adb.apiLevel(adbName);
     return new GenycloudEmulatorCookie(instance);
   }

--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.test.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.test.js
@@ -171,6 +171,7 @@ describe('Allocation driver for Genymotion cloud emulators', () => {
       await allocDriver.allocate(deviceConfig);
 
       expect(adb.disableAndroidAnimations).toHaveBeenCalledWith(instance.adbName);
+      expect(adb.setWiFiToggle).toHaveBeenCalledWith(instance.adbName, true);
     });
 
     it('should inquire the API level', async () => {

--- a/detox/src/devices/common/drivers/android/exec/ADB.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.js
@@ -206,6 +206,11 @@ class ADB {
     await this.shell(deviceId, `settings put global transition_animation_scale 0`);
   }
 
+  async setWiFiToggle(deviceId, state) {
+    const value = (state === true ? 'enable' : 'disable');
+    await this.shell(deviceId, `svc wifi ${value}`);
+  }
+
   async screencap(deviceId, path) {
     await this.shell(deviceId, `screencap ${path}`);
   }

--- a/detox/src/devices/common/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.test.js
@@ -326,18 +326,30 @@ describe('ADB', () => {
 
   describe('animation disabling', () => {
     it('should disable animator (e.g. ObjectAnimator) animations', async () => {
-      await adb.disableAndroidAnimations();
-      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  shell "settings put global animator_duration_scale 0"`, { retries: 1 });
+      await adb.disableAndroidAnimations(deviceId);
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}" -s ${deviceId} shell "settings put global animator_duration_scale 0"`, { retries: 1 });
     });
 
     it('should disable window animations', async () => {
-      await adb.disableAndroidAnimations();
-      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  shell "settings put global window_animation_scale 0"`, { retries: 1 });
+      await adb.disableAndroidAnimations(deviceId);
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}" -s ${deviceId} shell "settings put global window_animation_scale 0"`, { retries: 1 });
     });
 
     it('should disable transition (e.g. activity launch) animations', async () => {
-      await adb.disableAndroidAnimations();
-      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  shell "settings put global transition_animation_scale 0"`, { retries: 1 });
+      await adb.disableAndroidAnimations(deviceId);
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}" -s ${deviceId} shell "settings put global transition_animation_scale 0"`, { retries: 1 });
+    });
+  });
+
+  describe('WiFi toggle', () => {
+    it('should enable wifi', async () => {
+      await adb.setWiFiToggle(deviceId, true);
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}" -s ${deviceId} shell "svc wifi enable"`, { retries: 1 });
+    });
+
+    it('should disable wifi', async () => {
+      await adb.setWiFiToggle(deviceId, false);
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}" -s ${deviceId} shell "svc wifi disable"`, { retries: 1 });
     });
   });
 });


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #<?>

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have applied a work-around over a recently introduced (since August 1st) Genymotion-SaaS problem, where instance are launched with their WiFi toggle set to 'off', and thus without a network.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
