### PR TITLE
lint: fix trivial errors

### DIFF
--- a/detox/src/devices/lifecycle/GenyGlobalLifecycleHandler.js
+++ b/detox/src/devices/lifecycle/GenyGlobalLifecycleHandler.js
@@ -12,8 +12,6 @@ class GenyGlobalLifecycleHandler {
     this._instanceLifecycleService = instanceLifecycleService;
   }
 
-  // TODO: remove this ignore as soon as DetoxPrimaryContext is covered with tests
-  /* istanbul ignore next */
   async globalInit() {}
 
   emergencyCleanup() {

--- a/detox/src/devices/lifecycle/GenyGlobalLifecycleHandler.test.js
+++ b/detox/src/devices/lifecycle/GenyGlobalLifecycleHandler.test.js
@@ -38,6 +38,12 @@ describe('Global-context lifecycle handler for Genymotion SaaS emulators', () =>
     data: { name },
   });
 
+  describe('global init', () => {
+    it('should do nothing', async () => {
+      await expect(lifecycleHandler.globalInit()).resolves.toBeUndefined();
+    });
+  });
+
   describe('global clean-up', () => {
     const givenDeletionPendingDevices = (rawDevices) => deviceCleanupRegistry.readRegisteredDevices.mockResolvedValue({ rawDevices });
     const givenNoDeletionPendingDevices = () => givenDeletionPendingDevices([]);

--- a/detox/src/logger/DetoxLogger.js
+++ b/detox/src/logger/DetoxLogger.js
@@ -310,19 +310,19 @@ class DetoxLogger {
   /** @internal */
   static defaultOptions({ level }) {
     const ph = level === 'trace' || level === 'debug'
-      ? value => require('chalk').grey(value) + ' '
-      : value => require('chalk').grey(value);
+      ? value => require('chalk').default.grey(value) + ' '
+      : value => require('chalk').default.grey(value);
 
     const id = level === 'trace'
-      ? value => require('chalk').yellow(`@${value}`)
+      ? value => require('chalk').default.yellow(`@${value}`)
       : undefined;
 
     const cat = level === 'trace' || level === 'debug'
-      ? (value) => require('chalk').yellow(`${value}`.split(',', 1)[0])
+      ? (value) => require('chalk').default.yellow(`${value}`.split(',', 1)[0])
       : undefined;
 
     const event = level === 'trace' || level === 'debug'
-      ? (value) => require('chalk').grey(`:${value}`)
+      ? (value) => require('chalk').default.grey(`:${value}`)
       : undefined;
 
     const identity = x => x;

--- a/detox/src/utils/ExclusiveLockfile.js
+++ b/detox/src/utils/ExclusiveLockfile.js
@@ -86,6 +86,7 @@ class ExclusiveLockfile {
    */
   _doRead() {
     const contents = fs.readFileSync(this._lockFilePath, this._options.read);
+    // @ts-ignore Node.js can parse buffer as JSON
     return JSON.parse(contents);
   }
 


### PR DESCRIPTION
## Description

1. Fix chalk typing (use default).
2. Replenish test coverage for a very trivial case (globalInit is an empty function).