### PR TITLE
chore: use node 16 for local development

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,10 @@ tab_width = 2
 indent_size = 2
 tab_width = 2
 
+[{*.yaml,*.yml}]
+indent_size = 2
+tab_width = 2
+
 [{*.css,*.scss,*.har,*.jsb2,*.jsb3,*.json,.babelrc,.eslintrc,.prettierrc,.stylelintrc,bowerrc,jest.config}]
 indent_size = 2
 tab_width = 2

--- a/.github/workflows/broken-links-scan.yml
+++ b/.github/workflows/broken-links-scan.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version-file: '.nvmrc'
       - uses: bahmutov/npm-install@v1
         with:
           useLockFile: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version-file: '.nvmrc'
       - uses: bahmutov/npm-install@v1
         with:
           useLockFile: false

--- a/.github/workflows/rapid-test.yml
+++ b/.github/workflows/rapid-test.yml
@@ -4,15 +4,15 @@ on:
   push:
     branches: [master]
     paths:
-        - '.github/workflows/rapid-test.yml'
-        - 'detox/**'
-        - 'generation/**'
+      - '.github/workflows/rapid-test.yml'
+      - 'detox/**'
+      - 'generation/**'
   pull_request:
     branches: [master]
     paths:
-        - '.github/workflows/rapid-test.yml'
-        - 'detox/**'
-        - 'generation/**'
+      - '.github/workflows/rapid-test.yml'
+      - 'detox/**'
+      - 'generation/**'
 
 jobs:
 
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version-file: '.nvmrc'
       - name: Bootstrap Lerna
         run: npx lerna@3 bootstrap --no-ci
         env:
@@ -49,21 +49,21 @@ jobs:
         working-directory: generation
 
   windows:
-      name: Windows
-      runs-on: windows-latest
-      steps:
-          - uses: actions/checkout@v3
-          - uses: actions/setup-node@v3
-            with:
-                node-version: 14
-          - name: Bootstrap Lerna (Light)
-            run: npx lerna@3 bootstrap --no-ci --include-dependents --include-dependencies --scope=detox-test
-            env:
-                DETOX_DISABLE_POD_INSTALL: true
-                DETOX_DISABLE_POSTINSTALL: true
-          - name: Unit tests
-            run: npm run unit -- --coverageThreshold "{}"
-            working-directory: detox
-          - name: Integration tests
-            run: npm run integration
-            working-directory: detox/test
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+      - name: Bootstrap Lerna (Light)
+        run: npx lerna@3 bootstrap --no-ci --include-dependents --include-dependencies --scope=detox-test
+        env:
+          DETOX_DISABLE_POD_INSTALL: true
+          DETOX_DISABLE_POSTINSTALL: true
+      - name: Unit tests
+        run: npm run unit -- --coverageThreshold "{}"
+        working-directory: detox
+      - name: Integration tests
+        run: npm run integration
+        working-directory: detox/test

--- a/.github/workflows/surge-purge.yml
+++ b/.github/workflows/surge-purge.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version-file: '.nvmrc'
 
       - name: Install surge
         run: npm -g install surge

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version-file: '.nvmrc'
       - uses: dorny/paths-filter@v2
         id: changes
         with:
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version-file: '.nvmrc'
       - uses: webfactory/ssh-agent@v0.5.0
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
+legacy-peer-deps=true
 package-lock=false
+workspaces=false

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/fermium
+lts/gallium

--- a/lerna.json
+++ b/lerna.json
@@ -31,7 +31,8 @@
     },
     "bootstrap": {
       "npmClientArgs": [
-        "--no-package-lock"
+        "--no-package-lock",
+        "--legacy-peer-deps"
       ]
     }
   }


### PR DESCRIPTION
Node 14 has been deprecated for too long already.
While we technically still support Node 14 in Detox 20, let's move to Node 16.x at least for the local development.