### PR TITLE
feat(device): listApps() method

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -725,6 +725,11 @@ declare global {
             terminateApp(bundle?: string): Promise<void>;
 
             /**
+             * Returns an array of currently installed apps on the device.
+             */
+            listApps(): Promise<string[]>;
+
+            /**
              * Send application to background by bringing com.apple.springboard to the foreground.
              * Combining sendToHome() with launchApp({newInstance: false}) will simulate app coming back from background.
              * @example

--- a/detox/src/devices/common/drivers/android/exec/ADB.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.js
@@ -94,6 +94,14 @@ class ADB {
     return this.shell(deviceId, `date +"%m-%d %T.000"`);
   }
 
+  async listPackages(deviceId) {
+    const output = await this.shell(deviceId, `pm list packages`);
+    return output
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => line.split(':')[1]);
+  }
+
   async isPackageInstalled(deviceId, packageId) {
     const output = await this.shell(deviceId, `pm list packages ${packageId}`);
     const packageRegexp = new RegExp(`^package:${escape.inQuotedRegexp(packageId)}$`, 'm');

--- a/detox/src/devices/common/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.test.js
@@ -159,6 +159,13 @@ describe('ADB', () => {
     expect(await adb.pidof('', 'com.google.android.ext.services')).toBe(NaN);
   });
 
+  it(`listPackages`, async () => {
+    jest.spyOn(adb, 'shell').mockImplementation(async () =>
+      `package:com.android.mtp\npackage:com.android.nfc\n`);
+
+    expect(await adb.listPackages()).toEqual(['com.android.mtp', 'com.android.nfc']);
+  });
+
   it('push', async () => {
     const sourceFile = '/mock-source/file.xyz';
     const destFile = '/sdcard/file.abc';

--- a/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
@@ -464,6 +464,23 @@ class AppleSimUtils {
     }
   }
 
+  async listApps(udid) {
+    const apps = [];
+    const result = await this._execSimctl({ cmd: `listapps ${udid}` });
+    if (result && result.stdout) {
+      const pattern = /^\s{4}"([^"]+)"/gm;
+
+      let match;
+      // eslint-disable-next-line no-cond-assign
+      while (match = pattern.exec(result.stdout)) {
+        const [_, bundleId] = match;
+        apps.push(bundleId);
+      }
+    }
+
+    return apps;
+  }
+
   async statusBarReset(udid) {
     await this._execSimctl({ cmd: `status_bar ${udid} clear` });
   }

--- a/detox/src/devices/runtime/RuntimeDevice.js
+++ b/detox/src/devices/runtime/RuntimeDevice.js
@@ -23,6 +23,7 @@ class RuntimeDevice {
       'installApp',
       'installUtilBinaries',
       'launchApp',
+      'listApps',
       'matchFace',
       'matchFinger',
       'openURL',
@@ -181,6 +182,10 @@ class RuntimeDevice {
       params['newInstance'] = true;
     }
     await this.launchApp(params, bundleId);
+  }
+
+  async listApps() {
+    return await this.deviceDriver.listApps();
   }
 
   async takeScreenshot(name) {

--- a/detox/src/devices/runtime/RuntimeDevice.test.js
+++ b/detox/src/devices/runtime/RuntimeDevice.test.js
@@ -714,6 +714,15 @@ describe('Device', () => {
     });
   });
 
+  it(`listApps() should pass to device driver`, async () => {
+    const device = await aValidDevice();
+    driverMock.driver.listApps.mockResolvedValue(['com.app1', 'com.app2']);
+    const apps = await device.listApps();
+
+    expect(driverMock.driver.listApps).toHaveBeenCalledTimes(1);
+    expect(apps).toEqual(['com.app1', 'com.app2']);
+  });
+
   it(`sendToHome() should pass to device driver`, async () => {
     const device = await aValidDevice();
     await device.sendToHome();

--- a/detox/src/devices/runtime/drivers/DeviceDriverBase.js
+++ b/detox/src/devices/runtime/drivers/DeviceDriverBase.js
@@ -51,6 +51,10 @@ class DeviceDriverBase {
     return '';
   }
 
+  async listApps() {
+    return [];
+  }
+
   async sendToHome() {
     return '';
   }

--- a/detox/src/devices/runtime/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/runtime/drivers/android/AndroidDriver.js
@@ -171,6 +171,10 @@ class AndroidDriver extends DeviceDriverBase {
     await this.uiDevice.pressHome();
   }
 
+  async listApps() {
+    return await this.adb.listPackages(this.adbName);
+  }
+
   async typeText(text) {
     await this.adb.typeText(this.adbName, text);
   }

--- a/detox/src/devices/runtime/drivers/android/AndroidDriver.test.js
+++ b/detox/src/devices/runtime/drivers/android/AndroidDriver.test.js
@@ -468,6 +468,11 @@ describe('Android driver', () => {
     });
   });
 
+  it(`should invoke ADB listPackages`, async () => {
+    await uut.listApps();
+    expect(adb.listPackages).toHaveBeenCalledWith(adbName);
+  });
+
   describe('net-port reversing', () => {
     const port = 1337;
 

--- a/detox/src/devices/runtime/drivers/ios/SimulatorDriver.js
+++ b/detox/src/devices/runtime/drivers/ios/SimulatorDriver.js
@@ -133,6 +133,10 @@ class SimulatorDriver extends IosDriver {
     await this._applesimutils.unmatchBiometric(this.udid, 'Finger');
   }
 
+  async listApps() {
+    return await this._applesimutils.listApps(this.udid);
+  }
+
   async sendToHome() {
     await this._applesimutils.sendToHome(this.udid);
   }

--- a/detox/src/devices/runtime/drivers/ios/SimulatorDriver.test.js
+++ b/detox/src/devices/runtime/drivers/ios/SimulatorDriver.test.js
@@ -110,6 +110,11 @@ describe('IOS simulator driver', () => {
     });
   });
 
+  it(`should list apps via applesimutils`, async () => {
+    await uut.listApps();
+    expect(applesimutils.listApps).toHaveBeenCalledWith(udid);
+  });
+
   describe('biometrics', () => {
     it('enrolls in biometrics by passing to AppleSimUtils', async () => {
       await uut.setBiometricEnrollment('YES');

--- a/detox/test/e2e/06.device.test.js
+++ b/detox/test/e2e/06.device.test.js
@@ -1,3 +1,5 @@
+const jestExpect = require('expect').default;
+
 describe('Device', () => {
   it('reloadReactNative - should tap successfully', async () => {
     await device.reloadReactNative();
@@ -83,5 +85,11 @@ describe('Device', () => {
     await element(by.text('Actions')).tap();
     await device.pressBack();
     await expect(element(by.text('Back pressed !'))).toBeVisible();
+  });
+
+  it('should list the installed apps, including the test app', async () => {
+    const apps = await device.listApps();
+    const expectedBundleId = device.getPlatform() === 'ios' ? 'com.wix.detox-example' : 'com.wix.detox.test';
+    jestExpect(apps).toContain(expectedBundleId);
   });
 });

--- a/detox/test/integration/stub/StubRuntimeDriver.js
+++ b/detox/test/integration/stub/StubRuntimeDriver.js
@@ -47,6 +47,10 @@ class StubRuntimeDriver extends DeviceDriverBase {
     return process.pid;
   }
 
+  async listApps() {
+    return ['com.wix.detox.test'];
+  }
+
   async deliverPayload(params) {
     await sleepVeryLittle();
   }

--- a/detox/test/types/detox-global-tests.ts
+++ b/detox/test/types/detox-global-tests.ts
@@ -70,6 +70,7 @@ describe("Test", () => {
         await waitForElement.toBeVisible().withTimeout(2000);
 
         await device.pressBack();
+        assertType<string[]>(await device.listApps());
         await device.reverseTcpPort(32167);
         await device.unreverseTcpPort(32167);
 


### PR DESCRIPTION
## Description

- This pull request allows to optimize heavy uninstall steps at the device preparation stage. @overengineered hit this issue recently when the uninstallation took 1.5 minutes for 7-8 types of apps on CI.

In this pull request, I have added the `device.listApps()` method, which returns an array of package/bundle ids of apps installed on the device.

We'll use it to detect in a smart way which apps should be uninstalled (in the custom environment setup for Wix).

> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
