### PR TITLE
Detect when Emulator with SDK 31 boots

### DIFF
--- a/detox/src/devices/allocation/drivers/android/emulator/launchEmulatorProcess.js
+++ b/detox/src/devices/allocation/drivers/android/emulator/launchEmulatorProcess.js
@@ -49,20 +49,18 @@ function launchEmulatorProcess(emulatorName, emulatorExec, emulatorLaunchCommand
 
   // On Android SDK 31 `childProcessPromise` never resolves when Emulator boots,
   // so we have to continuosly scan for the process output until we detect that the emulator has booted.
-  const monitorOutputWithTimeout = async (timeoutMs) => {
-    const delayMs = 1000;
-    for (let i = 0; i < Math.floor(timeoutMs / delayMs); i++) {
-      await sleep(delayMs);
+  const monitorOutputWithTimeout = async (timeoutSeconds) => {
+    for (let i = 0; i < timeoutSeconds; i++) {
       const stdoutContent = fs.readFileSync(tempLog, 'utf8');
       if (stdoutContent.includes('boot completed')) {
         return;
       }
+
+      await sleep(1000);
     }
     throw new Error('Could not boot emulator');
   };
-  const monitorOutputWithTimeoutPromise = monitorOutputWithTimeout(
-    3 * 60 * 1000, // 3 mins
-  );
+  const monitorOutputWithTimeoutPromise = monitorOutputWithTimeout(180);
 
   return Promise.race([childProcessPromise, monitorOutputWithTimeoutPromise])
   .then(() => true).catch((err) => {

--- a/detox/src/devices/allocation/drivers/android/emulator/launchEmulatorProcess.js
+++ b/detox/src/devices/allocation/drivers/android/emulator/launchEmulatorProcess.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const { Tail } = require('tail');
 
 const unitLogger = require('../../../../../utils/logger').child({ __filename });
+const sleep = require('../../../../../utils/sleep');
 
 function launchEmulatorProcess(emulatorName, emulatorExec, emulatorLaunchCommand) {
   let childProcessOutput;
@@ -46,7 +47,25 @@ function launchEmulatorProcess(emulatorName, emulatorExec, emulatorLaunchCommand
 
   log = log.child({ child_pid: childProcessPromise.childProcess.pid });
 
-  return childProcessPromise.then(() => true).catch((err) => {
+  // On Android SDK 31 `childProcessPromise` never resolves when Emulator boots,
+  // so we have to continuosly scan for the process output until we detect that the emulator has booted.
+  const monitorOutputWithTimeout = async (timeoutMs) => {
+    const delayMs = 1000;
+    for (let i = 0; i < Math.floor(timeoutMs / delayMs); i++) {
+      await sleep(delayMs);
+      const stdoutContent = fs.readFileSync(tempLog, 'utf8');
+      if (stdoutContent.includes('boot completed')) {
+        return;
+      }
+    }
+    throw new Error('Could not boot emulator');
+  };
+  const monitorOutputWithTimeoutPromise = monitorOutputWithTimeout(
+    3 * 60 * 1000, // 3 mins
+  );
+
+  return Promise.race([childProcessPromise, monitorOutputWithTimeoutPromise])
+  .then(() => true).catch((err) => {
     detach();
 
     if (childProcessOutput.includes(`There's another emulator instance running with the current AVD`)) {

--- a/detox/src/devices/allocation/drivers/android/emulator/launchEmulatorProcess.js
+++ b/detox/src/devices/allocation/drivers/android/emulator/launchEmulatorProcess.js
@@ -60,7 +60,7 @@ function launchEmulatorProcess(emulatorName, emulatorExec, emulatorLaunchCommand
     }
     throw new Error('Could not boot emulator');
   };
-  const monitorOutputWithTimeoutPromise = monitorOutputWithTimeout(180);
+  const monitorOutputWithTimeoutPromise = monitorOutputWithTimeout(60);
 
   return Promise.race([childProcessPromise, monitorOutputWithTimeoutPromise])
   .then(() => true).catch((err) => {


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: https://github.com/wix/Detox/issues/3071
- Potentially this issue as well: https://github.com/wix/Detox/issues/3342

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

Before this PR

```logs
~/Detox/detox/test on bruno/detect-android-31 * !
❯ npm run e2e:android

> detox-test@19.12.5 e2e:android
> detox test -c android.emu.release

20:31:10.842 detox[25832] INFO:  [test.js] DETOX_CONFIGURATION="android.emu.release" DETOX_REPORT_SPECS=true DETOX_START_TIMESTAMP=1665016270838 DETOX_USE_CUSTOM_LOGGER=true nyc jest --config e2e/config.js --testNamePattern '^((?!:ios:).)*$' e2e/*.test.js
20:36:11.884 detox[25834] ERROR: Exceeded timeout of 300000ms while handling jest-circus "setup" event
20:36:11.907 detox[25834] INFO:  Actions is assigned to undefined
```

With this PR

```logs
~/Detox/detox/test on bruno/detect-android-31 ! 28s
❯ npm run e2e:android

> detox-test@19.12.5 e2e:android
> detox test -c android.emu.release

20:38:49.762 detox[26349] INFO:  [test.js] DETOX_CONFIGURATION="android.emu.release" DETOX_REPORT_SPECS=true DETOX_START_TIMESTAMP=1665016729759 DETOX_USE_CUSTOM_LOGGER=true nyc jest --config e2e/config.js --testNamePattern '^((?!:ios:).)*$' e2e/*.test.js
20:39:22.973 detox[26352] INFO:  Actions is assigned to emulator-16426 (Pixel_3A_API_31)
20:39:22.973 detox[26352] INFO:  Actions: should tap on an element
20:39:24.014 detox[26352] INFO:  Actions: should tap on an element [OK]
20:39:24.015 detox[26352] INFO:  Actions: should long press on an element
```

If you want to test:
1. `echo no | avdmanager create avd --name Pixel_3A_API_29 --abi arm64-v8a --package 'system-images;android-29;google_apis;arm64-v8a' --device "pixel"`
2. `cd detox/test/e2e`
3. Replace `Pixel_3A_API_31` with `Pixel_3A_API_29` in `detox.config.js`
4. `npm run e2e:android`

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
