### PR TITLE
[Website] Create a visual regression test suite

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -39,5 +39,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@percy/cli": "^1.17.0"
   }
 }

--- a/website/snapshots.yml
+++ b/website/snapshots.yml
@@ -1,0 +1,31 @@
+- name: Home page dark theme
+  url: https://wix.github.io/Detox/
+  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'dark')
+
+- name: Home page light theme
+  url: https://wix.github.io/Detox/
+  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'light')
+
+- name: Showcase page dark theme
+  url: https://wix.github.io/Detox/showcase
+  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'dark')
+
+- name: Showcase page light theme
+  url: https://wix.github.io/Detox/showcase
+  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'light')
+
+- name: Blog page dark theme
+  url: https://wix.github.io/Detox/blog
+  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'dark')
+
+- name: Blog page light theme
+  url: https://wix.github.io/Detox/blog
+  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'light')
+
+- name: Demo page dark theme
+  url: https://wix.github.io/Detox/docs/next/demo
+  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'dark')
+
+- name: Demo page light theme
+  url: https://wix.github.io/Detox/docs/next/demo
+  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'light')

--- a/website/snapshots.yml
+++ b/website/snapshots.yml
@@ -1,31 +1,23 @@
 - name: Home page dark theme
-  url: https://wix.github.io/Detox/
-  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'dark')
+  url: http://localhost:3000/Detox/
+  execute: document.documentElement.setAttribute("data-theme", "dark")
 
 - name: Home page light theme
-  url: https://wix.github.io/Detox/
-  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'light')
-
-- name: Showcase page dark theme
-  url: https://wix.github.io/Detox/showcase
-  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'dark')
-
-- name: Showcase page light theme
-  url: https://wix.github.io/Detox/showcase
-  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'light')
+  url: http://localhost:3000/Detox/
+  execute: document.documentElement.setAttribute("data-theme", "light")
 
 - name: Blog page dark theme
-  url: https://wix.github.io/Detox/blog
-  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'dark')
+  url: http://localhost:3000/Detox/blog
+  execute: document.documentElement.setAttribute("data-theme", "dark")
 
 - name: Blog page light theme
-  url: https://wix.github.io/Detox/blog
-  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'light')
+  url: http://localhost:3000/Detox/blog
+  execute: document.documentElement.setAttribute("data-theme", "light")
 
 - name: Demo page dark theme
-  url: https://wix.github.io/Detox/docs/next/demo
-  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'dark')
+  url: http://localhost:3000/Detox/docs/next/demo
+  execute: document.documentElement.setAttribute("data-theme", "dark")
 
 - name: Demo page light theme
-  url: https://wix.github.io/Detox/docs/next/demo
-  execute: document.querySelector('div.toggle_vylO.colorModeToggle_DEke > button').click('data-theme', 'light')
+  url: http://localhost:3000/Detox/docs/next/demo
+  execute: document.documentElement.setAttribute("data-theme", "light")


### PR DESCRIPTION
In this pull request, I have done the following:

- set up test suite in website project using Percy CLI
- create YAML test pages for homepage, showcase page, blog page and demo page
- light and dark modes

Resolves #3838.

![image](https://user-images.githubusercontent.com/34761997/212884976-1b263a25-2da8-41d6-a36b-97c94c40e74d.png)

![image](https://user-images.githubusercontent.com/34761997/212885008-e4ec3a80-e5ad-4998-803a-054c08b68da5.png)

NOTE:
Need to verify Percy.io dashboard functions correctly on image uploading. Some pages are not displaying correctly:
![image](https://user-images.githubusercontent.com/34761997/212885475-337a8807-bc08-43b6-842a-322cbad46dcb.png)


