### PR TITLE
fix(android gradle): replace jcenter with maven-center.

### DIFF
--- a/detox/android/build.gradle
+++ b/detox/android/build.gradle
@@ -37,7 +37,6 @@ allprojects {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
         maven {
             url "$projectDir/../../node_modules/react-native/android"
         }

--- a/examples/demo-native-android/build.gradle
+++ b/examples/demo-native-android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.1'
@@ -15,7 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/examples/demo-pure-native-android/build.gradle
+++ b/examples/demo-pure-native-android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.kotlin_version = "1.6.21"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.3"
@@ -17,7 +17,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
 
         // This is here in order to resolve the Detox .aar from the local folder (assuming it's
         // been prebuilt, regardless of this project). Commenting this out would have the app


### PR DESCRIPTION
Replace deprecated JCenter Bintray with Maven Center due to long outage.

Bintray is already deprecated and had its sunset long-ago, see [this blogpost](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter).