### PR TITLE
refactor(tests): reusable cli mock

### DIFF
--- a/detox/__tests__/helpers.js
+++ b/detox/__tests__/helpers.js
@@ -25,7 +25,7 @@ function callCli(modulePath, cmd) {
     return yargs
       .scriptName('detox')
       .parserConfiguration({
-        'boolean-negation': true,
+        'boolean-negation': false,
         'camel-case-expansion': false,
         'dot-notation': false,
         'duplicate-arguments-array': false,

--- a/detox/__tests__/helpers.js
+++ b/detox/__tests__/helpers.js
@@ -1,6 +1,8 @@
 const path = require('path');
 
+const fs = require('fs-extra');
 const _ = require('lodash');
+const tempfile = require('tempfile');
 const yargs = require('yargs');
 
 function callCli(modulePath, cmd) {
@@ -23,18 +25,62 @@ function callCli(modulePath, cmd) {
     return yargs
       .scriptName('detox')
       .parserConfiguration({
-        'boolean-negation': false,
+        'boolean-negation': true,
         'camel-case-expansion': false,
         'dot-notation': false,
         'duplicate-arguments-array': false,
+        'populate--': true,
       })
       .command(spiedModule)
+      .wrap(null)
       .exitProcess(false)
       .fail((msg, err) => reject(err || msg))
       .parse(cmd, (err) => err && reject(err));
   });
 }
 
+function buildMockCommand(options = {}) {
+  if (!options.stdout) {
+    options.stdout = tempfile('.txt');
+  }
+
+  return {
+    get cmd() {
+      const env = [
+        options.exitCode ? `CLI_EXIT_CODE=${options.exitCode}` : undefined,
+        options.sleep ? `CLI_SLEEP=${options.sleep}` : undefined,
+        `CLI_TEST_STDOUT=${options.stdout}`,
+      ].filter(Boolean).join(' ');
+
+      return `cross-env ${env} node ${path.join(__dirname, '../local-cli/__mocks__/executable')}`;
+    },
+
+    options,
+
+    _calls: undefined,
+
+    get calls() {
+      if (this._calls === undefined) {
+        if (fs.existsSync(options.stdout)) {
+          this._calls = fs.readFileSync(options.stdout, 'utf8')
+            .trim()
+            .split('\n')
+            .map(c => JSON.parse(c));
+        } else {
+          this._calls = [];
+        }
+      }
+
+      return this._calls;
+    },
+
+    async clean() {
+      await fs.remove(options.stdout);
+    },
+  };
+}
+
+exports.buildMockCommand = buildMockCommand;
 exports.callCli = callCli;
 exports.latestInstanceOf = (clazz) => _.last(clazz.mock.instances);
 exports.lastCallTo = (mocked) => _.last(mocked.mock.calls);

--- a/detox/local-cli/__mocks__/executable
+++ b/detox/local-cli/__mocks__/executable
@@ -4,22 +4,32 @@ const fs = require('fs');
 
 const DETOX_REGEXP = /^DETOX_(?!DISABLE_POD_INSTALL|DISABLE_POSTINSTALL)/;
 
-const env = Object.keys(process.env)
-  .filter(k => DETOX_REGEXP.test(k.toUpperCase()))
-  .reduce((acc, key) => {
-    acc[key] = process.env[key];
-    return acc;
-  }, {});
+function main() {
+    const [, ...argv] = process.argv;
+    const env = Object.keys(process.env)
+        .filter(k => DETOX_REGEXP.test(k.toUpperCase()))
+        .reduce((acc, key) => {
+            acc[key] = process.env[key];
+            return acc;
+        }, {});
 
-const [, ...argv] = process.argv;
+    const output = JSON.stringify({ env, argv }) + '\n';
 
-const output = JSON.stringify({ env, argv }) + '\n';
-if (process.env.CLI_TEST_STDOUT) {
-    fs.appendFileSync(process.env.CLI_TEST_STDOUT, output);
-} else {
-    process.stdout.write(output);
+    if (process.env.CLI_TEST_STDOUT) {
+        fs.appendFileSync(process.env.CLI_TEST_STDOUT, output);
+    } else {
+        process.stdout.write(output);
+    }
+
+    if (process.env.CLI_EXIT_CODE) {
+        process.exit(+process.env.CLI_EXIT_CODE);
+    } else {
+        process.exit(0);
+    }
 }
 
-if (process.env.CLI_EXIT_CODE) {
-    process.exit(+process.env.CLI_EXIT_CODE);
+if (process.env.CLI_SLEEP > 0) {
+    setTimeout(main, +process.env.CLI_SLEEP);
+} else {
+    main();
 }

--- a/detox/package.json
+++ b/detox/package.json
@@ -41,6 +41,7 @@
     "@types/ws": "^7.4.0",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
+    "cross-env": "^7.0.3",
     "eslint": "^8.3.0",
     "eslint-plugin-import": "^2.23.3",
     "eslint-plugin-no-only-tests": "^2.6.0",


### PR DESCRIPTION
## Description

This PR prepares ground for the `detox start` PR #3766.

It makes it simple to use the mock `executable` script for integration tests in `local-cli` subpackage when we're testing that the arguments and environment are passed correctly to the child processes.