### PR TITLE
refactor(trace): simpler primary PID detection

### DIFF
--- a/detox/src/logger/utils/DetoxLogFinalizer.test.js
+++ b/detox/src/logger/utils/DetoxLogFinalizer.test.js
@@ -85,14 +85,6 @@ describe('DetoxLogFinalizer', () => {
       let plainLog = await fs.readFile(path.join(artifactsDir(), 'detox.log'), 'utf8');
       let traceLog = JSON.parse(await fs.readFile(path.join(artifactsDir(), 'detox.trace.json'), 'utf8'));
 
-      plainLog = plainLog
-        .replace(new RegExp(`detox\\[${process.pid}]`, 'g'), 'detox[1234]')
-        .replace(new RegExp(`detox\\[${process.pid + 1}]`, 'g'), 'detox[1235]');
-
-      for (const t of traceLog) {
-        t.pid = 1234 + t.pid - process.pid;
-      }
-
       expect(plainLog).toMatchSnapshot('plain');
       expect(traceLog).toMatchSnapshot('chrome-trace');
     });
@@ -247,8 +239,8 @@ describe('DetoxLogFinalizer', () => {
       userConfig,
     });
 
-    const log1 = root1.child({ pid: process.pid });
-    const log2 = root2.child({ pid: process.pid + 1 });
+    const log1 = root1.child({ pid: 1234 });
+    const log2 = root2.child({ pid: 1235 });
 
     jest.useFakeTimers();
 

--- a/detox/src/logger/utils/streams/ChromeTraceTransformer.js
+++ b/detox/src/logger/utils/streams/ChromeTraceTransformer.js
@@ -47,6 +47,7 @@ class ChromeTraceTransformer {
    */
   createStream() {
     const transformFn = this._transformBunyanRecord.bind(this, {
+      primaryPid: NaN,
       knownPids: new Set(),
       knownTids: new Set(),
     });
@@ -62,7 +63,7 @@ class ChromeTraceTransformer {
   }
 
   /**
-   * @param {{ knownPids: Set<number>, knownTids: Set<number> }} state
+   * @param {{ knownPids: Set<number>; knownTids: Set<number>; primaryPid: number; }} state
    * @param {*} bunyanLogRecord
    * @returns {import('trace-event-lib').Event[]}
    * @private
@@ -76,7 +77,11 @@ class ChromeTraceTransformer {
 
     const builder = new SimpleEventBuilder();
     if (!state.knownPids.has(pid)) {
-      builder.metadata({ pid, ts, name: 'process_name', args: { name: pid === process.pid ? 'primary' : 'secondary' } });
+      if (Number.isNaN(state.primaryPid)) {
+        state.primaryPid = pid;
+      }
+
+      builder.metadata({ pid, ts, name: 'process_name', args: { name: pid === state.primaryPid ? 'primary' : 'secondary' } });
       builder.metadata({ pid, ts, name: 'process_sort_index', args: { sort_index: state.knownPids.size } });
       state.knownPids.add(pid);
     }


### PR DESCRIPTION
## Description

In this PR, I make it simpler to infer which PID is primary (when creating a Detox trace file).

Instead of making this logic tightly coupled with `process.pid`, I check which PID appears first.

That simplifies unit tests and makes the code more generic and reusable.