### PR TITLE
docs(getting started): update expo tab.

### DIFF
--- a/docs/introduction/partials/_getting-started-expo.md
+++ b/docs/introduction/partials/_getting-started-expo.md
@@ -3,15 +3,15 @@
 :::caution Note
 
 Expo integration with Detox is entirely a community-driven effort.
-We have no special support for Expo projects, and we do not maintain any Expo-specific code or documentation.
+There is no special support for Expo projects in Detox, and we do not maintain any Expo-specific code or documentation.
+
 :::
 
-There is a tutorial on how to set up Detox with Expo projects, which you can find on Expo official documentation site: [Running E2E tests on EAS Build](https://docs.expo.dev/build-reference/e2e-tests/). It is a great starting point for projects that are using Expo.
+There is a tutorial on how to set up Detox with Expo projects, which you can find on Expo official documentation site: [Running E2E tests on EAS Build]. It is a great starting point for projects that are using Expo.
 
 For support on how to use Detox with Expo, you should contact the Expo team or the Expo community.
 
-If you are experiencing a bug, which you believe is a Detox issue, please [open an issue](https://github.com/wix/Detox/issues) on our GitHub repository.
+If you are experiencing a bug, which you believe is a Detox issue, please [open an issue] on our GitHub repository.
 
-This introduction section is useful for Expo projects, but the next [Project Setup] article, in particular, is **not enough** to complete the setup with Expo. Please follow the [Expo guide](https://docs.expo.dev/build-reference/e2e-tests/) instead.
-
-[Project Setup]: ../project-setup.mdx
+[open an issue]: https://github.com/wix/Detox/issues
+[Running E2E tests on EAS Build]: https://docs.expo.dev/build-reference/e2e-tests/

--- a/docs/introduction/partials/_getting-started-expo.md
+++ b/docs/introduction/partials/_getting-started-expo.md
@@ -2,24 +2,16 @@
 
 :::caution Note
 
-Expo support with Detox is entirely a community driven effort. We have no specific support in Detox for Expo applications (ejected or otherwise).
-
+Expo integration with Detox is entirely a community-driven effort.
+We have no special support for Expo projects, and we do not maintain any Expo-specific code or documentation.
 :::
 
-There are a few resources on the Internet covering how to set up Detox with Expo apps:
+There is a tutorial on how to set up Detox with Expo projects, which you can find on Expo official documentation site: [Running E2E tests on EAS Build](https://docs.expo.dev/build-reference/e2e-tests/). It is a great starting point for projects that are using Expo.
 
-- <https://github.com/fschoenfeldt/clean-expo-detox-testing>
-- <https://toshev.medium.com/setting-up-detox-with-a-expo-managed-react-native-project-89342dce4df>
-- <https://blog.expo.dev/testing-expo-apps-with-detox-and-react-native-testing-library-7fbdbb82ac87>
+For support on how to use Detox with Expo, you should contact the Expo team or the Expo community.
 
-Unfortunately, we have no capacity to maintain this direction and hold no responsibility for content and
-quality of the mentioned or another available resources.
+If you are experiencing a bug, which you believe is a Detox issue, please [open an issue](https://github.com/wix/Detox/issues) on our GitHub repository.
 
-For support on how to use Detox with Expo, you should contact the Expo team or the Expo community. If you
-are seeing an issue, it is most likely not an issue with Detox itself, but with the Expo runtime or with
-an incorrect Detox setup. Genuine issues with Detox can be submitted to [our issue tracker](https://github.com/wix/Detox/issues)
-as usual.
-
-This introduction section is useful for Expo projects, but the next [Project Setup] article, in particular, is **not enough** to complete the setup with Expo.
+This introduction section is useful for Expo projects, but the next [Project Setup] article, in particular, is **not enough** to complete the setup with Expo. Please follow the [Expo guide](https://docs.expo.dev/build-reference/e2e-tests/) instead.
 
 [Project Setup]: ../project-setup.mdx

--- a/docs/introduction/project-setup.mdx
+++ b/docs/introduction/project-setup.mdx
@@ -17,6 +17,9 @@ This article mainly covers standard React Native projects.
 If some steps don't look applicable to your project, please adapt them accordingly, relying on the common sense –
 look for other file locations, use custom build commands and so on.
 
+If you're using **Expo**, please refer to the [setup guide] from their documentation website instead.
+The setup for Expo projects is different and is not covered in this article.
+
 :::
 
 ## Step 1: Bootstrap
@@ -369,3 +372,5 @@ nothing more and nothing less.
 :::
 
 Once your build is ready to use, please proceed to the next article.
+
+[setup guide]: https://docs.expo.dev/build-reference/e2e-tests


### PR DESCRIPTION
Update Expo tab under the "Getting Started" doc, with their official documentation guide for Detox integration and rewriting it a bit.