### PR TITLE
fix(logger): save files on Ctrl+C

### DIFF
--- a/detox/src/logger/utils/DetoxLogFinalizer.js
+++ b/detox/src/logger/utils/DetoxLogFinalizer.js
@@ -37,7 +37,7 @@ class DetoxLogFinalizer {
       return;
     }
 
-    if (this._areLogsEnabled()) {
+    if (this._shouldSaveLogs()) {
       const rootDir = this._config.artifacts.rootDir;
 
       await fs.mkdirp(rootDir);
@@ -69,14 +69,14 @@ class DetoxLogFinalizer {
       return;
     }
 
-    const logsEnabled = this._areLogsEnabled();
-    const rootDir = logsEnabled ? this._config.artifacts.rootDir : '';
-    if (logsEnabled) {
+    const shouldSaveLogs = this._shouldSaveLogs(true);
+    const rootDir = shouldSaveLogs ? this._config.artifacts.rootDir : '';
+    if (shouldSaveLogs) {
       fs.mkdirpSync(rootDir);
     }
 
     for (const log of logs) {
-      if (logsEnabled) {
+      if (shouldSaveLogs) {
         const dest = path.join(rootDir, path.basename(log));
         this._safeMoveSync(log, dest);
       } else {
@@ -137,7 +137,7 @@ class DetoxLogFinalizer {
   }
 
   /** @private */
-  _areLogsEnabled() {
+  _shouldSaveLogs(isEmergencyExit = false) {
     if (!this._config) {
       return false;
     }
@@ -152,6 +152,10 @@ class DetoxLogFinalizer {
     }
 
     if (!plugins.log.keepOnlyFailedTestsArtifacts) {
+      return true;
+    }
+
+    if (isEmergencyExit) {
       return true;
     }
 

--- a/detox/src/logger/utils/DetoxLogFinalizer.test.js
+++ b/detox/src/logger/utils/DetoxLogFinalizer.test.js
@@ -172,20 +172,9 @@ describe('DetoxLogFinalizer', () => {
       expect(fs.existsSync(temporaryFiles[2])).toBe(false);
     });
 
-    it('should not create logs for successful run when configured', async () => {
+    it('should create logs even for successful run when configured to keep failing logs', async () => {
       session.detoxConfig.artifacts.plugins.log.keepOnlyFailedTestsArtifacts = true;
       session.testResults = [{ success: true }];
-
-      await createLogFiles();
-      finalizer.finalizeSync();
-      expect(fs.existsSync(artifactsDir())).toBe(false);
-      expect(fs.existsSync(temporaryFiles[1])).toBe(false);
-      expect(fs.existsSync(temporaryFiles[2])).toBe(false);
-    });
-
-    it('should create logs for failing run when configured', async () => {
-      session.detoxConfig.artifacts.plugins.log.keepOnlyFailedTestsArtifacts = true;
-      session.testResults = [{ success: false }];
 
       await createLogFiles();
       finalizer.finalizeSync();
@@ -195,6 +184,10 @@ describe('DetoxLogFinalizer', () => {
         '.jsonl',
         '.jsonl',
       ]);
+
+      // assert that the temporary files have been moved, not copied
+      expect(fs.existsSync(temporaryFiles[1])).toBe(false);
+      expect(fs.existsSync(temporaryFiles[2])).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Description

Resolves #3679

Currently, when using `--record-logs failed` and interrupting Detox in the middle, it does not save the logs because it has not received a signalization about failing tests, so the logic is way too straightforward – discard the logs.

I suggest treating Ctrl+C (SIGINT, SIGTERM, etc) as an unsuccessful run so the logs are saved regardless.

That should reduce frustration when you are running into some timeout issues, and you want to interrupt Detox to read some saved logs, but oops – "no error, no logs". The latter rule is too strict, to my taste, in this case.