### PR TITLE
fix: logger termination and detox init

### DIFF
--- a/detox/src/logger/utils/BunyanLogger.js
+++ b/detox/src/logger/utils/BunyanLogger.js
@@ -41,13 +41,14 @@ class BunyanLogger {
       streamOptions.out = new PassThrough().pipe(process.stderr);
     }
 
-    this._debugStream = {
+    this._bunyan.addStream({
       type: 'raw',
       level: config.level,
       stream: bds.default(streamOptions),
-    };
+    });
 
-    this._bunyan.addStream(this._debugStream);
+    this._debugStream = _.last(this._bunyan['streams']);
+
     return this;
   }
 
@@ -93,7 +94,7 @@ class BunyanLogger {
           : bunyanStream.stream;
 
         /* istanbul ignore next */
-        return stream.fd !== undefined && !stream.closed;
+        return stream.fd > 2 && !stream.closed;
     }
   };
 

--- a/detox/src/realms/DetoxPrimaryContext.js
+++ b/detox/src/realms/DetoxPrimaryContext.js
@@ -135,7 +135,7 @@ class DetoxPrimaryContext extends DetoxContext {
     process.env.DETOX_CONFIG_SNAPSHOT_PATH = this[_sessionFile];
     this[_lifecycleLogger].trace(`Serialized the session state at: ${this[_sessionFile]}`);
 
-    if (opts.workerId != null) {
+    if (opts.workerId !== null) {
       await this[symbols.installWorker](opts);
     }
   }

--- a/detox/test/integration/utils/simplistic-runner.js
+++ b/detox/test/integration/utils/simplistic-runner.js
@@ -1,4 +1,5 @@
 const detox = require('detox/internals');
+const log = detox.log.child({ cat: ['lifecycle'] });
 
 async function main() {
   try {
@@ -11,11 +12,16 @@ async function main() {
 }
 
 async function test1() {
+  log.info('Test 1');
   await device.launchApp();
 }
 
 async function test2() {
+  log.info('Test 2');
   await device.terminateApp();
 }
 
-main().catch((e) => console.error(e));
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description

In this pull request, I fix two things at once – unfortunately, it is impossible to split them without making the build red:

1. The `simplistic-runner` integration test:
  * now it exits with a non-zero code when it catches an error
  * due to a freshly revealed error, I fixed the `!=` typo (and make `!== null` check strict as it was initially intended by me in Detox 20).
2. The logging after calling `detox.cleanup()`. When I started debugging the issues in the integration test, it turned out that `console.error(e)` call was not producing **anything**. So I had to go to the logger and see why, and I found two issues:
  * the `BunyanLogger#installDebugStream` fails to **replace** the stream - instead it just adds one more stream
  * the `BunyanLogger#closeFileStreams` closes `tty` streams (stdin=0, stdout=1, stderr=2) without my actual intent because they are technically file streams and I don't check what `fd` (file descriptor is)