### PR TITLE
website(showcase): shuffle apps order.

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@docusaurus/core": "^2.0.0",
     "@docusaurus/preset-classic": "^2.0.0",
-    "@docusaurus/theme-search-algolia": "^2.0.0",
     "@docusaurus/remark-plugin-npm2yarn": "^2.0.0",
+    "@docusaurus/theme-search-algolia": "^2.0.0",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
@@ -25,6 +25,7 @@
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-loader-spinner": "^5.3.4",
     "url-loader": "^4.1.1"
   },
   "browserslist": {

--- a/website/src/components/Showcase/Showcase.js
+++ b/website/src/components/Showcase/Showcase.js
@@ -4,15 +4,21 @@ import Card from './Card';
 import cardList from '@site/showcase.json';
 import styles from './Showcase.module.css';
 import _ from 'lodash';
+import { TailSpin } from 'react-loader-spinner';
 
 function Showcase() {
   const [cards, setCards] = useState([]);
+  const [toRender, setToRender] = useState([]);
 
   useEffect(() => {
     setCards(_makeShuffledCardList(cardList).map(_makeCard));
   }, []);
 
-  return _makeCardsContainer(cards);
+  useEffect(() => {
+    setToRender(cards.length > 0 ? _makeCardsContainer(cards) : _makeLoadingSpinner());
+  }, [cards]);
+
+  return toRender;
 }
 
 const _makeShuffledCardList = (cardList) => {
@@ -23,10 +29,19 @@ const _makeShuffledCardList = (cardList) => {
 const _makeCard = (props) => <Card key={props.title} {...props} />;
 
 const _makeCardsContainer = (cards) =>
-  (
-    <section className={clsx('container', styles.container)}>
-      <ul className={clsx('col', 'col--12', styles.list)}>{cards}</ul>
-    </section>
-  );
+  <section className={clsx('container', styles.container)}>
+    <ul className={clsx('col', 'col--12', styles.list)}>{cards}</ul>
+  </section>;
+
+const _makeLoadingSpinner = () =>
+  <TailSpin
+    height="60"
+    width="60"
+    color="#dddddd"
+    ariaLabel="loading"
+    radius="2"
+    wrapperClass={styles.spinner}
+    visible={true}
+  />;
 
 export default Showcase;

--- a/website/src/components/Showcase/Showcase.js
+++ b/website/src/components/Showcase/Showcase.js
@@ -1,17 +1,32 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import clsx from 'clsx';
 import Card from './Card';
 import cardList from '@site/showcase.json';
 import styles from './Showcase.module.css';
+import _ from 'lodash';
 
 function Showcase() {
-  const cards = cardList.map((props) => <Card key={props.title} {...props} />);
+  const [cards, setCards] = useState([]);
 
-  return (
+  useEffect(() => {
+    setCards(_makeShuffledCardList(cardList).map(_makeCard));
+  }, []);
+
+  return _makeCardsContainer(cards);
+}
+
+const _makeShuffledCardList = (cardList) => {
+  const partition = _.partition(cardList, 'shouldStayOnTop');
+  return partition[0].concat(_.shuffle(partition[1]));
+}
+
+const _makeCard = (props) => <Card key={props.title} {...props} />;
+
+const _makeCardsContainer = (cards) =>
+  (
     <section className={clsx('container', styles.container)}>
       <ul className={clsx('col', 'col--12', styles.list)}>{cards}</ul>
     </section>
   );
-}
 
 export default Showcase;

--- a/website/src/components/Showcase/Showcase.module.css
+++ b/website/src/components/Showcase/Showcase.module.css
@@ -9,3 +9,10 @@
   justify-content: center;
   gap: 60px;
 }
+
+.spinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 5rem;
+}


### PR DESCRIPTION
Improved implementation and fixes the issue mentioned on this comment: https://github.com/wix/Detox/pull/3696#issuecomment-1312688280, for shuffling the cards order in the Showcase page.