### PR TITLE
chore(website): replace Algolia DocSearch app ID and app key.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -71,8 +71,8 @@ const config = {
         ]
       },
       algolia: {
-        appId: 'BH4D9OD16A',
-        apiKey: 'f621c2d74268df173153c887526aebb3',
+        appId: 'KTM5GBP42S',
+        apiKey: 'd01d9c1bae30c64fa2b9bfbdad9adbfd',
         indexName: 'detox'
       },
       footer: {


### PR DESCRIPTION
Replace the old App ID and Key given by Algolia DocSearch for Detox website search.

The old app was migrated recently by DocSearch to the new app, see the migration details here: https://docsearch.algolia.com/docs/migrating-from-legacy/.

Worth-noting, the search-only API key is **public and safe to use in production front-end code**, so there is no need to use a GitHub secret for it. From their website:
> [**Search-only API key**](https://www.algolia.com/doc/guides/security/api-keys/#search-only-api-key)
As a convenience, Algolia provides you with a search-only API key that allows you to search your data immediately. It works on all the indices of your application and is safe to use in your production front-end code. Nevertheless, you may want to use this key to create more restricted API keys. For example, you can generate a search API key that limits access to a specific user, a specific index, or a set of indices.