### PR TITLE
Improve quality of testing over Detox assertions (expects etc.)

### DIFF
--- a/detox/src/android/AndroidExpect.test.js
+++ b/detox/src/android/AndroidExpect.test.js
@@ -1,4 +1,7 @@
 // @ts-nocheck
+
+const jestExpect = require('expect').default; // eslint-disable-line
+
 describe('AndroidExpect', () => {
   let e;
 
@@ -107,30 +110,36 @@ describe('AndroidExpect', () => {
     });
 
     it(`should throw for invalid toBeVisible parameters`, async () => {
-      await expectToThrow(() =>e.expect(e.element(e.by.label('test'))).toBeVisible(0));
-      await expectToThrow(() =>e.expect(e.element(e.by.label('test'))).toBeVisible(120));
-      await expectToThrow(() =>e.waitFor(e.element(e.by.label('test'))).toBeVisible(0));
-      await expectToThrow(() =>e.e.waitFor(e.element(e.by.label('test'))).toBeVisible(120));
+      const stubMatcher = e.element(e.by.label('test'));
+      const expectedErrorMsg = 'must be an integer between 1 and 100';
+
+      await jestExpect(() => e.expect(stubMatcher).toBeVisible(0)).rejects.toThrow(expectedErrorMsg);
+      await jestExpect(() => e.expect(stubMatcher).not.toBeVisible(0)).rejects.toThrow(expectedErrorMsg);
+      await jestExpect(() => e.expect(stubMatcher).toBeVisible(101)).rejects.toThrow(expectedErrorMsg);
+      await jestExpect(() => e.expect(stubMatcher).not.toBeVisible(101)).rejects.toThrow(expectedErrorMsg);
+
+      jestExpect(() => e.waitFor(stubMatcher).toBeVisible(0)).toThrow(expectedErrorMsg);
+      jestExpect(() => e.waitFor(stubMatcher).toBeVisible(101)).toThrow(expectedErrorMsg);
     });
 
     it(`expect with wrong parameters should throw`, async () => {
-      await expectToThrow(() => e.expect('notAnElement'));
-      await expectToThrow(() => e.expect(e.element('notAMatcher')));
+      jestExpect(() => e.expect('notAnElement')).toThrow();
+      jestExpect(() => e.expect(e.element('notAMatcher'))).toThrow();
     });
 
     it(`matchers with wrong parameters should throw`, async () => {
-      await expectToThrow(() => e.element(e.by.label(5)));
-      await expectToThrow(() => e.element(e.by.accessibilityLabel(5)));
-      await expectToThrow(() => e.element(e.by.id(5)));
-      await expectToThrow(() => e.element(e.by.type(0)));
-      await expectToThrow(() => e.by.traits(1));
-      await expectToThrow(() => e.by.traits(['nonExistentTrait']));
-      await expectToThrow(() => e.element(e.by.value(0)));
-      await expectToThrow(() => e.element(e.by.text(0)));
-      await expectToThrow(() => e.element(e.by.id('test').withAncestor('notAMatcher')));
-      await expectToThrow(() => e.element(e.by.id('test').withDescendant('notAMatcher')));
-      await expectToThrow(() => e.element(e.by.id('test').and('notAMatcher')));
-      await expectToThrow(() => e.element(e.by.id('test').or('notAMatcher')));
+      jestExpect(() => e.by.label(5)).toThrow();
+      jestExpect(() => e.by.accessibilityLabel(5)).toThrow();
+      jestExpect(() => e.by.id(5)).toThrow();
+      jestExpect(() => e.by.type(0)).toThrow();
+      jestExpect(() => e.by.traits(1)).toThrow();
+      jestExpect(() => e.by.value(0)).toThrow();
+      jestExpect(() => e.by.text(0)).toThrow();
+
+      jestExpect(() => e.element(e.by.id('test').withAncestor('notAMatcher'))).toThrow('Expected a matcher, got string');
+      jestExpect(() => e.element(e.by.id('test').withDescendant('notAMatcher'))).toThrow('Expected a matcher, got string');
+      jestExpect(() => e.element(e.by.id('test').and('notAMatcher'))).toThrow('Expected a matcher, got string');
+      jestExpect(() => e.element(e.by.id('test').or('notAMatcher'))).toThrow('Expected a matcher, got string');
     });
 
     it(`waitFor (element)`, async () => {
@@ -170,14 +179,15 @@ describe('AndroidExpect', () => {
     });
 
     it(`waitFor (element) with wrong parameters should throw`, async () => {
-      await expectToThrow(() => e.waitFor('notAnElement'));
-      await expectToThrow(() => e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout('notANumber'));
-      await expectToThrow(() => e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout(-1));
-      await expectToThrow(() => e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement('notAnElement'));
+      jestExpect(() => e.waitFor('notAnElement')).toThrow();
+      jestExpect(() => e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement('notAnElement')).toThrow();
+
+      await jestExpect(() => e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout('notANumber')).rejects.toThrow();
+      await jestExpect(() => e.waitFor(e.element(e.by.id('id'))).toExist().withTimeout(-1)).rejects.toThrow();
     });
 
     it(`waitFor (element) with non-elements should throw`, async () => {
-      await expectToThrow(() => e.waitFor('notAnElement').toBeVisible());
+      jestExpect(() => e.waitFor('notAnElement')).toThrow();
     });
 
     it('toHaveSliderPosition', async () => {
@@ -198,7 +208,7 @@ describe('AndroidExpect', () => {
 
       it('should not tap and long-press given bad args', async () => {
         await [null, undefined, 0, -1, 'NaN'].forEach(item => {
-          expectToThrow(() => e.element(e.by.id('UniqueId819')).multiTap(item));
+          jestExpect(() => e.element(e.by.id('UniqueId819')).multiTap(item)).rejects.toThrow();
         });
       });
 
@@ -214,8 +224,8 @@ describe('AndroidExpect', () => {
       });
 
       it('should not edit text given bad args', async () => {
-        await expectToThrow(() => e.element(e.by.id('UniqueId937')).typeText(0));
-        await expectToThrow(() => e.element(e.by.id('UniqueId005')).replaceText(3));
+        await jestExpect(() => e.element(e.by.id('UniqueId937')).typeText(0)).rejects.toThrow();
+        await jestExpect(() => e.element(e.by.id('UniqueId005')).replaceText(3)).rejects.toThrow();
       });
 
       it('should scroll', async () => {
@@ -232,22 +242,22 @@ describe('AndroidExpect', () => {
       });
 
       it('should not scroll given bad args', async () => {
-        await expectToThrow(() => e.element(e.by.id('ScrollView161')).scroll('NaN', 'down'));
-        await expectToThrow(() => e.element(e.by.id('ScrollView161')).scroll(100, 'noDirection'));
-        await expectToThrow(() => e.element(e.by.id('ScrollView161')).scroll(100, 0));
-        await expectToThrow(() => e.element(e.by.id('ScrollView161')).scrollTo(0));
-        await expectToThrow(() => e.element(e.by.id('ScrollView161')).scrollTo('noDirection'));
+        await jestExpect(() => e.element(e.by.id('ScrollView161')).scroll('NaN', 'down')).rejects.toThrow();
+        await jestExpect(() => e.element(e.by.id('ScrollView161')).scroll(100, 'noDirection')).rejects.toThrow();
+        await jestExpect(() => e.element(e.by.id('ScrollView161')).scroll(100, 0)).rejects.toThrow();
+        await jestExpect(() => e.element(e.by.id('ScrollView161')).scrollTo(0)).rejects.toThrow();
+        await jestExpect(() => e.element(e.by.id('ScrollView161')).scrollTo('noDirection')).rejects.toThrow();
       });
 
       it('should setDatePickerDate', async () => {
         await e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601');
         await e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019/02/06', 'YYYY/MM/DD');
+        await e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06', 'YYYY-MM-DD');
       });
 
       it('should not setDatePickerDate given bad args', async () => {
-        await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06', 'yyyy-mm-dd'));
-        await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00'));
-        await expectToThrow(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate(2019, 'ISO8601'));
+        await jestExpect(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00')).rejects.toThrow();
+        await jestExpect(() => e.element(e.by.type('android.widget.DatePicker')).setDatePickerDate(2019, 'ISO8601')).rejects.toThrow();
       });
 
       it('should swipe', async () => {
@@ -265,11 +275,11 @@ describe('AndroidExpect', () => {
       });
 
       it('should not swipe given bad args', async () => {
-        await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe(4, 'fast'));
-        await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('noDirection', 0));
-        await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('noDirection', 'fast'));
-        await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('down', 'NotFastNorSlow'));
-        await expectToThrow(() => e.element(e.by.id('ScrollView799')).swipe('down', 'NotFastNorSlow', 0.9));
+        await jestExpect(() => e.element(e.by.id('ScrollView799')).swipe(4, 'fast')).rejects.toThrow();
+        await jestExpect(() => e.element(e.by.id('ScrollView799')).swipe('noDirection', 0)).rejects.toThrow();
+        await jestExpect(() => e.element(e.by.id('ScrollView799')).swipe('noDirection', 'fast')).rejects.toThrow();
+        await jestExpect(() => e.element(e.by.id('ScrollView799')).swipe('down', 'NotFastNorSlow')).rejects.toThrow();
+        await jestExpect(() => e.element(e.by.id('ScrollView799')).swipe('down', 'NotFastNorSlow', 0.9)).rejects.toThrow();
       });
 
       it('should allow for index-based element discrepancy resolution', async () => {
@@ -277,7 +287,7 @@ describe('AndroidExpect', () => {
       });
 
       it('should fail to find index-based element given invalid args', async () => {
-        await expectToThrow(() => e.element(e.by.id('ScrollView799')).atIndex('NaN'));
+        jestExpect(() => e.element(e.by.id('ScrollView799')).atIndex('NaN')).toThrow();
       });
 
       it('should retrieve attributes', async () => {
@@ -367,24 +377,24 @@ describe('AndroidExpect', () => {
         await e.web(e.by.id('webview_id')).element(e.by.web.id('id')).tap();
       });
 
-      it(`with wrong matcher should throw`, async () => {
-        await expectToThrow(() => e.web(e.by.web.className('webMatcher')));
-        await expectToThrow(() => e.web(e.by.web.cssSelector('webMatcher')));
-        await expectToThrow(() => e.web(e.by.web.id('webMatcher')));
-        await expectToThrow(() => e.web(e.by.web.href('webMatcher')));
-        await expectToThrow(() => e.web(e.by.web.name('webMatcher')));
-        await expectToThrow(() => e.web(e.by.web.hrefContains('webMatcher')));
-        await expectToThrow(() => e.web(e.by.web.tag('webMatcher')));
-        await expectToThrow(() => e.web(e.by.web.xpath('webMatcher')));
+      it(`with wrong matcher arguments - should throw`, async () => {
+        jestExpect(() => e.web(e.by.web.className('webMatcher'))).toThrow();
+        jestExpect(() => e.web(e.by.web.cssSelector('webMatcher'))).toThrow();
+        jestExpect(() => e.web(e.by.web.id('webMatcher'))).toThrow();
+        jestExpect(() => e.web(e.by.web.href('webMatcher'))).toThrow();
+        jestExpect(() => e.web(e.by.web.name('webMatcher'))).toThrow();
+        jestExpect(() => e.web(e.by.web.hrefContains('webMatcher'))).toThrow();
+        jestExpect(() => e.web(e.by.web.tag('webMatcher'))).toThrow();
+        jestExpect(() => e.web(e.by.web.xpath('webMatcher'))).toThrow();
       });
 
       it(`inner element with wrong matcher should throw`, async () => {
-        await expectToThrow(() => e.web.element(e.by.accessibilityLabel('nativeMatcher')));
-        await expectToThrow(() => e.web.element(e.by.id('nativeMatcher')));
-        await expectToThrow(() => e.web.element(e.by.label('nativeMatcher')));
-        await expectToThrow(() => e.web.element(e.by.text('nativeMatcher')));
-        await expectToThrow(() => e.web.element(e.by.traits('nativeMatcher')));
-        await expectToThrow(() => e.web.element(e.by.value('nativeMatcher')));
+        jestExpect(() => e.web.element(e.by.accessibilityLabel('nativeMatcher'))).toThrow();
+        jestExpect(() => e.web.element(e.by.id('nativeMatcher'))).toThrow();
+        jestExpect(() => e.web.element(e.by.label('nativeMatcher'))).toThrow();
+        jestExpect(() => e.web.element(e.by.text('nativeMatcher'))).toThrow();
+        jestExpect(() => e.web.element(e.by.traits('nativeMatcher'))).toThrow();
+        jestExpect(() => e.web.element(e.by.value('nativeMatcher'))).toThrow();
       });
     });
 
@@ -629,14 +639,6 @@ describe('AndroidExpect', () => {
     });
   });
 });
-
-async function expectToThrow(func) {
-  try {
-    await func();
-  } catch (ex) {
-    expect(ex).toBeDefined();
-  }
-}
 
 class MockExecutor {
   constructor() {

--- a/detox/src/android/core/NativeMatcher.js
+++ b/detox/src/android/core/NativeMatcher.js
@@ -1,27 +1,42 @@
+const { DetoxRuntimeError } = require('../../errors');
 const invoke = require('../../invoke');
 const DetoxMatcherApi = require('../espressoapi/DetoxMatcher');
 
 class NativeMatcher {
+  static _assertMatcher(matcher) {
+    if (!(matcher instanceof NativeMatcher)) {
+      throw new DetoxRuntimeError(`Expected a matcher, got ${typeof matcher}`);
+    }
+  }
+
   constructor(call) {
     this._call = call || null;
   }
 
   withAncestor(matcher) {
+    NativeMatcher._assertMatcher(matcher);
+
     const call = invoke.callDirectly(DetoxMatcherApi.matcherWithAncestor(this, matcher));
     return new NativeMatcher(call);
   }
 
   withDescendant(matcher) {
+    NativeMatcher._assertMatcher(matcher);
+
     const call = invoke.callDirectly(DetoxMatcherApi.matcherWithDescendant(this, matcher));
     return new NativeMatcher(call);
   }
 
   and(matcher) {
+    NativeMatcher._assertMatcher(matcher);
+
     const call = invoke.callDirectly(DetoxMatcherApi.matcherForAnd(this, matcher));
     return new NativeMatcher(call);
   }
 
   or(matcher) {
+    NativeMatcher._assertMatcher(matcher);
+
     const call = invoke.callDirectly(DetoxMatcherApi.matcherForOr(this, matcher));
     return new NativeMatcher(call);
   }

--- a/detox/src/ios/expectTwo.test.js
+++ b/detox/src/ios/expectTwo.test.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+const jestExpect = require('expect').default; // eslint-disable-line
 const _ = require('lodash');
 
 describe('expectTwo', () => {
@@ -595,6 +596,19 @@ describe('expectTwo', () => {
     it(`should return a temporary path to the screenshot`, async () => {
       expect(result).toBe(tmpFilePath);
     });
+  });
+
+  it('toBeVisible() should throw with bad args', async () => {
+    const stubMatcher = e.element(e.by.label('test'));
+    const expectedErrorMsg = 'must be an integer between 1 and 100';
+
+    jestExpect(() => e.expect(stubMatcher).toBeVisible(0)).toThrow(expectedErrorMsg);
+    jestExpect(() => e.expect(stubMatcher).not.toBeVisible(0)).toThrow(expectedErrorMsg);
+    jestExpect(() => e.expect(stubMatcher).toBeVisible(101)).toThrow(expectedErrorMsg);
+    jestExpect(() => e.expect(stubMatcher).not.toBeVisible(101)).toThrow(expectedErrorMsg);
+
+    jestExpect(() => e.waitFor(stubMatcher).toBeVisible(0)).toThrow(expectedErrorMsg);
+    jestExpect(() => e.waitFor(stubMatcher).toBeVisible(101)).toThrow(expectedErrorMsg);
   });
 
   it('by.web should throw', async () => {

--- a/detox/test/e2e/04.assertions.test.js
+++ b/detox/test/e2e/04.assertions.test.js
@@ -1,91 +1,56 @@
-describe('Assertions', () => {
-  beforeEach(async () => {
+const driver = {
+  navToScreen: async () => {
     await device.reloadReactNative();
     await element(by.text('Assertions')).tap();
+  },
+  get textElement() { return element(by.id('main-text')) },
+  get invisibleTextElement() { return element(by.id('offscreen-text')) },
+  get toggleElement() { return element(by.id('toggle')) },
+}
+
+describe('Assertions', () => {
+  beforeEach(async () => {
+    await driver.navToScreen();
   });
 
   it('should assert an element is visible', async () => {
-    await expect(element(by.id('UniqueId204'))).toBeVisible();
+    await expect(driver.textElement).toBeVisible();
   });
 
   it('should assert an element is not visible', async () => {
-    await expect(element(by.id('UniqueId205'))).not.toBeVisible();
+    await expect(driver.invisibleTextElement).not.toBeVisible();
   });
 
-  // prefer toBeVisible to make sure the user actually sees this element
   it('should assert an element exists', async () => {
-    await expect(element(by.id('UniqueId205'))).toExist();
+    await expect(driver.invisibleTextElement).toExist();
   });
 
   it('should assert an element does not exist', async () => {
     await expect(element(by.id('RandomJunk959'))).not.toExist();
   });
 
-  // matches specific text elements like UIButton, UILabel, UITextField or UITextView, RCTText
   it('should assert an element has text', async () => {
-    await expect(element(by.id('UniqueId204'))).toHaveText('I contain some text');
+    await expect(driver.textElement).toHaveText('I contain some text');
   });
 
-  // matches by accessibility label, this might not be the specific displayed text but is much more generic
   it('should assert an element has (accessibility) label', async () => {
-    await expect(element(by.id('UniqueId204'))).toHaveLabel('I contain some text');
+    await expect(driver.textElement).toHaveLabel('I contain some text');
   });
 
   it('should assert an element has (accessibility) id', async () => {
     await expect(element(by.text('I contain some text'))).toHaveId('UniqueId204');
   });
 
-  // for example, the value of a UISwitch in the "on" state is "1"
   it.skip(':ios: should assert an element has (accessibility) value', async () => {
-    await expect(element(by.id('UniqueId146'))).toHaveValue('0');
-    await element(by.id('UniqueId146')).tap();
-    await expect(element(by.id('UniqueId146'))).toHaveValue('1');
+    await expect(driver.toggleElement).toHaveValue('0');
+    await driver.toggleElement.tap();
+    await expect(driver.toggleElement).toHaveValue('1');
   });
 
   it('assert toggle-switch widget', async () => {
-    await expect(element(by.id('UniqueId146'))).toHaveToggleValue(false);
-    await element(by.id('UniqueId146')).tap();
-    await expect(element(by.id('UniqueId146'))).toHaveToggleValue(true);
-    await expect(element(by.id('UniqueId146'))).not.toHaveToggleValue(false);
-  });
-
-  it('should throw exception for visibility threshold out of range (lower than 1)', async () => {
-    try {
-      await expect(element(by.text('UniqueId204'))).toBeVisible(0);
-    } catch (e) {
-      if (!e.toString().includes('must be an integer between 1 and 100')) {
-        throw new Exception('should throw exception for visibility out of range');
-      }
-    }
-  });
-
-  it('should throw exception for visibility threshold out of range when negated (lower than 1)', async () => {
-    try {
-      await expect(element(by.text('UniqueId204'))).not.toBeVisible(0);
-    } catch (e) {
-      if (!e.toString().includes('must be an integer between 1 and 100')) {
-        throw new Exception('should throw exception for visibility out of range');
-      }
-    }
-  });
-
-  it('should throw exception for visibility threshold out of range (greater than 100)', async () => {
-    try {
-      await expect(element(by.text('UniqueId204'))).toBeVisible(101);
-    } catch (e) {
-      if (!e.toString().includes('must be an integer between 1 and 100')) {
-        throw new Exception('should throw exception for visibility out of range');
-      }
-    }
-  });
-
-  it('should throw exception for visibility threshold out of range when negated (greater than 100)', async () => {
-    try {
-      await expect(element(by.text('UniqueId204'))).toBeVisible(101);
-    } catch (e) {
-      if (!e.toString().includes('must be an integer between 1 and 100')) {
-        throw new Exception('should throw exception for visibility out of range');
-      }
-    }
+    await expect(driver.toggleElement).toHaveToggleValue(false);
+    await driver.toggleElement.tap();
+    await expect(driver.toggleElement).toHaveToggleValue(true);
+    await expect(driver.toggleElement).not.toHaveToggleValue(false);
   });
 });

--- a/detox/test/e2e/04.assertions.test.js
+++ b/detox/test/e2e/04.assertions.test.js
@@ -38,7 +38,7 @@ describe('Assertions', () => {
   });
 
   it('should assert an element has (accessibility) id', async () => {
-    await expect(element(by.text('I contain some text'))).toHaveId('UniqueId204');
+    await expect(element(by.text('I contain some text'))).toHaveId('main-text');
   });
 
   it.skip(':ios: should assert an element has (accessibility) value', async () => {

--- a/detox/test/src/Screens/AssertionsScreen.js
+++ b/detox/test/src/Screens/AssertionsScreen.js
@@ -31,9 +31,9 @@ export default class AssertionsScreen extends Component {
   render() {
     return (
       <View style={{flex: 1, paddingTop: 20, justifyContent: 'center', alignItems: 'center'}}>
-        <Text testID='UniqueId204' style={{marginBottom: 20}} accessibilityLabel={'I contain some text'}>I contain some text</Text>
-        <Text testID='UniqueId205' style={{marginBottom: 20, position: 'absolute', left: -200}}>I am not visible</Text>
-        <TestSwitchWidget testID='UniqueId146'/>
+        <Text testID='main-text' style={{marginBottom: 20}} accessibilityLabel={'I contain some text'}>I contain some text</Text>
+        <Text testID='offscreen-text' style={{marginBottom: 20, position: 'absolute', left: -200}}>I am not visible</Text>
+        <TestSwitchWidget testID='toggle'/>
       </View>
     );
   }


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request is related the issue described here: #3977

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

This pull request introduces some preliminaries to #3977: It cleans up some Detox self-tests related to expectations (assertions). That allows, in turn, to introduce further tests related to that issue.

- Eliminated assertion E2E tests that have already been covered on unit-test level (i.e. invalid args detection).
- Improved expect unit-testing:
  - Replaced custom `expectToThrow()` with jest's `expect().toThrow()` which does the same thing
  - Removed the `by.traits()` test for unsupported traits at unit level, which only make sense on E2E-level because the error should come from native-detox code (todo: add such E2E's)
  - Added missing invalid-args assertions in some `expect()` calls which were unit-tested to throw but didn't fail because `expectToThrow()` was "penetrable".

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
