### PR TITLE
fix(iOS): adapt to new nothing-to-terminate error.

### DIFF
--- a/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
@@ -297,7 +297,7 @@ class AppleSimUtils {
       // want to make sure it isn't now.
       if (err.code === 3 &&
           (err.stderr.includes(`the app is not currently running`) ||
-           err.stderr.includes(`The operation couldn’t be completed. found nothing to terminate`))) {
+           err.stderr.includes(`found nothing to terminate`))) {
         return;
       }
 


### PR DESCRIPTION
The error message when failing to terminate has changed on a recent simctl version: `The request to terminate "com.wix.detox-example" failed. found nothing to terminate`