### PR TITLE
Update fs-extra from 4.x to 9.x

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -65,7 +65,7 @@
     "child-process-promise": "^2.2.0",
     "execa": "^5.1.1",
     "find-up": "^4.1.0",
-    "fs-extra": "^4.0.2",
+    "fs-extra": "^9.0.0",
     "funpermaproxy": "^1.1.0",
     "glob": "^8.0.3",
     "ini": "^1.3.4",


### PR DESCRIPTION
## Description

This preserves compat with node versions back to 10.x

https://github.com/jprichardson/node-fs-extra/blob/master/CHANGELOG.md

There are no API-level breaking changes that seem to affect behavior (tests pass), only deprecated node versions and some refactored the behavior of a few APIs – for instance more use of native node APIs instead of polyfills.
