### PR TITLE
docs: fix lint errors

### DIFF
--- a/docs/api/device.md
+++ b/docs/api/device.md
@@ -379,7 +379,7 @@ Takes a screenshot of the device. For full details on taking screenshots with De
 currently opened application to a temporary folder and schedules putting it to
 the artifacts' folder upon the completion of the current test. The file can be
 opened later in Xcode 12.0 and above.
-See [Xcode 12 Release notes: #57933113](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes#:\~:text=57933113)
+See [Xcode 12 Release notes: #57933113](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes#:~:text=57933113)
 for more details.
 
 The `name` parameter is optional — by default, it equals to `capture`.

--- a/docs/api/webviews.md
+++ b/docs/api/webviews.md
@@ -35,8 +35,8 @@ await expect(innerElement).toHaveText('Hello World!');
 In the example above:
 
 1. We use `web()` function and [`by.id()`] matcher to locate a web view by its accessibility identifier.
-2. We use `myWebView.element()` method and [`by.web.id()`] web matcher to find an HTML element inside that web view.
-3. We run the same expectation (to have text) as in the previous example.
+1. We use `myWebView.element()` method and [`by.web.id()`] web matcher to find an HTML element inside that web view.
+1. We run the same expectation (to have text) as in the previous example.
 
 ## Matchers
 
@@ -319,37 +319,63 @@ await expect(web.element(by.web.id('identifier'))).not.toHaveText('Hello World!'
 ```
 
 [native matchers]: matchers.md
+
 [`by.id()`]: matchers.md#byidid
 
 [web view matchers]: webviews.md#matchers
+
 [web view actions]: webviews.md#actions
+
 [web view expectations]: webviews.md#expectations
 
 [`by.web.id()`]: webviews.md#byidid
+
 [`by.web.className()`]: webviews.md#byclassnameclassname
+
 [`by.web.cssSelector()`]: webviews.md#bycssselectorcssselector
+
 [`by.web.name()`]: webviews.md#byname
+
 [`by.web.xpath()`]: webviews.md#byxpathxpath
+
 [`by.web.href()`]: webviews.md#byhrefhref
+
 [`by.web.hrefContains()`]: webviews.md#byhrefcontainshref
+
 [`by.web.tag()`]: webviews.md#bytagtag
+
 [`atIndex()`]: webviews.md#atindexindex
 
 [`tap()`]: webviews.md#tap
+
 [`typeText()`]: webviews.md#typetexttext-iscontenteditable
+
 [content-editable]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/contentEditable
+
 [`replaceText()`]: webviews.md#replacetexttext
+
 [`clearText()`]: webviews.md#cleartext
+
 [`selectAllText()`]: webviews.md#selectalltext
+
 [`getText()`]: webviews.md#gettext
+
 [`scrollToView()`]: webviews.md#scrolltoview
+
 [`focus()`]: webviews.md#focus
+
 [`moveCursorToEnd()`]: webviews.md#movecursortoend
+
 [`runScript()`]: webviews.md#runscriptscript
+
 [`runScriptWithArgs()`]: webviews.md#runscriptwithargsscript-args
+
 [`getCurrentUrl()`]: webviews.md#getcurrenturl
+
 [`getTitle()`]: webviews.md#gettitle
 
 [`toHaveText()`]: webviews.md#tohavetexttext
+
 [`toExist()`]: webviews.md#toexist
+
 [`not`]: webviews.md#not

--- a/docs/introduction/partials/_getting-started-expo.md
+++ b/docs/introduction/partials/_getting-started-expo.md
@@ -14,4 +14,5 @@ For support on how to use Detox with Expo, you should contact the Expo team or t
 If you are experiencing a bug, which you believe is a Detox issue, please [open an issue] on our GitHub repository.
 
 [open an issue]: https://github.com/wix/Detox/issues
+
 [Running E2E tests on EAS Build]: https://docs.expo.dev/build-reference/e2e-tests/


### PR DESCRIPTION
## Description

Fix broken links and remove warnings by Remark and Markdownlint.