### PR TITLE
website(showcase): make container left padding same as the right.

### DIFF
--- a/website/src/components/Showcase/Showcase.module.css
+++ b/website/src/components/Showcase/Showcase.module.css
@@ -1,5 +1,5 @@
 .container {
-  padding: 80px 0 60px 40px;
+  padding: 80px 20px 60px 20px;
 }
 
 .list {


### PR DESCRIPTION
This change affects small screens, where the showcase cards weren't centered in their container.