### PR TITLE
ci(github): add purge domains cron script

### DIFF
--- a/.github/workflows/surge-purge.yml
+++ b/.github/workflows/surge-purge.yml
@@ -1,0 +1,24 @@
+name: Purge old domains
+on:
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Older than (days)'
+        required: false
+
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  surge-purge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+
+      - name: Teardown old domains
+        run: npx zx scripts/purge_expired_domains.mjs --olderThan ${{ github.event.inputs.days || '10' }}
+        env:
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}

--- a/scripts/purge_expired_domains.mjs
+++ b/scripts/purge_expired_domains.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env zx
+
+async function main({ olderThan }) {
+  const now = new Date();
+  const surgeListOutput = await $`FORCE_COLOR=0 surge list`;
+  const lines = surgeListOutput.stdout.split('\n');
+  for (let line of lines) {
+    const parts = line.trim().split(/\s+/);
+    const domain = parts[1];
+    if (!domain || !domain.startsWith('allure-report-')) {
+      continue;
+    }
+
+    const creationDateStr = domain.split('-')[2] // Extract YYYYMMDDHHMMSS
+    const creationDate = new Date(
+      creationDateStr.slice(0, 4),
+      creationDateStr.slice(4, 6) - 1,
+      creationDateStr.slice(6, 8),
+      creationDateStr.slice(8, 10),
+      creationDateStr.slice(10, 12),
+      creationDateStr.slice(12, 14)
+    )
+
+    const daysDifference = Math.floor((now - creationDate) / (1000 * 60 * 60 * 24))
+    if (daysDifference > olderThan) {
+      console.log(`Deleting ${domain}`)
+      await $`surge teardown ${domain}`
+    }
+  }
+}
+
+await main({
+  days: Number(argv.olderThan || '30'),
+});


### PR DESCRIPTION
Adds a cron script to purge old domains allocated on Surge.sh for displaying Allure reports on Buildkite.