### PR TITLE
fix(Android): Add react-native-gradle-plugin to settings.gradle

### DIFF
--- a/detox/test/android/settings.gradle
+++ b/detox/test/android/settings.gradle
@@ -1,6 +1,8 @@
 rootProject.name = 'DetoxTest'
 include ':app'
 
+includeBuild('../node_modules/react-native-gradle-plugin')
+
 include ':detox'
 project(':detox').projectDir = new File(rootProject.projectDir, '../../android/detox')
 


### PR DESCRIPTION
## Description
There is some missing configuration in settings.gradle according to the RN upgrade helper, and this leads to an error about `missing react-native-gradle-plugin` when dependencies upgrade to the new architecture. This PR adds the missing line.

Fixes issue #3548 

