### PR TITLE
Docs: fix android/build.gradle indentation

### DIFF
--- a/docs/introduction/project-setup.mdx
+++ b/docs/introduction/project-setup.mdx
@@ -171,14 +171,15 @@ Open your main build script and apply the suggested changes:
 
  allprojects {
    repositories {
-   …
-   google()
+     …
+     google()
 // highlight-start
-+  maven { // (4)
-+    url("$rootDir/../node_modules/detox/Detox-android")
-+  }
++    maven { // (4)
++      url("$rootDir/../node_modules/detox/Detox-android")
++    }
 // highlight-end
-   maven { url 'https://www.jitpack.io' }
+     maven { url 'https://www.jitpack.io' }
+   }
  }
 ```
 


### PR DESCRIPTION
This docs-only PR fixes indentation of the changes to `android/build.gradle` in Project Setup.

Currently in 20.x and Next what is shown is:

<img width="538" alt="image" src="https://user-images.githubusercontent.com/15832198/226448900-d0741937-6916-4760-8985-794decd13108.png">


Note that `google` and `maven` are indented the same amount as `allrepositories`, even though they are nested under it.

I actually made a mistake in setting up Detox in my Android project as a result, because I'm not familiar with native Android development. I thought `google` and `maven` _did_ belong at the same level as `allrepositories` instead of underneath it. When I tried this, my project would not build.

This update makes the indentation more clear so users are less likely to be confused or make the same error as I did. Now it shows:

<img width="558" alt="image" src="https://user-images.githubusercontent.com/15832198/226448946-f482980b-30f2-4e63-abf3-1706ff14e232.png">
