### PR TITLE
e2e: Improved network tests styling and robustness

### DIFF
--- a/detox/test/e2e/14.network.test.js
+++ b/detox/test/e2e/14.network.test.js
@@ -32,7 +32,7 @@ describe('Network Synchronization', () => {
     await waitFor(driver.longRequest.sendButton).toBeVisible().withTimeout(4000);
 
     await driver.longRequest.sendButton.tap();
-    await driver.longRequest.expectRepliedUnsync();
+    await driver.longRequest.expectRepliedAsync();
 
     await device.enableSynchronization();
   });
@@ -45,7 +45,7 @@ describe('Network Synchronization', () => {
       await device.setURLBlacklist(['.*localhost.*']);
 
       await driver.longRequest.sendButton.tap();
-      await driver.longRequest.expectRepliedUnsync();
+      await driver.longRequest.expectRepliedAsync();
     });
 
     it('launchArgs with detoxURLBlacklistRegex should set the "black" (synchronization-ignore) list', async () => {
@@ -58,7 +58,7 @@ describe('Network Synchronization', () => {
       await element(by.text('Network')).tap();
 
       await driver.longRequest.sendButton.tap();
-      await driver.longRequest.expectRepliedUnsync();
+      await driver.longRequest.expectRepliedAsync();
     });
   });
 });
@@ -74,7 +74,7 @@ const driver = {
     get sendButton() { return element(by.id('LongNetworkRequest')) },
     get repliedText() { return element(by.text('Long Network Request Working!!!')) },
     expectReplied: () => expect(driver.longRequest.repliedText).toBeVisible(),
-    expectRepliedUnsync: async () => {
+    expectRepliedAsync: async () => {
       await expect(driver.longRequest.repliedText).not.toBeVisible();
       await waitFor(driver.longRequest.repliedText).toBeVisible().withTimeout(4000);
     },

--- a/detox/test/e2e/14.network.test.js
+++ b/detox/test/e2e/14.network.test.js
@@ -18,53 +18,65 @@ describe('Network Synchronization', () => {
   });
 
   it('Sync with short network requests - 100ms', async () => {
-    await element(by.id('ShortNetworkRequest')).tap();
-    await expect(element(by.text('Short Network Request Working!!!'))).toBeVisible();
+    await driver.shortRequest.sendButton.tap();
+    await driver.shortRequest.expectReplied();
   });
 
   it('Sync with long network requests - 3000ms', async () => {
-    await element(by.id('LongNetworkRequest')).tap();
-    await expect(element(by.text('Long Network Request Working!!!'))).toBeVisible();
+    await driver.longRequest.sendButton.tap();
+    await driver.longRequest.expectReplied();
   });
 
   it('disableSynchronization() should disable sync', async () => {
     await device.disableSynchronization();
-    await waitFor(element(by.id('LongNetworkRequest'))).toBeVisible().withTimeout(4000);
-    await element(by.id('LongNetworkRequest')).tap();
-    await expect(element(by.text('Long Network Request Working!!!'))).not.toBeVisible();
-    await waitFor(element(by.text('Long Network Request Working!!!'))).toBeVisible().withTimeout(4000);
-    await expect(element(by.text('Long Network Request Working!!!'))).toBeVisible();
+    await waitFor(driver.longRequest.sendButton).toBeVisible().withTimeout(4000);
+
+    await driver.longRequest.sendButton.tap();
+    await driver.longRequest.expectRepliedUnsync();
+
     await device.enableSynchronization();
   });
 
+  describe('URL black-list (endpoints to ignore in network synchronization)', () => {
 
-  it('setURLBlacklist() should disable synchronization for given endpoint', async () => {
-    await device.setURLBlacklist(['.*localhost.*']);
+    afterEach(() => device.launchApp({ delete: true }));
 
-    await element(by.id('LongNetworkRequest')).tap();
-    await expect(element(by.text('Long Network Request Working!!!'))).not.toBeVisible();
-    await waitFor(element(by.text('Long Network Request Working!!!'))).toBeVisible().withTimeout(4000);
-    await expect(element(by.text('Long Network Request Working!!!'))).toBeVisible();
+    it('setURLBlacklist() should disable synchronization for given endpoint', async () => {
+      await device.setURLBlacklist(['.*localhost.*']);
 
-    await device.launchApp({ delete: true });
-  });
-
-  it('launchArgs with detoxURLBlacklistRegex should set the "black" (synchronization-ignore) list', async () => {
-    const blackListRegexp = '^http://localhost:\\d{4}?\/[a-z]+\/\\d{4}?$';
-
-    await device.launchApp({
-      newInstance: true,
-      launchArgs: { detoxURLBlacklistRegex: `\\("http://meaningless\.first\.url","${blackListRegexp}"\\)` },
+      await driver.longRequest.sendButton.tap();
+      await driver.longRequest.expectRepliedUnsync();
     });
 
-    try {
+    it('launchArgs with detoxURLBlacklistRegex should set the "black" (synchronization-ignore) list', async () => {
+      const blackListRegexp = '^http://localhost:\\d{4}?\/[a-z]+\/\\d{4}?$';
+
+      await device.launchApp({
+        newInstance: true,
+        launchArgs: { detoxURLBlacklistRegex: `\\("http://meaningless\.first\.url","${blackListRegexp}"\\)` },
+      });
       await element(by.text('Network')).tap();
-      await element(by.id('LongNetworkRequest')).tap();
-      await expect(element(by.text('Long Network Request Working!!!'))).not.toBeVisible();
-      await waitFor(element(by.text('Long Network Request Working!!!'))).toBeVisible().withTimeout(4000);
-      await expect(element(by.text('Long Network Request Working!!!'))).toBeVisible();
-    } finally {
-      await device.launchApp({ newInstance: true });
-    }
+
+      await driver.longRequest.sendButton.tap();
+      await driver.longRequest.expectRepliedUnsync();
+    });
   });
 });
+
+const driver = {
+  shortRequest: {
+    get sendButton() { return element(by.id('ShortNetworkRequest')) },
+    get repliedText() { return element(by.text('Short Network Request Working!!!')) },
+    expectReplied: () => expect(driver.shortRequest.repliedText).toBeVisible(),
+  },
+
+  longRequest: {
+    get sendButton() { return element(by.id('LongNetworkRequest')) },
+    get repliedText() { return element(by.text('Long Network Request Working!!!')) },
+    expectReplied: () => expect(driver.longRequest.repliedText).toBeVisible(),
+    expectRepliedUnsync: async () => {
+      await expect(driver.longRequest.repliedText).not.toBeVisible();
+      await waitFor(driver.longRequest.repliedText).toBeVisible().withTimeout(4000);
+    },
+  },
+};


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #3953.

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have followed up on @asafkorem's comment on #3954, and optimized network testing. I took the extra mile and introduced a subtle driver, to help out with code duplication, etc.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
