### PR TITLE
fix: the occasional ConcurrentModificationException error

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
@@ -8,7 +8,6 @@ import com.facebook.react.bridge.ReactContext;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.List;

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResource.java
@@ -9,6 +9,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -32,7 +34,7 @@ public class NetworkIdlingResource extends DetoxBaseIdlingResource implements Ch
 
     private ResourceCallback callback;
     private Dispatcher dispatcher;
-    private final Set<String> busyResources = new HashSet<>();
+    private final Set<String> busyResources = new CopyOnWriteArraySet<>();
 
     private static final ArrayList<Pattern> blacklist = new ArrayList<>();
 
@@ -72,7 +74,7 @@ public class NetworkIdlingResource extends DetoxBaseIdlingResource implements Ch
     public IdlingResourceDescription getDescription() {
         return new IdlingResourceDescription.Builder()
                 .name("network")
-                .addDescription("urls", new ArrayList<>(busyResources))
+                .addDescription("urls", new CopyOnWriteArrayList<>(busyResources))
                 .build();
     }
 


### PR DESCRIPTION
## Description

When I executed my E2E testing on Android emulator, I found that sometimes there was a error of `ConcurrentModificationException`, it's occasional, doesn't 
appear every time, I reviewed the relevant code based on the error stack, found that the root cause is that the `ArrayList` and `HashSet` are used here, after I replaced the `ArrayList` with `CopyOnWriteArrayList` and `HashSet` with `CopyOnWriteArraySet`, and rebuilt the Detox, changed to reference the rebuilt package in my `build.gradle` file, then the issue went away and everything goes well.

Sorry for forgetting to take a screenshot of this error, but it indeed exists.
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/21986828/191943746-00aa035e-c197-4ab8-bfa1-4190a360e9b0.png">




