### PR TITLE
fix: randomize session.id between runs

### DIFF
--- a/detox/src/DetoxWorker.js
+++ b/detox/src/DetoxWorker.js
@@ -96,8 +96,6 @@ class DetoxWorker {
     this._behaviorConfig = behaviorConfig;
     this._deviceConfig = deviceConfig;
     this._sessionConfig = sessionConfig;
-    // @ts-ignore
-    this._sessionConfig.sessionId = sessionConfig.sessionId || uuid.UUID();
     this._runtimeErrorComposer.appsConfig = this._appsConfig;
 
     this._client = new Client(sessionConfig);

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -10,6 +10,7 @@ const failedToReachTheApp = require('../errors/longreads/failedToReachTheApp');
 const Deferred = require('../utils/Deferred');
 const { asError, createErrorWithUserStack, replaceErrorStack } = require('../utils/errorUtils');
 const log = require('../utils/logger').child({ cat: 'ws-client,ws' });
+const uuid = require('../utils/uuid');
 
 const AsyncWebSocket = require('./AsyncWebSocket');
 const actions = require('./actions/actions');
@@ -29,7 +30,7 @@ class Client {
     this._onUnhandledServerError = this._onUnhandledServerError.bind(this);
     this._logError = this._logError.bind(this);
 
-    this._sessionId = sessionId;
+    this._sessionId = sessionId || uuid.UUID();
     this._slowInvocationTimeout = debugSynchronization;
     this._slowInvocationStatusHandle = null;
     this._whenAppIsConnected = this._invalidState('before connecting to the app');
@@ -59,6 +60,10 @@ class Client {
    */
   get isConnected() {
     return this._asyncWebSocket.isOpen && this._whenAppIsConnected.isResolved();
+  }
+
+  get sessionId() {
+    return this._sessionId;
   }
 
   get serverUrl() {

--- a/detox/src/client/Client.test.js
+++ b/detox/src/client/Client.test.js
@@ -128,6 +128,20 @@ describe('Client', () => {
     });
   });
 
+  describe('.sessionId', () => {
+    it('should return sessionConfig.sessionId', () => {
+      expect(client.sessionId).toBe(sessionConfig.sessionId);
+    });
+
+    it('should return a randomly generated sessionId if not provided', () => {
+      const sessionIdFromConfig = sessionConfig.sessionId;
+      delete sessionConfig.sessionId;
+      client = new Client(sessionConfig);
+      expect(client.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(client.sessionId).not.toBe(sessionIdFromConfig);
+    });
+  });
+
   describe('.open()', () => {
     it('should open the web socket', async () => {
       mockAws.mockResponse('loginSuccess', {});

--- a/detox/src/devices/runtime/RuntimeDevice.js
+++ b/detox/src/devices/runtime/RuntimeDevice.js
@@ -12,7 +12,7 @@ class RuntimeDevice {
     behaviorConfig,
     deviceConfig,
     eventEmitter,
-    sessionConfig,
+    client,
     runtimeErrorComposer,
   }, deviceDriver) {
     const methodNames = [
@@ -56,7 +56,11 @@ class RuntimeDevice {
     this._appsConfig = appsConfig;
     this._behaviorConfig = behaviorConfig;
     this._deviceConfig = deviceConfig;
-    this._sessionConfig = sessionConfig;
+    this._sessionInfo = {
+      server: client.serverUrl,
+      sessionId: client.sessionId,
+    };
+
     this._emitter = eventEmitter;
     this._errorComposer = runtimeErrorComposer;
 
@@ -401,8 +405,8 @@ class RuntimeDevice {
 
   _prepareLaunchArgs(additionalLaunchArgs) {
     return {
-      detoxServer: this._sessionConfig.server,
-      detoxSessionId: this._sessionConfig.sessionId,
+      detoxServer: this._sessionInfo.server,
+      detoxSessionId: this._sessionInfo.sessionId,
       ...additionalLaunchArgs
     };
   }

--- a/detox/src/devices/runtime/RuntimeDevice.test.js
+++ b/detox/src/devices/runtime/RuntimeDevice.test.js
@@ -118,7 +118,10 @@ describe('Device', () => {
         default: configurationsMock.appWithRelativeBinaryPath,
       },
       deviceConfig: configurationsMock.iosSimulatorWithShorthandQuery,
-      sessionConfig: configurationsMock.validSession,
+      client: {
+        sessionId: configurationsMock.validSession.sessionId,
+        serverUrl: configurationsMock.validSession.server,
+      },
     }), overrides);
 
     if (overrides && overrides.appsConfig === null) {


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #3768

In this pull request, I have moved random UUID generation to Client.js so as not to mutate the sessionConfig (as it will be preserved for the next test suites within the same Jest worker).

## Before

Two consequent test file runs: see before-app-launch events – detoxSessionId is the same, `c87c6cee-8409-1998-b434-cbe71a6ce286`:

<table><tr><td>

![before-1](https://user-images.githubusercontent.com/1962469/225388814-61b6f236-b1a4-4f45-a363-fdf02c0f59b1.png)

</td><td>

![before-2](https://user-images.githubusercontent.com/1962469/225388870-1ccc1225-18db-44f0-ba2d-c92b5929765b.png)

</td></tr></table>

## After

Two consequent test file runs: see before-app-launch events – detoxSessionId is random:

<table><tr><td>

![after-1](https://user-images.githubusercontent.com/1962469/225390412-95bc350d-023b-409a-9fb0-b1e4a38a597a.png)

</td><td>

![after-2](https://user-images.githubusercontent.com/1962469/225390446-e70b137d-599a-41b5-9cf2-c1881b77b899.png)

</td></tr></table>