### PR TITLE
build: bump funpermaproxy@^1.1.0

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -64,7 +64,7 @@
     "duplexify": "^4.1.2",
     "find-up": "^4.1.0",
     "fs-extra": "^4.0.2",
-    "funpermaproxy": "^1.0.1",
+    "funpermaproxy": "^1.1.0",
     "glob": "^8.0.3",
     "ini": "^1.3.4",
     "json-cycle": "^1.3.0",


### PR DESCRIPTION
## Description

Resolves #3690

The issue is likely caused by `yarn.lock` and `package-lock.json`.
In any case, this fix is legit because it tells us that we can't use `funpermaproxy@1.0.1` as a compromise version resolution anymore.
