### PR TITLE
fix(ios): ignore "nothing to terminate" simctl error

### DIFF
--- a/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
@@ -246,7 +246,9 @@ class AppleSimUtils {
       // ```
       // This workaround is done to ignore the error above, as we do not care if the app was running before, we just
       // want to make sure it isn't now.
-      if (err.code === 3 && err.stderr.includes(`the app is not currently running`)) {
+      if (err.code === 3 && 
+          (err.stderr.includes(`the app is not currently running`) ||
+           err.stderr.includes(`The operation couldn’t be completed. found nothing to terminate`))) {
         return;
       }
 


### PR DESCRIPTION
## Description

I was having [problems running my detox tests in CI](https://github.com/invertase/react-native-firebase/runs/7816107911?check_suite_focus=true#step:23:19) (but not locally?) that looked exactly like #3518 and it seemed easy enough to patch, so I tried it and it seems to work for me.

Unsure on formatting here but either CI will tell me or you all will :-) - I was hacking it locally via patch-package so don't have devtools for the repo set up + available at the moment sorry

@asafkorem you marked this as assigned to yourself, so perhaps you want to give it a look?

Fixes #3518 (I think - it does for me anyway)

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
