### PR TITLE
[Genymotion SaaS] Update gmsaas start flag to fix wrong device timeout

### DIFF
--- a/detox/src/devices/common/drivers/android/genycloud/exec/GenyCloudExec.js
+++ b/detox/src/devices/common/drivers/android/genycloud/exec/GenyCloudExec.js
@@ -28,7 +28,7 @@ class GenyCloudExec {
   }
 
   startInstance(recipeUUID, instanceName) {
-    return this._exec(`instances start --stop-when-inactive --no-wait ${recipeUUID} "${instanceName}"`, { retries: 0 });
+    return this._exec(`instances start --no-wait ${recipeUUID} "${instanceName}"`, { retries: 0 });
   }
 
   adbConnect(instanceUUID) {

--- a/detox/src/devices/common/drivers/android/genycloud/exec/GenyCloudExec.test.js
+++ b/detox/src/devices/common/drivers/android/genycloud/exec/GenyCloudExec.test.js
@@ -69,7 +69,7 @@ describe('Genymotion-cloud executable', () => {
     {
       commandName: 'Start Instance',
       commandExecFn: () => uut.startInstance(recipeUUID, instanceName),
-      expectedExec: `"mock/path/to/gmsaas" --format compactjson instances start --stop-when-inactive --no-wait ${recipeUUID} "${instanceName}"`,
+      expectedExec: `"mock/path/to/gmsaas" --format compactjson instances start --no-wait ${recipeUUID} "${instanceName}"`,
       expectedExecOptions: { retries: 0 },
     },
     {


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: N/A

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have repeated #3926 by @lilinor with the necessary unit-test fixes.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
