### PR TITLE
Bump find-up to 5.x

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -64,7 +64,7 @@
     "chalk": "^4.0.0",
     "child-process-promise": "^2.2.0",
     "execa": "^5.1.1",
-    "find-up": "^4.1.0",
+    "find-up": "^5.0.0",
     "fs-extra": "^11.0.0",
     "funpermaproxy": "^1.1.0",
     "glob": "^8.0.3",


### PR DESCRIPTION
https://github.com/sindresorhus/find-up/releases/tag/v5.0.0

Only breaking change is it drops node 10 support.

I didn't bump to 6.x now, since that version is rewritten to ESM.

Related to https://github.com/wix/Detox/issues/3994