### PR TITLE
Androidx.test core 1.5.0

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -102,10 +102,10 @@ dependencies {
     api('org.hamcrest:hamcrest:2.2') {
         because 'See https://github.com/wix/Detox/issues/3920. Need to force hamcrest 2.2 win in battle of 2.2 vs. 1.3 (specified by Espresso).'
     }
-    api('androidx.test:rules:1.4.0') {
+    api('androidx.test:rules:1.5.0') {
         because 'of ActivityTestRule. Needed by users *and* internally used by Detox.'
     }
-    api('androidx.test.ext:junit:1.1.3') {
+    api('androidx.test.ext:junit:1.1.5') {
         because 'Needed so as to seamlessly provide AndroidJUnit4 to Detox users. Depends on junit core.'
     }
 

--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     testImplementation 'org.json:json:20140107'
 
 // https://github.com/spekframework/spek/issues/232#issuecomment-610732158
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.6.0'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.7.2'
 
     testImplementation 'org.assertj:assertj-core:3.16.1'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$_kotlinVersion"

--- a/detox/package.json
+++ b/detox/package.json
@@ -24,6 +24,8 @@
     "build:android-native": "cd android && ./gradlew publish -Dversion=999.999.999 -DbuildFlavour=coreNative -DforceLocal=true && cd ..",
     "lint": "eslint .",
     "unit": "jest --coverage --verbose",
+    "unit:android-debug": "cd android && ./gradlew testFullDebug",
+    "unit:android-release": "cd android && ./gradlew testFullRelease",
     "pretest": "npm run lint",
     "test": "npm run unit",
     "posttest": "cp coverage/lcov.info coverage/unit.lcov",

--- a/scripts/ci.android.sh
+++ b/scripts/ci.android.sh
@@ -20,7 +20,7 @@ popd
 
 if [[ $currentRnVersion -ge 66 ]]; then
   pushd detox/android
-  run_f "./gradlew testFullRelease"
+  run_f "npm run unit:android-release"
   popd
 else
   echo "Skipping Android unit tests (react-native version ${currentRnVersion} is not ≥66)"


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #3867; It is meant to make workarounds such as [this one](https://github.com/wix/Detox/issues/3867#issuecomment-1458654925) scarce, in favor of better usability with RN .71 (and above).

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have upgraded Detox's Android-native dep, `androidx.test:core` from `1.4.0` to `1.5.0`.
Technically, `androidx.test:core` is specified indirectly via `androidx.test.ext:junit`, so effectively I've change this dep (and the `:rules` dep accordingly) in order to get that into effect.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
