### PR TITLE
ci: allure reports as html

### DIFF
--- a/.buildkite/jobs/pipeline.android_rn_68.yml
+++ b/.buildkite/jobs/pipeline.android_rn_68.yml
@@ -8,5 +8,5 @@
       DETOX_DISABLE_POSTINSTALL: true
     artifact_paths:
       - "/Users/builder/work/coverage/**/*.lcov"
-      - "/Users/builder/work/allure*.tar.gz"
+      - "/Users/builder/work/**/allure-report-*.html"
       - "/Users/builder/work/artifacts*.tar.gz"

--- a/.buildkite/jobs/pipeline.android_rn_70.yml
+++ b/.buildkite/jobs/pipeline.android_rn_70.yml
@@ -9,5 +9,5 @@
       SKIP_UNIT_TESTS: true
     artifact_paths:
       - "/Users/builder/work/coverage/**/*.lcov"
-      - "/Users/builder/work/allure*.tar.gz"
+      - "/Users/builder/work/**/allure-report-*.html"
       - "/Users/builder/work/artifacts*.tar.gz"

--- a/.buildkite/jobs/pipeline.ios_rn_68.yml
+++ b/.buildkite/jobs/pipeline.ios_rn_68.yml
@@ -6,5 +6,5 @@
       REACT_NATIVE_VERSION: 0.68.5
     artifact_paths:
       - "/Users/builder/work/coverage/**/*.lcov"
-      - "/Users/builder/work/allure*.tar.gz"
+      - "/Users/builder/work/**/allure-report-*.html"
       - "/Users/builder/work/artifacts*.tar.gz"

--- a/.buildkite/jobs/pipeline.ios_rn_70.yml
+++ b/.buildkite/jobs/pipeline.ios_rn_70.yml
@@ -6,5 +6,5 @@
       REACT_NATIVE_VERSION: 0.70.7
     artifact_paths:
       - "/Users/builder/work/coverage/**/*.lcov"
-      - "/Users/builder/work/allure*.tar.gz"
+      - "/Users/builder/work/**/allure-report-*.html"
       - "/Users/builder/work/artifacts*.tar.gz"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ pids
 lib-cov
 
 # Allure reports
+allure-report-*.html
 allure-report
 allure-results
 # Coverage directory used by tools like istanbul

--- a/scripts/create_iframe_html.js
+++ b/scripts/create_iframe_html.js
@@ -1,0 +1,30 @@
+function template({ title = 'iframe viewer', url }) {
+  return `\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title}</title>
+  <style>
+    html, body, iframe {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      width: 100%;
+      overflow: hidden;
+      border: none;
+    }
+    iframe {
+      position: absolute;
+    }
+  </style>
+</head>
+<body>
+  <iframe src="${url}" frameborder="0" allowfullscreen></iframe>
+</body>
+</html>
+`;
+}
+
+process.stdout.write(template({ url: process.argv[2], title: process.argv[3] }));

--- a/scripts/upload_artifact.sh
+++ b/scripts/upload_artifact.sh
@@ -34,7 +34,7 @@ upload_to_surge() {
 
   if [ -d "${SURGE_PROJECT}" ]; then
     surge --domain "${SURGE_DOMAIN}" --project "${SURGE_PROJECT}" && \
-    generate_iframe>>"${SURGE_SUBDOMAIN}.html" "http://${SURGE_DOMAIN}" "${IFRAME_TITLE}"
+    generate_iframe>>"${SURGE_SUBDOMAIN}.html" "https://${SURGE_DOMAIN}" "${IFRAME_TITLE}"
   else
     echo "Could not find directory named ${SURGE_PROJECT}."
   fi

--- a/scripts/upload_artifact.sh
+++ b/scripts/upload_artifact.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 DATE=`date '+%Y-%m-%d_%H-%M-%S'`
+SCRIPTS_DIR=$(dirname "$0")
+GENERATE_IFRAME="$(readlink -f "${SCRIPTS_DIR}/create_iframe_html.js")"
 
 pack() {
   local BASE_NAME=$1
@@ -19,11 +21,36 @@ pack() {
   fi
 }
 
+generate_iframe() {
+  node "${GENERATE_IFRAME}" "$@"
+}
+
+upload_to_surge() {
+  local TIMESTAMP=$(date +%Y%m%d%H%M%S)
+  local SURGE_PROJECT=$1
+  local IFRAME_TITLE=$2
+  local SURGE_SUBDOMAIN="${SURGE_PROJECT}-${TIMESTAMP}"
+  local SURGE_DOMAIN="${SURGE_SUBDOMAIN}.surge.sh"
+
+  if [ -d "${SURGE_PROJECT}" ]; then
+    surge --domain "${SURGE_DOMAIN}" --project "${SURGE_PROJECT}" && \
+    generate_iframe>>"${SURGE_SUBDOMAIN}.html" "http://${SURGE_DOMAIN}" "${IFRAME_TITLE}"
+  else
+    echo "Could not find directory named ${SURGE_PROJECT}."
+  fi
+}
+
 generate_allure_report() {
   local ROOT_DIR=$1
 
   cd $ROOT_DIR
-  [ -d "allure-results" ] && allure generate || echo "No allure-results found."
+  if [ -d "allure-results" ]; then
+    set -x
+    allure generate && upload_to_surge allure-report "Detox Allure Report"
+    set +x
+  else
+    echo "No allure-results found in ${ROOT_DIR}"
+  fi
   cd -
 }
 
@@ -33,5 +60,3 @@ generate_allure_report detox/test
 pack artifacts "detox/test/artifacts" "detoxtest"
 pack artifacts "examples/demo-react-native/artifacts" "rnexample"
 pack artifacts "examples/demo-react-native-jest/artifacts" "rnexamplejest"
-pack allure "detox/test/allure-report" "allure-e2e"
-pack allure "detox/allure-report" "allure-unit"

--- a/scripts/upload_artifact.sh
+++ b/scripts/upload_artifact.sh
@@ -55,6 +55,7 @@ generate_allure_report() {
 }
 
 cd "$(dirname "$0")/.."
+npm -g install surge
 generate_allure_report detox
 generate_allure_report detox/test
 pack artifacts "detox/test/artifacts" "detoxtest"


### PR DESCRIPTION
## Description

This pull request should improve UX when visiting Buildkite build artifacts. Instead of having to download, unpack and open the allure reports, we should be able to open straight from UI the html files pointing us to the static hosting on surge.sh, where the reports will be residing from now on.

Ideally, we should create a nightly job to delete old domains with reports.