### PR TITLE
test(dependencies): lock `react-native-community/checkbox` version.

### DIFF
--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.17.3",
-    "@react-native-community/checkbox": "^0.5.11",
+    "@react-native-community/checkbox": "0.5.12",
     "@react-native-community/geolocation": "^2.0.2",
     "@react-native-community/slider": "4.2.4",
     "@react-native-picker/picker": "^2.1.0",


### PR DESCRIPTION
Version 0.5.13 is broken, let's follow on this issue: https://github.com/react-native-checkbox/react-native-checkbox/issues/182

We can unlock it again once there will be a proper solution.