### PR TITLE
Ensure correct working directory

### DIFF
--- a/detox/android/rninfo.gradle
+++ b/detox/android/rninfo.gradle
@@ -1,6 +1,6 @@
 import groovy.json.JsonSlurper
 
-def rnVersion = getRNVersion()
+def rnVersion = getRNVersion(project.rootDir)
 def rnMajorVer = getMajorVersion(rnVersion)
 println "[$project] RNInfo: detected React Native version: $rnVersion (major=$rnMajorVer)"
 
@@ -12,9 +12,9 @@ project.ext.rnInfo = [
     isRN71OrHigher: rnMajorVer >= 71,
 ]
 
-private static def getRNVersion() {
+private static def getRNVersion(workingDir) {
     def jsonSlurper = new JsonSlurper()
-    Map<String, Object> packageJSON  = jsonSlurper.parse(new File('../node_modules/react-native/package.json'))
+    Map<String, Object> packageJSON  = jsonSlurper.parse(new File("$workingDir/../node_modules/react-native/package.json"))
     String rnVersion = packageJSON.get('version')
     return rnVersion
 }


### PR DESCRIPTION
# Problem
 this Gradle script assumes that the working directory is always the android working directory. When you run something like fastlane, that runs gradle scripts from your react-native project root, the working directory is NOT the android directory

# Solution
Use gradle's `project.rootDir` variable instead to ensure that we're always in the right working directory instead of assuming this to be true