### PR TITLE
perf(genymotion): fail-fast when device hangs

### DIFF
--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
@@ -1,18 +1,20 @@
-// @ts-nocheck
-const DetoxRuntimeError = require('../../../../../errors/DetoxRuntimeError');
+const { DetoxRuntimeError } = require('../../../../../errors');
+const Timer = require('../../../../../utils/Timer');
 const GenycloudEmulatorCookie = require('../../../../cookies/GenycloudEmulatorCookie');
 const AllocationDriverBase = require('../../AllocationDriverBase');
 
 class GenyAllocDriver extends AllocationDriverBase {
 
   /**
-   * @param adb { ADB }
-   * @param recipeQuerying { GenyRecipeQuerying }
-   * @param allocationHelper { GenyInstanceAllocationHelper }
-   * @param instanceLauncher { GenyInstanceLauncher }
+   * @param {object} options
+   * @param {import('../../../../common/drivers/android/exec/ADB')} options.adb
+   * @param {import('./GenyRecipeQuerying')} options.recipeQuerying
+   * @param {import('./GenyInstanceAllocationHelper')} options.allocationHelper
+   * @param {import('./GenyInstanceLauncher')} options.instanceLauncher
    */
   constructor({ adb, recipeQuerying, allocationHelper, instanceLauncher }) {
     super();
+
     this._adb = adb;
     this._recipeQuerying = recipeQuerying;
     this._instanceLauncher = instanceLauncher;
@@ -44,9 +46,11 @@ class GenyAllocDriver extends AllocationDriverBase {
     const readyInstance = cookie.instance = await this._instanceLauncher.launch(instance, isNew);
 
     const { adbName } = readyInstance;
-    await this._adb.disableAndroidAnimations(adbName);
-    await this._adb.setWiFiToggle(adbName, true);
-    await this._adb.apiLevel(adbName);
+    await Timer.run(20000, 'waiting for device to respond', async () => {
+      await this._adb.disableAndroidAnimations(adbName);
+      await this._adb.setWiFiToggle(adbName, true);
+      await this._adb.apiLevel(adbName);
+    });
   }
 
   /**

--- a/detox/src/utils/Timer.js
+++ b/detox/src/utils/Timer.js
@@ -77,6 +77,12 @@ class Timer {
       Promise.resolve().then(action),
     ]);
   }
+
+  static run(timeout, description, action) {
+    const timer = new Timer();
+    timer.schedule(timeout);
+    return timer.run(description, action);
+  }
 }
 
 module.exports = Timer;

--- a/detox/src/utils/Timer.test.js
+++ b/detox/src/utils/Timer.test.js
@@ -76,4 +76,14 @@ describe('Timer', () => {
     await expect(timer.run('testing', () => 5))
       .rejects.toThrowError(/Exceeded timeout of 100ms while testing/);
   });
+
+  it('should run action in time with static method', async () => {
+    await expect(Timer.run(1000, 'running test', () => 5)).resolves.toBe(5);
+  });
+
+  it('should throw if an action takes longer with static method', async () => {
+    const promise = Timer.run(999, 'running this test', () => new Deferred().promise);
+    jest.advanceTimersByTime(1000);
+    await expect(promise).rejects.toThrowError(/Exceeded timeout of 999ms while running this test/);
+  });
 });


### PR DESCRIPTION
## Description

This pull request should allow users to utilize CI agents better until we come up with a specific recovery logic.
I wonder if using ` gmsaas instances adbdisconnect` + ` gmsaas instances adbconnect` retry loop could help.

![Screenshot 2023-04-11 at 12 07 32](https://user-images.githubusercontent.com/1962469/231115100-8da4730b-25b7-4108-a6e1-873f9317916e.png)

According to internal bug reports (see the screenshot above), when Genymotion SaaS instances hang up, the first code to start choking is this sequence:

```js
await this._adb.disableAndroidAnimations(adbName);
await this._adb.setWiFiToggle(adbName, true);
await this._adb.apiLevel(adbName);
```

I added a heuristical timeout to detect this state quicker than wait 180s (or 300s) until Jest Environment times out:

```diff
+    await Timer.run(20000, 'waiting for device to respond', async () => {
       await this._adb.disableAndroidAnimations(adbName);
       await this._adb.setWiFiToggle(adbName, true);
       await this._adb.apiLevel(adbName);
+    });
```
Experimentally I measured that in a simulated 3G network it takes about 4 seconds to run all these three commands.
I assume that limiting this to 20 seconds is a safe enough time window to allow our suites to fail reasonably fast.

![image](https://user-images.githubusercontent.com/1962469/231114942-b86c8c1a-edf5-4b1f-b601-ffb9b05188eb.png)

This is not the final resolution of this issue – it just supplements https://github.com/wix/Detox/pull/4005 as an extra patch.