### PR TITLE
chore: replace /next/ links in code

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -482,7 +482,7 @@ declare global {
              * @param promiseOrFunction Promise or a function that provides a promise.
              * @param args Optional arguments to pass to the trace.
              * @returns The returned value of the traced call.
-             * @see https://wix.github.io/Detox/docs/next/api/detox-object-api/#detoxtracecall.
+             * @see https://wix.github.io/Detox/docs/api/detox-object-api/#detoxtracecall.
              */
             readonly traceCall: <T>(event: string, action: () => Promise<T>, args?: Record<string, unknown>) => Promise<T>;
         }

--- a/detox/internals.d.ts
+++ b/detox/internals.d.ts
@@ -24,7 +24,7 @@ declare global {
 
       /**
        * Starts a new Detox test session with the provided configuration.
-       * See {@link https://wix.github.io/Detox/docs/next/api/internals} for more details.
+       * See {@link https://wix.github.io/Detox/docs/api/internals} for more details.
        */
       init(options?: Partial<DetoxInitOptions>): Promise<void>;
 
@@ -42,7 +42,7 @@ declare global {
 
       /**
        * This method should be called when the main or child process is about to exit.
-       * See {@link https://wix.github.io/Detox/docs/next/api/internals} for more details.
+       * See {@link https://wix.github.io/Detox/docs/api/internals} for more details.
        */
       cleanup(): Promise<void>;
       //#endregion

--- a/detox/runners/deprecation.js
+++ b/detox/runners/deprecation.js
@@ -26,7 +26,7 @@ console.error(centerText(`\
 
 ${bold(header)}
 
-https://wix.github.io/Detox/docs/next/guide/migration
+https://wix.github.io/Detox/docs/guide/migration
 
 Sorry to say that Detox 20 comes without old adapters for Jest.
 You have to rearrange your init code before you can continue your journey.
@@ -40,6 +40,6 @@ ${bold(header)}
 
 `, header.length));
 
-const error = new Error('\nPlease follow the migration guide:\nhttps://wix.github.io/Detox/docs/next/guide/migration\n\n');
+const error = new Error('\nPlease follow the migration guide:\nhttps://wix.github.io/Detox/docs/guide/migration\n\n');
 error.stack = '';
 throw error;

--- a/detox/src/configuration/composeRunnerConfig.js
+++ b/detox/src/configuration/composeRunnerConfig.js
@@ -91,7 +91,7 @@ function adaptLegacyRunnerConfig(globalConfig) {
     return globalConfig.testRunner;
   }
 
-  log.warn(`Please migrate your Detox config according to the guide:\nhttps://wix.github.io/Detox/docs/next/guide/migration\n`);
+  log.warn(`Please migrate your Detox config according to the guide:\nhttps://wix.github.io/Detox/docs/guide/migration\n`);
   const testRunner = globalConfig[testRunnerKey];
   const runnerConfig = globalConfig[runnerConfigKey];
   const specs = globalConfig.specs != null ? String(globalConfig.specs) : undefined;

--- a/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
@@ -93,7 +93,7 @@ class AppleSimUtils {
       `(https://developer.apple.com/xcode/). In case you already have the latest Xcode version installed, ` +
       `try run the command: \`sudo xcode-select -s /Applications/Xcode.app\`. If you are running tests from CI, ` +
       `we recommend running them with "--headless" device configuration (see: ` +
-      `https://wix.github.io/Detox/docs/next/cli/test/#options).`
+      `https://wix.github.io/Detox/docs/cli/test/#options).`
     );
   }
 


### PR DESCRIPTION
Updates `/next/` links with the standard ones.
This PR has to be merged before the release to NPM.