### PR TITLE
lint: fix "unused" warnings

### DIFF
--- a/detox/.eslintrc.js
+++ b/detox/.eslintrc.js
@@ -54,12 +54,7 @@ module.exports = {
       }
     ],
     'no-prototype-builtins': 'off',
-    'no-unused-vars': [
-      'error',
-      {
-        'argsIgnorePattern': '^_'
-      }
-    ],
+    'no-unused-vars': 'off',
     'node/no-unpublished-require': 'warn',
     'object-curly-spacing': [
       'error',

--- a/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
+++ b/detox/src/artifacts/templates/plugin/ArtifactPlugin.js
@@ -1,5 +1,5 @@
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "args": "none" }] */
 // @ts-nocheck
-/* eslint-disable no-unused-vars */
 
 const _ = require('lodash');
 

--- a/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.js
+++ b/detox/src/artifacts/templates/plugin/TwoSnapshotsPerTestPlugin.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "args": "none" }] */
 // @ts-nocheck
 const DetoxRuntimeError = require('../../../errors/DetoxRuntimeError');
 
@@ -85,7 +86,7 @@ class TwoSnapshotsPerTestPlugin extends ArtifactPlugin {
    * @protected
    * @abstract
    */
-  async preparePathForSnapshot(testSummary, snapshotName) {} // eslint-disable-line no-unused-vars
+  async preparePathForSnapshot(testSummary, snapshotName) {}
 
   /***
    * Creates a handle for a test artifact (video recording, log, etc.)

--- a/detox/src/artifacts/templates/plugin/WholeTestRecorderPlugin.js
+++ b/detox/src/artifacts/templates/plugin/WholeTestRecorderPlugin.js
@@ -1,4 +1,4 @@
-// @ts-nocheck
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "args": "none" }] */
 const ArtifactPlugin = require('./ArtifactPlugin');
 
 /***
@@ -8,6 +8,7 @@ class WholeTestRecorderPlugin extends ArtifactPlugin {
   constructor({ api }) {
     super({ api });
 
+    /** @type {*} */
     this.testRecording = null;
   }
 
@@ -51,7 +52,7 @@ class WholeTestRecorderPlugin extends ArtifactPlugin {
    * @abstract
    * @protected
    */
-  createTestRecording() {}
+  createTestRecording(config) {}
 
   /***
    * @abstract

--- a/detox/src/client/AsyncWebSocket.js
+++ b/detox/src/client/AsyncWebSocket.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "args": "none" }] */
 // @ts-nocheck
 const _ = require('lodash');
 const WebSocket = require('ws');
@@ -176,7 +177,7 @@ class AsyncWebSocket {
    * @param {WebSocket.OpenEvent} event
    * @private
    */
-  _onOpen(event) { // eslint-disable-line no-unused-vars
+  _onOpen(event) {
     log.trace(`opened web socket to: ${this._url}`);
     this._opening.resolve();
     this._opening = null;
@@ -268,7 +269,7 @@ class AsyncWebSocket {
    * @param {WebSocket.CloseEvent | null} event
    * @private
    */
-  _onClose(event) { // eslint-disable-line no-unused-vars
+  _onClose(event) {
     if (this._closing) {
       this._closing.resolve();
     }

--- a/detox/src/configuration/composeLoggerConfig.js
+++ b/detox/src/configuration/composeLoggerConfig.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "args": "none" }] */
 const _ = require('lodash');
 
 const { castLevel, defaultOptions } = require('../logger/DetoxLogger');

--- a/detox/src/devices/allocation/drivers/AllocationDriverBase.js
+++ b/detox/src/devices/allocation/drivers/AllocationDriverBase.js
@@ -1,4 +1,6 @@
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "args": "none" }] */
 // @ts-nocheck
+
 /**
  * @typedef DeallocOptions
  * @property shutdown { Boolean }
@@ -9,14 +11,14 @@ class AllocationDriverBase {
    * @param deviceConfig { Object }
    * @return {Promise<DeviceCookie>}
    */
-  async allocate(deviceConfig) {} // eslint-disable-line no-unused-vars
+  async allocate(deviceConfig) {}
 
   /**
    * @param cookie { DeviceCookie }
    * @param options { DeallocOptions }
    * @return {Promise<void>}
    */
-  async free(cookie, options) {} // eslint-disable-line no-unused-vars
+  async free(cookie, options) {}
 }
 
 module.exports = AllocationDriverBase;

--- a/detox/src/devices/allocation/factories/base.js
+++ b/detox/src/devices/allocation/factories/base.js
@@ -16,7 +16,7 @@ class DeviceAllocatorFactory {
    * @returns { AllocationDriverBase }
    * @private
    */
-  _createDriver(deps) {} // eslint-disable-line no-unused-vars
+  _createDriver(deps) {} // eslint-disable-line @typescript-eslint/no-unused-vars
 }
 
 module.exports = DeviceAllocatorFactory;

--- a/detox/src/devices/runtime/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/runtime/drivers/android/AndroidDriver.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "args": "none" }] */
 // @ts-nocheck
 const path = require('path');
 const URL = require('url').URL;
@@ -162,11 +163,11 @@ class AndroidDriver extends DeviceDriverBase {
       }
   }
 
-  async pressBack() { // eslint-disable-line no-unused-vars
+  async pressBack() {
     await this.uiDevice.pressBack();
   }
 
-  async sendToHome(params) { // eslint-disable-line no-unused-vars
+  async sendToHome(params) {
     await this.uiDevice.pressHome();
   }
 

--- a/detox/src/devices/runtime/factories/android.js
+++ b/detox/src/devices/runtime/factories/android.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "args": "none" }] */
 const RuntimeDeviceFactory = require('./base');
 
 class RuntimeDriverFactoryAndroid extends RuntimeDeviceFactory {
@@ -41,7 +42,7 @@ class AndroidEmulator extends RuntimeDriverFactoryAndroid {
 }
 
 class AndroidAttached extends RuntimeDriverFactoryAndroid {
-  _createDriver(deviceCookie, deps, configs) { // eslint-disable-line no-unused-vars
+  _createDriver(deviceCookie, deps, configs) {
     const props = {
       adbName: deviceCookie.adbName,
     };
@@ -52,7 +53,7 @@ class AndroidAttached extends RuntimeDriverFactoryAndroid {
 }
 
 class Genycloud extends RuntimeDriverFactoryAndroid {
-  _createDriver(deviceCookie, deps, configs) { // eslint-disable-line no-unused-vars
+  _createDriver(deviceCookie, deps, configs) {
     const props = {
       instance: deviceCookie.instance,
     };

--- a/detox/src/devices/runtime/factories/base.js
+++ b/detox/src/devices/runtime/factories/base.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "args": "none" }] */
 const RuntimeDevice = require('../RuntimeDevice');
 
 class RuntimeDeviceFactory {
@@ -7,8 +8,8 @@ class RuntimeDeviceFactory {
     return new RuntimeDevice({ ...commonDeps, ...configs }, runtimeDriver);
   }
 
-  _createDriverDependencies(commonDeps) { } // eslint-disable-line no-unused-vars
-  _createDriver(deviceCookie, deps, configs) {} // eslint-disable-line no-unused-vars
+  _createDriverDependencies(commonDeps) { }
+  _createDriver(deviceCookie, deps, configs) {}
 }
 
 module.exports = RuntimeDeviceFactory;


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #3292

Mostly, I fix this by relaxing ESLint rule for unused function **args** only.

Unfortunately, I can't make it smarter (it does not discern concrete and virtual methods), so this is the most I can come up with.

On the other side, allowing unused variables is a road to hell, so I'm better off with special ESLint comments than with disabling it at all.