### PR TITLE
docs: fix `detoxURLBlacklistRegex` usage example.

### DIFF
--- a/docs/api/device.md
+++ b/docs/api/device.md
@@ -229,7 +229,7 @@ Useful if the app makes frequent network calls to blacklisted endpoints upon sta
 ```js
 await device.launchApp({
   newInstance: true,
-  launchArgs: { detoxURLBlacklistRegex: '\\("^http://192\.168\.1\.253:d{4}/.*","https://e\.crashlytics\.com/spi/v2/events"\\)' },
+  launchArgs: { detoxURLBlacklistRegex: '\\("^http://192\.168\.1\.253:\\d{4}/.*","https://e\.crashlytics\.com/spi/v2/events"\\)' },
 });
 ```
 

--- a/website/versioned_docs/version-20.x/api/device.md
+++ b/website/versioned_docs/version-20.x/api/device.md
@@ -229,7 +229,7 @@ Useful if the app makes frequent network calls to blacklisted endpoints upon sta
 ```js
 await device.launchApp({
   newInstance: true,
-  launchArgs: { detoxURLBlacklistRegex: '\\("^http://192\.168\.1\.253:d{4}/.*","https://e\.crashlytics\.com/spi/v2/events"\\)' },
+  launchArgs: { detoxURLBlacklistRegex: '\\("^http://192\.168\.1\.253:\\d{4}/.*","https://e\.crashlytics\.com/spi/v2/events"\\)' },
 });
 ```
 


### PR DESCRIPTION
Without the backward slash before, `d{4}` will not be handled as a regex pattern.
In this example `\d{4}` is used to match exactly four consecutive digits (which is the port component in this case).