### PR TITLE
fix: device.setOrientation for iOS 16

### DIFF
--- a/detox/ios/Detox.xcodeproj/project.pbxproj
+++ b/detox/ios/Detox.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		12BDDA602971652D00FDBBA8 /* UIApplication+DetoxActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12BDDA5F2971652D00FDBBA8 /* UIApplication+DetoxActions.swift */; };
 		390DED83248906FC00E27BE8 /* UIWindow+DetoxUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 390DED81248906FC00E27BE8 /* UIWindow+DetoxUtils.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		390DED84248906FC00E27BE8 /* UIWindow+DetoxUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 390DED82248906FC00E27BE8 /* UIWindow+DetoxUtils.m */; };
 		390DEDDC248D56F600E27BE8 /* String+LocalizedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390DEDDB248D56F600E27BE8 /* String+LocalizedError.swift */; };
@@ -186,6 +187,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		12BDDA5F2971652D00FDBBA8 /* UIApplication+DetoxActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+DetoxActions.swift"; sourceTree = "<group>"; };
 		390D1C981E3A2893007F5F46 /* Detox.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Detox.xcconfig; sourceTree = "<group>"; };
 		390DED81248906FC00E27BE8 /* UIWindow+DetoxUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIWindow+DetoxUtils.h"; sourceTree = "<group>"; };
 		390DED82248906FC00E27BE8 /* UIWindow+DetoxUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIWindow+DetoxUtils.m"; sourceTree = "<group>"; };
@@ -548,6 +550,7 @@
 				3980D164244DC8F0004812DD /* UIPickerView+DetoxActions.m */,
 				3980D16B244DDCD7004812DD /* UIScrollView+DetoxActions.h */,
 				3980D16C244DDCD7004812DD /* UIScrollView+DetoxActions.m */,
+				12BDDA5F2971652D00FDBBA8 /* UIApplication+DetoxActions.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -853,6 +856,7 @@
 				390DEDDC248D56F600E27BE8 /* String+LocalizedError.swift in Sources */,
 				3946CD4A2566EBCB000A3606 /* NSObject+DetoxUtils.m in Sources */,
 				3990BA36245AC98C00B608C8 /* DTXAssertionHandler+Swift.swift in Sources */,
+				12BDDA602971652D00FDBBA8 /* UIApplication+DetoxActions.swift in Sources */,
 				39CA978D245B13CB00A7FC43 /* UIDevice+DetoxActions.m in Sources */,
 				396D455225238BB90096E7FA /* UIView+Drawing.m in Sources */,
 				39CE25AC22197F0900D78AA1 /* DetoxInstrumentsManager.m in Sources */,

--- a/detox/ios/Detox/Actions/UIApplication+DetoxActions.swift
+++ b/detox/ios/Detox/Actions/UIApplication+DetoxActions.swift
@@ -11,9 +11,10 @@ import UIKit
 extension UIApplication {
 	@available(iOS 16.0, *)
 	class func dtx_setOrientation(_ mask: UIInterfaceOrientationMask) {
-		let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+		let windowScene = UIWindow.dtx_keyWindowScene() as? UIWindowScene
 		windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: mask))
-		let keyWindow = windowScene?.windows.first { $0.isKeyWindow }
+
+		let keyWindow = UIWindow.dtx_keyWindow
 		keyWindow?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
 	}
 }

--- a/detox/ios/Detox/Actions/UIApplication+DetoxActions.swift
+++ b/detox/ios/Detox/Actions/UIApplication+DetoxActions.swift
@@ -1,0 +1,19 @@
+//
+//  UIApplication+DetoxActions.swift
+//  Detox
+//
+//  Created by brent.kelly on 13/01/2023.
+//  Copyright © 2023 Wix. All rights reserved.
+//
+
+import UIKit
+
+extension UIApplication {
+	@available(iOS 16.0, *)
+	class func dtx_setOrientation(_ mask: UIInterfaceOrientationMask) {
+		let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+		windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: mask))
+		let keyWindow = windowScene?.windows.first { $0.isKeyWindow }
+		keyWindow?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+	}
+}

--- a/detox/ios/Detox/DetoxManager.swift
+++ b/detox/ios/Detox/DetoxManager.swift
@@ -340,20 +340,27 @@ public class DetoxManager : NSObject, WebSocketDelegate {
 			return
 		case "setOrientation":
 			let orientationString = params["orientation"] as! String
-			let orientation : UIDeviceOrientation
+			let deviceOrientation : UIDeviceOrientation
+			let maskOrientation: UIInterfaceOrientationMask
 			switch orientationString {
 			case "portrait":
-				orientation = .portrait
+				deviceOrientation = .portrait
+				maskOrientation = .portrait
 				break
 			case "landscape":
-				orientation = .landscapeRight
+				deviceOrientation = .landscapeRight
+				maskOrientation = .landscapeRight
 				break
 			default:
 				fatalError("Unknown orientation provided: \(orientationString)")
 			}
 			
 			DTXSyncManager.enqueueMainQueueIdleClosure {
-				UIDevice.dtx_setOrientation(orientation)
+				if #available(iOS 16.0, *) {
+					UIApplication.dtx_setOrientation(maskOrientation)
+				} else {
+					UIDevice.dtx_setOrientation(deviceOrientation)
+				}
 				
 				self.safeSend(action: done, messageId: messageId)
 			}

--- a/detox/ios/Detox/DetoxManager.swift
+++ b/detox/ios/Detox/DetoxManager.swift
@@ -340,28 +340,15 @@ public class DetoxManager : NSObject, WebSocketDelegate {
 			return
 		case "setOrientation":
 			let orientationString = params["orientation"] as! String
-			let deviceOrientation : UIDeviceOrientation
-			let maskOrientation: UIInterfaceOrientationMask
-			switch orientationString {
-			case "portrait":
-				deviceOrientation = .portrait
-				maskOrientation = .portrait
-				break
-			case "landscape":
-				deviceOrientation = .landscapeRight
-				maskOrientation = .landscapeRight
-				break
-			default:
-				fatalError("Unknown orientation provided: \(orientationString)")
-			}
-			
+			let shouldSetToLandscape = orientationString == "landscape"
+
 			DTXSyncManager.enqueueMainQueueIdleClosure {
 				if #available(iOS 16.0, *) {
-					UIApplication.dtx_setOrientation(maskOrientation)
+					UIApplication.dtx_setOrientation(shouldSetToLandscape ? .landscapeRight : .portrait)
 				} else {
-					UIDevice.dtx_setOrientation(deviceOrientation)
+					UIDevice.dtx_setOrientation(shouldSetToLandscape ? .landscapeRight : .portrait)
 				}
-				
+
 				self.safeSend(action: done, messageId: messageId)
 			}
 			return


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: https://github.com/wix/Detox/issues/3823

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have used the new iOS orientation APIs available from iOS 16 onwards, instead of the UIDevice orientation API's (which no longer work when building using Xcode 14 and running on iOS 16+).

_Note: I need some help/advice on how to verify these changes locally. No matter how I run it doesn't seem to be pulling in my code changes. I've tried intentionally putting compilation errors in the code and the tests still build and run without issue. I've ran `lerna bootstrap`, following by `yarn build:ios` and `yarn e2e:ios`. The tests run but don't seem to be exercising any new code._

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
