### PR TITLE
test(fix): use new early-crash method.

### DIFF
--- a/detox/test/earlyCrash.js
+++ b/detox/test/earlyCrash.js
@@ -1,0 +1,37 @@
+import { LaunchArguments } from 'react-native-launch-arguments';
+
+const earlyCrashIfNeeded = () => {
+  if (LaunchArguments.value().simulateEarlyCrash) {
+    console.warn('simulateEarlyCrash=true detected: Will crash in a few seconds from now (all-the-while keeping the app busy)...');
+    _setupBusyFutureCrash();
+  }
+}
+
+/**
+ * What we're aiming at here is to have the app crash while Detox is waiting for it to become *ready* (i.e. idle)
+ * for the first time, because this is a soft-spot, as we know. If we crash immediately, it might be too soon (i.e. before 'isReady'
+ * is sent & received). We therefore wait a few seconds, and only then crash, provided that in a 99% chance we'll be past
+ * the isReady request. We also want to keep things busy (i.e. make sure a 'ready' isn't responded), so we use short *timeouts*
+ * rather than setInterval() and >1500ms intervals.
+ */
+const _setupBusyFutureCrash = () => {
+  const INTERVAL = 1000;
+  const ITERATIONS = 8;
+
+  let count = 0;
+
+  const handler = () => {
+    count++;
+
+    if (count === ITERATIONS) {
+      console.warn('simulateEarlyCrash=true', 'Simulating a crash now!');
+      throw new Error('Simulating early crash');
+    }
+    setTimeout(handler, INTERVAL);
+  };
+  setTimeout(handler, INTERVAL);
+}
+
+module.exports = {
+  registerEarlyCrashIfNeeded: earlyCrashIfNeeded
+};

--- a/detox/test/index.android.js
+++ b/detox/test/index.android.js
@@ -1,46 +1,15 @@
 import {
   AppRegistry,
 } from 'react-native';
-import {LaunchArguments} from 'react-native-launch-arguments';
 
 import example from './src/app';
+
+import { registerEarlyCrashIfNeeded } from './earlyCrash';
 
 class exampleAndroid extends example {
   async componentDidMount() {
     await super.componentDidMount();
-    await this._registerEarlyCrashIfNeeded();
-  }
-
-  async _registerEarlyCrashIfNeeded() {
-    if (LaunchArguments.value().simulateEarlyCrash) {
-      console.warn('simulateEarlyCrash=true detected: Will crash in a few seconds from now (all-the-while keeping the app busy)...');
-      this._setupBusyFutureCrash();
-    }
-  }
-
-  /**
-   * What we're aiming at here is to have the app crash while Detox is waiting for it to become *ready* (i.e. idle)
-   * for the first time, because this is a soft-spot, as we know. If we crash immediately, it might be too soon (i.e. before 'isReady'
-   * is sent & received). We therefore wait a few seconds, and only then crash, provided that in a 99% chance we'll be past
-   * the isReady request. We also want to keep things busy (i.e. make sure a 'ready' isn't responded), so we use short *timeouts*
-   * rather than setInterval() and >1500ms intervals.
-   */
-  _setupBusyFutureCrash() {
-    const INTERVAL = 1000;
-    const ITERATIONS = 8;
-
-    let count = 0;
-
-    const handler = () => {
-      count++;
-
-      if (count === ITERATIONS) {
-        console.warn('simulateEarlyCrash=true', 'Simulating a crash now!');
-        throw new Error('Simulating early crash');
-      }
-      setTimeout(handler, INTERVAL);
-    };
-    setTimeout(handler, INTERVAL);
+    registerEarlyCrashIfNeeded();
   }
 }
 

--- a/detox/test/index.ios.js
+++ b/detox/test/index.ios.js
@@ -1,13 +1,11 @@
 import { LogBox, AppRegistry } from 'react-native';
-import {LaunchArguments} from 'react-native-launch-arguments';
 
 import example from './src/app';
+import { registerEarlyCrashIfNeeded } from './earlyCrash';
 
 class exampleIos extends example {}
 
-if (LaunchArguments.value().simulateEarlyCrash) {
-  throw new Error('Simulating early crash');
-}
+registerEarlyCrashIfNeeded();
 
 LogBox.ignoreAllLogs();
 AppRegistry.registerComponent('example', () => exampleIos);


### PR DESCRIPTION
See original comment from on the extracted code, the same issue we had on Android is now relevant for iOS (regression, still investigating what was changed, probably a dependency):

> What we're aiming at here is to have the app crash while Detox is waiting for it to become *ready* (i.e. idle) for the first time, because this is a soft-spot, as we know. If we crash immediately, it might be too soon (i.e. before 'isReady' is sent & received). We therefore wait a few seconds, and only then crash, provided that in a 99% chance we'll be past the isReady request. We also want to keep things busy (i.e. make sure a 'ready' isn't responded), so we use short timeouts rather than setInterval() and >1500ms intervals.
