### PR TITLE
Stabilize new crash e2e test on Android

### DIFF
--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -94,7 +94,6 @@ dependencies {
     implementation project(':react-native-webview')
     implementation project(':react-native-community-checkbox')
     implementation project(':react-native-community-geolocation')
-    implementation project(':react-native-launch-arguments')
 
     androidTestImplementation(project(path: ':detox'))
     androidTestImplementation 'com.linkedin.testbutler:test-butler-library:2.2.1'

--- a/detox/test/android/app/src/main/java/com/example/DetoxRNHost.java
+++ b/detox/test/android/app/src/main/java/com/example/DetoxRNHost.java
@@ -10,7 +10,6 @@ import com.reactnativecommunity.checkbox.ReactCheckBoxPackage;
 import com.reactnativecommunity.geolocation.GeolocationPackage;
 import com.reactnativecommunity.slider.ReactSliderPackage;
 import com.reactnativecommunity.webview.RNCWebViewPackage;
-import com.reactnativelauncharguments.LaunchArgumentsPackage;
 
 import java.util.Arrays;
 import java.util.List;
@@ -40,8 +39,7 @@ class DetoxRNHost extends ReactNativeHost {
               new RNCWebViewPackage(),
               new NativeModulePackage(),
               new AsyncStoragePackage(),
-              new ReactCheckBoxPackage(),
-              new LaunchArgumentsPackage()
+              new ReactCheckBoxPackage()
       );
    }
 }

--- a/detox/test/android/settings.gradle
+++ b/detox/test/android/settings.gradle
@@ -23,6 +23,3 @@ project(':react-native-community-geolocation').projectDir = new File(rootProject
 
 include ':@react-native-community_slider'
 project(':@react-native-community_slider').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/slider/android')
-
-include ':react-native-launch-arguments'
-project(':react-native-launch-arguments').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-launch-arguments/android')

--- a/detox/test/index.android.js
+++ b/detox/test/index.android.js
@@ -1,19 +1,21 @@
-import { LaunchArguments } from 'react-native-launch-arguments';
 import {
   AppRegistry,
+  NativeModules,
 } from 'react-native';
 
 import example from './src/app';
 
+const { NativeModule } = NativeModules;
+
 class exampleAndroid extends example {
   async componentDidMount() {
     await super.componentDidMount();
-
-    this._registerEarlyCrashIfNeeded();
+    await this._registerEarlyCrashIfNeeded();
   }
 
-  _registerEarlyCrashIfNeeded() {
-    if (LaunchArguments.value().simulateEarlyCrash) {
+  async _registerEarlyCrashIfNeeded() {
+    const launchArguments = await NativeModule.getLaunchArguments();
+    if (launchArguments.simulateEarlyCrash) {
       console.warn('simulateEarlyCrash=true detected: Will crash in a few seconds from now (all-the-while keeping the app busy)...');
       this._setupBusyFutureCrash();
     }
@@ -39,9 +41,8 @@ class exampleAndroid extends example {
         console.warn('simulateEarlyCrash=true', 'Simulating a crash now!');
         throw new Error('Simulating early crash');
       }
-      setTimeout(handler, INTERVAL)
+      setTimeout(handler, INTERVAL);
     };
-
     setTimeout(handler, INTERVAL);
   }
 }

--- a/detox/test/index.ios.js
+++ b/detox/test/index.ios.js
@@ -7,7 +7,7 @@ import {
 
 class exampleIos extends example {}
 
-if (LaunchArguments.value().simulateEarlyCrash) {
+if (LaunchArguments.value().simulateEarlyCrash) { // TODO integrate this into iOS' NativeModule and lose react-native-launch-arguments
   throw new Error('Simulating early crash');
 }
 


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request is associated with #3500.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have made changes that should stabilize, on Android, the crashing e2e-test that was added in #3498. In particular, I've eliminated usage of `react-native-launch-arguments` on Android, which seems to be unstable (sometimes it returns an empty set of launch arguments), which our very own implementation in the Detox test project's `NativeModule`.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
