### PR TITLE
fix: incorrect session serialization

### DIFF
--- a/detox/src/configuration/composeLoggerConfig.js
+++ b/detox/src/configuration/composeLoggerConfig.js
@@ -35,7 +35,7 @@ function composeLoggerConfig(opts) {
         options: typeof options === 'function' ? options(acc) : options
       });
     },
-    items.reduce((a, b) => _.merge(a, _.omit(b, 'options')))
+    items.reduce((a, b) => _.merge(a, _.omit(b, 'options')), {})
   );
 }
 

--- a/detox/src/configuration/composeLoggerConfig.test.js
+++ b/detox/src/configuration/composeLoggerConfig.test.js
@@ -40,6 +40,10 @@ describe('composeLoggerConfig', () => {
     });
   });
 
+  it('should never return "options" as a function', () => {
+    expect(composed().options).not.toBeInstanceOf(Function);
+  });
+
   describe.each([
     ['local config'],
     ['global config'],


### PR DESCRIPTION
## Description

Turns out, that in older Lodash versions (`<=4.17.10`), `_.merge({ a: function () { /*...*/ } }, { a: { b: 'c' } })` does not overwrite the `a` property.

See: https://github.com/lodash/lodash/wiki/Changelog#v41711
> Ensured _.merge handles function properties consistently regardless of number of sources

- This pull request addresses the issue described here: #3849.

In this pull request, I added a fix and a test for this situation. By adding an initial value (`{}`) to the reducer, I prevent this possibility.

@tyronet-sportsbet, huge thanks to you!

@d4vidi let's reserve an achievement **NPM Detective** for @tyronet-sportsbet in our future "Contributors" section on the website.