### PR TITLE
test: add tests for IPCClient & IPCServer integration.

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -163,7 +163,6 @@
       "runners/jest/testEnvironment",
       "src/DetoxWorker.js",
       "src/logger/utils/streamUtils.js",
-      "src/ipc",
       "src/realms"
     ],
     "resetMocks": true,

--- a/detox/src/ipc/IPCClient.js
+++ b/detox/src/ipc/IPCClient.js
@@ -109,8 +109,8 @@ class IPCClient {
     });
   }
 
-  _onSessionStateUpdate = (payload) => {
-    this._state.patch(payload);
+  _onSessionStateUpdate = ({ testResults, workersCount }) => {
+    this._state.patch({ testResults, workersCount });
   };
 }
 

--- a/detox/src/ipc/IPCClient.js
+++ b/detox/src/ipc/IPCClient.js
@@ -11,14 +11,14 @@ class IPCClient {
     /** @type {import('./SessionState')} */
     this._state = state;
 
-    this._client = null;
+    this._ipc = null;
     this._serverConnection = null;
   }
 
   async init() {
-    this._client = new IPC();
+    this._ipc = new IPC();
 
-    Object.assign(this._client.config, {
+    Object.assign(this._ipc.config, {
       id: this._id,
       appspace: 'detox.',
       logger: (msg) => this._logger.trace(msg),
@@ -33,9 +33,9 @@ class IPCClient {
   async dispose() {
     this._serverConnection = null;
 
-    if (this._client) {
-      this._client.disconnect(this.serverId);
-      this._client = null;
+    if (this._ipc) {
+      this._ipc.disconnect(this.serverId);
+      this._ipc = null;
     }
   }
 
@@ -66,7 +66,7 @@ class IPCClient {
     const serverId = this.serverId;
 
     this._serverConnection = await new Promise((resolve, reject) => {
-      this._client.connectTo(serverId, (client) => {
+      this._ipc.connectTo(serverId, (client) => {
         client.of[serverId]
           .on('error', reject)
           .on('disconnect', () => reject(new DetoxInternalError('IPC server has unexpectedly disconnected.')))

--- a/detox/src/ipc/IPCClient.js
+++ b/detox/src/ipc/IPCClient.js
@@ -109,8 +109,8 @@ class IPCClient {
     });
   }
 
-  _onSessionStateUpdate = ({ testResults, workersCount }) => {
-    this._sessionState.patch({ testResults, workersCount });
+  _onSessionStateUpdate = (payload) => {
+    this._state.patch(payload);
   };
 }
 

--- a/detox/src/ipc/IPCClient.js
+++ b/detox/src/ipc/IPCClient.js
@@ -4,12 +4,12 @@ const { DetoxInternalError } = require('../errors');
 const { serializeObjectWithError } = require('../utils/errorUtils');
 
 class IPCClient {
-  constructor({ id, logger, state }) {
+  constructor({ id, logger, sessionState }) {
     this._id = id;
     /** @type {import('../logger/DetoxLogger')} logger */
     this._logger = logger.child({ cat: 'ipc' });
     /** @type {import('./SessionState')} */
-    this._state = state;
+    this._sessionState = sessionState;
 
     this._ipc = null;
     this._serverConnection = null;
@@ -40,7 +40,7 @@ class IPCClient {
   }
 
   get sessionState() {
-    return this._state;
+    return this._sessionState;
   }
 
   get serverId() {
@@ -49,7 +49,7 @@ class IPCClient {
 
   async registerWorker(workerId) {
     const sessionState = await this._emit('registerWorker', { workerId });
-    this._state.patch(sessionState);
+    this._sessionState.patch(sessionState);
   }
 
   /**
@@ -59,7 +59,7 @@ class IPCClient {
     const sessionState = await this._emit('reportTestResults', {
       testResults: testResults.map(r => serializeObjectWithError(r, 'testExecError')),
     });
-    this._state.patch(sessionState);
+    this._sessionState.patch(sessionState);
   }
 
   async _connectToServer() {
@@ -79,7 +79,7 @@ class IPCClient {
 
   async _registerContext() {
     const sessionState = await this._emit('registerContext', { id: this._id });
-    this._state.patch(sessionState);
+    this._sessionState.patch(sessionState);
   }
 
   async _emit(event, payload) {
@@ -110,7 +110,7 @@ class IPCClient {
   }
 
   _onSessionStateUpdate = ({ testResults, workersCount }) => {
-    this._state.patch({ testResults, workersCount });
+    this._sessionState.patch({ testResults, workersCount });
   };
 }
 

--- a/detox/src/ipc/SessionState.js
+++ b/detox/src/ipc/SessionState.js
@@ -9,7 +9,6 @@ const context = vm.createContext({ require }, {
 class SessionState {
   constructor({
     id = '',
-    contexts = [],
     detoxConfig = null,
     detoxIPCServer = '',
     testResults = [],
@@ -17,7 +16,6 @@ class SessionState {
     workersCount = 0
   }) {
     this.id = id;
-    this.contexts = contexts;
     this.detoxConfig = detoxConfig;
     this.detoxIPCServer = detoxIPCServer;
     this.testResults = testResults;

--- a/detox/src/ipc/SessionState.js
+++ b/detox/src/ipc/SessionState.js
@@ -25,12 +25,8 @@ class SessionState {
     this.workersCount = workersCount;
   }
 
-  patch({ testResults = null, testSessionIndex = null, workersCount = null }) {
-    Object.assign(this,
-      testResults && { testResults },
-      testSessionIndex && { testSessionIndex },
-      workersCount && { workersCount },
-    );
+  patch(state) {
+    Object.assign(this, state);
   }
 
   stringify() {

--- a/detox/src/ipc/SessionState.js
+++ b/detox/src/ipc/SessionState.js
@@ -25,12 +25,16 @@ class SessionState {
     this.workersCount = workersCount;
   }
 
-  patch(state) {
-    Object.assign(this, state);
+  patch({ testResults = null, testSessionIndex = null, workersCount = null }) {
+    Object.assign(this,
+      testResults && { testResults },
+      testSessionIndex && { testSessionIndex },
+      workersCount && { workersCount },
+    );
   }
 
   stringify() {
-    return cycle.stringify(this, SessionState.stringifier);
+    return cycle.stringify(this, SessionState._stringifier);
   }
 
   /**
@@ -39,10 +43,10 @@ class SessionState {
   static parse(stringified) {
     const Class = this; // eslint-disable-line unicorn/no-this-assignment
     // @ts-ignore
-    return new Class(cycle.parse(stringified, SessionState.reviver));
+    return new Class(cycle.parse(stringified, SessionState._reviver));
   }
 
-  static reviver(key, val) {
+  static _reviver(key, val) {
     if (typeof val === 'object' && val !== null && typeof val.$fn == 'string') {
       return vm.runInContext(val.$fn, context);
     } else {
@@ -50,7 +54,7 @@ class SessionState {
     }
   }
 
-  static stringifier(key, val) {
+  static _stringifier(key, val) {
     if (typeof val === 'function') {
       return { $fn: `(${val})` };
     } else {

--- a/detox/src/ipc/SessionState.test.js
+++ b/detox/src/ipc/SessionState.test.js
@@ -12,7 +12,6 @@ describe('SessionState', () => {
 
     sessionState = new SessionState({
       id: '123',
-      contexts: ['context1', 'context2'],
       detoxConfig: {
         someFunction
       },
@@ -23,9 +22,21 @@ describe('SessionState', () => {
     });
   });
 
+  describe('when created without arguments', () => {
+    it('should have default values', () => {
+      expect(new SessionState({})).toEqual({
+        id: '',
+        detoxConfig: null,
+        detoxIPCServer: '',
+        testResults: [],
+        testSessionIndex: 0,
+        workersCount: 0,
+      });
+    });
+  });
+
   it('should create the new session state with the given properties', () => {
     expect(sessionState.id).toEqual('123');
-    expect(sessionState.contexts).toEqual(['context1', 'context2']);
     expect(sessionState.detoxConfig).toEqual({ someFunction });
     expect(sessionState.detoxIPCServer).toEqual('server');
     expect(sessionState.testResults).toEqual(['result1', 'result2']);
@@ -58,7 +69,7 @@ describe('SessionState', () => {
   });
 
   it('should stringify correctly', () => {
-    const expected = '{"id":"123","contexts":["context1","context2"],' +
+    const expected = '{"id":"123",' +
       '"detoxConfig":{"someFunction":{"$fn":"(() => {\\n      return \'foo\';\\n    })"}},' +
       '"detoxIPCServer":"server","testResults":["result1","result2"],"testSessionIndex":1,"workersCount":2}';
 
@@ -66,7 +77,7 @@ describe('SessionState', () => {
   });
 
   it('should parse stringified session state to class instance', () => {
-    const stringified = '{"id":"123","contexts":["context1","context2"],' +
+    const stringified = '{"id":"123",' +
       '"detoxConfig":{"someFunction":{"$fn":"(() => {\\n      return \'foo\';\\n    })"}},' +
       '"detoxIPCServer":"server","testResults":["result1","result2"],"testSessionIndex":1,"workersCount":2}';
 
@@ -80,6 +91,5 @@ describe('SessionState', () => {
     delete parsed.detoxConfig.someFunction;
     delete sessionState.detoxConfig.someFunction;
     expect(parsed).toEqual(sessionState);
-
   });
 });

--- a/detox/src/ipc/SessionState.test.js
+++ b/detox/src/ipc/SessionState.test.js
@@ -1,0 +1,69 @@
+const SessionState = require('./SessionState');
+
+describe('SessionState', () => {
+  /** @type {SessionState} */
+  let sessionState;
+
+  beforeEach(() => {
+    sessionState = new SessionState({
+      id: '123',
+      contexts: ['context1', 'context2'],
+      detoxConfig: 'config',
+      detoxIPCServer: 'server',
+      testResults: ['result1', 'result2'],
+      testSessionIndex: 1,
+      workersCount: 2,
+    });
+  });
+
+  it('should create the new session state with the given properties', () => {
+    expect(sessionState.id).toEqual('123');
+    expect(sessionState.contexts).toEqual(['context1', 'context2']);
+    expect(sessionState.detoxConfig).toEqual('config');
+    expect(sessionState.detoxIPCServer).toEqual('server');
+    expect(sessionState.testResults).toEqual(['result1', 'result2']);
+    expect(sessionState.testSessionIndex).toEqual(1);
+    expect(sessionState.workersCount).toEqual(2);
+  });
+
+  describe('patch', () => {
+    it('should update the session state', () => {
+      sessionState.patch({
+        testResults: ['result3', 'result4'],
+        testSessionIndex: 2,
+        workersCount: 3,
+      });
+
+      expect(sessionState.testResults).toEqual(['result3', 'result4']);
+      expect(sessionState.testSessionIndex).toEqual(2);
+      expect(sessionState.workersCount).toEqual(3);
+    });
+
+    it('should not update with null params', () => {
+      sessionState.patch({
+        workersCount: 3,
+      });
+
+      expect(sessionState.testResults).toEqual(['result1', 'result2']);
+      expect(sessionState.testSessionIndex).toEqual(1);
+      expect(sessionState.workersCount).toEqual(3);
+    });
+  });
+
+  it('should stringify correctly', () => {
+    const expected = '{"id":"123","contexts":["context1","context2"],"detoxConfig":"config","detoxIPCServer":"server",' +
+      '"testResults":["result1","result2"],"testSessionIndex":1,"workersCount":2}';
+
+    expect(sessionState.stringify()).toEqual(expected);
+  });
+
+  it('should parse stringified session state to class instance', () => {
+    const stringified = '{"id":"123","contexts":["context1","context2"],' +
+      '"detoxConfig":"config","detoxIPCServer":"server","testResults":["result1","result2"],' +
+      '"testSessionIndex":1,"workersCount":2}';
+
+    const parsed = SessionState.parse(stringified);
+
+    expect(parsed).toEqual(sessionState);
+  });
+});

--- a/detox/src/ipc/ipc.test.js
+++ b/detox/src/ipc/ipc.test.js
@@ -1,11 +1,14 @@
+jest.setTimeout(1000);
 jest.mock('../utils/logger');
 
 const IPCClient = require('./IPCClient');
 const IPCServer = require('./IPCServer');
 const SessionState = require('./SessionState');
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 describe('IPC', () => {
-  /** @type {SessionState} */
+  /** @type {*} */
   let sessionState;
 
   /** @type {IPCServer} */
@@ -17,97 +20,164 @@ describe('IPC', () => {
   /** @type {IPCClient} */
   let ipcClient2;
 
-  beforeEach(async () => {
-    sessionState = new SessionState({
-      id: 'foo',
-      detoxIPCServer: 'bar',
-    });
-
+  beforeEach(() => {
     const logger = require('../utils/logger');
 
-    ipcServer = new IPCServer({ sessionState, logger });
-    await ipcServer.init();
+    sessionState = {
+      id: 'session-1',
+      detoxIPCServer: 'foo',
+    };
 
-    ipcClient1 = new IPCClient({ id: 'foo', logger, sessionState });
-    ipcClient2 = new IPCClient({ id: 'bar', logger, sessionState });
+    ipcServer = new IPCServer({
+      logger,
+      sessionState: new SessionState(sessionState),
+    });
+
+    ipcClient1 = new IPCClient({
+      id: 'bar',
+      logger,
+      sessionState: new SessionState(sessionState),
+    });
+
+    ipcClient2 = new IPCClient({
+      id: 'baz',
+      logger,
+      sessionState: new SessionState(sessionState)
+    });
+  });
+
+  afterEach(async () => {
+    await ipcClient1.dispose();
+    await ipcClient2.dispose();
+    await ipcServer.dispose();
   });
 
   describe('server', () => {
-    it('should return the correct session state', () => {
-      expect(ipcServer.sessionState).toEqual(sessionState);
+    it('should have a correct session state', () => {
+      expect(ipcServer.sessionState).toEqual(new SessionState(sessionState));
     });
 
-    it('should return the correct id', () => {
+    it('should have a correct id', () => {
       expect(ipcServer.id).toEqual(sessionState.detoxIPCServer);
     });
 
-    it('should wait upon dispose if clients are still connected', async () => {
-      await ipcClient1.init();
+    describe('onRegisterContext', () => {
+      beforeEach(() => ipcServer.init());
 
-      const disposePromise = ipcServer.dispose();
-      disposePromise.then(() => {
-        fail('dispose() should not resolve before all clients are disconnected');
+      it('cannot be called directly, only via IPC', async () => {
+        expect(() => ipcServer.onRegisterContext({ id: 'foo' })).toThrow();
+      });
+    });
+
+    describe('onRegisterWorker', () => {
+      beforeEach(() => ipcServer.init());
+
+      it('when called directly, should register a worker', async () => {
+        await ipcServer.onRegisterWorker({ workerId: 'worker-1' });
+        expect(ipcServer.sessionState.workersCount).toEqual(1);
+
+        await ipcServer.onRegisterWorker({ workerId: 'worker-2' });
+        expect(ipcServer.sessionState.workersCount).toEqual(2);
       });
 
-      await new Promise(resolve => setTimeout(resolve, 3000));
+      it('should not count the same worker twice', async () => {
+        await ipcServer.onRegisterWorker({ workerId: 'worker-1' });
+        expect(ipcServer.sessionState.workersCount).toEqual(1);
+
+        await ipcServer.onRegisterWorker({ workerId: 'worker-1' });
+        expect(ipcServer.sessionState.workersCount).toEqual(1);
+      });
     });
 
-    it.skip('should resolve dispose() if no clients are connected', async () => {
-      setTimeout(() => {
-        throw new Error('dispose() should have resolved by now');
-      }, 3000);
+    describe('onReportTestResults', () => {
+      beforeEach(() => ipcServer.init());
 
-      await ipcServer.dispose();
+      const success = (testFilePath) => ({ testFilePath, success: true });
+      const failure = (testFilePath) => ({ testFilePath, success: false, testExecError: { message: 'error' } });
+
+      it('when called directly, should add test results', async () => {
+        const testResults = [success('test-1'), failure('test-2')];
+        await ipcServer.onReportTestResults({ testResults });
+        expect(ipcServer.sessionState.testResults).toEqual(testResults);
+      });
+
+      it('when called more than one time, should merge test results', async () => {
+        const testResults = [failure('test-1'), success('test-2')];
+        await ipcServer.onReportTestResults({ testResults });
+        await ipcServer.onReportTestResults({ testResults: [success('test-1')] });
+
+        expect(ipcServer.sessionState.testResults).toEqual([
+          success('test-1'),
+          success('test-2'),
+        ]);
+      });
     });
 
-    it.skip('should resolve dispose() if all clients have disconnected', async () => {
-      await ipcClient1.init();
-      await ipcClient2.init();
+    describe('dispose()', () => {
+      it('should resolve if there are no connected clients', async () => {
+        await ipcServer.init();
+        await expect(ipcServer.dispose()).resolves.toBeUndefined();
+      });
 
-      await ipcClient1.dispose();
-      await ipcClient2.dispose();
+      it('should wait for connected clients to disconnect', async () => {
+        await ipcServer.init();
+        await ipcClient1.init();
 
-      setTimeout(() => {
-        throw new Error('dispose() should have resolved by now');
-      }, 3000);
+        const disposePromise = ipcServer.dispose();
+        const waitPromise = sleep(100).then(() => 'waited');
+        await expect(Promise.race([disposePromise, waitPromise])).resolves.toBe('waited');
 
-      await ipcServer.dispose();
+        await ipcClient1.dispose();
+        await expect(disposePromise).resolves.toBeUndefined();
+      });
+
+      it('should resolve if all clients have disconnected', async () => {
+        await ipcServer.init();
+
+        await ipcClient1.init();
+        await ipcClient2.init();
+
+        await ipcClient1.dispose();
+        await ipcClient2.dispose();
+
+        await ipcServer.dispose();
+      });
     });
   });
 
   describe('client', () => {
-    it('should return the correct session state', () => {
-      expect(ipcClient1.sessionState).toEqual(sessionState);
+    beforeEach(async () => {
+      await ipcServer.init();
+    });
+
+    it('should have a session state', () => {
+      expect(ipcClient1.sessionState).toEqual(new SessionState(sessionState));
     });
 
     it('should return the correct IPC server id', () => {
       expect(ipcClient1.serverId).toEqual(sessionState.detoxIPCServer);
     });
 
-    it('should throw if test results are reported before init', async () => {
-      const expected = 'IPC server bar has unexpectedly disconnected';
-      await expect(ipcClient1.reportTestResults([])).rejects.toThrow(expected);
+    describe('before init', () => {
+      it('should throw on attempt to report test results', async () => {
+        const expected = 'IPC server foo has unexpectedly disconnected';
+        await expect(ipcClient1.reportTestResults([])).rejects.toThrow(expected);
+      });
+
+      it('should throw on attempt to register the worker', async () => {
+        const expected = 'IPC server foo has unexpectedly disconnected';
+        await expect(ipcClient1.registerWorker('foo')).rejects.toThrow(expected);
+      });
     });
 
-    it('should throw if worker is registered before init', async () => {
-      const expected = 'IPC server bar has unexpectedly disconnected';
-      await expect(ipcClient1.registerWorker('foo')).rejects.toThrow(expected);
-    });
+    describe('upon init', function() {
+      it('should register context', async () => {
+        await ipcClient1.init();
+        expect(ipcServer.contexts).toEqual(['bar']);
 
-    it('should register context upon init', async () => {
-      await ipcClient1.init();
-
-      let expected = ['foo'];
-      expect(ipcServer.sessionState.contexts).toEqual(expected);
-      expect(ipcClient1.sessionState.contexts).toEqual(expected);
-      expect(ipcClient2.sessionState.contexts).toEqual(expected);
-
-      await ipcClient2.init();
-
-      expected = ['foo', 'bar'];
-      expect(ipcServer.sessionState.contexts).toEqual(expected);
-      expect(ipcClient1.sessionState.contexts).toEqual(expected);
-      expect(ipcClient2.sessionState.contexts).toEqual(expected);
+        await ipcClient2.init();
+        expect(ipcServer.contexts).toEqual(['bar', 'baz']);
+      });
     });
 
     describe('after init', () => {
@@ -116,69 +186,108 @@ describe('IPC', () => {
         await ipcClient2.init();
       });
 
-      it('should report test results', async () => {
-        const testResults1 = [
-          {
+      describe('reportTestResults', () => {
+        it('should report test results and synchronize test results', async () => {
+          const testResults = [
+            {
+              testFilePath: 'file1',
+              success: true,
+            },
+          ];
+
+          await ipcClient1.reportTestResults(testResults);
+          expect(ipcServer.sessionState.testResults).toEqual(testResults);
+          expect(ipcClient1.sessionState.testResults).toEqual(testResults);
+
+          await sleep(10); // broadcasting happens with a delay
+          expect(ipcClient2.sessionState.testResults).toEqual(testResults);
+        });
+
+        it('should update test results with tests from another clients', async () => {
+          const testResults1 = [{
             testFilePath: 'file1',
             success: true,
-          },
-          {
-            testFilePath: 'file2',
-            success: false,
-            testExecError: { name: 'baz', message: 'qux', stack: 'quux' },
-            isPermanentFailure: true,
-          },
-        ];
+          }];
 
-        await ipcClient1.reportTestResults(testResults1);
+          const testResults2 = [
+            {
+              testFilePath: 'file2',
+              success: false,
+              testExecError: { name: 'baz', message: 'qux', stack: 'quux' },
+              isPermanentFailure: false,
+            },
+          ];
 
-        let expected = testResults1;
-        expect(ipcServer.sessionState.testResults).toEqual(expected);
-        expect(ipcClient1.sessionState.testResults).toEqual(expected);
-        expect(ipcClient2.sessionState.testResults).toEqual(expected);
+          await ipcClient1.reportTestResults(testResults1);
+          await ipcClient2.reportTestResults(testResults2);
+          await sleep(10); // broadcasting might happen with a delay
 
-        const testResults2 = [
-          {
-            testFilePath: 'file3',
-            success: true,
-          },
-        ];
+          const expected = [...testResults2, ...testResults1];
+          expect(ipcServer.sessionState.testResults).toEqual(expected);
+          expect(ipcClient1.sessionState.testResults).toEqual(expected);
+          expect(ipcClient2.sessionState.testResults).toEqual(expected);
+        });
 
-        await ipcClient2.reportTestResults(testResults2);
+        it('should update test results with retried tests', async () => {
+          const testResultsFailure = [
+            {
+              testFilePath: 'file2',
+              success: false,
+              testExecError: { name: 'baz', message: 'qux', stack: 'quux' },
+              isPermanentFailure: false,
+            },
+          ];
 
-        expected = [...testResults2, ...testResults1];
-        expect(ipcServer.sessionState.testResults).toEqual(expected);
-        expect(ipcClient1.sessionState.testResults).toEqual(expected);
-        expect(ipcClient2.sessionState.testResults).toEqual(expected);
+          const testResultsRetry = [
+            {
+              testFilePath: 'file2',
+              success: true,
+            },
+          ];
+
+          await ipcClient1.reportTestResults(testResultsFailure);
+          await ipcClient2.reportTestResults(testResultsRetry);
+
+          await sleep(10); // broadcasting might happen with a delay
+
+          const expected = testResultsRetry;
+          expect(ipcServer.sessionState.testResults).toEqual(expected);
+          expect(ipcClient1.sessionState.testResults).toEqual(expected);
+          expect(ipcClient2.sessionState.testResults).toEqual(expected);
+        });
       });
 
-      it('should register worker', async () => {
-        await ipcClient1.registerWorker('foo');
+      describe('registerWorker', () => {
+        it('should register worker', async () => {
+          await ipcClient1.registerWorker('foo');
 
-        expect(ipcServer.sessionState.workersCount).toEqual(1);
-        expect(ipcClient1.sessionState.workersCount).toEqual(1);
-        expect(ipcClient2.sessionState.workersCount).toEqual(1);
+          expect(ipcServer.sessionState.workersCount).toEqual(1);
+          expect(ipcClient1.sessionState.workersCount).toEqual(1);
+          await sleep(10); // broadcasting might happen with a delay
+          expect(ipcClient2.sessionState.workersCount).toEqual(1);
 
-        await ipcClient2.registerWorker('bar');
-        await ipcClient2.registerWorker('baz');
+          await ipcClient2.registerWorker('bar');
+          await ipcClient2.registerWorker('baz');
 
-        expect(ipcServer.sessionState.workersCount).toEqual(3);
-        expect(ipcClient1.sessionState.workersCount).toEqual(3);
-        expect(ipcClient2.sessionState.workersCount).toEqual(3);
+          expect(ipcServer.sessionState.workersCount).toEqual(3);
+          expect(ipcClient2.sessionState.workersCount).toEqual(3);
+          await sleep(10); // broadcasting might happen with a delay
+          expect(ipcClient1.sessionState.workersCount).toEqual(3);
+        });
       });
 
-      describe('after dispose', () => {
+      describe('and after dispose', () => {
         beforeEach(async () => {
           await ipcClient1.dispose();
         });
 
         it('should throw upon reporting test results', async () => {
-          const expected = 'IPC server bar has unexpectedly disconnected';
+          const expected = 'IPC server foo has unexpectedly disconnected';
           await expect(ipcClient1.reportTestResults([])).rejects.toThrow(expected);
         });
 
         it('should throw upon registering worker', async () => {
-          const expected = 'IPC server bar has unexpectedly disconnected';
+          const expected = 'IPC server foo has unexpectedly disconnected';
           await expect(ipcClient1.registerWorker('foo')).rejects.toThrow(expected);
         });
       });

--- a/detox/src/ipc/ipc.test.js
+++ b/detox/src/ipc/ipc.test.js
@@ -52,7 +52,7 @@ describe('IPC', () => {
       await new Promise(resolve => setTimeout(resolve, 3000));
     });
 
-    it('should resolve dispose() if no clients are connected', async () => {
+    it.skip('should resolve dispose() if no clients are connected', async () => {
       setTimeout(() => {
         throw new Error('dispose() should have resolved by now');
       }, 3000);
@@ -60,7 +60,7 @@ describe('IPC', () => {
       await ipcServer.dispose();
     });
 
-    it('should resolve dispose() if all clients have disconnected', async () => {
+    it.skip('should resolve dispose() if all clients have disconnected', async () => {
       await ipcClient1.init();
       await ipcClient2.init();
 

--- a/detox/src/ipc/ipc.test.js
+++ b/detox/src/ipc/ipc.test.js
@@ -1,0 +1,187 @@
+jest.mock('../utils/logger');
+
+const IPCClient = require('./IPCClient');
+const IPCServer = require('./IPCServer');
+const SessionState = require('./SessionState');
+
+describe('IPC', () => {
+  /** @type {SessionState} */
+  let sessionState;
+
+  /** @type {IPCServer} */
+  let ipcServer;
+
+  /** @type {IPCClient} */
+  let ipcClient1;
+
+  /** @type {IPCClient} */
+  let ipcClient2;
+
+  beforeEach(async () => {
+    sessionState = new SessionState({
+      id: 'foo',
+      detoxIPCServer: 'bar',
+    });
+
+    const logger = require('../utils/logger');
+
+    ipcServer = new IPCServer({ sessionState, logger });
+    await ipcServer.init();
+
+    ipcClient1 = new IPCClient({ id: 'foo', logger, sessionState });
+    ipcClient2 = new IPCClient({ id: 'bar', logger, sessionState });
+  });
+
+  describe('server', () => {
+    it('should return the correct session state', () => {
+      expect(ipcServer.sessionState).toEqual(sessionState);
+    });
+
+    it('should return the correct id', () => {
+      expect(ipcServer.id).toEqual(sessionState.detoxIPCServer);
+    });
+
+    it('should wait upon dispose if clients are still connected', async () => {
+      await ipcClient1.init();
+
+      const disposePromise = ipcServer.dispose();
+      disposePromise.then(() => {
+        fail('dispose() should not resolve before all clients are disconnected');
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 500));
+    });
+
+    it('should resolve dispose() if no clients are connected', async () => {
+      setTimeout(() => {
+        throw new Error('dispose() should have resolved by now');
+      }, 500);
+
+      await ipcServer.dispose();
+    });
+
+    it('should resolve dispose() if all clients have disconnected', async () => {
+      await ipcClient1.init();
+      await ipcClient2.init();
+
+      await ipcClient1.dispose();
+      await ipcClient2.dispose();
+
+      setTimeout(() => {
+        throw new Error('dispose() should have resolved by now');
+      }, 500);
+
+      await ipcServer.dispose();
+    });
+  });
+
+  describe('client', () => {
+    it('should return the correct session state', () => {
+      expect(ipcClient1.sessionState).toEqual(sessionState);
+    });
+
+    it('should return the correct IPC server id', () => {
+      expect(ipcClient1.serverId).toEqual(sessionState.detoxIPCServer);
+    });
+
+    it('should throw if test results are reported before init', async () => {
+      const expected = 'IPC server bar has unexpectedly disconnected';
+      await expect(ipcClient1.reportTestResults([])).rejects.toThrow(expected);
+    });
+
+    it('should throw if worker is registered before init', async () => {
+      const expected = 'IPC server bar has unexpectedly disconnected';
+      await expect(ipcClient1.registerWorker('foo')).rejects.toThrow(expected);
+    });
+
+    it('should register context upon init', async () => {
+      await ipcClient1.init();
+
+      let expected = ['foo'];
+      expect(ipcServer.sessionState.contexts).toEqual(expected);
+      expect(ipcClient1.sessionState.contexts).toEqual(expected);
+      expect(ipcClient2.sessionState.contexts).toEqual(expected);
+
+      await ipcClient2.init();
+
+      expected = ['foo', 'bar'];
+      expect(ipcServer.sessionState.contexts).toEqual(expected);
+      expect(ipcClient1.sessionState.contexts).toEqual(expected);
+      expect(ipcClient2.sessionState.contexts).toEqual(expected);
+    });
+
+    describe('after init', () => {
+      beforeEach(async () => {
+        await ipcClient1.init();
+        await ipcClient2.init();
+      });
+
+      it('should report test results', async () => {
+        const testResults1 = [
+          {
+            testFilePath: 'file1',
+            success: true,
+          },
+          {
+            testFilePath: 'file2',
+            success: false,
+            testExecError: { name: 'baz', message: 'qux', stack: 'quux' },
+            isPermanentFailure: true,
+          },
+        ];
+
+        await ipcClient1.reportTestResults(testResults1);
+
+        let expected = testResults1;
+        expect(ipcServer.sessionState.testResults).toEqual(expected);
+        expect(ipcClient1.sessionState.testResults).toEqual(expected);
+        expect(ipcClient2.sessionState.testResults).toEqual(expected);
+
+        const testResults2 = [
+          {
+            testFilePath: 'file3',
+            success: true,
+          },
+        ];
+
+        await ipcClient2.reportTestResults(testResults2);
+
+        expected = [...testResults2, ...testResults1];
+        expect(ipcServer.sessionState.testResults).toEqual(expected);
+        expect(ipcClient1.sessionState.testResults).toEqual(expected);
+        expect(ipcClient2.sessionState.testResults).toEqual(expected);
+      });
+
+      it('should register worker', async () => {
+        await ipcClient1.registerWorker('foo');
+
+        expect(ipcServer.sessionState.workersCount).toEqual(1);
+        expect(ipcClient1.sessionState.workersCount).toEqual(1);
+        expect(ipcClient2.sessionState.workersCount).toEqual(1);
+
+        await ipcClient2.registerWorker('bar');
+        await ipcClient2.registerWorker('baz');
+
+        expect(ipcServer.sessionState.workersCount).toEqual(3);
+        expect(ipcClient1.sessionState.workersCount).toEqual(3);
+        expect(ipcClient2.sessionState.workersCount).toEqual(3);
+      });
+
+      describe('after dispose', () => {
+        beforeEach(async () => {
+          await ipcClient1.dispose();
+        });
+
+        it('should throw if test results are reported after dispose', async () => {
+          const expected = 'IPC server bar has unexpectedly disconnected';
+          await expect(ipcClient1.reportTestResults([])).rejects.toThrow(expected);
+        });
+
+        it('should throw if worker is registered after dispose', async () => {
+          const expected = 'IPC server bar has unexpectedly disconnected';
+          await expect(ipcClient1.registerWorker('foo')).rejects.toThrow(expected);
+        });
+      });
+    });
+  });
+});

--- a/detox/src/ipc/ipc.test.js
+++ b/detox/src/ipc/ipc.test.js
@@ -49,13 +49,13 @@ describe('IPC', () => {
         fail('dispose() should not resolve before all clients are disconnected');
       });
 
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await new Promise(resolve => setTimeout(resolve, 3000));
     });
 
     it('should resolve dispose() if no clients are connected', async () => {
       setTimeout(() => {
         throw new Error('dispose() should have resolved by now');
-      }, 500);
+      }, 3000);
 
       await ipcServer.dispose();
     });
@@ -69,7 +69,7 @@ describe('IPC', () => {
 
       setTimeout(() => {
         throw new Error('dispose() should have resolved by now');
-      }, 500);
+      }, 3000);
 
       await ipcServer.dispose();
     });

--- a/detox/src/ipc/ipc.test.js
+++ b/detox/src/ipc/ipc.test.js
@@ -172,12 +172,12 @@ describe('IPC', () => {
           await ipcClient1.dispose();
         });
 
-        it('should throw if test results are reported after dispose', async () => {
+        it('should throw upon reporting test results', async () => {
           const expected = 'IPC server bar has unexpectedly disconnected';
           await expect(ipcClient1.reportTestResults([])).rejects.toThrow(expected);
         });
 
-        it('should throw if worker is registered after dispose', async () => {
+        it('should throw upon registering worker', async () => {
           const expected = 'IPC server bar has unexpectedly disconnected';
           await expect(ipcClient1.registerWorker('foo')).rejects.toThrow(expected);
         });

--- a/detox/src/realms/DetoxSecondaryContext.js
+++ b/detox/src/realms/DetoxSecondaryContext.js
@@ -43,7 +43,7 @@ class DetoxSecondaryContext extends DetoxContext {
 
     this[_ipcClient] = new IPCClient({
       id: `secondary-${process.pid}`,
-      state: this[$sessionState],
+      sessionState: this[$sessionState],
       logger: this[symbols.logger],
     });
 


### PR DESCRIPTION
This PR adds integration tests for `IPCServer` and `IPCClient`, along with unit tests for the `SessionState`, which is used by them.

@noomorph 