### PR TITLE
[website] Update Android project setup docs on proguardFile

### DIFF
--- a/website/versioned_docs/version-20.x/introduction/project-setup.mdx
+++ b/website/versioned_docs/version-20.x/introduction/project-setup.mdx
@@ -215,7 +215,7 @@ Now let's move on to the next build script and prepare it:
      release {
        minifyEnabled true
        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-+      proguardFile "${project(':detox').projectDir}/proguard-rules-app.pro"
++      proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
 
        signingConfig signingConfigs.release
      }


### PR DESCRIPTION
I just went through the website docs on [Project Setup](https://wix.github.io/Detox/docs/introduction/project-setup/) for Android. Everything went smoothly except for the line about the `proguardFile`.

Following the website docs as is, I get an error that says "Project with path ':detox' could not be found in project ':app'". With the proposed change, Gradle is happy. Also, this change brings the website's `proguardFile` docs in line with what I found [here](https://github.com/wix/Detox/blob/master/website/versioned_docs/version-20.x/guide/proguard-configuration.md).