### PR TITLE
Apply DETOX_DBG_SELECTED_CFG env-var to allow for IDE jest-debugging

### DIFF
--- a/detox/src/realms/DetoxPrimaryContext.js
+++ b/detox/src/realms/DetoxPrimaryContext.js
@@ -51,7 +51,7 @@ class DetoxPrimaryContext extends DetoxContext {
     }
   }
 
-  async [symbols.resolveConfig](opts = {}) {
+  async [symbols.resolveConfig](opts = { argv: { configuration: process.env.DETOX_DBG_SELECTED_CFG } }) {
     const session = this[$sessionState];
     if (!session.detoxConfig) {
       const configuration = require('../configuration');


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: N/A

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have introduced `DETOX_DBG_SELECTED_CFG` which allows for an env-var based selection of configuration. This opens the door to debug-based execution of Detox tests in IDE's (e.g. webstorm), which jest must be executed explicitly:
<img width="479" alt="image" src="https://user-images.githubusercontent.com/9818880/217550109-76ed9488-2479-4796-a385-9e2d70d8bd5d.png">


@noomorph if there's a better way to do this which I've overlooked, please let me know

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
