### PR TITLE
Update chalk dependency to version 4

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -61,7 +61,7 @@
     "bunyan": "^1.8.12",
     "bunyan-debug-stream": "^3.1.0",
     "caf": "^15.0.1",
-    "chalk": "^2.4.2",
+    "chalk": "^4.0.0",
     "child-process-promise": "^2.2.0",
     "execa": "^5.1.1",
     "find-up": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "chalk": "^2.4.2",
+    "chalk": "^4.0.0",
     "dictionary-en": "^3.1.0",
     "lerna": "3.22.1",
     "lodash": "4.17.x",


### PR DESCRIPTION
https://github.com/chalk/chalk/releases

This version of Chalk is faster, and drags in less transitive dependencies.

Version 4 still supports node back to v10, and I see that Detox declares Node 14 as a minimum.

I did not upgrade all the way to Chalk 5 since it is ESM only.