### PR TITLE
Fix: Log native errors *with* stacktraces (no trimming), on Android

### DIFF
--- a/detox/src/devices/common/drivers/android/tools/MonitoredInstrumentation.js
+++ b/detox/src/devices/common/drivers/android/tools/MonitoredInstrumentation.js
@@ -77,7 +77,7 @@ class MonitoredInstrumentation {
         'while it was waiting for "ready" message (over WebSocket) ' +
         'from the instrumentation process.',
       debugInfo: this.instrumentationStackTrace
-        ? `Native stacktrace dump: ${this.instrumentationStackTrace}`
+        ? `Native stacktrace dump:\n${this.instrumentationStackTrace}`
         : '',
     });
   }

--- a/detox/src/devices/common/drivers/android/tools/MonitoredInstrumentation.test.js
+++ b/detox/src/devices/common/drivers/android/tools/MonitoredInstrumentation.test.js
@@ -187,7 +187,7 @@ describe('Monitored instrumentation', () => {
     const assertRejectedWithNativeStacktrace = () => {
       const e = onReject.mock.calls[0][0];
       expect(e.toString()).toContain('DetoxRuntimeError: Failed to run application on the device');
-      expect(e.toString()).toContain(`Native stacktrace dump: ${INSTRUMENTATION_STACKTRACE_MOCK}`);
+      expect(e.toString()).toContain(`Native stacktrace dump:\n${INSTRUMENTATION_STACKTRACE_MOCK}`);
     };
 
     const assertRejectedWithoutStacktrace = () => {

--- a/detox/src/utils/errorUtils.js
+++ b/detox/src/utils/errorUtils.js
@@ -16,11 +16,12 @@ function filterErrorStack(error, predicate) {
 }
 
 function replaceErrorStack(source, target) {
-  const sourceStack = source.stack || source.message;
-  const targetStack = target.stack || target.message;
+  const sourceStack = (source.stack || '');
   const sourceMessage = sourceStack.replace(CLEAN_AT, '');
-  const targetMessage = targetStack.replace(CLEAN_AT, '');
   const actualSourceStack = sourceStack.slice(sourceMessage.length);
+
+  const targetMessage = target.message || target.stack.replace(CLEAN_AT, '');
+
   target.stack = targetMessage + actualSourceStack;
   return target;
 }

--- a/detox/src/utils/errorUtils.test.js
+++ b/detox/src/utils/errorUtils.test.js
@@ -32,18 +32,33 @@ describe('sliceErrorStack(error, fromIndex)', () => {
 });
 
 describe('replaceErrorStack(source, target)', () => {
-  it('should replace error stack in the target error using the source error', () => {
-    function sourceFunction() { throw new Error('Source Error'); }
-    function targetFunction() { throw new Error('Target Error'); }
+
+  function sourceFunction() { throw new Error('Source Error message'); }
+  function targetFunction() { throw new Error('Target Error message'); }
+
+  it('should return the target error', () => {
     const source = _.attempt(sourceFunction);
     const target = _.attempt(targetFunction);
-    expect(target.stack).toMatch(/Target Error/);
-    expect(target.stack).toMatch(/at targetFunction/);
-    expect(target.stack).not.toMatch(/at sourceFunction/);
     expect(errorUtils.replaceErrorStack(source, target)).toBe(target);
-    expect(target.stack).toMatch(/Target Error/);
+  });
+
+  it('should replace error stack in the target error using the source error', () => {
+    const source = _.attempt(sourceFunction);
+    const target = _.attempt(targetFunction);
+
+    errorUtils.replaceErrorStack(source, target);
+    expect(target.stack).toMatch(/Target Error message/);
     expect(target.stack).toMatch(/at sourceFunction/);
     expect(target.stack).not.toMatch(/at targetFunction/);
+  });
+
+  it('should not trim down stack-frames from a (native) stack-trace reported as the message', () => {
+    const nativeStacktrace = 'Target native error:\n  at native.stack.Class.method()';
+    const source = _.attempt(sourceFunction);
+    const target = new Error(nativeStacktrace);
+
+    errorUtils.replaceErrorStack(source, target);
+    expect(target.stack).toMatch(nativeStacktrace);
   });
 
   it('should not ruin already malformed errors', () => {

--- a/detox/test/e2e/utils/custom-expects.js
+++ b/detox/test/e2e/utils/custom-expects.js
@@ -1,22 +1,18 @@
 async function expectToThrow(testBlock, withMessage) {
-  let hasFailed = false;
 
   try {
     await testBlock();
   } catch (e) {
-    hasFailed = true;
-
     if (withMessage && !e.message.includes(withMessage)) {
       throw new Error(`Caught an expected error but message was different:\nExpected: ${withMessage}\nReceived: ${e.message}`)
-    } else {
-      const [firstLine] = e.message.split('\n', 1);
-      console.log('Caught an expected error:', firstLine);
     }
+
+    const [firstLine] = e.message.split('\n', 1);
+    console.log('Caught an expected error:', firstLine);
+    return e;
   }
 
-  if (!hasFailed) {
-    throw new Error('Expected an error but nothing was thrown');
-  }
+  throw new Error('Expected an error but nothing was thrown');
 }
 
 module.exports = {


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request is related to #3500. Fixes #3471.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

Simply put, in this pull request, I have applied some changes to the error-utils such that _native_ stack traces, reported upon instrumentation "crashes", would be fully reported into the Jest summary message.

Namely, from this:
<img width="1210" alt="Screen Shot 2022-08-14 at 23 27 37" src="https://user-images.githubusercontent.com/9818880/184555695-f3dc2ca1-a037-4309-951f-112b9325c80b.png">

Into this:
<img width="1222" alt="Screen Shot 2022-08-14 at 23 26 17" src="https://user-images.githubusercontent.com/9818880/184555704-750a401a-e7a1-40fe-ba16-85094360f274.png">


<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
