### PR TITLE
fix(cli): unhandled rejection after tests

### DIFF
--- a/detox/local-cli/startCommand/AppStartCommand.js
+++ b/detox/local-cli/startCommand/AppStartCommand.js
@@ -36,7 +36,10 @@ class AppStartCommand {
       }
     };
 
-    this._cpHandle = execa.command(cmd, { stdio: 'inherit', shell: true });
+    this._cpHandle = execa.command(cmd, {
+      stdio: ['ignore', 'inherit', 'inherit'],
+      shell: true
+    });
     this._cpHandle.on('error', onError);
     this._cpHandle.on('exit', (code, signal) => {
       const reason = code == null ? `signal ${signal}` : `code ${code}`;


### PR DESCRIPTION
## Description

After running Detox tests in one of the projects, I noticed that after pressing the `Enter` key, I see this:

```
... detox test finishes ...
my-project> [I'm pressing Enter key and boom!]

node:events:491                                                                                                                                                                                                                                                               
      throw er; // Unhandled 'error' event
      ^

Error: read EIO
    at TTY.onStreamRead (node:internal/stream_base_commons:217:20)
Emitted 'error' event on ReadStream instance at:
    at emitErrorNT (node:internal/streams/destroy:157:8)
    at emitErrorCloseNT (node:internal/streams/destroy:122:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -5,
  code: 'EIO',
  syscall: 'read'
}
```

The investigation brought me to the implementation of `AppStartCommand` in Detox. It turns out, it is a bad idea to listen into `stdin` in the spawned child processes, so from now on, we shall ignore it.

That resolves the said bug.