### PR TITLE
fix(generation): invalid isArray assertion

### DIFF
--- a/detox/src/android/AndroidExpect.test.js
+++ b/detox/src/android/AndroidExpect.test.js
@@ -515,6 +515,15 @@ describe('AndroidExpect', () => {
         await e.web.element(e.by.web.tag('tag')).runScriptWithArgs(script, argsArr);
       });
 
+      it('runScriptWithArgs (unhappy paths)', async () => {
+        const script = 'function bar(a,b) {}';
+        const someElement = e.web.element(e.by.web.id('id'));
+
+        await expect(someElement.runScriptWithArgs(script, 42)).rejects.toThrowError(/args must be an array/);
+        await expect(someElement.runScriptWithArgs(script, null)).rejects.toThrowError(/args must be an array/);
+        await expect(someElement.runScriptWithArgs(script, {})).rejects.toThrowError(/args must be an array/);
+      });
+
       it('getCurrentUrl', async () => {
         await e.web.element(e.by.web.id('id')).getCurrentUrl();
         await e.web.element(e.by.web.className('className')).getCurrentUrl();

--- a/detox/src/android/espressoapi/EspressoDetox.js
+++ b/detox/src/android/espressoapi/EspressoDetox.js
@@ -52,7 +52,7 @@ class EspressoDetox {
   }
 
   static setURLBlacklist(urls) {
-    if (typeof urls !== 'object' || !urls instanceof Array) {
+    if (typeof urls !== 'object' || !Array.isArray(urls)) {
       throw new Error('urls must be an array, got ' + typeof urls);
     }
 

--- a/detox/src/android/espressoapi/web/WebElement.js
+++ b/detox/src/android/espressoapi/web/WebElement.js
@@ -69,7 +69,7 @@ class WebElement {
   static runScriptWithArgs(element, script, args) {
     if (typeof script !== "string") throw new Error("script should be a string, but got " + (script + (" (" + (typeof script + ")"))));
 
-    if (typeof args !== 'object' || !args instanceof Array) {
+    if (typeof args !== 'object' || !Array.isArray(args)) {
       throw new Error('args must be an array, got ' + typeof args);
     }
 

--- a/generation/core/type-checks.js
+++ b/generation/core/type-checks.js
@@ -23,9 +23,9 @@ function isGreyMatcher({ name }) {
   return templateFromString(
     `
   if (
-    typeof ARG !== "object" || 
+    typeof ARG !== "object" ||
     ARG.type !== "Invocation" ||
-    typeof ARG.value !== "object" || 
+    typeof ARG.value !== "object" ||
     typeof ARG.value.target !== "object" ||
     ARG.value.target.value !== "GREYMatchers"
   ) {
@@ -40,9 +40,9 @@ function isGreyAction({ name }) {
   return templateFromString(
     `
   if (
-    typeof ARG !== "object" || 
+    typeof ARG !== "object" ||
     ARG.type !== "Invocation" ||
-    typeof ARG.value !== "object" || 
+    typeof ARG.value !== "object" ||
     typeof ARG.value.target !== "object" ||
     ARG.value.target.value !== "GREYActions"
   ) {
@@ -70,8 +70,8 @@ function isArray({ name }) {
   return templateFromString(
     `
 if (
-  (typeof ARG !== 'object') || 
-  (!ARG instanceof Array)
+  (typeof ARG !== 'object') ||
+  !Array.isArray(ARG)
 ) {
     throw new Error('${name} must be an array, got ' + typeof ARG);
   }


### PR DESCRIPTION
## Description

I noticed thanks to the linter that our assertion here was never correct:

```diff
-if (typeof X !== 'object' || !X instanceof Array) {
+if (typeof X !== 'object' || !Array.isArray(X)) {
```

That's because `!X` gets evaluated as a boolean first, and then it is never an instance of an array, for an obvious reason.