### PR TITLE
build: increase minimum lodash requirement

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -69,7 +69,7 @@
     "glob": "^8.0.3",
     "ini": "^1.3.4",
     "json-cycle": "^1.3.0",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.11",
     "multi-sort-stream": "^1.0.3",
     "multipipe": "^4.0.0",
     "node-ipc": "^9.2.1",


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #3849 

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have simply increased the minimum `lodash` requirement from `^4.17.5` to `^4.17.11`, since before PR #3851 Detox relied on `merge` behaviour from lodash that was only fixed in `4.17.11`.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files. (no documentation update needed -- this change should be picked up automatically by package managers)

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file. (does not affect API)
