### PR TITLE
Restore usage of launch-args lib

### DIFF
--- a/detox/test/android/app/build.gradle
+++ b/detox/test/android/app/build.gradle
@@ -98,6 +98,7 @@ dependencies {
     implementation project(':react-native-community-checkbox')
     implementation project(':react-native-community-geolocation')
     implementation project(':react-native-datetimepicker')
+    implementation project(':react-native-launcharguments')
 
     androidTestImplementation(project(path: ':detox'))
     androidTestImplementation 'com.linkedin.testbutler:test-butler-library:2.2.1'

--- a/detox/test/android/app/src/main/java/com/example/DetoxRNHost.java
+++ b/detox/test/android/app/src/main/java/com/example/DetoxRNHost.java
@@ -11,37 +11,39 @@ import com.reactnativecommunity.geolocation.GeolocationPackage;
 import com.reactnativecommunity.slider.ReactSliderPackage;
 import com.reactnativecommunity.webview.RNCWebViewPackage;
 import com.reactcommunity.rndatetimepicker.RNDateTimePickerPackage;
+import com.reactnativelauncharguments.LaunchArgumentsPackage;
 
 import java.util.Arrays;
 import java.util.List;
 
 class DetoxRNHost extends ReactNativeHost {
-   protected DetoxRNHost(Application application) {
-      super(application);
-   }
+    protected DetoxRNHost(Application application) {
+        super(application);
+    }
 
-   @Override
-   public boolean getUseDeveloperSupport() {
-      return BuildConfig.DEBUG;
-   }
+    @Override
+    public boolean getUseDeveloperSupport() {
+        return BuildConfig.DEBUG;
+    }
 
-   @Override
-   protected List<ReactPackage> getPackages() {
-      // Packages that cannot be autolinked yet can be added manually here, for example:
-      //     packages.add(new MyReactNativePackage());
-      // TurboModules must also be loaded here providing a valid TurboReactPackage implementation:
-      //     packages.add(new TurboReactPackage() { ... });
-      // If you have custom Fabric Components, their ViewManagers should also be loaded here
-      // inside a ReactPackage.
-      return Arrays.asList(
-              new MainReactPackage(),
-              new ReactSliderPackage(),
-              new GeolocationPackage(),
-              new RNCWebViewPackage(),
-              new NativeModulePackage(),
-              new AsyncStoragePackage(),
-              new ReactCheckBoxPackage(),
-              new RNDateTimePickerPackage()
-      );
-   }
+    @Override
+    protected List<ReactPackage> getPackages() {
+        // Packages that cannot be autolinked yet can be added manually here, for example:
+        //     packages.add(new MyReactNativePackage());
+        // TurboModules must also be loaded here providing a valid TurboReactPackage implementation:
+        //     packages.add(new TurboReactPackage() { ... });
+        // If you have custom Fabric Components, their ViewManagers should also be loaded here
+        // inside a ReactPackage.
+        return Arrays.asList(
+            new MainReactPackage(),
+            new ReactSliderPackage(),
+            new GeolocationPackage(),
+            new RNCWebViewPackage(),
+            new NativeModulePackage(),
+            new AsyncStoragePackage(),
+            new ReactCheckBoxPackage(),
+            new RNDateTimePickerPackage(),
+            new LaunchArgumentsPackage()
+        );
+    }
 }

--- a/detox/test/android/app/src/main/java/com/example/NativeModule.java
+++ b/detox/test/android/app/src/main/java/com/example/NativeModule.java
@@ -19,7 +19,6 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.WritableMap;
 
 public class NativeModule extends ReactContextBaseJavaModule {
 
@@ -79,11 +78,6 @@ public class NativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getLaunchArguments(Promise promise) {
-        promise.resolve(parseIntentExtras("launchArgs"));
-    }
-
-    @ReactMethod
     public void parseNotificationData(String innerKey, Promise promise) {
         Bundle data = getIntentExtras(innerKey);
         data.remove("launchArgs");
@@ -120,11 +114,6 @@ public class NativeModule extends ReactContextBaseJavaModule {
         rnExtension.toggleUISynchronization(enable);
         rnExtension.toggleTimersSynchronization(enable);
         rnExtension.toggleNetworkSynchronization(enable);
-    }
-
-    private WritableMap parseIntentExtras(String bundleKey) {
-        Bundle extras = getIntentExtras(bundleKey);
-        return Arguments.fromBundle(extras);
     }
 
     private Bundle getIntentExtras(String bundleKey) {

--- a/detox/test/android/settings.gradle
+++ b/detox/test/android/settings.gradle
@@ -41,3 +41,6 @@ project(':@react-native-community_slider').projectDir = new File(rootProject.pro
 
 include ':react-native-datetimepicker'
 project(':react-native-datetimepicker').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/datetimepicker/android')
+
+include ':react-native-launcharguments'
+project(':react-native-launcharguments').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-launch-arguments/android')

--- a/detox/test/index.android.js
+++ b/detox/test/index.android.js
@@ -1,7 +1,6 @@
 import {
   AppRegistry,
 } from 'react-native';
-import {LaunchArguments} from 'react-native-launch-arguments';
 
 import example from './src/app';
 
@@ -12,6 +11,10 @@ class exampleAndroid extends example {
   }
 
   async _registerEarlyCrashIfNeeded() {
+    // Never import this at top-level or it would trigger an initialization of the launch-arguments'
+    // native module too early (i.e. before the Activity has been initialized).
+    const {LaunchArguments} = require('react-native-launch-arguments');
+
     if (LaunchArguments.value().simulateEarlyCrash) {
       console.warn('simulateEarlyCrash=true detected: Will crash in a few seconds from now (all-the-while keeping the app busy)...');
       this._setupBusyFutureCrash();

--- a/detox/test/index.android.js
+++ b/detox/test/index.android.js
@@ -11,8 +11,9 @@ class exampleAndroid extends example {
   }
 
   async _registerEarlyCrashIfNeeded() {
-    // Never import this at top-level or it would trigger an initialization of the launch-arguments'
-    // native module too early (i.e. before the Activity has been initialized).
+    // Never import this at the index.js (i.e. RN entry point file) at top-level, or it would trigger an
+    // initialization of the launch-arguments' native-module too early (i.e. before the Android Activity has
+    // been initialized; It needs to be at the RESUMED state in order to be accessible from native-modules).
     const {LaunchArguments} = require('react-native-launch-arguments');
 
     if (LaunchArguments.value().simulateEarlyCrash) {

--- a/detox/test/index.android.js
+++ b/detox/test/index.android.js
@@ -1,11 +1,9 @@
+import {LaunchArguments} from 'react-native-launch-arguments';
 import {
   AppRegistry,
-  NativeModules,
 } from 'react-native';
 
 import example from './src/app';
-
-const { NativeModule } = NativeModules;
 
 class exampleAndroid extends example {
   async componentDidMount() {
@@ -14,8 +12,7 @@ class exampleAndroid extends example {
   }
 
   async _registerEarlyCrashIfNeeded() {
-    const launchArguments = await NativeModule.getLaunchArguments();
-    if (launchArguments.simulateEarlyCrash) {
+    if (LaunchArguments.value().simulateEarlyCrash) {
       console.warn('simulateEarlyCrash=true detected: Will crash in a few seconds from now (all-the-while keeping the app busy)...');
       this._setupBusyFutureCrash();
     }

--- a/detox/test/index.android.js
+++ b/detox/test/index.android.js
@@ -1,6 +1,7 @@
 import {
   AppRegistry,
 } from 'react-native';
+import {LaunchArguments} from 'react-native-launch-arguments';
 
 import example from './src/app';
 
@@ -11,11 +12,6 @@ class exampleAndroid extends example {
   }
 
   async _registerEarlyCrashIfNeeded() {
-    // Never import this at the index.js (i.e. RN entry point file) at top-level, or it would trigger an
-    // initialization of the launch-arguments' native-module too early (i.e. before the Android Activity has
-    // been initialized; It needs to be at the RESUMED state in order to be accessible from native-modules).
-    const {LaunchArguments} = require('react-native-launch-arguments');
-
     if (LaunchArguments.value().simulateEarlyCrash) {
       console.warn('simulateEarlyCrash=true detected: Will crash in a few seconds from now (all-the-while keeping the app busy)...');
       this._setupBusyFutureCrash();

--- a/detox/test/index.android.js
+++ b/detox/test/index.android.js
@@ -1,7 +1,7 @@
-import {LaunchArguments} from 'react-native-launch-arguments';
 import {
   AppRegistry,
 } from 'react-native';
+import {LaunchArguments} from 'react-native-launch-arguments';
 
 import example from './src/app';
 

--- a/detox/test/index.ios.js
+++ b/detox/test/index.ios.js
@@ -8,7 +8,7 @@ import {
 
 class exampleIos extends example {}
 
-if (LaunchArguments.value().simulateEarlyCrash) { // TODO integrate this into iOS' NativeModule and lose react-native-launch-arguments
+if (LaunchArguments.value().simulateEarlyCrash) {
   throw new Error('Simulating early crash');
 }
 

--- a/detox/test/index.ios.js
+++ b/detox/test/index.ios.js
@@ -1,10 +1,7 @@
+import { LogBox, AppRegistry } from 'react-native';
 import {LaunchArguments} from 'react-native-launch-arguments';
-import example from './src/app';
-import { LogBox } from 'react-native';
 
-import {
-  AppRegistry,
-} from 'react-native';
+import example from './src/app';
 
 class exampleIos extends example {}
 

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -42,7 +42,7 @@
     "react": "18.1.0",
     "react-native": "0.70.7",
     "react-native-gradle-plugin": "^0.0.7",
-    "react-native-launch-arguments": "^3.1.0",
+    "react-native-launch-arguments": "next",
     "react-native-webview": "^11.18.1"
   },
   "devDependencies": {

--- a/detox/test/src/Screens/AbstractArgsListScreen.js
+++ b/detox/test/src/Screens/AbstractArgsListScreen.js
@@ -4,7 +4,6 @@ import {
   Text,
   View,
 } from 'react-native';
-import {LaunchArguments} from 'react-native-launch-arguments';
 
 export default class AbstractArgsListScreen extends Component {
 

--- a/detox/test/src/Screens/AbstractArgsListScreen.js
+++ b/detox/test/src/Screens/AbstractArgsListScreen.js
@@ -4,6 +4,7 @@ import {
   Text,
   View,
 } from 'react-native';
+import {LaunchArguments} from 'react-native-launch-arguments';
 
 export default class AbstractArgsListScreen extends Component {
 
@@ -51,7 +52,7 @@ export default class AbstractArgsListScreen extends Component {
 
   renderArgsList() {
     return _.reduce(this.state.argsList, (result, argValue, argName) => {
-      const _argValue = (_.isArray(argValue) || _.isObject(argValue) ? JSON.stringify(argValue) : argValue);
+      const _argValue = (_.isArray(argValue) || _.isObject(argValue) ? JSON.stringify(argValue) : argValue.toString());
       const itemId = `${this.contextName}-${argName}`;
       const nameId = itemId + '.name';
       const valueId = itemId + '.value';

--- a/detox/test/src/Screens/LaunchArgsScreen.js
+++ b/detox/test/src/Screens/LaunchArgsScreen.js
@@ -1,10 +1,6 @@
 import React from 'react';
-import {
-  NativeModules,
-} from 'react-native';
+import {LaunchArguments} from 'react-native-launch-arguments';
 import AbstractArgsListScreen from './AbstractArgsListScreen';
-
-const { NativeModule } = NativeModules;
 
 export default class LaunchArgsScreen extends AbstractArgsListScreen {
   constructor(props) {
@@ -12,7 +8,7 @@ export default class LaunchArgsScreen extends AbstractArgsListScreen {
   }
 
   async readArguments() {
-    return await NativeModule.getLaunchArguments();
+    return LaunchArguments.value();
   }
 
   getTitle() {


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: https://github.com/iamolegga/react-native-launch-arguments/issues/44

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have restored the usage of `react-native-launch-arguments` in Detox's self-test project.

Context: While revisiting https://github.com/iamolegga/react-native-launch-arguments/issues/44, it has occurred to me through the details of the problem that its root could be in a react native bug. This is due to the following circumstances:
- The bug stems from `LaunchArgumentsModule.getConstants()` returning an empty map
- Source code shows this can happen if there is no intent available (unlikely) or otherwise in case there's no activity available (might be?).
- Deduced: because `getConstants()` is a react-native framework-level hook, it doesn't make sense for it to be called before there's an activity involved. Ergo, an RN bug is likely.

All of this has led me to test out again from scratch whether this happens with our current default, RN `0.70.x`. So far, seems stable enough - in particular, when compared to the flakiness seen with older RN versions.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
