### PR TITLE
fix: missing Jest summary

### DIFF
--- a/detox/runners/jest/reporters/DetoxReporter.js
+++ b/detox/runners/jest/reporters/DetoxReporter.js
@@ -1,24 +1,77 @@
 const resolveFrom = require('resolve-from');
-/** @type {typeof import('@jest/reporters').VerboseReporter} */
+/** @type {new (globalConfig: any) => import('@jest/reporters').VerboseReporter} */
 const JestVerboseReporter = require(resolveFrom(process.cwd(), '@jest/reporters')).VerboseReporter;
+/** @type {new (globalConfig: any) => import('@jest/reporters').SummaryReporter} */
+const SummaryReporter = require(resolveFrom(process.cwd(), '@jest/reporters')).SummaryReporter;
 
 const { config, reportTestResults } = require('../../../internals');
 
 class DetoxReporter extends JestVerboseReporter {
+  constructor(globalConfig) {
+    super(globalConfig);
+    /** @type {import('@jest/reporters').SummaryReporter | null} */
+    this._summaryReporter = this._initSummaryReporter();
+    /** @type {Promise<any> | null} */
+    this._runCompletePromise = null;
+    /** @type {[Set<import('@jest/reporters').TestContext>, import('@jest/reporters').AggregatedResult]} */
+    this._lastResults = [null, null];
+  }
+
+  onRunStart(aggregatedResults, options) {
+    super.onRunStart(aggregatedResults, options);
+
+    if (this._summaryReporter) {
+      this._summaryReporter.onRunStart(aggregatedResults, options);
+    }
+  }
+
   /**
-   * @param {import('@jest/test-result').AggregatedResult} results
+   * @param {Set<import('@jest/reporters').TestContext>} contexts
+   * @param {import('@jest/reporters').AggregatedResult} results
+   * @returns {Promise<any> | null}
    */
   // @ts-ignore
-  async onRunComplete(_contexts, results) {
-    // @ts-ignore
-    await super.onRunComplete(_contexts, results);
+  onRunComplete(contexts, results) {
+    // Both `_lastResults` and `_runCompletePromise` are used to prevent
+    // a bug in Jest, where `onRunComplete` is called multiple times when
+    // Jest runs with `--bail` and multiple workers, and `onRunComplete`
+    // is implemented as an asynchronous long-running operation.
+    this._lastResults = [contexts, results];
+    if (!this._runCompletePromise) {
+      // @ts-expect-error TS2554: Expected 0 arguments, but got 2.
+      super.onRunComplete(...this._lastResults);
+      this._runCompletePromise = this._onRunComplete();
+    }
 
+    return this._runCompletePromise;
+  }
+
+  async _onRunComplete() {
+    let results = this._lastResults[1];
     await reportTestResults(results.testResults.map(r => ({
       success: !r.failureMessage,
       testFilePath: r.testFilePath,
       testExecError: r.testExecError,
       isPermanentFailure: this._isPermanentFailure(r),
     })));
+
+    if (this._summaryReporter) {
+      this._summaryReporter.onRunComplete(...this._lastResults);
+    }
+  }
+
+  /**
+   * @returns {import('@jest/reporters').SummaryReporter | null}
+   * @private
+   */
+  _initSummaryReporter() {
+    /** @type {(config: import('@jest/types').Config.ReporterConfig) => boolean} */
+    const isSummaryReporter = (config) => config[0] === 'summary';
+    if (this._globalConfig.reporters.some(isSummaryReporter)) {
+      return null;
+    }
+
+    return new SummaryReporter(this._globalConfig);
   }
 
   /**


### PR DESCRIPTION
## Description

This fix addresses the bug highlighted in the discussion #4121.

The core issue stems from Jest's behavior: [it automatically adds a summary reporter when the default string is found in reporters](https://github.com/jestjs/jest/blob/a640c6513f08f6d97827050010a8a28fff530ac9/packages/jest-core/src/TestScheduler.ts#L344-L356). We recommend users exclusively use the Detox report as the primary one, given the challenges and potential problems arising with the default reporter, especially in contexts like `--bail`, and that's why we have to solve this problem on our side once again.

So the proposed solution is:
- Check if users have not yet specified a `summary` string in the reporters.
- If not, we morph DetoxReporter into a composition of Verbose and Summary reporters.

Furthermore, this fix tackles the problem of the test summary being redundantly printed. This duplication arises when onRunComplete is triggered several times, notably when Jest operates with --bail and multiple workers, and when onRunComplete unfolds as an asynchronous extended operation—a typical situation with custom reporters. Addressing this is pivotal for the integration of PR #4115.