### PR TITLE
fix(genymotion): restore forceAdbInstall support

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -146,6 +146,7 @@
       "src/devices/common/drivers/ios/tools",
       "src/devices/runtime/drivers/android/AndroidDriver.js",
       "src/devices/runtime/drivers/android/emulator/EmulatorDriver.js",
+      "src/devices/runtime/drivers/android/genycloud/GenyCloudDriver.js",
       "src/devices/runtime/drivers/DeviceDriverBase.js",
       "src/devices/runtime/drivers/ios",
       "src/devices/runtime/factories",

--- a/detox/package.json
+++ b/detox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "detox",
   "description": "E2E tests and automation for mobile",
-  "version": "20.1.2",
+  "version": "20.1.3-smoke.0",
   "bin": {
     "detox": "local-cli/cli.js"
   },

--- a/detox/src/devices/runtime/drivers/android/genycloud/GenyCloudDriver.js
+++ b/detox/src/devices/runtime/drivers/android/genycloud/GenyCloudDriver.js
@@ -9,6 +9,7 @@ const AndroidDriver = require('../AndroidDriver');
 /**
  * @typedef GenycloudDriverProps
  * @property instance { GenyInstance } The DTO associated with the cloud instance
+ * @property forceAdbInstall { Boolean }
  */
 
 class GenyCloudDriver extends AndroidDriver {
@@ -16,9 +17,10 @@ class GenyCloudDriver extends AndroidDriver {
    * @param deps { GenycloudDriverDeps }
    * @param props { GenycloudDriverProps }
    */
-  constructor(deps, { instance }) {
+  constructor(deps, { instance, forceAdbInstall }) {
     super(deps, { adbName: instance.adbName });
     this.instance = instance;
+    this._forceAdbInstall = forceAdbInstall;
   }
 
   getDeviceName() {
@@ -30,6 +32,14 @@ class GenyCloudDriver extends AndroidDriver {
   }
 
   async _installAppBinaries(appBinaryPath, testBinaryPath) {
+    if (this._forceAdbInstall) {
+      await super._installAppBinaries(appBinaryPath, testBinaryPath);
+    } else {
+      await this.__installAppBinaries(appBinaryPath, testBinaryPath);
+    }
+  }
+
+  async __installAppBinaries(appBinaryPath, testBinaryPath) {
     await this.appInstallHelper.install(this.adbName, appBinaryPath, testBinaryPath);
   }
 }

--- a/detox/src/devices/runtime/factories/android.js
+++ b/detox/src/devices/runtime/factories/android.js
@@ -56,6 +56,7 @@ class Genycloud extends RuntimeDriverFactoryAndroid {
   _createDriver(deviceCookie, deps, configs) {
     const props = {
       instance: deviceCookie.instance,
+      forceAdbInstall: configs.deviceConfig.forceAdbInstall,
     };
 
     const { GenycloudRuntimeDriver } = require('../drivers');

--- a/detox/test/e2e/detox.config.js
+++ b/detox/test/e2e/detox.config.js
@@ -127,6 +127,7 @@ const config = {
     'android.emulator': {
       type: 'android.emulator',
       headless: Boolean(process.env.CI),
+      forceAdbInstall: true,
       gpuMode: process.env.CI ? 'off' : undefined,
       device: {
         avdName: 'Pixel_3A_API_29'
@@ -135,6 +136,7 @@ const config = {
 
     'android.genycloud.uuid': {
       type: 'android.genycloud',
+      forceAdbInstall: true,
       device: {
         recipeUUID: '90450ce0-cdd8-4229-8618-18a1fc195b62',
       },
@@ -142,6 +144,7 @@ const config = {
 
     'android.genycloud.name': {
       type: 'android.genycloud',
+      forceAdbInstall: true,
       device: {
         recipeName: 'Detox_Pixel_3A_API_29',
       },

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-test",
-  "version": "20.1.2",
+  "version": "20.1.3-smoke.0",
   "private": true,
   "engines": {
     "node": ">=14.5.0"
@@ -54,7 +54,7 @@
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "cross-env": "^7.0.3",
-    "detox": "^20.1.2",
+    "detox": "^20.1.3-smoke.0",
     "eslint": "^7.32.0",
     "eslint-plugin-unicorn": "^39.0.0",
     "execa": "^5.1.1",

--- a/examples/demo-native-android/package.json
+++ b/examples/demo-native-android/package.json
@@ -1,13 +1,13 @@
 {
   "name": "detox-demo-native-android",
-  "version": "20.1.2",
+  "version": "20.1.3-smoke.0",
   "private": true,
   "scripts": {
     "packager": "react-native start",
     "detox-server": "detox run-server"
   },
   "devDependencies": {
-    "detox": "^20.1.2"
+    "detox": "^20.1.3-smoke.0"
   },
   "detox": {}
 }

--- a/examples/demo-native-ios/package.json
+++ b/examples/demo-native-ios/package.json
@@ -1,9 +1,9 @@
 {
   "name": "detox-demo-native-ios",
-  "version": "20.1.2",
+  "version": "20.1.3-smoke.0",
   "private": true,
   "devDependencies": {
-    "detox": "^20.1.2"
+    "detox": "^20.1.3-smoke.0"
   },
   "detox": {
     "specs": "",

--- a/examples/demo-plugin/package.json
+++ b/examples/demo-plugin/package.json
@@ -1,12 +1,12 @@
 {
   "name": "demo-plugin",
-  "version": "20.1.2",
+  "version": "20.1.3-smoke.0",
   "private": true,
   "scripts": {
     "test:plugin": "detox test --configuration plugin -l verbose"
   },
   "devDependencies": {
-    "detox": "^20.1.2",
+    "detox": "^20.1.3-smoke.0",
     "jest": "^28.0.0"
   },
   "detox": {

--- a/examples/demo-react-native-detox-instruments/package.json
+++ b/examples/demo-react-native-detox-instruments/package.json
@@ -1,10 +1,10 @@
 {
   "name": "demo-react-native-detox-instruments",
-  "version": "20.1.2",
+  "version": "20.1.3-smoke.0",
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "detox": "^20.1.2"
+    "detox": "^20.1.3-smoke.0"
   },
   "detox": {
     "configurations": {

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "20.1.2",
+  "version": "20.1.3-smoke.0",
   "private": true,
   "scripts": {
     "start": "react-native start",
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^29.2.1",
-    "detox": "^20.1.2",
+    "detox": "^20.1.3-smoke.0",
     "fs-extra": "^9.1.0",
     "jest": "^29.2.1",
     "ts-jest": "^29.0.3",

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
     "generation",
     "."
   ],
-  "version": "20.1.2",
+  "version": "20.1.3-smoke.0",
   "npmClient": "npm",
   "command": {
     "publish": {

--- a/package.json
+++ b/package.json
@@ -54,5 +54,5 @@
     "shell-utils": "1.x.x",
     "unified": "^10.1.0"
   },
-  "version": "20.1.2"
+  "version": "20.1.3-smoke.0"
 }


### PR DESCRIPTION
## Description

Turns out, `forceAdbInstall` was somehow not implemented for Genymotion driver. It was working only for local devices.

This code is not very pretty but I want to test how it works on our CI, so I'll do a pre-release.