### PR TITLE
feat(drivers): add postAllocate() method

### DIFF
--- a/detox/src/DetoxWorker.js
+++ b/detox/src/DetoxWorker.js
@@ -138,6 +138,8 @@ class DetoxWorker {
     this._deviceAllocator = deviceAllocatorFactory.createDeviceAllocator(commonDeps);
     this._deviceCookie = yield this._deviceAllocator.allocate(this._deviceConfig);
 
+    yield this._deviceAllocator.postAllocate(this._deviceCookie);
+
     this.device = runtimeDeviceFactory.createRuntimeDevice(
       this._deviceCookie,
       commonDeps,
@@ -200,9 +202,12 @@ class DetoxWorker {
     }
 
     if (this.device) {
-      const shutdown = this._behaviorConfig ? this._behaviorConfig.cleanup.shutdownDevice : false;
       // @ts-ignore
       await this.device._cleanup();
+    }
+
+    if (this._deviceCookie) {
+      const shutdown = this._behaviorConfig ? this._behaviorConfig.cleanup.shutdownDevice : false;
       await this._deviceAllocator.free(this._deviceCookie, { shutdown });
     }
 

--- a/detox/src/devices/allocation/DeviceAllocator.js
+++ b/detox/src/devices/allocation/DeviceAllocator.js
@@ -24,6 +24,10 @@ class DeviceAllocator {
    * @return {Promise<unknown>}
    */
   postAllocate(deviceCookie) {
+    if (typeof this._driver.postAllocate !== 'function') {
+      return Promise.resolve();
+    }
+
     return this._driver.postAllocate(deviceCookie);
   }
 

--- a/detox/src/devices/allocation/DeviceAllocator.js
+++ b/detox/src/devices/allocation/DeviceAllocator.js
@@ -8,7 +8,7 @@ class DeviceAllocator {
    */
   constructor(allocationDriver) {
     this._driver = allocationDriver;
-    traceMethods(log, this, ['allocate', 'free']);
+    traceMethods(log, this, ['allocate', 'postAllocate', 'free']);
   }
 
   /**
@@ -17,6 +17,14 @@ class DeviceAllocator {
    */
   allocate(deviceConfig) {
     return this._driver.allocate(deviceConfig);
+  }
+
+  /**
+   * @param {DeviceCookie} deviceCookie
+   * @return {Promise<unknown>}
+   */
+  postAllocate(deviceCookie) {
+    return this._driver.postAllocate(deviceCookie);
   }
 
   /**

--- a/detox/src/devices/allocation/DeviceAllocator.test.js
+++ b/detox/src/devices/allocation/DeviceAllocator.test.js
@@ -7,6 +7,7 @@ describe('Device allocator', () => {
   beforeEach(() => {
     allocDriver = {
       allocate: jest.fn(),
+      postAllocate: jest.fn(),
       free: jest.fn(),
     };
 
@@ -25,6 +26,18 @@ describe('Device allocator', () => {
     const result = await deviceAllocator.allocate(query);
     expect(result).toEqual(device);
     expect(allocDriver.allocate).toHaveBeenCalledWith(query);
+  });
+
+  it('should post-allocate via driver', async () => {
+    const cookie = {};
+
+    const result = await deviceAllocator.postAllocate(cookie);
+    expect(allocDriver.postAllocate).toHaveBeenCalledWith(cookie);
+  });
+
+  it('should not post-allocate if the driver does not implement this function', async () => {
+    delete allocDriver.postAllocate;
+    await expect(deviceAllocator.postAllocate({})).resolves.not.toThrow();
   });
 
   it('should deallocate via driver', async () => {

--- a/detox/src/devices/allocation/drivers/AllocationDriverBase.js
+++ b/detox/src/devices/allocation/drivers/AllocationDriverBase.js
@@ -14,6 +14,12 @@ class AllocationDriverBase {
   async allocate(deviceConfig) {}
 
   /**
+   * @param {DeviceCookie} deviceCookie
+   * @return {Promise<void>}
+   */
+  async postAllocate(deviceCookie) {}
+
+  /**
    * @param cookie { DeviceCookie }
    * @param options { DeallocOptions }
    * @return {Promise<void>}

--- a/detox/src/devices/allocation/drivers/android/attached/AttachedAndroidAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/attached/AttachedAndroidAllocDriver.js
@@ -25,11 +25,20 @@ class AttachedAndroidAllocDriver extends AllocationDriverBase {
     const adbNamePattern = deviceConfig.device.adbName;
     const adbName = await this._deviceRegistry.allocateDevice(() => this._freeDeviceFinder.findFreeDevice(adbNamePattern));
 
+    return new AttachedAndroidDeviceCookie(adbName);
+  }
+
+  /**
+   * @param {AttachedAndroidDeviceCookie} deviceCookie
+   * @returns {Promise<void>}
+   */
+  async postAllocate(deviceCookie) {
+    const { adbName } = deviceCookie;
+
     // TODO Also disable native animations?
     await this._adb.apiLevel(adbName);
     await this._adb.unlockScreen(adbName);
     await this._attachedAndroidLauncher.notifyLaunchCompleted(adbName);
-    return new AttachedAndroidDeviceCookie(adbName);
   }
 
   /**

--- a/detox/src/devices/allocation/drivers/android/attached/AttachedAndroidAllocDriver.test.js
+++ b/detox/src/devices/allocation/drivers/android/attached/AttachedAndroidAllocDriver.test.js
@@ -62,27 +62,6 @@ describe('Allocation driver for attached Android devices', () => {
       await expect(allocDriver.allocate(deviceConfig)).rejects.toThrowError('mock error');
     });
 
-    it('should init ADB\'s API-level', async () => {
-      givenDeviceAllocationResult(adbName);
-
-      await allocDriver.allocate(deviceConfig);
-      expect(adb.apiLevel).toHaveBeenCalledWith(adbName);
-    });
-
-    it('should unlock the screen using ADB', async () => {
-      givenDeviceAllocationResult(adbName);
-
-      await allocDriver.allocate(deviceConfig);
-      expect(adb.unlockScreen).toHaveBeenCalledWith(adbName);
-    });
-
-    it('should report boot-event via launcher', async () => {
-      givenDeviceAllocationResult(adbName);
-
-      await allocDriver.allocate(deviceConfig);
-      expect(attachedAndroidLauncher.notifyLaunchCompleted).toHaveBeenCalledWith(adbName);
-    });
-
     it('should return a valid cookie', async () => {
       const Cookie = require('../../../../cookies/AttachedAndroidDeviceCookie');
 
@@ -91,6 +70,28 @@ describe('Allocation driver for attached Android devices', () => {
       const result = await allocDriver.allocate(deviceConfig);
       expect(result.constructor.name).toEqual('AttachedAndroidDeviceCookie');
       expect(Cookie).toHaveBeenCalledWith(adbName);
+    });
+
+    describe('post-allocation', () => {
+      beforeEach(async () => {
+        givenDeviceAllocationResult(adbName);
+        await allocDriver.allocate(deviceConfig);
+      });
+
+      it('should init ADB\'s API-level', async () => {
+        await allocDriver.postAllocate({ adbName });
+        expect(adb.apiLevel).toHaveBeenCalledWith(adbName);
+      });
+
+      it('should unlock the screen using ADB', async () => {
+        await allocDriver.postAllocate({ adbName });
+        expect(adb.unlockScreen).toHaveBeenCalledWith(adbName);
+      });
+
+      it('should report boot-event via launcher', async () => {
+        await allocDriver.postAllocate({ adbName });
+        expect(attachedAndroidLauncher.notifyLaunchCompleted).toHaveBeenCalledWith(adbName);
+      });
     });
   });
 

--- a/detox/src/devices/allocation/drivers/ios/SimulatorAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/ios/SimulatorAllocDriver.js
@@ -16,6 +16,7 @@ class SimulatorAllocDriver extends AllocationDriverBase {
     this._deviceRegistry = deviceRegistry;
     this._applesimutils = applesimutils;
     this._simulatorLauncher = simulatorLauncher;
+    this._launchInfo = {};
   }
 
   /**
@@ -35,14 +36,18 @@ class SimulatorAllocDriver extends AllocationDriverBase {
       throw new DetoxRuntimeError(`Failed to find device matching ${deviceComment}`);
     }
 
-    try {
-      await this._simulatorLauncher.launch(udid, deviceConfig.type, deviceConfig.bootArgs, deviceConfig.headless);
-    } catch (e) {
-      await this._deviceRegistry.disposeDevice(udid);
-      throw e;
-    }
-
+    this._launchInfo[udid] = { deviceConfig };
     return new IosSimulatorCookie(udid);
+  }
+
+  /**
+   * @param {IosSimulatorCookie} deviceCookie
+   * @returns {Promise<void>}
+   */
+  async postAllocate(deviceCookie) {
+    const { udid } = deviceCookie;
+    const { deviceConfig } = this._launchInfo[udid];
+    await this._simulatorLauncher.launch(udid, deviceConfig.type, deviceConfig.bootArgs, deviceConfig.headless);
   }
 
   /**

--- a/detox/test/e2e/detox.config.js
+++ b/detox/test/e2e/detox.config.js
@@ -200,6 +200,10 @@ const config = {
       device: 'android.emulator',
       apps: ['android.release', 'android.release.withArgs'],
     },
+    'android.genycloud.debug': {
+      device: 'android.genycloud.uuid',
+      apps: ['android.debug'],
+    },
     'android.genycloud.release': {
       device: 'android.genycloud.uuid',
       apps: ['android.release', 'android.release.withArgs'],

--- a/docs/articles/third-party-drivers.md
+++ b/docs/articles/third-party-drivers.md
@@ -102,6 +102,11 @@ class MyNewAllocationDriver {
     return new Cookie(id); // This is where a cookie is formed once for the entire process
   }
 
+  async postAllocate(cookie) {
+    // Optional method to handle operations after the device is allocated
+    // like waiting until the boot animation is finished, configuring the device, etc.
+  }
+
   async free(cookie, options) {
     // ...
   }


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #3655

In this pull request, I have added a new method, `postAllocate` to the device allocation drivers, which is an optional method to handle operations after the device is allocated, such as waiting until the boot animation is finished, configuring the device, etc.

```diff
class MyNewAllocationDriver {
  constructor(deps) {
    this.emitter = deps.eventEmitter;
  }
  async allocate(deviceConfig) {
    // ...
    return new Cookie(id); // This is where a cookie is formed once for the entire process
  }
+  async postAllocate(cookie) {
+   // Optional method to handle operations after the device is allocated
+    // like waiting until the boot animation is finished, configuring the device, etc.
+  }
  async free(cookie, options) {
    // ...
  }
}
```
This helps to separate "acquiring a _cookie_" from "finishing the preparation" so that even in case the preparation goes wrong, the layer responsible for the teardown is guaranteed to receive the cookie and be able to clean up.

Previously, a broken post-cookie preparation resulted in us not having a cookie to use when freeing the device – i.e., not freeing the device. So, I rewrote our allocation drivers to leverage this method. This simplified a few `try-catch` places where we were aware of this problem yet applied a workaround (and missed this problem with Genymotion drivers). 

> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.