### PR TITLE
fix(logger): closing unbalanced duration events

### DIFF
--- a/detox/src/logger/DetoxLogger.js
+++ b/detox/src/logger/DetoxLogger.js
@@ -192,7 +192,7 @@ class DetoxLogger {
 
   /** @private */
   _beginInternal(level, context, msg) {
-    this._sharedConfig.messageStack.push(context.tid, msg);
+    this._sharedConfig.messageStack.push(context, msg);
     this._sharedConfig.bunyan.logger[level](context, ...msg);
   }
 
@@ -204,7 +204,7 @@ class DetoxLogger {
 
   /** @private */
   _endInternal(level, context, msg) {
-    const beginMsg = this._sharedConfig.messageStack.pop(context.tid);
+    const beginMsg = this._sharedConfig.messageStack.pop(context);
     if (msg.length === 0) {
       msg = beginMsg;
     }

--- a/detox/src/logger/DetoxLogger.test.js
+++ b/detox/src/logger/DetoxLogger.test.js
@@ -233,6 +233,19 @@ describe('DetoxLogger', () => {
       await expect(txt()).resolves.toMatchSnapshot();
     });
 
+    it('should log end duration events correctly for different categories', async () => {
+      const parent = logger();
+      const cat1 = parent.child({ cat: 'cat1' });
+      const cat2 = parent.child({ cat: 'cat2' });
+
+      cat1.info.begin('Activity 1 start');
+      cat2.info.begin('Activity 2 start');
+      cat1.info.end();
+      cat2.info.end();
+
+      await expect(txt()).resolves.toMatchSnapshot();
+    });
+
     it.each([
       ['trace'],
       ['debug'],

--- a/detox/src/logger/__snapshots__/DetoxLogger.test.js.snap
+++ b/detox/src/logger/__snapshots__/DetoxLogger.test.js.snap
@@ -103,3 +103,10 @@ exports[`DetoxLogger - main functionality - should log complete duration events 
 00:00:00.000 detox[PID] E  Error duration (async)
   error: Error: Oops (async)!"
 `;
+
+exports[`DetoxLogger - main functionality - should log end duration events correctly for different categories 1`] = `
+"00:00:00.000 detox[PID] B cat1 Activity 1 start
+00:00:00.000 detox[PID] B cat2 Activity 2 start
+00:00:00.000 detox[PID] E cat1 Activity 1 start
+00:00:00.000 detox[PID] E cat2 Activity 2 start"
+`;

--- a/detox/src/logger/utils/CategoryThreadDispatcher.js
+++ b/detox/src/logger/utils/CategoryThreadDispatcher.js
@@ -1,4 +1,5 @@
 const ThreadDispatcher = require('./ThreadDispatcher');
+const getMainCategory = require('./getMainCategory');
 
 class CategoryThreadDispatcher {
   constructor() {
@@ -24,7 +25,7 @@ class CategoryThreadDispatcher {
 
   /** @returns {ThreadDispatcher} */
   _resolveDispatcher(cat) {
-    const mainCategory = cat ? cat.split(',', 1)[0] : 'undefined';
+    const mainCategory = getMainCategory(cat);
     if (!this._dispatchers[mainCategory]) {
       this._dispatchers[mainCategory] = new ThreadDispatcher(mainCategory);
     }

--- a/detox/src/logger/utils/DetoxLogFinalizer.js
+++ b/detox/src/logger/utils/DetoxLogFinalizer.js
@@ -11,6 +11,8 @@ const globAsync = promisify(glob);
 const globSync = glob.sync;
 const streamUtils = () => require('../../logger/utils/streamUtils');
 
+const getMainCategory = require('./getMainCategory');
+
 /**
  * @typedef DetoxLogFinalizerConfig
  * @property {import('../../ipc/SessionState')} session
@@ -118,7 +120,7 @@ class DetoxLogFinalizer {
           const { ph, pid, tid, cat } = event;
           if (ph === 'B' || ph === 'i') {
             const categories = (result[pid] = result[pid] || {});
-            const mainCategory = String(cat).split(',')[0];
+            const mainCategory = getMainCategory(cat);
             const tids = (categories[mainCategory] = categories[mainCategory] || []);
             if (!tids.includes(tid)) {
               tids.push(tid);

--- a/detox/src/logger/utils/MessageStack.js
+++ b/detox/src/logger/utils/MessageStack.js
@@ -1,23 +1,34 @@
+const getMainCategory = require('./getMainCategory');
+
 class MessageStack {
   constructor() {
     this._map = {};
   }
 
-  push(tid, msg) {
-    if (this._map[tid] == null) {
-      this._map[tid] = [];
+  push(context, msg) {
+    const hash = this._hash(context);
+
+    if (this._map[hash] == null) {
+      this._map[hash] = [];
     }
 
-    return this._map[tid].push(msg);
+    return this._map[hash].push(msg);
   }
 
-  pop(tid) {
-    const stack = this._map[tid];
+  pop(context) {
+    const hash = this._hash(context);
+    const stack = this._map[hash];
     if (stack == null || stack.length === 0) {
       return ['<no begin message>'];
     }
 
     return stack.pop();
+  }
+
+  _hash(context) {
+    const cat = getMainCategory(context.cat);
+    const tid = context.tid;
+    return `${cat}:${tid}`;
   }
 }
 

--- a/detox/src/logger/utils/getMainCategory.js
+++ b/detox/src/logger/utils/getMainCategory.js
@@ -1,0 +1,5 @@
+function getMainCategory(category) {
+  return category ? String(category).split(',', 1)[0] : 'undefined';
+}
+
+module.exports = getMainCategory;

--- a/detox/src/logger/utils/streamUtils.js
+++ b/detox/src/logger/utils/streamUtils.js
@@ -11,6 +11,8 @@ const { AbstractEventBuilder } = require('trace-event-lib');
 
 const log = require('../../utils/logger').child({ cat: 'logger' });
 
+const getMainCategory = require('./getMainCategory');
+
 function compareTimestamps(a, b) {
   return +(a.value.time > b.value.time) - +(a.value.time < b.value.time);
 }
@@ -144,7 +146,7 @@ class SimpleEventBuilder extends AbstractEventBuilder {
 const ERROR_TID = 37707;
 
 function getTidHash({ pid, tid, cat }) {
-  const mainCategory = String(cat).split(',')[0];
+  const mainCategory = getMainCategory(cat);
   return `${pid}:${mainCategory}:${tid}`;
 }
 
@@ -180,8 +182,8 @@ function chromeTraceStream(tidHashMap) {
     }
 
     if (!knownTids.has(tid)) {
-      const primaryCategory = cat.split(',', 1)[0];
-      builder.metadata({ pid, tid, ts, name: 'thread_name', args: { name: primaryCategory } });
+      const mainCategory = getMainCategory(cat);
+      builder.metadata({ pid, tid, ts, name: 'thread_name', args: { name: mainCategory } });
       builder.metadata({ pid, tid, ts, name: 'thread_sort_index', args: { sort_index: tid } });
       knownTids.add(tid);
     }


### PR DESCRIPTION
## Description

I noticed that when interrupting the `detox test` with Ctrl+C, I see a weird message `E` (end) event in the logs coming from an unrelated duration event.

This is a regression from my fix to #3639. The regression appeared because my mechanism for inferring logger end messages[^1] relied only on TID (thread ID). That was correct for the implementation generating unique TIDs, but now is not.

The fix to #3639 on purpose changed the invariant. Currently, the unique identifier for an asynchronous lane on the timeline is `${pid}:${mainCategory}:${tid}`, which is post-processed to a globally unique TID in the Chrome Trace Event document with a double-pass algorithm.

My PR adds a new test case demonstrating the issue, and I rewrote the `MessageStack` implementation to pass the new test. Besides, extracting the main (first) category is itself extracted to a separate utility.

```js
const parent = logger();
const cat1 = parent.child({ cat: 'cat1' });
const cat2 = parent.child({ cat: 'cat2' });

cat1.info.begin('Activity 1 start');
cat2.info.begin('Activity 2 start');
cat1.info.end(); // actual: Activity 2 start, expected: Activity 1 start
cat2.info.end(); // actual: Activity 1 start, expected: Activity 2 start
```

[^1]: When in `log.*.end(msg)` the message is empty, it should take at least the message from the B (begin) phase as a fallback.