### PR TITLE
chore(android): bump `org.json:json` (vulnerable version).

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -140,7 +140,7 @@ dependencies {
 // Unit-testing deps.
 dependencies {
     testImplementation "${_rnNativeArtifact}"
-    testImplementation 'org.json:json:20140107'
+    testImplementation 'org.json:json:20230227'
 
 // https://github.com/spekframework/spek/issues/232#issuecomment-610732158
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.7.2'


### PR DESCRIPTION
Resolves https://github.com/wix/Detox/issues/4106.

See recommended fixes ([synk.io](https://security.snyk.io/package/maven/org.json:json)):
https://security.snyk.io/vuln/SNYK-JAVA-ORGJSON-5488379
https://security.snyk.io/vuln/SNYK-JAVA-ORGJSON-2841369