### PR TITLE
fix(android): Revert used kotlin ver due to compat. issues

### DIFF
--- a/detox/android/build.gradle
+++ b/detox/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 
     ext {
         isOfficialDetoxLib = true
-        kotlinVersion = '1.8.22'
+        kotlinVersion = '1.6.21'
         dokkaVersion = '1.6.0'
         buildToolsVersion = '33.0.0'
         compileSdkVersion = 33


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: N/A

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have fixed Kotlin compatibility issues arising in internal builds, in the form of this error:

```
[21:04:51][Multi-app build] e: /Users/builder/.gradle/caches/transforms-3/7e1994271b0ac195885b9b3cc4f97c1e/transformed/jetified-detox-20.11.0-api.jar!/META-INF/detox_fullRelease.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.8.0, expected version is 1.6.0.
[21:04:52][Multi-app build] 
```

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
