### PR TITLE
build: freeze node-ipc version

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -73,7 +73,7 @@
     "lodash": "^4.17.11",
     "multi-sort-stream": "^1.0.3",
     "multipipe": "^4.0.0",
-    "node-ipc": "^9.2.1",
+    "node-ipc": "9.2.1",
     "proper-lockfile": "^3.0.2",
     "resolve-from": "^5.0.0",
     "sanitize-filename": "^1.6.1",


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #4015

Although this is not required, in this pull request, I have frozen `node-ipc` version to prevent unintended automatic upgrades in case 9.x gets compromised for some reason again.