### PR TITLE
fix(cli): increase testRunner.jest.setupTimeout from 2 min to 5 min

### DIFF
--- a/detox/local-cli/init.js
+++ b/detox/local-cli/init.js
@@ -76,7 +76,7 @@ function createDefaultConfigurations() {
         config: 'e2e/jest.config.js',
       },
       jest: {
-        setupTimeout: 120000,
+        setupTimeout: 300000,
       },
     },
     apps: {


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: 

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have updated the `.detoxrc.js` config generated by the CLI to match the value in the [documentation](https://wix.github.io/Detox/docs/config/testRunner/#testrunnerjestsetuptimeout-number):

```
testRunner.jest.setupTimeout: 300000 (5 minutes)
```

This fixes timeout issues on CI:

```
FAIL e2e/starter.test.ts
  ● Test suite failed to run

    Exceeded timeout of 120000ms while setting up Detox environment
```

See https://github.com/remarkablemark/react-native-cli-quickstart

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
