### PR TITLE
bugfix: avd validator emulator version should obey `headless`

### DIFF
--- a/detox/src/devices/allocation/drivers/android/emulator/AVDValidator.js
+++ b/detox/src/devices/allocation/drivers/android/emulator/AVDValidator.js
@@ -12,11 +12,11 @@ class AVDValidator {
     this._emulatorVersionResolver = emulatorVersionResolver;
   }
 
-  async validate(avdName) {
+  async validate(avdName, isHeadless) {
     const avds = await this._avdsResolver.resolve(avdName);
     this._assertAVDs(avds);
     await this._assertAVDMatch(avds, avdName);
-    await this._validateEmulatorVer();
+    await this._validateEmulatorVer(isHeadless);
   }
 
   _assertAVDs(avds) {
@@ -37,8 +37,8 @@ class AVDValidator {
     }
   }
 
-  async _validateEmulatorVer() {
-    const emulatorVersion = await this._emulatorVersionResolver.resolve();
+  async _validateEmulatorVer(isHeadless) {
+    const emulatorVersion = await this._emulatorVersionResolver.resolve(isHeadless);
     if (!emulatorVersion) {
       logger.warn({ event: 'AVD_VALIDATION' }, 'Emulator version detection failed (See previous logs)');
       return;

--- a/detox/src/devices/allocation/drivers/android/emulator/AVDValidator.test.js
+++ b/detox/src/devices/allocation/drivers/android/emulator/AVDValidator.test.js
@@ -111,4 +111,13 @@ describe('AVD validator', () => {
       'Emulator version detection failed (See previous logs)'
       );
   });
+
+  it('should run emulator version resolver as headless if required', async () => {
+    givenExpectedAVD();
+    givenProperEmulatorVersion();
+
+    await uut.validate('mock-avd-name', true);
+
+    expect(versionResolver.resolve).toHaveBeenCalledWith(true);
+  });
 });

--- a/detox/src/devices/allocation/drivers/android/emulator/EmulatorAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/emulator/EmulatorAllocDriver.js
@@ -31,7 +31,7 @@ class EmulatorAllocDriver extends AllocationDriverBase {
   async allocate(deviceConfig) {
     const avdName = deviceConfig.device.avdName;
 
-    await this._avdValidator.validate(avdName);
+    await this._avdValidator.validate(avdName, deviceConfig.headless);
     await this._fixAvdConfigIniSkinNameIfNeeded(avdName, deviceConfig.headless);
 
     const allocResult = await this._allocationHelper.allocateDevice(avdName);

--- a/detox/src/devices/allocation/drivers/android/emulator/EmulatorAllocDriver.test.js
+++ b/detox/src/devices/allocation/drivers/android/emulator/EmulatorAllocDriver.test.js
@@ -156,7 +156,7 @@ describe('Allocation driver for Google emulators', () => {
     it('should pre-validate proper AVD configuration', async () => {
       givenValidAVD();
       await allocDriver.allocate(deviceConfig);
-      expect(avdValidator.validate).toHaveBeenCalledWith(avdName, deviceConfig.headless);
+      expect(avdValidator.validate).toHaveBeenCalledWith(avdName, undefined);
     });
 
     it('should respect headless avd configuration during AVD validation', async () => {

--- a/detox/src/devices/allocation/drivers/android/emulator/EmulatorAllocDriver.test.js
+++ b/detox/src/devices/allocation/drivers/android/emulator/EmulatorAllocDriver.test.js
@@ -156,7 +156,7 @@ describe('Allocation driver for Google emulators', () => {
     it('should pre-validate proper AVD configuration', async () => {
       givenValidAVD();
       await allocDriver.allocate(deviceConfig);
-      expect(avdValidator.validate).toHaveBeenCalledWith(avdName);
+      expect(avdValidator.validate).toHaveBeenCalledWith(avdName, deviceConfig.headless);
     });
 
     it('should throw if AVD configuration is invalid', async () => {

--- a/detox/src/devices/allocation/drivers/android/emulator/EmulatorAllocDriver.test.js
+++ b/detox/src/devices/allocation/drivers/android/emulator/EmulatorAllocDriver.test.js
@@ -159,6 +159,12 @@ describe('Allocation driver for Google emulators', () => {
       expect(avdValidator.validate).toHaveBeenCalledWith(avdName, deviceConfig.headless);
     });
 
+    it('should respect headless avd configuration during AVD validation', async () => {
+      givenValidAVD();
+      await allocDriver.allocate({ ...deviceConfig, headless: true });
+      expect(avdValidator.validate).toHaveBeenCalledWith(avdName, true);
+    });
+
     it('should throw if AVD configuration is invalid', async () => {
       givenInvalidAVD('mock invalid AVD');
 


### PR DESCRIPTION
## Description
This is a bugfix to address the `headless` config when running tests (invoked as `emulator -version` by the `AVDValidator`s emulator version validator.

- Resolves #3613 

In this pull request, I have forwarded the `headless` config option to the `AVDValidator` so that the existing emulator version query can operate as expected and in accordance to the configuration provided by the user

