### PR TITLE
fix(DetoxCoreListener.js): remove duplicated `status` value.

### DIFF
--- a/detox/runners/jest-circus/listeners/DetoxCoreListener.js
+++ b/detox/runners/jest-circus/listeners/DetoxCoreListener.js
@@ -80,7 +80,6 @@ class DetoxCoreListener {
       title: test.name,
       parent: test.parent.name,
       fullName: getFullTestName(test),
-      status: 'running',
       functionCode: test.fn.toString(),
       invocations: this._getTestInvocations(test),
     };


### PR DESCRIPTION
This change has no affect on functionality, as well as this field value, we override this field with the real test status anyway.