### PR TITLE
fix(cli): detox-server should consider --loglevel

### DIFF
--- a/detox/local-cli/run-server.js
+++ b/detox/local-cli/run-server.js
@@ -1,5 +1,8 @@
-const DetoxRuntimeError = require('../src/errors/DetoxRuntimeError');
+const collectCliConfig = require('../src/configuration/collectCliConfig');
+const composeLoggerConfig = require('../src/configuration/composeLoggerConfig');
+const { DetoxRuntimeError } = require('../src/errors');
 const DetoxServer = require('../src/server/DetoxServer');
+const logger = require('../src/utils/logger');
 
 module.exports.command = 'run-server';
 module.exports.desc = 'Start a standalone Detox server';
@@ -27,6 +30,14 @@ module.exports.handler = async function runServer(argv) {
   if (isNaN(argv.port) || argv.port < 1 || argv.port > 65535) {
     throw new DetoxRuntimeError(`The port should be between 1 and 65535, got ${argv.port}`);
   }
+
+  await logger.setConfig(composeLoggerConfig({
+    // @ts-ignore
+    globalConfig: {},
+    // @ts-ignore
+    localConfig: {},
+    cliConfig: collectCliConfig({ argv }),
+  }));
 
   await new DetoxServer({
     port: +argv.port,

--- a/detox/src/utils/logger.js
+++ b/detox/src/utils/logger.js
@@ -1,4 +1,4 @@
 /**
- * @type {Detox.Logger}
+ * @type {import('../logger/DetoxLogger')}
  */
 module.exports = require('../../internals').log;


### PR DESCRIPTION
## Description

Resolves #3886.

Although the suggested solution is a bit hacky, it is good enough to fix the reported issue.

### Notes 

Among less hackier ways to fix it was to change `run-server` signature to accept `-c ...configuration name` instead of using direct `-p <port>`, but I don't want to introduce breaking changes at the moment.

On the other hand, the `run-server` concept itself might be outdated in the light of the recent architectural shift towards encapsulating such functionality entirely inside drivers, so it's not worth serious investment at the moment anyway.