### PR TITLE
feat(android): support setDatePickerDate

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -97,6 +97,7 @@ dependencies {
     }
     api('androidx.test.espresso:espresso-contrib:3.4.0') {
         because 'Android datepicker support'
+        exclude group: "org.checkerframework", module: "checker"
     }
     api('androidx.test:rules:1.4.0') {
         because 'of ActivityTestRule. Needed by users *and* internally used by Detox.'

--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -95,6 +95,9 @@ dependencies {
     api('androidx.test.espresso:espresso-web:3.4.0') {
         because 'Web-View testing'
     }
+    api('androidx.test.espresso:espresso-contrib:3.4.0') {
+        because 'Android datepicker support'
+    }
     api('androidx.test:rules:1.4.0') {
         because 'of ActivityTestRule. Needed by users *and* internally used by Detox.'
     }

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
@@ -19,6 +19,7 @@ import com.wix.detox.espresso.scroll.ScrollHelper;
 import com.wix.detox.espresso.scroll.SwipeHelper;
 
 import org.hamcrest.Matcher;
+import java.time.ZonedDateTime;
 
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
@@ -31,6 +32,7 @@ import androidx.test.espresso.contrib.PickerActions;
 import static androidx.test.espresso.action.ViewActions.actionWithAssertions;
 import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+
 import static org.hamcrest.Matchers.allOf;
 
 
@@ -150,8 +152,9 @@ public class DetoxAction {
         return new ScrollToIndexAction(index);
     }
 
-    public static ViewAction setDatePickerDate(int year, int monthOfYear, int dayOfMonth) {
-        return PickerActions.setDate(year, monthOfYear, dayOfMonth);
+    public static ViewAction setDatePickerDate(String dateString) {
+        ZonedDateTime date = ZonedDateTime.parse(dateString);
+        return PickerActions.setDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
     }
 
     public static ViewAction adjustSliderToPosition(final double newPosition) {

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
@@ -26,6 +26,7 @@ import androidx.test.espresso.action.CoordinatesProvider;
 import androidx.test.espresso.action.GeneralClickAction;
 import androidx.test.espresso.action.GeneralLocation;
 import androidx.test.espresso.action.Press;
+import androidx.test.espresso.contrib.PickerActions;
 
 import static androidx.test.espresso.action.ViewActions.actionWithAssertions;
 import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
@@ -147,6 +148,10 @@ public class DetoxAction {
 
     public static ViewAction scrollToIndex(int index) {
         return new ScrollToIndexAction(index);
+    }
+
+    public static ViewAction setDatePickerDate(int year, int monthOfYear, int dayOfMonth) {
+        return PickerActions.setDate(year, monthOfYear, dayOfMonth);
     }
 
     public static ViewAction adjustSliderToPosition(final double newPosition) {

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
@@ -20,9 +20,11 @@ import com.wix.detox.espresso.scroll.ScrollHelper;
 import com.wix.detox.espresso.scroll.SwipeHelper;
 
 import org.hamcrest.Matcher;
-import java.time.format.DateTimeFormatter;
-import java.time.LocalDate;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
 
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
@@ -155,19 +157,19 @@ public class DetoxAction {
         return new ScrollToIndexAction(index);
     }
 
-    public static ViewAction setDatePickerDate(String dateString, String formatString) {
-        if (Build.VERSION.SDK_INT < 26) {
-            throw new AssertionError("To use DatePicker on Android you must use API 26 or above");
-        }
-
+    public static ViewAction setDatePickerDate(String dateString, String formatString) throws ParseException {
         if (formatString.equals("ISO8601")) {
+            if (Build.VERSION.SDK_INT < 26) {
+                throw new AssertionError("To use DatePicker on Android you must use API 26 or above");
+            }
             ZonedDateTime date = ZonedDateTime.parse(dateString);
             return PickerActions.setDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
         } 
             
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(formatString);
-        LocalDate date = LocalDate.parse(dateString, formatter);
-        return PickerActions.setDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+        Date date = new SimpleDateFormat(formatString).parse(dateString);
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        return PickerActions.setDate(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH));
     }
 
     public static ViewAction adjustSliderToPosition(final double newPosition) {

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
@@ -47,6 +47,8 @@ import static org.hamcrest.Matchers.allOf;
 
 public class DetoxAction {
     private static final String LOG_TAG = "detox";
+    private static final String ISO8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
+    private static final String ISO8601_FORMAT_NO_TZ = "yyyy-MM-dd'T'HH:mm:ss";
 
     private DetoxAction() {
         // static class
@@ -160,11 +162,11 @@ public class DetoxAction {
     public static ViewAction setDatePickerDate(String dateString, String formatString) throws ParseException {
         Date date;
         if (formatString.equals("ISO8601")) {
-            date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(dateString);
+            date = parseDateISO8601(dateString);
         } else {
             date = new SimpleDateFormat(formatString).parse(dateString);
         }
-            
+
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);
         return PickerActions.setDate(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH));
@@ -199,5 +201,13 @@ public class DetoxAction {
                 return (result == null ? null : result.asBase64String());
             }
         };
+    }
+
+    private static Date parseDateISO8601(String dateString) throws ParseException {
+        try {
+            return new SimpleDateFormat(ISO8601_FORMAT).parse(dateString);
+        } catch (ParseException e) {
+            return new SimpleDateFormat(ISO8601_FORMAT_NO_TZ).parse(dateString);
+        }
     }
 }

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
@@ -1,6 +1,7 @@
 package com.wix.detox.espresso;
 
 import android.view.View;
+import android.os.Build;
 
 import com.wix.detox.common.DetoxErrors.DetoxRuntimeException;
 import com.wix.detox.common.DetoxErrors.StaleActionException;
@@ -19,6 +20,8 @@ import com.wix.detox.espresso.scroll.ScrollHelper;
 import com.wix.detox.espresso.scroll.SwipeHelper;
 
 import org.hamcrest.Matcher;
+import java.time.format.DateTimeFormatter;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 
 import androidx.test.espresso.UiController;
@@ -152,8 +155,18 @@ public class DetoxAction {
         return new ScrollToIndexAction(index);
     }
 
-    public static ViewAction setDatePickerDate(String dateString) {
-        ZonedDateTime date = ZonedDateTime.parse(dateString);
+    public static ViewAction setDatePickerDate(String dateString, String formatString) {
+        if (Build.VERSION.SDK_INT < 26) {
+            throw new AssertionError("To use DatePicker on Android you must use API 26 or above");
+        }
+
+        if (formatString.equals("ISO8601")) {
+            ZonedDateTime date = ZonedDateTime.parse(dateString);
+            return PickerActions.setDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+        } 
+            
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(formatString);
+        LocalDate date = LocalDate.parse(dateString, formatter);
         return PickerActions.setDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
     }
 

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAction.java
@@ -158,15 +158,13 @@ public class DetoxAction {
     }
 
     public static ViewAction setDatePickerDate(String dateString, String formatString) throws ParseException {
+        Date date;
         if (formatString.equals("ISO8601")) {
-            if (Build.VERSION.SDK_INT < 26) {
-                throw new AssertionError("To use DatePicker on Android you must use API 26 or above");
-            }
-            ZonedDateTime date = ZonedDateTime.parse(dateString);
-            return PickerActions.setDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
-        } 
+            date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(dateString);
+        } else {
+            date = new SimpleDateFormat(formatString).parse(dateString);
+        }
             
-        Date date = new SimpleDateFormat(formatString).parse(dateString);
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);
         return PickerActions.setDate(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH));

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1365,12 +1365,13 @@ declare global {
             setColumnToValue(column: number, value: string): Promise<void>;
 
             /**
-             * Sets the date of a date picker to a date generated from the provided string and date format. (iOS only)
+             * Sets the date of a date picker to a date generated from the provided string and date format.
              * @param dateString string representing a date in the supplied `dateFormat`
              * @param dateFormat format for the `dateString` supplied
              * @example
              * await expect(element(by.id('datePicker'))).toBeVisible();
-             * await element(by.id('datePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "yyyy-MM-dd'T'HH:mm:ssZZZZZ");
+             * await element(by.id('datePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "yyyy-MM-dd'T'HH:mm:ssZZZZZ"); //iOS example
+             * await element(by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "ISO8601"); //Android example
              */
             setDatePickerDate(dateString: string, dateFormat: string): Promise<void>;
 

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1369,9 +1369,9 @@ declare global {
              * @param dateString string representing a date in the supplied `dateFormat`
              * @param dateFormat format for the `dateString` supplied
              * @example
-             * await expect(element(by.id('datePicker'))).toBeVisible();
-             * await element(by.id('datePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "yyyy-MM-dd'T'HH:mm:ssZZZZZ"); //iOS example
-             * await element(by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "ISO8601"); //Android example
+             * await element(by.id('datePicker')).setDatePickerDate('2023-01-01T00:00:00Z', 'ISO8601');
+             * await element(by.id('datePicker')).setDatePickerDate(new Date().toISOString(), 'ISO8601');
+             * await element(by.id('datePicker')).setDatePickerDate('2023/01/01', "yyyy/MM/dd"); // iOS only
              */
             setDatePickerDate(dateString: string, dateFormat: string): Promise<void>;
 

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1371,7 +1371,7 @@ declare global {
              * @example
              * await element(by.id('datePicker')).setDatePickerDate('2023-01-01T00:00:00Z', 'ISO8601');
              * await element(by.id('datePicker')).setDatePickerDate(new Date().toISOString(), 'ISO8601');
-             * await element(by.id('datePicker')).setDatePickerDate('2023/01/01', "yyyy/MM/dd"); // iOS only
+             * await element(by.id('datePicker')).setDatePickerDate('2023/01/01', "yyyy/MM/dd");
              */
             setDatePickerDate(dateString: string, dateFormat: string): Promise<void>;
 

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1365,13 +1365,15 @@ declare global {
             setColumnToValue(column: number, value: string): Promise<void>;
 
             /**
-             * Sets the date of a date picker to a date generated from the provided string and date format.
-             * @param dateString string representing a date in the supplied `dateFormat`
-             * @param dateFormat format for the `dateString` supplied
+             * Sets the date of a date-picker according to the specified date-string and format.
+             * @param dateString Textual representation of a date (e.g. '2023/01/01'). Should be in coherence with the format specified by `dateFormat`.
+             * @param dateFormat Format of `dateString`: Generally either 'ISO8601' or an explicitly specified format (e.g. 'yyyy/MM/dd'); It should
+             *      follow the rules of NSDateFormatter for iOS and DateTimeFormatter for Android.
+             * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
              * @example
              * await element(by.id('datePicker')).setDatePickerDate('2023-01-01T00:00:00Z', 'ISO8601');
              * await element(by.id('datePicker')).setDatePickerDate(new Date().toISOString(), 'ISO8601');
-             * await element(by.id('datePicker')).setDatePickerDate('2023/01/01', "yyyy/MM/dd");
+             * await element(by.id('datePicker')).setDatePickerDate('2023/01/01', 'yyyy/MM/dd');
              */
             setDatePickerDate(dateString: string, dateFormat: string): Promise<void>;
 

--- a/detox/src/android/AndroidExpect.test.js
+++ b/detox/src/android/AndroidExpect.test.js
@@ -237,6 +237,16 @@ describe('AndroidExpect', () => {
         await expectToThrow(() => e.element(e.by.id('ScrollView161')).scrollTo('noDirection'));
       });
 
+      it('should setDatePickerDate', async () => {
+        await e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601');
+      });
+
+      it('should not setDatePickerDate given bad args', async () => {
+        await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601'));
+        await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06', 'yyyy-mm-dd'));
+        await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate(2019, 'ISO8601'));
+      });
+
       it('should swipe', async () => {
         await e.element(e.by.id('ScrollView799')).swipe('down');
         await e.element(e.by.id('ScrollView799')).swipe('down', 'fast');

--- a/detox/src/android/AndroidExpect.test.js
+++ b/detox/src/android/AndroidExpect.test.js
@@ -239,6 +239,7 @@ describe('AndroidExpect', () => {
 
       it('should setDatePickerDate', async () => {
         await e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601');
+        await e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019/02/06', 'YYYY/MM/DD');
       });
 
       it('should not setDatePickerDate given bad args', async () => {

--- a/detox/src/android/AndroidExpect.test.js
+++ b/detox/src/android/AndroidExpect.test.js
@@ -244,6 +244,7 @@ describe('AndroidExpect', () => {
       it('should not setDatePickerDate given bad args', async () => {
         await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601'));
         await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06', 'yyyy-mm-dd'));
+        await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00'));
         await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate(2019, 'ISO8601'));
       });
 

--- a/detox/src/android/AndroidExpect.test.js
+++ b/detox/src/android/AndroidExpect.test.js
@@ -242,7 +242,6 @@ describe('AndroidExpect', () => {
       });
 
       it('should not setDatePickerDate given bad args', async () => {
-        await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601'));
         await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06', 'yyyy-mm-dd'));
         await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00'));
         await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate(2019, 'ISO8601'));

--- a/detox/src/android/actions/native.js
+++ b/detox/src/android/actions/native.js
@@ -125,9 +125,9 @@ class ScrollToIndex extends Action {
 }
 
 class SetDatePickerDateAction extends Action {
-  constructor(year, monthOfYear, dayOfMonth) {
+  constructor(dateString) {
     super();
-    this._call = invoke.callDirectly(DetoxActionApi.setDatePickerDate(year, monthOfYear, dayOfMonth));
+    this._call = invoke.callDirectly(DetoxActionApi.setDatePickerDate(dateString));
   }
 }
 

--- a/detox/src/android/actions/native.js
+++ b/detox/src/android/actions/native.js
@@ -125,9 +125,9 @@ class ScrollToIndex extends Action {
 }
 
 class SetDatePickerDateAction extends Action {
-  constructor(dateString) {
+  constructor(dateString, formatString) {
     super();
-    this._call = invoke.callDirectly(DetoxActionApi.setDatePickerDate(dateString));
+    this._call = invoke.callDirectly(DetoxActionApi.setDatePickerDate(dateString, formatString));
   }
 }
 

--- a/detox/src/android/actions/native.js
+++ b/detox/src/android/actions/native.js
@@ -124,6 +124,13 @@ class ScrollToIndex extends Action {
   }
 }
 
+class SetDatePickerDateAction extends Action {
+  constructor(year, monthOfYear, dayOfMonth) {
+    super();
+    this._call = invoke.callDirectly(DetoxActionApi.setDatePickerDate(year, monthOfYear, dayOfMonth));
+  }
+}
+
 class AdjustSliderToPosition extends Action {
   constructor(newPosition) {
     super();
@@ -155,5 +162,6 @@ module.exports = {
   SwipeAction,
   TakeElementScreenshot,
   ScrollToIndex,
+  SetDatePickerDateAction,
   AdjustSliderToPosition,
 };

--- a/detox/src/android/core/NativeElement.js
+++ b/detox/src/android/core/NativeElement.js
@@ -113,13 +113,9 @@ class NativeElement {
   }
 
   async setDatePickerDate(dateString, dateFormat) {
-    if (typeof dateString !== 'string') throw new Error('dateString should be a string, but got ' + (dateString + (' (' + (typeof dateString + ')'))));
-    if (typeof dateFormat !== 'string') throw new Error('dateFormat should be a string, but got ' + (dateFormat + (' (' + (typeof dateFormat + ')'))));
     if (dateFormat !== 'ISO8601') throw new Error('dateFormat must be "ISO8601" on android, but got ' + (dateFormat));
 
-    const date = new Date(dateString);
-
-    const action = new actions.SetDatePickerDateAction(date.getFullYear(), date.getMonth() + 1, date.getDate());
+    const action = new actions.SetDatePickerDateAction(dateString);
     const traceDescription = actionDescription.setDatePickerDate();
     return await new ActionInteraction(this._invocationManager, this, action, traceDescription).execute();
   }

--- a/detox/src/android/core/NativeElement.js
+++ b/detox/src/android/core/NativeElement.js
@@ -112,6 +112,18 @@ class NativeElement {
     return await new ActionInteraction(this._invocationManager, this, action, traceDescription).execute();
   }
 
+  async setDatePickerDate(dateString, dateFormat) {
+    if (typeof dateString !== 'string') throw new Error('dateString should be a string, but got ' + (dateString + (' (' + (typeof dateString + ')'))));
+    if (typeof dateFormat !== 'string') throw new Error('dateFormat should be a string, but got ' + (dateFormat + (' (' + (typeof dateFormat + ')'))));
+    if (dateFormat !== 'ISO8601') throw new Error('dateFormat must be "ISO8601" on android, but got ' + (dateFormat));
+
+    const date = new Date(dateString);
+
+    const action = new actions.SetDatePickerDateAction(date.getFullYear(), date.getMonth() + 1, date.getDate());
+    const traceDescription = actionDescription.setDatePickerDate();
+    return await new ActionInteraction(this._invocationManager, this, action, traceDescription).execute();
+  }
+
   /**
    * @param {'up' | 'right' | 'down' | 'left'} direction
    * @param {'slow' | 'fast'} [speed]

--- a/detox/src/android/core/NativeElement.js
+++ b/detox/src/android/core/NativeElement.js
@@ -112,10 +112,8 @@ class NativeElement {
     return await new ActionInteraction(this._invocationManager, this, action, traceDescription).execute();
   }
 
-  async setDatePickerDate(dateString, dateFormat) {
-    if (dateFormat !== 'ISO8601') throw new Error('dateFormat must be "ISO8601" on android, but got ' + (dateFormat));
-
-    const action = new actions.SetDatePickerDateAction(dateString);
+  async setDatePickerDate(dateString, formatString) {
+    const action = new actions.SetDatePickerDateAction(dateString, formatString);
     const traceDescription = actionDescription.setDatePickerDate();
     return await new ActionInteraction(this._invocationManager, this, action, traceDescription).execute();
   }

--- a/detox/src/android/core/NativeElement.js
+++ b/detox/src/android/core/NativeElement.js
@@ -119,7 +119,7 @@ class NativeElement {
       : rawDateString;
 
     const action = new actions.SetDatePickerDateAction(dateString, formatString);
-    const traceDescription = actionDescription.setDatePickerDate();
+    const traceDescription = actionDescription.setDatePickerDate(dateString, formatString);
     return await new ActionInteraction(this._invocationManager, this, action, traceDescription).execute();
   }
 

--- a/detox/src/android/core/NativeElement.js
+++ b/detox/src/android/core/NativeElement.js
@@ -5,6 +5,7 @@ const tempfile = require('tempfile');
 
 const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
 const invoke = require('../../invoke');
+const { removeMilliseconds } = require('../../utils/dateUtils');
 const { actionDescription } = require('../../utils/invocationTraceDescriptions');
 const actions = require('../actions/native');
 const DetoxMatcherApi = require('../espressoapi/DetoxMatcher');
@@ -112,7 +113,11 @@ class NativeElement {
     return await new ActionInteraction(this._invocationManager, this, action, traceDescription).execute();
   }
 
-  async setDatePickerDate(dateString, formatString) {
+  async setDatePickerDate(rawDateString, formatString) {
+    const dateString = formatString === 'ISO8601'
+      ? removeMilliseconds(rawDateString)
+      : rawDateString;
+
     const action = new actions.SetDatePickerDateAction(dateString, formatString);
     const traceDescription = actionDescription.setDatePickerDate();
     return await new ActionInteraction(this._invocationManager, this, action, traceDescription).execute();

--- a/detox/src/android/espressoapi/DetoxAction.js
+++ b/detox/src/android/espressoapi/DetoxAction.js
@@ -194,6 +194,29 @@ class DetoxAction {
     };
   }
 
+  static setDatePickerDate(year, monthOfYear, dayOfMonth) {
+    if (typeof year !== "number") throw new Error("year should be a number, but got " + (year + (" (" + (typeof year + ")"))));
+    if (typeof monthOfYear !== "number") throw new Error("monthOfYear should be a number, but got " + (monthOfYear + (" (" + (typeof monthOfYear + ")"))));
+    if (typeof dayOfMonth !== "number") throw new Error("dayOfMonth should be a number, but got " + (dayOfMonth + (" (" + (typeof dayOfMonth + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.espresso.DetoxAction"
+      },
+      method: "setDatePickerDate",
+      args: [{
+        type: "Integer",
+        value: year
+      }, {
+        type: "Integer",
+        value: monthOfYear
+      }, {
+        type: "Integer",
+        value: dayOfMonth
+      }]
+    };
+  }
+
   static adjustSliderToPosition(newPosition) {
     if (typeof newPosition !== "number") throw new Error("newPosition should be a number, but got " + (newPosition + (" (" + (typeof newPosition + ")"))));
     return {

--- a/detox/src/android/espressoapi/DetoxAction.js
+++ b/detox/src/android/espressoapi/DetoxAction.js
@@ -233,6 +233,18 @@ class DetoxAction {
     };
   }
 
+  static parseDateISO8601(dateString) {
+    if (typeof dateString !== "string") throw new Error("dateString should be a string, but got " + (dateString + (" (" + (typeof dateString + ")"))));
+    return {
+      target: {
+        type: "Class",
+        value: "com.wix.detox.espresso.DetoxAction"
+      },
+      method: "parseDateISO8601",
+      args: [dateString]
+    };
+  }
+
 }
 
 module.exports = DetoxAction;

--- a/detox/src/android/espressoapi/DetoxAction.js
+++ b/detox/src/android/espressoapi/DetoxAction.js
@@ -194,15 +194,16 @@ class DetoxAction {
     };
   }
 
-  static setDatePickerDate(dateString) {
+  static setDatePickerDate(dateString, formatString) {
     if (typeof dateString !== "string") throw new Error("dateString should be a string, but got " + (dateString + (" (" + (typeof dateString + ")"))));
+    if (typeof formatString !== "string") throw new Error("formatString should be a string, but got " + (formatString + (" (" + (typeof formatString + ")"))));
     return {
       target: {
         type: "Class",
         value: "com.wix.detox.espresso.DetoxAction"
       },
       method: "setDatePickerDate",
-      args: [dateString]
+      args: [dateString, formatString]
     };
   }
 

--- a/detox/src/android/espressoapi/DetoxAction.js
+++ b/detox/src/android/espressoapi/DetoxAction.js
@@ -194,26 +194,15 @@ class DetoxAction {
     };
   }
 
-  static setDatePickerDate(year, monthOfYear, dayOfMonth) {
-    if (typeof year !== "number") throw new Error("year should be a number, but got " + (year + (" (" + (typeof year + ")"))));
-    if (typeof monthOfYear !== "number") throw new Error("monthOfYear should be a number, but got " + (monthOfYear + (" (" + (typeof monthOfYear + ")"))));
-    if (typeof dayOfMonth !== "number") throw new Error("dayOfMonth should be a number, but got " + (dayOfMonth + (" (" + (typeof dayOfMonth + ")"))));
+  static setDatePickerDate(dateString) {
+    if (typeof dateString !== "string") throw new Error("dateString should be a string, but got " + (dateString + (" (" + (typeof dateString + ")"))));
     return {
       target: {
         type: "Class",
         value: "com.wix.detox.espresso.DetoxAction"
       },
       method: "setDatePickerDate",
-      args: [{
-        type: "Integer",
-        value: year
-      }, {
-        type: "Integer",
-        value: monthOfYear
-      }, {
-        type: "Integer",
-        value: dayOfMonth
-      }]
+      args: [dateString]
     };
   }
 

--- a/detox/src/ios/expectTwo.js
+++ b/detox/src/ios/expectTwo.js
@@ -8,6 +8,7 @@ const tempfile = require('tempfile');
 
 const { assertEnum, assertNormalized } = require('../utils/assertArgument');
 const { actionDescription, expectDescription } = require('../utils/invocationTraceDescriptions');
+const { removeMilliseconds } = require('../utils/dateUtils');
 const log = require('../utils/logger').child({ cat: 'ws-client, ws' });
 const traceInvocationCall = require('../utils/traceInvocationCall').bind(null, log);
 
@@ -275,6 +276,9 @@ class Element {
   setDatePickerDate(dateString, dateFormat) {
     if (typeof dateString !== 'string') throw new Error('dateString should be a string, but got ' + (dateString + (' (' + (typeof dateString + ')'))));
     if (typeof dateFormat !== 'string') throw new Error('dateFormat should be a string, but got ' + (dateFormat + (' (' + (typeof dateFormat + ')'))));
+    if (dateFormat === 'ISO8601') {
+      dateString = removeMilliseconds(dateString);
+    }
 
     const traceDescription = actionDescription.setDatePickerDate(dateString, dateFormat);
     return this.withAction('setDatePickerDate', traceDescription, dateString, dateFormat);

--- a/detox/src/ios/expectTwo.js
+++ b/detox/src/ios/expectTwo.js
@@ -7,8 +7,8 @@ const _ = require('lodash');
 const tempfile = require('tempfile');
 
 const { assertEnum, assertNormalized } = require('../utils/assertArgument');
-const { actionDescription, expectDescription } = require('../utils/invocationTraceDescriptions');
 const { removeMilliseconds } = require('../utils/dateUtils');
+const { actionDescription, expectDescription } = require('../utils/invocationTraceDescriptions');
 const log = require('../utils/logger').child({ cat: 'ws-client, ws' });
 const traceInvocationCall = require('../utils/traceInvocationCall').bind(null, log);
 

--- a/detox/src/ios/expectTwo.test.js
+++ b/detox/src/ios/expectTwo.test.js
@@ -435,6 +435,34 @@ describe('expectTwo', () => {
     expect(testCall).toDeepEqual(jsonOutput);
   });
 
+  it(`should trim milliseconds for setDatePickerDate with ISO8601 format`, async () => {
+    const testCall = await e.element(e.by.id('datePicker')).setDatePickerDate('2019-01-01T00:00:00.000Z', 'ISO8601');
+    const jsonOutput = {
+      'invocation': {
+        'type': 'action',
+        'action': 'setDatePickerDate',
+        'params': ['2019-01-01T00:00:00Z', 'ISO8601'],
+        'predicate': { 'type': 'id', 'value': 'datePicker' }
+      }
+    };
+
+    expect(testCall).toDeepEqual(jsonOutput);
+  });
+
+  it(`should not trim milliseconds for setDatePickerDate with a custom format`, async () => {
+    const testCall = await e.element(e.by.id('datePicker')).setDatePickerDate('2019-01-01T00:00:00.000Z', 'YYYY-MM-DDTHH:mm:sss.fT');
+    const jsonOutput = {
+      'invocation': {
+        'type': 'action',
+        'action': 'setDatePickerDate',
+        'params': ['2019-01-01T00:00:00.000Z', 'YYYY-MM-DDTHH:mm:sss.fT'],
+        'predicate': { 'type': 'id', 'value': 'datePicker' }
+      }
+    };
+
+    expect(testCall).toDeepEqual(jsonOutput);
+  });
+
   describe(`waitFor`, () => {
     it(`should produce correct JSON for toBeNotVisible expectation`, async () => {
       const testCall = await e.waitFor(e.element(e.by.text('Text5'))).toBeNotVisible().whileElement(e.by.id('ScrollView630')).scroll(50, 'down');

--- a/detox/src/utils/dateUtils.js
+++ b/detox/src/utils/dateUtils.js
@@ -10,6 +10,11 @@ function shortFormat(date) {
   return `${HH}:${MM}:${ss}.${milli}`;
 }
 
+function removeMilliseconds(isoDate) {
+  return isoDate.replace(/(T\d\d:\d\d:\d\d)(\.\d\d\d)/, '$1');
+}
+
 module.exports = {
   shortFormat,
+  removeMilliseconds,
 };

--- a/detox/src/utils/dateUtils.test.js
+++ b/detox/src/utils/dateUtils.test.js
@@ -20,4 +20,21 @@ describe('Date/time utils', () => {
       expect(dateUtils.shortFormat(date)).toEqual('00:00:00.000');
     });
   });
+
+  describe('removeMilliseconds', () => {
+    it('should remove milliseconds for zero timezone', () => {
+      const isoDate = '2019-02-06T14:10:05.000Z';
+      expect(dateUtils.removeMilliseconds(isoDate)).toBe('2019-02-06T14:10:05Z');
+    });
+
+    it('should remove milliseconds for specific timezone', () => {
+      const isoDate = '2019-02-06T21:23:45.000-10:00';
+      expect(dateUtils.removeMilliseconds(isoDate)).toBe('2019-02-06T21:23:45-10:00');
+    });
+
+    it('should not affect a correct string', () => {
+      const isoDate = '2019-02-06T14:12:34+00:00';
+      expect(dateUtils.removeMilliseconds(isoDate)).toBe(isoDate);
+    });
+  });
 });

--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -97,6 +97,7 @@ dependencies {
     implementation project(':react-native-webview')
     implementation project(':react-native-community-checkbox')
     implementation project(':react-native-community-geolocation')
+    implementation project(':react-native-datetimepicker')
 
     androidTestImplementation(project(path: ':detox'))
     androidTestImplementation 'com.linkedin.testbutler:test-butler-library:2.2.1'

--- a/detox/test/android/app/src/main/java/com/example/DetoxRNHost.java
+++ b/detox/test/android/app/src/main/java/com/example/DetoxRNHost.java
@@ -10,6 +10,7 @@ import com.reactnativecommunity.checkbox.ReactCheckBoxPackage;
 import com.reactnativecommunity.geolocation.GeolocationPackage;
 import com.reactnativecommunity.slider.ReactSliderPackage;
 import com.reactnativecommunity.webview.RNCWebViewPackage;
+import com.reactcommunity.rndatetimepicker.RNDateTimePickerPackage;
 
 import java.util.Arrays;
 import java.util.List;
@@ -39,7 +40,8 @@ class DetoxRNHost extends ReactNativeHost {
               new RNCWebViewPackage(),
               new NativeModulePackage(),
               new AsyncStoragePackage(),
-              new ReactCheckBoxPackage()
+              new ReactCheckBoxPackage(),
+              new RNDateTimePickerPackage()
       );
    }
 }

--- a/detox/test/android/settings.gradle
+++ b/detox/test/android/settings.gradle
@@ -38,3 +38,6 @@ project(':react-native-community-geolocation').projectDir = new File(rootProject
 
 include ':@react-native-community_slider'
 project(':@react-native-community_slider').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/slider/android')
+
+include ':react-native-datetimepicker'
+project(':react-native-datetimepicker').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/datetimepicker/android')

--- a/detox/test/e2e/17.datePicker.test.js
+++ b/detox/test/e2e/17.datePicker.test.js
@@ -1,8 +1,15 @@
 const jestExpect = require('expect').default;
 
 describe('DatePicker', () => {
+  let lastTestFailed = false;
+
   beforeEach(async () => {
-    await device.reloadReactNative();
+    if (lastTestFailed) {
+      await device.launchApp({newInstance: true});
+    } else {
+      await device.reloadReactNative();
+    }
+
     await element(by.text('DatePicker')).tap();
   });
 
@@ -20,14 +27,19 @@ describe('DatePicker', () => {
     });
 
     async function setDate(dateString, dateFormat) {
-      if (platform === 'ios') {
-        await element(by.id('datePicker')).setDatePickerDate(dateString, dateFormat);
-      } else {
-        await element(by.id('openDatePicker')).tap();
-        //rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker right now
-        //@see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
-        await element(by.type('android.widget.DatePicker')).setDatePickerDate(dateString, dateFormat);
-        await element(by.text('OK')).tap();
+      try {
+        if (platform === 'ios') {
+          await element(by.id('datePicker')).setDatePickerDate(dateString, dateFormat);
+        } else {
+          await element(by.id('openDatePicker')).tap();
+          //rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker right now
+          //@see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
+          await element(by.type('android.widget.DatePicker')).setDatePickerDate(dateString, dateFormat);
+          await element(by.text('OK')).tap();
+        }
+      } catch (e) {
+        lastTestFailed = true;
+        throw e;
       }
     }
 

--- a/detox/test/e2e/17.datePicker.test.js
+++ b/detox/test/e2e/17.datePicker.test.js
@@ -20,28 +20,32 @@ describe('DatePicker', () => {
       }
     });
 
-    for (const [dateString, formatString] of [
-      ['2019-02-06T05:10:00-08:00', 'ISO8601'], 
-      ['2019/02/06 14:10', 'yyyy/MM/dd HH:mm']]
-    ) {
-      it(':ios: can select dates on a UIDatePicker, format: ' + formatString, async () => {
-        await element(by.id('datePicker')).setDatePickerDate(dateString, formatString);
-        await expect(element(by.id('localDateLabel'))).toHaveText('Date (Local): Feb 6th, 2019');
-        await expect(element(by.id('localTimeLabel'))).toHaveText('Time (Local): 2:10 PM');
-      });
-    }
 
-    for (const [dateString, formatString] of [
-      ['2019-02-06T05:10:00-08:00', 'ISO8601'], 
-      ['2019/02/06', 'yyyy/MM/dd']]
-    ) {
-      it(':android: can select dates on a UIDatePicker, format: ' + formatString, async () => {
+      it(':ios: can select dates on a UIDatePicker, format: ISO8601', async () => {
+        await element(by.id('datePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601');
+        await expect(element(by.id('utcDateLabel'))).toHaveText('Date (UTC): Feb 6th, 2019');
+        await expect(element(by.id('utcTimeLabel'))).toHaveText('Time (UTC): 1:10 PM');
+      });
+
+      it(':ios: can select dates on a UIDatePicker, format: yyyy/MM/dd HH:mm', async () => {
+        await element(by.id('datePicker')).setDatePickerDate('2019/02/06 13:10', 'yyyy/MM/dd HH:mm');
+        await expect(element(by.id('localDateLabel'))).toHaveText('Date (Local): Feb 6th, 2019');
+        await expect(element(by.id('localTimeLabel'))).toHaveText('Time (Local): 1:10 PM');
+      });
+    
+      it(':android: can select dates on a UIDatePicker, format: ISO8601', async () => {
         //rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker right now
         //@see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
-        await element(by.type('android.widget.DatePicker')).setDatePickerDate(dateString, formatString);
+        await element(by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601');
+        await element(by.text('OK')).tap();
+
+        await waitFor(element(by.id('utcDateLabel'))).toHaveText('Date (UTC): Feb 6th, 2019').withTimeout(3000);
+      });
+
+      it(':android: can select dates on a UIDatePicker, format: yyyy/MM/dd', async () => {
+        await element(by.type('android.widget.DatePicker')).setDatePickerDate('2019/02/06', 'yyyy/MM/dd');
         await element(by.text('OK')).tap();
 
         await waitFor(element(by.id('localDateLabel'))).toHaveText('Date (Local): Feb 6th, 2019').withTimeout(3000);
       });
-    }
 });

--- a/detox/test/e2e/17.datePicker.test.js
+++ b/detox/test/e2e/17.datePicker.test.js
@@ -19,29 +19,44 @@ describe('DatePicker', () => {
       }
     });
 
-    test.each([
-      ['ISO8601', new Date(2019, 1, 6, 14, 10, 0).toISOString()],
-      ['yyyy/MM/dd HH:mm', '2019/02/06 14:10'],
-    ])('can select dates in %j format', async (formatString, dateString) => {
+    async function setDate(dateString, dateFormat) {
       if (platform === 'ios') {
-        await element(by.id('datePicker')).setDatePickerDate(dateString, formatString);
-        await expect(element(by.id('localDateLabel'))).toHaveText('Date (Local): Feb 6th, 2019');
-        await expect(element(by.id('localTimeLabel'))).toHaveText('Time (Local): 2:10 PM');
+        await element(by.id('datePicker')).setDatePickerDate(dateString, dateFormat);
       } else {
         await element(by.id('openDatePicker')).tap();
         //rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker right now
         //@see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
-        await element(by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601');
+        await element(by.type('android.widget.DatePicker')).setDatePickerDate(dateString, dateFormat);
         await element(by.text('OK')).tap();
+      }
+    }
 
-        await waitFor(element(by.id('utcDateLabel'))).toHaveText('Date (UTC): Feb 6th, 2019').withTimeout(3000);
+    test.each([
+      ['2019-02-06T05:10:00-08:00', 'Feb 6th, 2019', '1:10 PM'],
+      ['2019-02-06T05:10:00.435-08:00', 'Feb 6th, 2019', '1:10 PM'],
+      ['2023-01-11T10:41:26.912Z', 'Jan 11th, 2023', '10:41 AM'],
+    ])('ISO 8601 format: %s', async (dateString, expectedUtcDate, expectedUtcTime) => {
+      await setDate(dateString, 'ISO8601');
+      await expect(element(by.id('utcDateLabel'))).toHaveText(`Date (UTC): ${expectedUtcDate}`);
+      if (platform === 'ios') {
+        await expect(element(by.id('utcTimeLabel'))).toHaveText(`Time (UTC): ${expectedUtcTime}`);
+      }
+    });
+
+    test.each([
+      ['yyyy/MM/dd HH:mm', '2019/02/06 13:10', 'Feb 6th, 2019', '1:10 PM'],
+    ])('custom format: %s', async (dateFormat, dateString, expectedLocalDate, expectedLocalTime) => {
+      await setDate(dateString, dateFormat);
+      await expect(element(by.id('localDateLabel'))).toHaveText(`Date (Local): ${expectedLocalDate}`);
+      if (platform === 'ios') {
+        await expect(element(by.id('localTimeLabel'))).toHaveText(`Time (Local): ${expectedLocalTime}`);
       }
     });
 
     // Spinner-specific tests
     if (platform !== 'ios' || mode !== 'spinner') return;
 
-    it('setColumnToValue should not work for a date picker', async () => {
+    it('setColumnToValue should not work for a spinner date picker', async () => {
       const invalidAction = element(by.id('datePicker')).setColumnToValue(1, "6");
       await jestExpect(invalidAction).rejects.toThrow(/is not an instance of.*UIPickerView/);
     });

--- a/detox/test/e2e/17.datePicker.test.js
+++ b/detox/test/e2e/17.datePicker.test.js
@@ -20,18 +20,28 @@ describe('DatePicker', () => {
       }
     });
 
-    it(':ios: can select dates on a UIDatePicker', async () => {
-      await element(by.id('datePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "ISO8601");
-      await expect(element(by.id('utcDateLabel'))).toHaveText('Date (UTC): Feb 6th, 2019');
-      await expect(element(by.id('utcTimeLabel'))).toHaveText('Time (UTC): 1:10 PM');
-    });
+    for (const [dateString, formatString] of [
+      ['2019-02-06T05:10:00-08:00', 'ISO8601'], 
+      ['2019/02/06 14:10', 'yyyy/MM/dd HH:mm']]
+    ) {
+      it(':ios: can select dates on a UIDatePicker, format: ' + formatString, async () => {
+        await element(by.id('datePicker')).setDatePickerDate(dateString, formatString);
+        await expect(element(by.id('localDateLabel'))).toHaveText('Date (Local): Feb 6th, 2019');
+        await expect(element(by.id('localTimeLabel'))).toHaveText('Time (Local): 2:10 PM');
+      });
+    }
 
-    it(':android: can select dates on a UIDatePicker', async () => {
-      //rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker right now
-      //@see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
-      await element(by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "ISO8601");
-      await element(by.text('OK')).tap();
+    for (const [dateString, formatString] of [
+      ['2019-02-06T05:10:00-08:00', 'ISO8601'], 
+      ['2019/02/06', 'yyyy/MM/dd']]
+    ) {
+      it(':android: can select dates on a UIDatePicker, format: ' + formatString, async () => {
+        //rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker right now
+        //@see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
+        await element(by.type('android.widget.DatePicker')).setDatePickerDate(dateString, formatString);
+        await element(by.text('OK')).tap();
 
-      await waitFor(element(by.id('utcDateLabel'))).toHaveText('Date (UTC): Feb 6th, 2019').withTimeout(3000);
-    });
+        await waitFor(element(by.id('localDateLabel'))).toHaveText('Date (Local): Feb 6th, 2019').withTimeout(3000);
+      });
+    }
 });

--- a/detox/test/e2e/17.datePicker.test.js
+++ b/detox/test/e2e/17.datePicker.test.js
@@ -7,12 +7,12 @@ describe('DatePicker', () => {
     ['ios', 'spinner', 2],
     ['android', 'calendar', 0],
     ['android', 'spinner', 1],
-  ])(`:%s: %s mode`, (platform, mode, times) => {
+  ])(`:%s: %s mode`, (platform, mode, toggleTimes) => {
     beforeEach(async () => {
       if (platform === 'ios') {
         await device.reloadReactNative();
       } else {
-        // Android: calendar doesn't disappear if we just reloadReactNative() after an error
+        // Android: Native date selector doesn't disappear if we just reloadReactNative() after an error
         await device.launchApp({newInstance: true});
       }
 
@@ -20,7 +20,7 @@ describe('DatePicker', () => {
     });
 
     beforeEach(async () => {
-      for (let i = 0; i < times; i++) {
+      for (let i = 0; i < toggleTimes; i++) {
         await element(by.id('toggleDatePicker')).tap();
       }
     });
@@ -30,8 +30,9 @@ describe('DatePicker', () => {
         await element(by.id('datePicker')).setDatePickerDate(dateString, dateFormat);
       } else {
         await element(by.id('openDatePicker')).tap();
-        //rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker right now
-        //@see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
+
+        // rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker view ATM
+        // @see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
         await element(by.type('android.widget.DatePicker')).setDatePickerDate(dateString, dateFormat);
         await element(by.text('OK')).tap();
       }
@@ -40,6 +41,7 @@ describe('DatePicker', () => {
     test.each([
       ['2019-02-06T05:10:00-08:00', 'Feb 6th, 2019', '1:10 PM'],
       ['2019-02-06T05:10:00.435-08:00', 'Feb 6th, 2019', '1:10 PM'],
+      // This case is important because Date.toISOString() doesn't output a TZ (assumes UTC 0)
       ['2023-01-11T10:41:26.912Z', 'Jan 11th, 2023', '10:41 AM'],
     ])('ISO 8601 format: %s', async (dateString, expectedUtcDate, expectedUtcTime) => {
       await setDate(dateString, 'ISO8601');

--- a/detox/test/e2e/17.datePicker.test.js
+++ b/detox/test/e2e/17.datePicker.test.js
@@ -2,6 +2,7 @@ describe('DatePicker', () => {
     beforeEach(async () => {
       await device.reloadReactNative();
       await element(by.text('DatePicker')).tap();
+      await element(by.id('showDatePicker')).tap();
     });
 
     it(':ios: setColumnToValue should not work for a date picker', async () => {
@@ -26,13 +27,11 @@ describe('DatePicker', () => {
     });
 
     it(':android: can select dates on a UIDatePicker', async () => {
-      await element(by.id('openAndroidDatePicker')).tap();
-
       //rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker right now
       //@see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
       await element(by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "ISO8601");
       await element(by.text('OK')).tap();
 
-      await expect(element(by.id('utcDateLabel'))).toHaveText('Date (UTC): Feb 6th, 2019');
+      await waitFor(element(by.id('utcDateLabel'))).toHaveText('Date (UTC): Feb 6th, 2019').withTimeout(3000);
     });
 });

--- a/detox/test/e2e/17.datePicker.test.js
+++ b/detox/test/e2e/17.datePicker.test.js
@@ -1,10 +1,10 @@
-describe(':ios: DatePicker', () => {
+describe('DatePicker', () => {
     beforeEach(async () => {
       await device.reloadReactNative();
       await element(by.text('DatePicker')).tap();
     });
 
-    it('setColumnToValue should not work for a date picker', async () => {
+    it(':ios: setColumnToValue should not work for a date picker', async () => {
       let failed = false;
       try {
         await element(by.id('datePicker')).setColumnToValue(1, "6");
@@ -19,9 +19,20 @@ describe(':ios: DatePicker', () => {
       }
     });
 
-    it('can select dates on a UIDatePicker', async () => {
+    it(':ios: can select dates on a UIDatePicker', async () => {
       await element(by.id('datePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "ISO8601");
       await expect(element(by.id('utcDateLabel'))).toHaveText('Date (UTC): Feb 6th, 2019');
       await expect(element(by.id('utcTimeLabel'))).toHaveText('Time (UTC): 1:10 PM');
+    });
+
+    it(':android: can select dates on a UIDatePicker', async () => {
+      await element(by.id('openAndroidDatePicker')).tap();
+
+      //rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker right now
+      //@see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
+      await element(by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "ISO8601");
+      await element(by.text('OK')).tap();
+
+      await expect(element(by.id('utcDateLabel'))).toHaveText('Date (UTC): Feb 6th, 2019');
     });
 });

--- a/detox/test/e2e/17.datePicker.test.js
+++ b/detox/test/e2e/17.datePicker.test.js
@@ -1,18 +1,6 @@
 const jestExpect = require('expect').default;
 
 describe('DatePicker', () => {
-  let lastTestFailed = false;
-
-  beforeEach(async () => {
-    if (lastTestFailed) {
-      await device.launchApp({newInstance: true});
-    } else {
-      await device.reloadReactNative();
-    }
-
-    await element(by.text('DatePicker')).tap();
-  });
-
   describe.each([
     ['ios', 'compact', 0],
     ['ios', 'inline', 1],
@@ -21,25 +9,31 @@ describe('DatePicker', () => {
     ['android', 'spinner', 1],
   ])(`:%s: %s mode`, (platform, mode, times) => {
     beforeEach(async () => {
+      if (platform === 'ios') {
+        await device.reloadReactNative();
+      } else {
+        // Android: calendar doesn't disappear if we just reloadReactNative() after an error
+        await device.launchApp({newInstance: true});
+      }
+
+      await element(by.text('DatePicker')).tap();
+    });
+
+    beforeEach(async () => {
       for (let i = 0; i < times; i++) {
         await element(by.id('toggleDatePicker')).tap();
       }
     });
 
     async function setDate(dateString, dateFormat) {
-      try {
-        if (platform === 'ios') {
-          await element(by.id('datePicker')).setDatePickerDate(dateString, dateFormat);
-        } else {
-          await element(by.id('openDatePicker')).tap();
-          //rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker right now
-          //@see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
-          await element(by.type('android.widget.DatePicker')).setDatePickerDate(dateString, dateFormat);
-          await element(by.text('OK')).tap();
-        }
-      } catch (e) {
-        lastTestFailed = true;
-        throw e;
+      if (platform === 'ios') {
+        await element(by.id('datePicker')).setDatePickerDate(dateString, dateFormat);
+      } else {
+        await element(by.id('openDatePicker')).tap();
+        //rn-datepicker does not support testId's on android, so by.type is the only way to match the datepicker right now
+        //@see https://github.com/react-native-datetimepicker/datetimepicker#view-props-optional-ios-only
+        await element(by.type('android.widget.DatePicker')).setDatePickerDate(dateString, dateFormat);
+        await element(by.text('OK')).tap();
       }
     }
 

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.17.3",
     "@react-native-community/checkbox": "0.5.12",
+    "@react-native-community/datetimepicker": "^6.7.1",
     "@react-native-community/geolocation": "^2.0.2",
     "@react-native-community/slider": "4.2.4",
     "@react-native-picker/picker": "^2.1.0",

--- a/detox/test/src/Screens/DatePickerScreen.js
+++ b/detox/test/src/Screens/DatePickerScreen.js
@@ -1,17 +1,15 @@
 import moment from 'moment';
 import React, { Component } from 'react';
-import { Text, View, StyleSheet, Platform, Button } from 'react-native';
-import { default as DatePicker, DateTimePickerAndroid } from "@react-native-community/datetimepicker";
-
-const isAndroid = Platform.OS === 'android';
-const isIos = Platform.OS === 'ios';
+import { Text, View, StyleSheet, Button, Platform } from 'react-native';
+import { default as DatePicker } from "@react-native-community/datetimepicker";
 
 export default class DatePickerScreen extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      chosenDate: new Date()
+      chosenDate: new Date(),
+      showDatePicker: false
     };
 
     this.setDate = this.setDate.bind(this);
@@ -47,20 +45,21 @@ export default class DatePickerScreen extends Component {
         <Text style={styles.dateText} testID='localTimeLabel'>
           {"Time: " + this.getTimeLocal()}
         </Text>
-        { isAndroid && <View style={styles.openDatePickerButtonContainer}>
+         <View style={styles.openDatePickerButtonContainer}>
             <Button 
               title="Open datepicker"
-              testID='openAndroidDatePicker'
-              onPress={() => {
-                DateTimePickerAndroid.open({
-                  value: this.state.chosenDate,
-                  onChange: (_, newDate) => this.setDate(newDate),
-                  mode: "date",
-                });
-              }}
+              testID='showDatePicker'
+              onPress={() => this.setState({ showDatePicker: true })}
             />
-        </View>}
-        {isIos && <DatePicker testID="datePicker" style={styles.datePickerIos} value={this.state.chosenDate} onChange={this.setDate} />}
+        </View>
+        {this.state.showDatePicker && (
+          <DatePicker 
+            testID="datePicker" 
+            mode='date' 
+            display={Platform.OS === 'ios' ? "spinner" : "default"} 
+            value={this.state.chosenDate} 
+            onChange={this.setDate} />
+        )}
       </View>
     );
   }
@@ -72,10 +71,6 @@ const styles = StyleSheet.create({
     paddingTop: 20,
     justifyContent: 'center',
     alignItems: 'center'
-  },
-  datePickerIos: {
-    width:'100%',
-    height:200
   },
   openDatePickerButtonContainer: {
     paddingTop: 20,

--- a/detox/test/src/Screens/DatePickerScreen.js
+++ b/detox/test/src/Screens/DatePickerScreen.js
@@ -104,6 +104,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingTop: 20,
+    paddingBottom: 50,
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'flex-start',

--- a/detox/test/src/Screens/DatePickerScreen.js
+++ b/detox/test/src/Screens/DatePickerScreen.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import React, { Component } from 'react';
-import { Text, View, StyleSheet, DatePickerIOS, TouchableOpacity, Platform } from 'react-native';
+import { Text, View, StyleSheet, DatePickerIOS, Platform, Button } from 'react-native';
 import { DateTimePickerAndroid } from "@react-native-community/datetimepicker";
 
 const isAndroid = Platform.OS === 'android';
@@ -38,16 +38,6 @@ export default class DatePickerScreen extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <TouchableOpacity testID='openAndroidDatePicker' onPress={() => {
-            if (!isAndroid) return;
-
-            DateTimePickerAndroid.open({
-              testID: "datePicker44",
-              value: this.state.chosenDate,
-              onChange: (_, newDate) => this.setDate(newDate),
-              mode: "date",
-            });
-        }} >
         <Text style={styles.dateText} testID="utcDateLabel">
           {"Date (UTC): " + this.getDateUTC()}
         </Text>
@@ -57,8 +47,20 @@ export default class DatePickerScreen extends Component {
         <Text style={styles.dateText} testID='localTimeLabel'>
           {"Time: " + this.getTimeLocal()}
         </Text>
-        </TouchableOpacity>
-        {isIos && <DatePickerIOS testID="datePicker" style={styles.datePicker} date={this.state.chosenDate} onDateChange={this.setDate} />}
+        { isAndroid && <View style={styles.openDatePickerButtonContainer}>
+            <Button 
+              title="Open datepicker"
+              testID='openAndroidDatePicker'
+              onPress={() => {
+                DateTimePickerAndroid.open({
+                  value: this.state.chosenDate,
+                  onChange: (_, newDate) => this.setDate(newDate),
+                  mode: "date",
+                });
+              }}
+            />
+        </View>}
+        {isIos && <DatePickerIOS testID="datePicker" style={styles.datePickerIos} date={this.state.chosenDate} onDateChange={this.setDate} />}
       </View>
     );
   }
@@ -71,9 +73,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center'
   },
-  datePicker: {
+  datePickerIos: {
     width:'100%',
     height:200
+  },
+  openDatePickerButtonContainer: {
+    paddingTop: 20,
   },
   dateText: {
     textAlign:'center'

--- a/detox/test/src/Screens/DatePickerScreen.js
+++ b/detox/test/src/Screens/DatePickerScreen.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import React, { Component } from 'react';
-import { Text, View, StyleSheet, DatePickerIOS, Platform, Button } from 'react-native';
-import { DateTimePickerAndroid } from "@react-native-community/datetimepicker";
+import { Text, View, StyleSheet, Platform, Button } from 'react-native';
+import { default as DatePicker, DateTimePickerAndroid } from "@react-native-community/datetimepicker";
 
 const isAndroid = Platform.OS === 'android';
 const isIos = Platform.OS === 'ios';
@@ -17,7 +17,7 @@ export default class DatePickerScreen extends Component {
     this.setDate = this.setDate.bind(this);
   }
 
-  setDate(newDate) {
+  setDate(e, newDate) {
     this.setState({
       chosenDate: newDate
     });
@@ -60,7 +60,7 @@ export default class DatePickerScreen extends Component {
               }}
             />
         </View>}
-        {isIos && <DatePickerIOS testID="datePicker" style={styles.datePickerIos} date={this.state.chosenDate} onDateChange={this.setDate} />}
+        {isIos && <DatePicker testID="datePicker" style={styles.datePickerIos} value={this.state.chosenDate} onChange={this.setDate} />}
       </View>
     );
   }

--- a/detox/test/src/Screens/DatePickerScreen.js
+++ b/detox/test/src/Screens/DatePickerScreen.js
@@ -25,25 +25,18 @@ export default class DatePickerScreen extends Component {
     return moment(this.state.chosenDate).format("hh:mm");
   }
 
-  getTimeUTC() {
-    return moment(this.state.chosenDate).utc().format("h:mm A");
-  }
-
-  getDateUTC() {
-    return moment(this.state.chosenDate).utc().format("MMM Do, YYYY");
+  getDateLocal() {
+    return moment(this.state.chosenDate).format("MMM Do, YYYY");
   }
 
   render() {
     return (
       <View style={styles.container}>
         <Text style={styles.dateText} testID="utcDateLabel">
-          {"Date (UTC): " + this.getDateUTC()}
-        </Text>
-        <Text style={styles.dateText} testID='utcTimeLabel'>
-          {"Time (UTC): " + this.getTimeUTC()}
+          {"Date (Local): " + this.getDateLocal()}
         </Text>
         <Text style={styles.dateText} testID='localTimeLabel'>
-          {"Time: " + this.getTimeLocal()}
+          {"Time (Local): " + this.getTimeLocal()}
         </Text>
          <View style={styles.openDatePickerButtonContainer}>
             <Button 

--- a/detox/test/src/Screens/DatePickerScreen.js
+++ b/detox/test/src/Screens/DatePickerScreen.js
@@ -22,7 +22,7 @@ export default class DatePickerScreen extends Component {
   }
 
   getTimeLocal() {
-    return moment(this.state.chosenDate).format("hh:mm");
+    return moment(this.state.chosenDate).format("h:mm A");
   }
 
   getDateLocal() {
@@ -32,7 +32,7 @@ export default class DatePickerScreen extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <Text style={styles.dateText} testID="utcDateLabel">
+        <Text style={styles.dateText} testID="localDateLabel">
           {"Date (Local): " + this.getDateLocal()}
         </Text>
         <Text style={styles.dateText} testID='localTimeLabel'>

--- a/detox/test/src/Screens/DatePickerScreen.js
+++ b/detox/test/src/Screens/DatePickerScreen.js
@@ -1,6 +1,10 @@
 import moment from 'moment';
 import React, { Component } from 'react';
-import { Text, View, StyleSheet, DatePickerIOS } from 'react-native';
+import { Text, View, StyleSheet, DatePickerIOS, TouchableOpacity, Platform } from 'react-native';
+import { DateTimePickerAndroid } from "@react-native-community/datetimepicker";
+
+const isAndroid = Platform.OS === 'android';
+const isIos = Platform.OS === 'ios';
 
 export default class DatePickerScreen extends Component {
   constructor(props) {
@@ -34,6 +38,16 @@ export default class DatePickerScreen extends Component {
   render() {
     return (
       <View style={styles.container}>
+        <TouchableOpacity testID='openAndroidDatePicker' onPress={() => {
+            if (!isAndroid) return;
+
+            DateTimePickerAndroid.open({
+              testID: "datePicker44",
+              value: this.state.chosenDate,
+              onChange: (_, newDate) => this.setDate(newDate),
+              mode: "date",
+            });
+        }} >
         <Text style={styles.dateText} testID="utcDateLabel">
           {"Date (UTC): " + this.getDateUTC()}
         </Text>
@@ -43,7 +57,8 @@ export default class DatePickerScreen extends Component {
         <Text style={styles.dateText} testID='localTimeLabel'>
           {"Time: " + this.getTimeLocal()}
         </Text>
-        <DatePickerIOS testID="datePicker" style={styles.datePicker} date={this.state.chosenDate} onDateChange={this.setDate} />
+        </TouchableOpacity>
+        {isIos && <DatePickerIOS testID="datePicker" style={styles.datePicker} date={this.state.chosenDate} onDateChange={this.setDate} />}
       </View>
     );
   }

--- a/detox/test/src/Screens/DatePickerScreen.js
+++ b/detox/test/src/Screens/DatePickerScreen.js
@@ -103,7 +103,7 @@ export default class DatePickerScreen extends Component {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: 20,
+    paddingTop: 100,
     paddingBottom: 50,
     flexDirection: 'column',
     alignItems: 'center',

--- a/detox/test/src/Screens/DatePickerScreen.js
+++ b/detox/test/src/Screens/DatePickerScreen.js
@@ -29,9 +29,23 @@ export default class DatePickerScreen extends Component {
     return moment(this.state.chosenDate).format("MMM Do, YYYY");
   }
 
+  getTimeUTC() {
+    return moment(this.state.chosenDate).utc().format("h:mm A");
+  }
+
+  getDateUTC() {
+    return moment(this.state.chosenDate).utc().format("MMM Do, YYYY");
+  }
+
   render() {
     return (
       <View style={styles.container}>
+        <Text style={styles.dateText} testID="utcDateLabel">
+          {"Date (UTC): " + this.getDateUTC()}
+        </Text>
+        <Text style={styles.dateText} testID='utcTimeLabel'>
+          {"Time (UTC): " + this.getTimeUTC()}
+        </Text>
         <Text style={styles.dateText} testID="localDateLabel">
           {"Date (Local): " + this.getDateLocal()}
         </Text>

--- a/detox/test/src/app.js
+++ b/detox/test/src/app.js
@@ -120,7 +120,7 @@ export default class example extends Component {
         {this.renderScreenButton('Device', Screens.DeviceScreen)}
         {isIos && this.renderScreenButton('Overlay', Screens.OverlayScreen)}
         {this.renderScreenButton('Location', Screens.LocationScreen)}
-        {isIos && this.renderScreenButton('DatePicker', Screens.DatePickerScreen)}
+        {this.renderScreenButton('DatePicker', Screens.DatePickerScreen)}
         {isIos && this.renderScreenButton('Picker', Screens.PickerViewScreen)}
         {isAndroid && this.renderScreenButton('WebView', Screens.WebViewScreen)}
         {this.renderScreenButton('Attributes', Screens.AttributesScreen)}

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -241,6 +241,14 @@ await element(by.id('datePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00'
 await element(by.id('datePicker')).setDatePickerDate('2019/02/06', "yyyy/MM/dd"); //iOS only
 ```
 
+On Android your DatePicker library might not support setting testID's. In that case you can reference it by the className like this:
+
+```js
+await element(by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "ISO8601");
+```
+
+Also be aware that on Android only the date is set. The time part from the dateString is ignored.
+
 ### `adjustSliderToPosition(normalizedPosition)`
 
 Manipulates the UI to change the displayed value of the slider element to a new value, based on a normalized position.

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -228,29 +228,29 @@ await element(by.id('pickerView')).setColumnToValue(2, "Hello World");
 
 ### `setDatePickerDate(dateString, dateFormat)`
 
-Sets the element’s date to the specified date string, parsed using the specified date format.
+Sets the date-picker’s date to the specified date and time.
 
-The recommended `dateFormat` is `ISO8601`. To create a `dateString` in this format, use the built-in [`Date.prototype.toISOString()`] method, or specify a literal date string following the `YYYY-MM-DDTHH:mm:ss.sssZ` mask, e.g.:
+`dateString`—The date to set. Should match the format provided by `dateFormat`.<br/>
+`dateFormat`—The format of `dateString`. Should be either [`'ISO8601'`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString), or an explicit date representation format, as supported by [`NSDateFormatter`] on iOS / [`DateTimeFormatter`] on Android (e.g. `'yyyy/MM/dd'`).
+
+>_The recommended `dateFormat` is `ISO8601`._
+
+Examples:
 
 ```js
 const datePicker = element(by.id('datePicker'));
 
+// ISO8601:
 await datePicker.setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601');
-await datePicker.setDatePickerDate(new Date().toISOString(), 'ISO8601');
+await datePicker.setDatePickerDate(new Date().toISOString(), 'ISO8601'); // toISOString returns an ISO8601 format with no timezone (UTC-0)
+
+// Explicit format:
+await datePicker.setDatePickerDate('2019/02/06', "yyyy/MM/dd");
 ```
-
-You can also use any of the date formats supported by [`NSDateFormatter`] on iOS or [`DateTimeFormatter`] on Android, e.g.:
-
-```js
-await element(by.id('datePicker')).setDatePickerDate('2019/02/06', "yyyy/MM/dd");
-```
-
-`dateString`—the date to set (valid input: valid, parsable date string) <br/>
-`dateFormat`—the date format of `dateString` (valid input: `"ISO8601"` (**Android and iOS**), or any format supported by [`NSDateFormatter`] on **iOS**)
 
 :::info
 
-On Android, older versions of a popular [`@react-native-community/datetimepicker`] package don’t support setting [`testID`], so you’ll need either to upgrade to a newer version containing [PR #705] inside, or use the [`by.type`] matcher as a workaround, e.g.:
+As far as element-matching is concerned, on Android, older versions of the popular [`@react-native-community/datetimepicker`] package don’t allow for the specification of your own [`testID`] prop for the date-picker component. Therefore, you'd have to either upgrade your package  to a newer version containing [PR datetimepicker#705] inside, or use Detox's [`by.type`] matcher as a workaround. For example:
 
 ```js
 const datePicker = device.getPlatform() === 'android'
@@ -367,4 +367,4 @@ await element(by.id('PinchableScrollView')).pinchWithAngle('outward', 'slow', 0)
 [`NSDateFormatter`]: https://developer.apple.com/documentation/foundation/dateformatter
 [`DateTimeFormatter`]: https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
 [`@react-native-community/datetimepicker`]: https://www.npmjs.com/package/@react-native-community/datetimepicker
-[PR #705]: https://github.com/react-native-datetimepicker/datetimepicker/pull/705
+[PR datetimepicker#705]: https://github.com/react-native-datetimepicker/datetimepicker/pull/705

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -22,7 +22,7 @@ Use [expectations](expect.md) to verify element states.
 - [`.tapReturnKey()`](#tapreturnkey)
 - [`.tapBackspaceKey()`](#tapbackspacekey)
 - [`.setColumnToValue()`](#setcolumntovaluecolumn-value--ios-only) **iOS only**
-- [`.setDatePickerDate()`](#setdatepickerdatedatestring-dateformat--ios-only) **iOS only**
+- [`.setDatePickerDate()`](#setdatepickerdatedatestring-dateformat)
 - [`.adjustSliderToPosition()`](#adjustslidertopositionnormalizedposition)
 - [`.getAttributes()`](#getattributes)
 - [`.takeScreenshot(name)`](#takescreenshotname)
@@ -214,7 +214,7 @@ Sets the element’s specified column to the specified value, using the system�
 
 Values accepted by this method are strings only, and the system will do its best to match complex picker view cells to the string.
 
-This function does not support date pickers. Use [`.setDatePickerDate()`](#setdatepickerdatedatestring-dateformat--ios-only) instead.
+This function does not support date pickers. Use [`.setDatePickerDate()`](#setdatepickerdatedatestring-dateformat) instead.
 
 `column`—the element’s column to set (valid input: number, 0 and above) <br/>
 `value`—the string value to set (valid input: string)
@@ -226,18 +226,19 @@ await element(by.id('pickerView')).setColumnToValue(2, "Hello World");
 
 > **Note:** When working with date pickers, you should always set an explicit locale when launching your app in order to prevent flakiness from different date and time styles. See [here](device.md#9-languageandlocalelaunch-with-a-specific-language-andor-local-ios-only) for more information.
 
-### `setDatePickerDate(dateString, dateFormat)`  iOS only
+### `setDatePickerDate(dateString, dateFormat)`
 
 Sets the element’s date to the specified date string, parsed using the specified date format.
 
-The specified date string is converted by the system to an [`NSDate`](https://developer.apple.com/documentation/foundation/nsdate) object, using [`NSDateFormatter`](https://developer.apple.com/documentation/foundation/dateformatter) with the specified date format, or [`NSISO8601DateFormatter`](https://developer.apple.com/documentation/foundation/iso8601dateformatter) in case of ISO 8601 date strings. If you use JavaScript’s [Date.toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) or otherwise provide a valid ISO 8601 date string, set the date format to `"ISO8601"`, which is supported as a special case.
+In case of dateFormat set to `"ISO8601"`, the specified date string is converted using JavaScript’s `new Date(dateString)` on Android and [`NSISO8601DateFormatter`](https://developer.apple.com/documentation/foundation/iso8601dateformatter) on iOS. You can use [Date.toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) to format a JavaScript date accordingly.
+Other options for dateFormat on iOS are formats that can be parsed by [`NSDateFormatter`](https://developer.apple.com/documentation/foundation/dateformatter). Android does not support other formats than `"ISO8601"`.
 
 `dateString`—the date to set (valid input: valid, parsable date string) <br/>
-`dateFormat`—the date format of `dateString` (valid input: `"ISO8601"` or a valid, parsable date format supported by [`NSDateFormatter`](https://developer.apple.com/documentation/foundation/dateformatter))
+`dateFormat`—the date format of `dateString` (valid input: `"ISO8601"` (**Android and iOS**) or a valid, parsable date format supported by [`NSDateFormatter`](https://developer.apple.com/documentation/foundation/dateformatter)) (**iOS only**)
 
 ```js
 await element(by.id('datePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "ISO8601");
-await element(by.id('datePicker')).setDatePickerDate('2019/02/06', "yyyy/MM/dd");
+await element(by.id('datePicker')).setDatePickerDate('2019/02/06', "yyyy/MM/dd"); //iOS only
 ```
 
 ### `adjustSliderToPosition(normalizedPosition)`

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -230,24 +230,35 @@ await element(by.id('pickerView')).setColumnToValue(2, "Hello World");
 
 Sets the element’s date to the specified date string, parsed using the specified date format.
 
-In case of dateFormat set to `"ISO8601"`, the specified date string is converted using JavaScript’s `new Date(dateString)` on Android and [`NSISO8601DateFormatter`](https://developer.apple.com/documentation/foundation/iso8601dateformatter) on iOS. You can use [Date.toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) to format a JavaScript date accordingly.
-Other options for dateFormat on iOS are formats that can be parsed by [`NSDateFormatter`](https://developer.apple.com/documentation/foundation/dateformatter). Android does not support other formats than `"ISO8601"`.
+The recommended `dateFormat` is `ISO8601`, which is supported on both Android and iOS. To create a `dateString` in this format, use the built-in [`Date.prototype.toISOString()`] method, or specify a literal date string following the `YYYY-MM-DDTHH:mm:ss.sssZ` mask, e.g.:
+
+```js
+const datePicker = element(by.id('datePicker'));
+
+await datePicker.setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601');
+await datePicker.setDatePickerDate(new Date().toISOString(), 'ISO8601');
+```
+
+On iOS, you can also use any of the date formats supported by [`NSDateFormatter`], e.g.:
+
+```js
+await element(by.id('datePicker')).setDatePickerDate('2019/02/06', "yyyy/MM/dd"); // iOS only
+```
 
 `dateString`—the date to set (valid input: valid, parsable date string) <br/>
-`dateFormat`—the date format of `dateString` (valid input: `"ISO8601"` (**Android and iOS**) or a valid, parsable date format supported by [`NSDateFormatter`](https://developer.apple.com/documentation/foundation/dateformatter)) (**iOS only**)
+`dateFormat`—the date format of `dateString` (valid input: `"ISO8601"` (**Android and iOS**), or any format supported by [`NSDateFormatter`] on **iOS**)
+
+:::info
+
+On Android, older versions of a popular [`@react-native-community/datetimepicker`] package don’t support setting [`testID`], so you’ll need either to upgrade to a newer version containing [PR #705] inside, or use the [`by.type`] matcher as a workaround, e.g.:
 
 ```js
-await element(by.id('datePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "ISO8601");
-await element(by.id('datePicker')).setDatePickerDate('2019/02/06', "yyyy/MM/dd"); //iOS only
+const datePicker = device.getPlatform() === 'android'
+  ? element(by.type('android.widget.DatePicker'))
+  : element(by.id('datePicker'));
 ```
 
-On Android your DatePicker library might not support setting testID's. In that case you can reference it by the className like this:
-
-```js
-await element(by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', "ISO8601");
-```
-
-Also be aware that on Android only the date is set. The time part from the dateString is ignored.
+:::
 
 ### `adjustSliderToPosition(normalizedPosition)`
 
@@ -349,3 +360,10 @@ Simulates a pinch on the element with the provided options.
 ```js
 await element(by.id('PinchableScrollView')).pinchWithAngle('outward', 'slow', 0);
 ```
+
+[`testID`]: ../guide/test-id.mdx
+[`by.type`]: ../api/matchers.md#bytypeclassname
+[`Date.prototype.toISOString()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+[`NSDateFormatter`]: https://developer.apple.com/documentation/foundation/dateformatter
+[`@react-native-community/datetimepicker`]: https://www.npmjs.com/package/@react-native-community/datetimepicker
+[PR #705]: https://github.com/react-native-datetimepicker/datetimepicker/pull/705

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -229,7 +229,6 @@ await element(by.id('pickerView')).setColumnToValue(2, "Hello World");
 ### `setDatePickerDate(dateString, dateFormat)`
 
 Sets the element’s date to the specified date string, parsed using the specified date format.
-(Requires API level 26+ on Android)
 
 The recommended `dateFormat` is `ISO8601`. To create a `dateString` in this format, use the built-in [`Date.prototype.toISOString()`] method, or specify a literal date string following the `YYYY-MM-DDTHH:mm:ss.sssZ` mask, e.g.:
 

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -229,8 +229,9 @@ await element(by.id('pickerView')).setColumnToValue(2, "Hello World");
 ### `setDatePickerDate(dateString, dateFormat)`
 
 Sets the element’s date to the specified date string, parsed using the specified date format.
+(Requires API level 26+ on Android)
 
-The recommended `dateFormat` is `ISO8601`, which is supported on both Android and iOS. To create a `dateString` in this format, use the built-in [`Date.prototype.toISOString()`] method, or specify a literal date string following the `YYYY-MM-DDTHH:mm:ss.sssZ` mask, e.g.:
+The recommended `dateFormat` is `ISO8601`. To create a `dateString` in this format, use the built-in [`Date.prototype.toISOString()`] method, or specify a literal date string following the `YYYY-MM-DDTHH:mm:ss.sssZ` mask, e.g.:
 
 ```js
 const datePicker = element(by.id('datePicker'));
@@ -239,10 +240,10 @@ await datePicker.setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601');
 await datePicker.setDatePickerDate(new Date().toISOString(), 'ISO8601');
 ```
 
-On iOS, you can also use any of the date formats supported by [`NSDateFormatter`], e.g.:
+You can also use any of the date formats supported by [`NSDateFormatter`] on iOS or [`DateTimeFormatter`] on Android, e.g.:
 
 ```js
-await element(by.id('datePicker')).setDatePickerDate('2019/02/06', "yyyy/MM/dd"); // iOS only
+await element(by.id('datePicker')).setDatePickerDate('2019/02/06', "yyyy/MM/dd");
 ```
 
 `dateString`—the date to set (valid input: valid, parsable date string) <br/>
@@ -365,5 +366,6 @@ await element(by.id('PinchableScrollView')).pinchWithAngle('outward', 'slow', 0)
 [`by.type`]: ../api/matchers.md#bytypeclassname
 [`Date.prototype.toISOString()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
 [`NSDateFormatter`]: https://developer.apple.com/documentation/foundation/dateformatter
+[`DateTimeFormatter`]: https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
 [`@react-native-community/datetimepicker`]: https://www.npmjs.com/package/@react-native-community/datetimepicker
 [PR #705]: https://github.com/react-native-datetimepicker/datetimepicker/pull/705

--- a/examples/demo-pure-native-android/app/build.gradle
+++ b/examples/demo-pure-native-android/app/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'com.wix:detox:999.999.999'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.3.0'
     androidTestImplementation 'com.google.truth:truth:1.1.3'
 }
 


### PR DESCRIPTION
## Description
- This pull request addresses the issue described here: #3789 

In this pull request, I have extended the setDatePickerDate action to work on android as well.

setDatePickerDate is already working for android in this pr and I also updated one relevant test.
I have yet to investigate whether more tests need changes. 
I also have yet to update the docs.

Feel free to comment on how to improve this implementation.

> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
