### PR TITLE
[Genymotion SaaS] Update gmsaas start flag to fix wrong device timeout

### DIFF
--- a/detox/src/devices/common/drivers/android/genycloud/exec/GenyCloudExec.js
+++ b/detox/src/devices/common/drivers/android/genycloud/exec/GenyCloudExec.js
@@ -28,7 +28,7 @@ class GenyCloudExec {
   }
 
   startInstance(recipeUUID, instanceName) {
-    return this._exec(`instances start --stop-when-inactive --no-wait ${recipeUUID} "${instanceName}"`, { retries: 0 });
+    return this._exec(`instances start --no-wait ${recipeUUID} "${instanceName}"`, { retries: 0 });
   }
 
   adbConnect(instanceUUID) {


### PR DESCRIPTION
## Description

- When starting a device, `--stop-when-inactive` flag was added to the `gmsaas start` command in the past when the global timeout didn't existed but only the front end inactivity timeout. When the global timeout was released, this flag still pointed to the front end inactivity timeout which is the wrong time out for devices started from gmsaas. Removing it solves the issue.
