### PR TITLE
ci: remove invalid `JAVA_HOME` variable setting.

### DIFF
--- a/.buildkite/pipeline.release.fast.yml
+++ b/.buildkite/pipeline.release.fast.yml
@@ -11,12 +11,12 @@
     command:
       - "nvm install"
       - "npm install"
-      - "JAVA_HOME=/usr/local/opt/openjdk@11/ npm run package:android"
+      - "npm run package:android"
     env:
       DETOX_DISABLE_POSTINSTALL: true
       DETOX_DISABLE_POD_INSTALL: true
     artifact_paths: "/Users/builder/work/detox/Detox-android/**/*"
-      
+
   - label: ":shipit: Publish"
     depends_on:
       - 'android_package'


### PR DESCRIPTION
This fixes the release process, since it was broken with the error:
```
ERROR: JAVA_HOME is set to an invalid directory: /usr/local/opt/openjdk@11/
  |  
  | Please set the JAVA_HOME variable in your environment to match the
  | location of your Java installation.
```

`JAVA_HOME` variable assigning was recently removed from other pipelines except for the release pipeline as part of the mac-mini bare metal migration, this removal was missed in the migration removals PR: https://github.com/wix/Detox/pull/3742 (`pipeline.release.fast.yml` is being used for both fast and non-fast releases)