### PR TITLE
[Website] Fix issue overlay docs code headers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,5 +26,6 @@ tab_width = 2
 indent_size = 2
 tab_width = 2
 
-[{*.css, *.scss, *.har,*.jsb2,*.jsb3,*.json,.babelrc,.eslintrc,.prettierrc,.stylelintrc,bowerrc,jest.config}]
+[{*.css,*.scss,*.har,*.jsb2,*.jsb3,*.json,.babelrc,.eslintrc,.prettierrc,.stylelintrc,bowerrc,jest.config}]
 indent_size = 2
+tab_width = 2

--- a/docs/demo.mdx
+++ b/docs/demo.mdx
@@ -49,9 +49,9 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam auctor, odio euismo
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam auctor, odio euismod accumsan dignissim, risus mi blandit ipsum, id ullamcorper risus urna eget augue.
 
-## Example Heading with Long Code Line
+### `example.​heading.​with.​a.​very.​very.​and.​really.​very.​long.​line.​which.​should.​be.​wrapped` \[string \| number\]
 
-- [`Lorem ipsum dolor sit (amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut)` iIpsum only](#Lorem ipsum dolor sit amet, consectetur elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.)
+- Lorem ipsum dolor sit amet, consectetur elit, sed do eiusmod tempor `incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam`, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.)
 
 ###### `id` \[string \| number\]
 

--- a/docs/demo.mdx
+++ b/docs/demo.mdx
@@ -49,6 +49,10 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam auctor, odio euismo
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam auctor, odio euismod accumsan dignissim, risus mi blandit ipsum, id ullamcorper risus urna eget augue.
 
+## Example Heading with Long Code Line
+
+- [`Lorem ipsum dolor sit (amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut)` iIpsum only](#Lorem ipsum dolor sit amet, consectetur elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.)
+
 ###### `id` \[string \| number\]
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam auctor, odio euismod accumsan dignissim, risus mi blandit ipsum, id ullamcorper risus urna eget augue.

--- a/website/package.json
+++ b/website/package.json
@@ -23,6 +23,7 @@
     "@percy/cli": "^1.17.0",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
+    "docusaurus": "^1.14.7",
     "docusaurus-plugin-sass": "^0.2.3",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^1.2.1",

--- a/website/percy.mjs
+++ b/website/percy.mjs
@@ -39,7 +39,7 @@ class Server {
       this.childPromise.stdout.on('data', (data) => {
         if (`${data}`.startsWith('[SUCCESS] Serving')) {
           clearTimeout(handle);
-          resolve();
+          setTimeout(resolve, 2000);
         }
       });
     });

--- a/website/src/css/_markdown.scss
+++ b/website/src/css/_markdown.scss
@@ -3,7 +3,3 @@
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
-
-.markdown code {
-  white-space: pre;
-}

--- a/website/src/css/_markdown.scss
+++ b/website/src/css/_markdown.scss
@@ -3,3 +3,17 @@
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
+
+.markdown {
+  @media (min-width: 768px) {
+    code {
+      white-space: pre;
+    }
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    code {
+      white-space: pre-wrap;
+    }
+  }
+}


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #4016 

In this pull request, I have …

Targeted the issue causing long code line headers overlaying on other elements:
- Remove markdown code added with `white-space: pre` in SCSS markdown file
- Added test case to the _demo page
---
cc: @asafkorem 