### PR TITLE
Update yargs + yargs-parser dependencies

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -88,8 +88,8 @@
     "trace-event-lib": "^1.3.1",
     "which": "^1.3.1",
     "ws": "^7.0.0",
-    "yargs": "^16.0.3",
-    "yargs-parser": "^20.2.9",
+    "yargs": "^17.0.0",
+    "yargs-parser": "^21.0.0",
     "yargs-unparser": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
A new major version has been out for a while for both.

https://github.com/yargs/yargs/blob/main/CHANGELOG.md https://github.com/yargs/yargs-parser/blob/main/CHANGELOG.md

The biggest breaking change in both libraries is that they've dropped node 10 support, which is already dropped by Detox.

Related to https://github.com/wix/Detox/issues/3994