### PR TITLE
Reimplement TextFileReader.read()

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/common/TextFileReader.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/common/TextFileReader.kt
@@ -3,5 +3,5 @@ package com.wix.detox.common
 import java.io.File
 
 internal class TextFileReader(private val fileName: String) {
-    fun read() = File(fileName).inputStream().readBytes().toString(Charsets.UTF_8)
+    fun read() = File(fileName).readText(Charsets.UTF_8)
 }


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have introduced an attempt to fix the following rogue crash, appearing in one of Wix's internal modules - when integrating Android:

```
09-04 16:26:09.275  8015  8177 D Detox   : class com.wix.detox.Detox, startActivityFromNotification, [/data/local/tmp/detox/notification.json]
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: Test exception
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: java.lang.reflect.InvocationTargetException
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at java.lang.reflect.Method.invoke(Native Method)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at org.apache.commons.lang3.reflect.MethodUtils.invokeStaticMethod(MethodUtils.java:443)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at org.apache.commons.lang3.reflect.MethodUtils.invokeStaticMethod(MethodUtils.java:405)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.invoke.types.ClassTarget.execute(ClassTarget.java:23)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.invoke.types.Target.invoke(Target.java:59)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.invoke.MethodInvocation.invoke(MethodInvocation.java:35)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.invoke.MethodInvocation.invoke(MethodInvocation.java:26)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.invoke.MethodInvocation.invoke(MethodInvocation.java:20)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.detox.adapters.server.InvokeActionHandler.handle(DetoxActionHandlers.kt:54)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.detox.adapters.server.ActionsExecutor$executeAction$$inlined$let$lambda$1.run(DetoxActionsDispatcher.kt:64)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at android.os.Handler.handleCallback(Handler.java:873)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at android.os.Handler.dispatchMessage(Handler.java:99)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at android.os.Looper.loop(Looper.java:193)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.detox.adapters.server.ActionsExecutor$1.run(DetoxActionsDispatcher.kt:50)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at java.lang.Thread.run(Thread.java:764)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: Caused by: java.lang.NoSuchMethodError: No static method readBytes(Ljava/io/InputStream;)[B in class Lkotlin/io/ByteStreamsKt; or its super classes (declaration of 'kotlin.io.ByteStreamsKt' appears in base.apk!classes3.dex)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.detox.common.TextFileReader.read(TextFileReader.kt:6)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.detox.NotificationDataParser.readNotificationData(NotificationDataParser.kt:17)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.detox.NotificationDataParser.parseNotificationData(NotificationDataParser.kt:10)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	at com.wix.detox.Detox.startActivityFromNotification(Detox.java:217)
09-04 16:26:09.281  8015  8177 I DetoxActionHandlers: 	... 15 more
```

Unfortunately, I can't say I understand this error very well, and that is why I'm trying to work-around by using a more kotlin-pure (and btw, more concise) implementation.

Normally, this type of an error is a result of incomplete minification definitions. In this case, the only package involved is `kotlin.io`, so I'm inclined to say that it's not the problem here. By switching to a single Kotlin method (whose internal impl. is more pure) I'm in hopes of that the code would be less sensitive.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
