### PR TITLE
🚨 chore(deps): bump react-native versions (patch).

### DIFF
--- a/.buildkite/jobs/pipeline.android_demo_app_rn_68.yml
+++ b/.buildkite/jobs/pipeline.android_demo_app_rn_68.yml
@@ -3,7 +3,7 @@
       - "nvm install"
       - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/demo-projects.android.sh"
     env:
-      REACT_NATIVE_VERSION: 0.68.3
+      REACT_NATIVE_VERSION: 0.68.5
       REACT_NATIVE_COMPAT_TEST: true
       DETOX_DISABLE_POD_INSTALL: true
       DETOX_DISABLE_POSTINSTALL: true

--- a/.buildkite/jobs/pipeline.android_demo_app_rn_69.yml
+++ b/.buildkite/jobs/pipeline.android_demo_app_rn_69.yml
@@ -3,7 +3,7 @@
       - "nvm install"
       - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/demo-projects.android.sh"
     env:
-      REACT_NATIVE_VERSION: 0.69.5
+      REACT_NATIVE_VERSION: 0.69.7
       DETOX_DISABLE_POD_INSTALL: true
       DETOX_DISABLE_POSTINSTALL: true
     artifact_paths:

--- a/.buildkite/jobs/pipeline.android_rn_68.yml
+++ b/.buildkite/jobs/pipeline.android_rn_68.yml
@@ -3,7 +3,7 @@
       - "nvm install"
       - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/ci.android.sh"
     env:
-      REACT_NATIVE_VERSION: 0.68.3
+      REACT_NATIVE_VERSION: 0.68.5
       DETOX_DISABLE_POD_INSTALL: true
       DETOX_DISABLE_POSTINSTALL: true
     artifact_paths:

--- a/.buildkite/jobs/pipeline.android_rn_69.yml
+++ b/.buildkite/jobs/pipeline.android_rn_69.yml
@@ -3,7 +3,7 @@
       - "nvm install"
       - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/ci.android.sh"
     env:
-      REACT_NATIVE_VERSION: 0.69.5
+      REACT_NATIVE_VERSION: 0.69.7
       DETOX_DISABLE_POD_INSTALL: true
       DETOX_DISABLE_POSTINSTALL: true
       SKIP_UNIT_TESTS: true

--- a/.buildkite/jobs/pipeline.ios_demo_app_rn_68.yml
+++ b/.buildkite/jobs/pipeline.ios_demo_app_rn_68.yml
@@ -3,7 +3,7 @@
       - "nvm install"
       - "./scripts/demo-projects.ios.sh"
     env:
-      REACT_NATIVE_VERSION: 0.68.3
+      REACT_NATIVE_VERSION: 0.68.5
     artifact_paths:
       - "/Users/builder/work/coverage/**/*.lcov"
       - "/Users/builder/work/artifacts*.tar.gz"

--- a/.buildkite/jobs/pipeline.ios_demo_app_rn_69.yml
+++ b/.buildkite/jobs/pipeline.ios_demo_app_rn_69.yml
@@ -3,7 +3,7 @@
       - "nvm install"
       - "JAVA_HOME=/usr/local/opt/openjdk@11/ ./scripts/demo-projects.ios.sh"
     env:
-      REACT_NATIVE_VERSION: 0.69.5
+      REACT_NATIVE_VERSION: 0.69.7
     artifact_paths:
       - "/Users/builder/work/coverage/**/*.lcov"
       - "/Users/builder/work/artifacts*.tar.gz"

--- a/.buildkite/jobs/pipeline.ios_rn_68.yml
+++ b/.buildkite/jobs/pipeline.ios_rn_68.yml
@@ -3,7 +3,7 @@
       - "nvm install"
       - "./scripts/ci.ios.sh"
     env:
-      REACT_NATIVE_VERSION: 0.68.3
+      REACT_NATIVE_VERSION: 0.68.5
     artifact_paths:
       - "/Users/builder/work/coverage/**/*.lcov"
       - "/Users/builder/work/artifacts*.tar.gz"

--- a/.buildkite/jobs/pipeline.ios_rn_69.yml
+++ b/.buildkite/jobs/pipeline.ios_rn_69.yml
@@ -3,7 +3,7 @@
       - "nvm install"
       - "./scripts/ci.ios.sh"
     env:
-      REACT_NATIVE_VERSION: 0.69.5
+      REACT_NATIVE_VERSION: 0.69.7
     artifact_paths:
       - "/Users/builder/work/coverage/**/*.lcov"
       - "/Users/builder/work/artifacts*.tar.gz"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following React Native versions have been tested:
 
 | iOS             | Android                                                                                                                   |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------|
-| 0.68.x - 0.69.5 | 0.68.x - 0.69.5 -<br/>Visibility edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/23870) \* |
+| 0.68.x - 0.69.7 | 0.68.x - 0.69.7 -<br/>Visibility edge-case: see this [RN issue](https://github.com/facebook/react-native/issues/23870) \* |
 
 Future versions are most likely supported, but have not been tested yet. Please open issues if you find specific issues with newer React Native versions.
 

--- a/detox/package.json
+++ b/detox/package.json
@@ -47,7 +47,7 @@
     "mocha": ">=6.0.0",
     "mockdate": "^2.0.1",
     "prettier": "1.7.0",
-    "react-native": "0.69.5",
+    "react-native": "0.69.7",
     "react-native-codegen": "^0.0.8",
     "typescript": "^4.5.2",
     "wtfnode": "^0.9.1"

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -38,7 +38,7 @@
     "@react-native-segmented-control/segmented-control": "2.3.0",
     "moment": "^2.24.0",
     "react": "18.0.0",
-    "react-native": "0.69.5",
+    "react-native": "0.69.7",
     "react-native-gradle-plugin": "^0.0.7",
     "react-native-launch-arguments": "^3.1.0",
     "react-native-webview": "^11.18.1"
@@ -49,7 +49,7 @@
     "@react-native-community/eslint-config": "^3.0.1",
     "@types/node": "^12.20.37",
     "@types/react": "18.0.0",
-    "@types/react-native": "0.69.5",
+    "@types/react-native": "0.69.7",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "detox": "^19.12.6",

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.17.3",
     "react": "18.0.0",
-    "react-native": "0.69.5",
+    "react-native": "0.69.7",
     "tslib": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump react-native versions due to test app's android build failures, resolved on the new patch versions.

Read the full incident details here: https://github.com/facebook/react-native/issues/35210.