### PR TITLE
refactor: drop minimist package

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -69,7 +69,6 @@
     "ini": "^1.3.4",
     "json-cycle": "^1.3.0",
     "lodash": "^4.17.5",
-    "minimist": "^1.2.0",
     "multi-sort-stream": "^1.0.3",
     "multipipe": "^4.0.0",
     "node-ipc": "^9.2.1",

--- a/detox/src/configuration/collectCliConfig.js
+++ b/detox/src/configuration/collectCliConfig.js
@@ -23,7 +23,7 @@ const asNumber = (value) => {
 };
 
 function collectCliConfig({ argv }) {
-  const env = (key) => argparse.getArgValue(key);
+  const env = (key) => argparse.getEnvValue(key);
   const get = (key, fallback) => {
     const value = argv && Reflect.has(argv, key) ? argv[key] : env(key);
     return value === undefined ? fallback : value;

--- a/detox/src/configuration/index.test.js
+++ b/detox/src/configuration/index.test.js
@@ -18,7 +18,7 @@ describe('composeDetoxConfig', () => {
 
     args = {};
 
-    require('../utils/argparse').getArgValue.mockImplementation(key => args[key]);
+    require('../utils/argparse').getEnvValue.mockImplementation(key => args[key]);
     configuration = require('./index');
   });
 

--- a/detox/src/devices/runtime/RuntimeDevice.test.js
+++ b/detox/src/devices/runtime/RuntimeDevice.test.js
@@ -11,16 +11,12 @@ describe('Device', () => {
   let errorComposer;
   let emitter;
   let RuntimeDevice;
-  let argparse;
   let Client;
   let client;
   let driverMock;
 
   beforeEach(async () => {
     jest.mock('../../utils/logger');
-
-    jest.mock('../../utils/argparse');
-    argparse = require('../../utils/argparse');
 
     jest.mock('./drivers/DeviceDriverBase');
     DeviceDriverBase = require('./drivers/DeviceDriverBase');
@@ -362,7 +358,6 @@ describe('Device', () => {
     it(`(relaunch) with delete=false when reuse is enabled should not uninstall and install`, async () => {
       const expectedArgs = expectedDriverArgs;
       const device = await aValidDevice();
-      argparse.getArgValue.mockReturnValue(true);
 
       await device.relaunchApp();
 

--- a/detox/src/utils/argparse.js
+++ b/detox/src/utils/argparse.js
@@ -1,14 +1,8 @@
 const path = require('path');
 
 const _ = require('lodash');
-const argv = require('minimist')(process.argv.slice(2));
 
 const { escape } = require('./pipeCommands');
-
-function getArgValue(key, alias) {
-  const value = _getArgvValue(key, alias);
-  return value === undefined ? getEnvValue(key) : value;
-}
 
 function getEnvValue(key) {
   const envKey = _.findKey(process.env, matchesKey(
@@ -23,29 +17,10 @@ function getEnvValue(key) {
   return value;
 }
 
-function _getArgvValue(...aliases) {
-  if (!argv) {
-    return;
-  }
-
-  for (const alias of aliases) {
-    if (alias && argv[alias]) {
-      return argv[alias];
-    }
-  }
-}
-
 function matchesKey(key) {
   return /* istanbul ignore next */ process.platform === 'win32'
     ? (value, envKey) => envKey.toUpperCase() === key
     : (value, envKey) => envKey === key;
-}
-
-function getFlag(key) {
-  if (argv && argv[key]) {
-    return true;
-  }
-  return false;
 }
 
 const DEFAULT_JOIN_ARGUMENTS_OPTIONS = {
@@ -92,9 +67,7 @@ function getCurrentCommand() {
 }
 
 module.exports = {
-  getArgValue,
   getEnvValue,
-  getFlag,
   joinArgs,
   getCurrentCommand,
 };

--- a/detox/src/utils/argparse.test.js
+++ b/detox/src/utils/argparse.test.js
@@ -1,92 +1,40 @@
 jest.unmock('process');
 
 describe('argparse', () => {
-  let minimist;
-
-  beforeEach(() => {
-    jest.mock('minimist');
-    minimist = require('minimist');
-  });
-
-  describe('getArgValue()', () => {
-    describe('using env variables', () => {
-      let _env;
-      let argparse;
-
-      beforeEach(() => {
-        _env = process.env;
-
-        process.env = {
-          ..._env,
-          DETOX_FOO_BAR: 'value',
-        };
-
-        minimist.mockReturnValue(undefined);
-        argparse = require('./argparse');
-      });
-
-      afterEach(() => {
-        process.env = _env;
-      });
-
-      it(`nonexistent key should return undefined`, () => {
-        expect(argparse.getArgValue('blah')).not.toBeDefined();
-      });
-
-      it(`existing DETOX_SNAKE_FORMAT key should return its value (kebab-case input)`, () => {
-        expect(argparse.getArgValue('foo-bar')).toBe('value');
-      });
-
-      it(`existing DETOX_SNAKE_FORMAT key should return its value (camelCase input)`, () => {
-        expect(argparse.getArgValue('fooBar')).toBe('value');
-      });
-
-      it('should return undefined if process.env contain something with a string of undefined' ,() => {
-        process.env.DETOX_FOO_BAR = 'undefined';
-        expect(argparse.getArgValue('fooBar')).toBe(undefined);
-      });
-    });
-
-    describe('using arguments', () => {
-      let argparse;
-
-      beforeEach(() => {
-        minimist.mockReturnValue({ 'kebab-case-key': 'a value', 'b': 'shortened' });
-        argparse = require('./argparse');
-      });
-
-      it(`nonexistent key should return undefined result`, () => {
-        expect(argparse.getArgValue('blah')).not.toBeDefined();
-      });
-
-      it(`alias alternative should fiind the result`, () => {
-        expect(argparse.getArgValue('blah', 'b')).toBe('shortened');
-      });
-
-      it(`existing key should return a result`, () => {
-        expect(argparse.getArgValue('kebab-case-key')).toBe('a value');
-      });
-    });
-  });
-
-  describe('getFlag()', () => {
+  describe('getEnvValue()', () => {
+    let _env;
     let argparse;
 
     beforeEach(() => {
-      minimist.mockReturnValue({ 'flag-true': 1, 'flag-false': 0 });
+      _env = process.env;
+
+      process.env = {
+        ..._env,
+        DETOX_FOO_BAR: 'value',
+      };
+
       argparse = require('./argparse');
     });
 
-    it('should return true if flag value is truthy', () => {
-      expect(argparse.getFlag('flag-true')).toBe(true);
+    afterEach(() => {
+      process.env = _env;
     });
 
-    it('should return false if flag is not set', () => {
-      expect(argparse.getFlag('flag-false')).toBe(false);
+    it(`nonexistent key should return undefined`, () => {
+      expect(argparse.getEnvValue('blah')).not.toBeDefined();
     });
 
-    it('should return true if flag is not set', () => {
-      expect(argparse.getFlag('flag-missing')).toBe(false);
+    it(`existing DETOX_SNAKE_FORMAT key should return its value (kebab-case input)`, () => {
+      expect(argparse.getEnvValue('foo-bar')).toBe('value');
+    });
+
+    it(`existing DETOX_SNAKE_FORMAT key should return its value (camelCase input)`, () => {
+      expect(argparse.getEnvValue('fooBar')).toBe('value');
+    });
+
+    it('should return undefined if process.env contain something with a string of undefined' ,() => {
+      process.env.DETOX_FOO_BAR = 'undefined';
+      expect(argparse.getEnvValue('fooBar')).toBe(undefined);
     });
   });
 
@@ -129,6 +77,15 @@ describe('argparse', () => {
     it('should return the current command in relative path format', () => {
       expect(argparse.getCurrentCommand()).toMatch(/^[^\\/]\S*jest.*$/);
       expect(argparse.getCurrentCommand()).toContain(process.argv.slice(2).join(' '));
+    });
+
+    it('should return the rest of the command as-is', () => {
+      process.argv.push(__dirname);
+      try {
+        expect(argparse.getCurrentCommand()).toContain(__dirname);
+      } finally {
+        process.argv.pop();
+      }
     });
   });
 });


### PR DESCRIPTION
## Description

Turns out, we don't need this package anymore since Detox 20 huge refactors in config.

And this is for the good, because earlier we had two different libraries for parsing `process.argv` under the same roof.

This is a refactor PR without intended side effects.