### PR TITLE
Fix detoxURLBlacklistRegex arg for launchApp() on iOS

### DIFF
--- a/detox/ios/Detox/DetoxInit.m
+++ b/detox/ios/Detox/DetoxInit.m
@@ -45,12 +45,12 @@ __attribute__((constructor))
 static void detoxConditionalInit()
 {
 	__DTXInstallCrashHandlersIfNeeded();
-
+	
 	//This forces accessibility support in the application.
 	[[[NSUserDefaults alloc] initWithSuiteName:@"com.apple.Accessibility"] setBool:YES forKey:@"ApplicationAccessibilityEnabled"];
-
+	
 	NSUserDefaults* options = [NSUserDefaults standardUserDefaults];
-
+	
 #if DEBUG
 	if([options boolForKey:@"detoxEnableSyncDebug"])
 	{
@@ -58,15 +58,15 @@ static void detoxConditionalInit()
 		DTXSyncManager.delegate = _detoxSyncDebugger;
 	}
 #endif
-
+	
 	NSMutableDictionary* settings = [NSMutableDictionary new];
-
+	
 	NSString* syncEnabled = [options objectForKey:@"detoxEnableSynchronization"];
 	if(syncEnabled)
 	{
 		settings[@"enabled"] = @([syncEnabled boolValue]);
 	}
-
+	
 	NSString *blacklistRegex = [options stringForKey:@"detoxURLBlacklistRegex"];
 	if (blacklistRegex)
 	{
@@ -76,15 +76,15 @@ static void detoxConditionalInit()
         NSPredicate* predicate = [NSPredicate predicateWithFormat:@"length>1"];
         settings[@"blacklistURLs"] = [_blacklistArray filteredArrayUsingPredicate:predicate];
 	}
-
+	
 	NSString* maxTimerWait = [options objectForKey:@"detoxMaxSynchronizedDelay"];
 	settings[@"maxTimerWait"] = @(maxTimerWait ? maxTimerWait.integerValue : 1500);
-
+	
 	NSString* waitForDebugger = [options objectForKey:@"detoxWaitForDebugger"];
 	if(waitForDebugger)
 	{
 		settings[@"waitForDebugger"] = @([waitForDebugger integerValue]);
 	}
-
+	
 	[DTXDetoxManager.sharedManager startWithSynchronizationSettings:settings];
 }

--- a/detox/test/e2e/14.network.test.js
+++ b/detox/test/e2e/14.network.test.js
@@ -46,23 +46,25 @@ describe('Network Synchronization', () => {
     await waitFor(element(by.text('Long Network Request Working!!!'))).toBeVisible().withTimeout(4000);
     await expect(element(by.text('Long Network Request Working!!!'))).toBeVisible();
 
-    await device.setURLBlacklist([]);
+    await device.launchApp({ newInstance: true });
   });
 
-  it(':android: launchArgs with detoxURLBlacklistRegex should set the blacklist', async () => {
+  it('launchArgs with detoxURLBlacklistRegex should set the "black" (synchronization-ignore) list', async () => {
+    const blackListRegexp = '^http://localhost:\\d{4}?\/[a-z]+\/\\d{4}?$';
+
     await device.launchApp({
       newInstance: true,
-      launchArgs: { detoxURLBlacklistRegex: ' \\("^http:\/\/localhost:\\d{4}?\/[a-z]+\/\\d{4}?$"\\)' },
+      launchArgs: { detoxURLBlacklistRegex: `\\("http://meaningless\.first\.url","${blackListRegexp}"\\)` },
     });
 
-    await device.reloadReactNative();
-
-    await element(by.text('Network')).tap();
-    await element(by.id('LongNetworkRequest')).tap();
-    await expect(element(by.text('Long Network Request Working!!!'))).not.toBeVisible();
-    await waitFor(element(by.text('Long Network Request Working!!!'))).toBeVisible().withTimeout(4000);
-    await expect(element(by.text('Long Network Request Working!!!'))).toBeVisible();
-
-    await device.setURLBlacklist([]);
+    try {
+      await element(by.text('Network')).tap();
+      await element(by.id('LongNetworkRequest')).tap();
+      await expect(element(by.text('Long Network Request Working!!!'))).not.toBeVisible();
+      await waitFor(element(by.text('Long Network Request Working!!!'))).toBeVisible().withTimeout(4000);
+      await expect(element(by.text('Long Network Request Working!!!'))).toBeVisible();
+    } finally {
+      await device.launchApp({ newInstance: true });
+    }
   });
 });

--- a/detox/test/e2e/14.network.test.js
+++ b/detox/test/e2e/14.network.test.js
@@ -46,7 +46,7 @@ describe('Network Synchronization', () => {
     await waitFor(element(by.text('Long Network Request Working!!!'))).toBeVisible().withTimeout(4000);
     await expect(element(by.text('Long Network Request Working!!!'))).toBeVisible();
 
-    await device.launchApp({ newInstance: true });
+    await device.launchApp({ delete: true });
   });
 
   it('launchArgs with detoxURLBlacklistRegex should set the "black" (synchronization-ignore) list', async () => {

--- a/docs/api/device.md
+++ b/docs/api/device.md
@@ -220,12 +220,16 @@ await device.launchApp({
 
 #### 11. `detoxURLBlacklistRegex`—Initialize the URL Blacklist at app launch
 
-Launches the app with a URL blacklist to disable network synchronization on certain endpoints. Useful if the app makes frequent network calls to blacklisted endpoints upon startup.
+Launches the app with a URL blacklist to disable network synchronization on certain endpoints.
+Useful if the app makes frequent network calls to blacklisted endpoints upon startup.
+
+> Note that due to the complexity of reg-exps and interoperability concerns, the implementation is fairly sensitive to the format of the string of urls.
+> Please do your best to follow the example below:
 
 ```js
 await device.launchApp({
   newInstance: true,
-  launchArgs: { detoxURLBlacklistRegex: ' \\("http://192.168.1.253:19001/onchange","https://e.crashlytics.com/spi/v2/events"\\)' },
+  launchArgs: { detoxURLBlacklistRegex: '\\("^http://192\.168\.1\.253:d{4}/.*","https://e\.crashlytics\.com/spi/v2/events"\\)' },
 });
 ```
 


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request fixes #3953

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have aligned the usage of the `detoxURLBlacklistRegex` to the docs (and Android).
Apparently, `detoxURLBlacklistRegex` cannot be extracted from `NSUserDefaults` as an `arrayForKey` (`nil` is returned). Therefore, I've switched to `stringForKey` and implemented a simplified means of string-splitting.

I honestly don't know whether this has ever worked before - perhaps in older iOS versions. In any case, it is what it is... Thanks to the added coverage we shouldn't be having this regression in the future.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
