### PR TITLE
fix(trace): undo `traceCall` breaking change, accept function argument.

### DIFF
--- a/detox/src/utils/trace.js
+++ b/detox/src/utils/trace.js
@@ -40,9 +40,20 @@ class Trace {
 
 let trace = new Trace();
 
-function traceCall(sectionName, promise, args = {}) {
+/**
+ * Trace a single call, with a given name and arguments.
+ * @param sectionName The name of the section to trace.
+ * @param promiseOrFunction {Promise|Function} Promise or a function that provides a promise.
+ * @param args {Object} Optional arguments to pass to the trace.
+ * @returns {any} The returned value of the traced call.
+ *
+ * @see https://wix.github.io/Detox/docs/next/api/detox-object-api/#detoxtracecall.
+ */
+function traceCall(sectionName, promiseOrFunction, args = {}) {
   assert(sectionName,
     `must provide section name when calling \`traceCall\` with args: \n ${JSON.stringify(args)}`);
+
+  const promise = typeof promiseOrFunction === 'function' ? promiseOrFunction() : promiseOrFunction;
 
   trace.startSection(sectionName, args);
   return promise

--- a/detox/src/utils/trace.test.js
+++ b/detox/src/utils/trace.test.js
@@ -99,7 +99,7 @@ describe('Trace util', () => {
       trace.reset();
     });
 
-    it('should trace a successful call', async () => {
+    it('should trace a successful promise call', async () => {
       const promise = Promise.resolve(42);
 
       trace.init();
@@ -112,7 +112,20 @@ describe('Trace util', () => {
       expect(result).toEqual(42);
     });
 
-    it('should trace a failed call', async () => {
+    it('should trace a successful function call', async () => {
+      const functionCall = () => Promise.resolve(42);
+
+      trace.init();
+      const result = await traceCall(sectionName, functionCall);
+      expect(trace.events).toEqual([
+        expect.any(Object),
+        expect.objectContaining(startEventTraits),
+        expect.objectContaining(successEndEventTraits),
+      ]);
+      expect(result).toEqual(42);
+    });
+
+    it('should trace a failed promise call', async () => {
       const error = new Error('error mock');
       const promise = Promise.reject(error);
 
@@ -124,6 +137,20 @@ describe('Trace util', () => {
         expect.objectContaining(aFailEndEventTraits(error)),
       ]);
     });
+
+    it('should trace a failed function call', async () => {
+      const error = new Error('error mock');
+      const functionCall = () => Promise.reject(error);
+
+      trace.init();
+      await expect(traceCall(sectionName, functionCall)).rejects.toThrowError(error);
+      expect(trace.events).toEqual([
+        expect.any(Object),
+        expect.objectContaining(startEventTraits),
+        expect.objectContaining(aFailEndEventTraits(error)),
+      ]);
+    });
+
   });
 
   describe('trace-invocation-call function', () => {


### PR DESCRIPTION
Allow to pass a function that returns a promise as an argument to the `traceCall` function (undo [API](https://wix.github.io/Detox/docs/next/api/detox-object-api/#detoxtracecall) breakage introduced in https://github.com/wix/Detox/commit/450477f2fe2da98d32cacf25dbcc64e1cd991537).

See https://wix.github.io/Detox/docs/next/api/detox-object-api/#detoxtracecall