### PR TITLE
Update docs related to detoxURLBlacklistRegex

### DIFF
--- a/docs/api/device.md
+++ b/docs/api/device.md
@@ -229,7 +229,7 @@ Useful if the app makes frequent network calls to blacklisted endpoints upon sta
 ```js
 await device.launchApp({
   newInstance: true,
-  launchArgs: { detoxURLBlacklistRegex: '\\("^http://192\.168\.1\.253:d{4}/.*","https://e\.crashlytics\.com/spi/v2/events"\\)' },
+  launchArgs: { detoxURLBlacklistRegex: '("http://192.168.1.253:d{4}/.*","https://e.crashlytics.com/spi/v2/events")' },
 });
 ```
 


### PR DESCRIPTION
## Description

According to the v18 migration guide here https://wix.github.io/Detox/docs/guide/migration/#180, the escaping of the regex for detoxURLBlacklistRegex is no longer required. This PR updates the docs to reflect this