### PR TITLE
fix(android): extract material slider value attribute with reflection.

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -126,9 +126,6 @@ dependencies {
 
 // Third-party/extension deps.
 dependencies {
-    implementation("com.google.android.material:material:$_materialMinVersion") {
-        because 'Material components are mentioned explicitly (e.g. Slider in get-attributes handler)'
-    }
     implementation('org.apache.commons:commons-lang3:3.7') {
         because 'Needed by invoke. Warning: Upgrading to newer versions is not seamless.'
     }
@@ -150,6 +147,10 @@ dependencies {
     testImplementation 'org.apache.commons:commons-io:1.3.2'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:4.0.0'
     testImplementation 'org.robolectric:robolectric:4.4'
+
+    testImplementation("com.google.android.material:material:$_materialMinVersion") {
+        because 'Material components are mentioned explicitly (e.g. Slider in get-attributes handler)'
+    }
 }
 
 // Spek (https://spekframework.org/setup-android)

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/action/AdjustSliderToPositionAction.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/action/AdjustSliderToPositionAction.kt
@@ -6,7 +6,7 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import com.wix.detox.espresso.common.SliderHelper
+import com.wix.detox.espresso.common.ReactSliderHelper
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
 
@@ -16,7 +16,7 @@ class AdjustSliderToPositionAction(private val targetPositionPct: Double) : View
         Matchers.allOf( isDisplayed(), isAssignableFrom(AppCompatSeekBar::class.java) )
 
     override fun perform(uiController: UiController?, view: View) {
-        val sliderHelper = SliderHelper.create(view)
+        val sliderHelper = ReactSliderHelper.create(view)
         sliderHelper.setProgressPct(targetPositionPct)
     }
 }

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/action/GetAttributesAction.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/action/GetAttributesAction.kt
@@ -7,7 +7,6 @@ import android.widget.CheckBox
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.test.espresso.UiController
-import com.google.android.material.slider.Slider
 import com.wix.detox.espresso.ViewActionWithResult
 import com.wix.detox.espresso.MultipleViewsAction
 import com.wix.detox.espresso.common.ReactSliderHelper
@@ -19,7 +18,7 @@ import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.notNullValue
 import org.json.JSONObject
 
-interface AttributeExtractor {
+private interface AttributeExtractor {
     fun extractAttributes(json: JSONObject, view: View)
 }
 
@@ -156,8 +155,8 @@ private class ProgressBarAttributes : AttributeExtractor {
 
 private class MaterialSliderAttributes : AttributeExtractor {
     override fun extractAttributes(json: JSONObject, view: View) {
-        MaterialSliderHelper(view).getValueIfSlider()?.run {
-            json.put("value", this)
+        MaterialSliderHelper(view).getValueIfSlider()?.let {
+            json.put("value", it)
         }
     }
 }

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/common/MaterialSliderHelper.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/common/MaterialSliderHelper.kt
@@ -1,0 +1,20 @@
+package com.wix.detox.espresso.common
+
+import android.view.View
+import com.wix.detox.espresso.action.common.ReflectUtils
+import org.joor.Reflect
+
+private const val CLASS_MATERIAL_SLIDER = "com.google.android.material.slider.Slider"
+
+open class MaterialSliderHelper(protected val view: View) {
+    fun getValueIfSlider(): Double? {
+        if (!isSlider()) {
+            null
+        }
+        return getValue()
+    }
+
+    private fun isSlider() = ReflectUtils.isAssignableFrom(view, CLASS_MATERIAL_SLIDER)
+
+    private fun getValue() = Reflect.on(view).call("getValue").get() as Double
+}

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/common/MaterialSliderHelper.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/common/MaterialSliderHelper.kt
@@ -7,7 +7,7 @@ import org.joor.Reflect
 private const val CLASS_MATERIAL_SLIDER = "com.google.android.material.slider.Slider"
 
 open class MaterialSliderHelper(protected val view: View) {
-    fun getValueIfSlider(): Double? {
+    fun getValueIfSlider(): Float? {
         if (!isSlider()) {
             return null
         }
@@ -17,5 +17,5 @@ open class MaterialSliderHelper(protected val view: View) {
 
     private fun isSlider() = ReflectUtils.isAssignableFrom(view, CLASS_MATERIAL_SLIDER)
 
-    private fun getValue() = Reflect.on(view).call("getValue").get() as Double
+    private fun getValue() = Reflect.on(view).call("getValue").get() as Float
 }

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/common/MaterialSliderHelper.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/common/MaterialSliderHelper.kt
@@ -9,8 +9,9 @@ private const val CLASS_MATERIAL_SLIDER = "com.google.android.material.slider.Sl
 open class MaterialSliderHelper(protected val view: View) {
     fun getValueIfSlider(): Double? {
         if (!isSlider()) {
-            null
+            return null
         }
+
         return getValue()
     }
 

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/common/ReactSliderHelper.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/common/ReactSliderHelper.kt
@@ -11,8 +11,9 @@ import org.joor.Reflect
 
 private const val CLASS_REACT_SLIDER_LEGACY = "com.facebook.react.views.slider.ReactSlider"
 private const val CLASS_REACT_SLIDER_COMMUNITY = "com.reactnativecommunity.slider.ReactSlider"
+private const val CLASS_REACT_SLIDER_COMMUNITY_MANAGER = "com.reactnativecommunity.slider.ReactSliderManager"
 
-abstract class SliderHelper(protected val slider: AppCompatSeekBar) {
+abstract class ReactSliderHelper(protected val slider: AppCompatSeekBar) {
     fun getCurrentProgressPct(): Double {
         val nativeProgress = slider.progress.toDouble()
         val nativeMax = slider.max
@@ -46,7 +47,7 @@ abstract class SliderHelper(protected val slider: AppCompatSeekBar) {
                 ?: throw DetoxIllegalStateException("Cannot handle this type of a seek-bar view (Class ${view.javaClass.canonicalName}). " +
                         "Only React Native sliders are currently supported.")
 
-        fun maybeCreate(view: View): SliderHelper? =
+        fun maybeCreate(view: View): ReactSliderHelper? =
             when {
                 ReflectUtils.isAssignableFrom(view, CLASS_REACT_SLIDER_LEGACY)
                    -> LegacySliderHelper(view as ReactSlider)
@@ -58,7 +59,7 @@ abstract class SliderHelper(protected val slider: AppCompatSeekBar) {
     }
 }
 
-private class LegacySliderHelper(slider: ReactSlider): SliderHelper(slider) {
+private class LegacySliderHelper(slider: ReactSlider): ReactSliderHelper(slider) {
     override fun setProgressJS(valueJS: Double) {
         val reactSliderManager = com.facebook.react.views.slider.ReactSliderManager()
         reactSliderManager.updateProperties(slider as ReactSlider, buildStyles("value", valueJS))
@@ -67,9 +68,9 @@ private class LegacySliderHelper(slider: ReactSlider): SliderHelper(slider) {
     private fun buildStyles(vararg keysAndValues: Any) = ReactStylesDiffMap(JavaOnlyMap.of(*keysAndValues))
 }
 
-private class CommunitySliderHelper(slider: AppCompatSeekBar): SliderHelper(slider) {
+private class CommunitySliderHelper(slider: AppCompatSeekBar): ReactSliderHelper(slider) {
     override fun setProgressJS(valueJS: Double) {
-        val reactSliderManager = Class.forName("com.reactnativecommunity.slider.ReactSliderManager").newInstance()
+        val reactSliderManager = Class.forName(CLASS_REACT_SLIDER_COMMUNITY_MANAGER).newInstance()
         Reflect.on(reactSliderManager).call("setValue", slider, valueJS)
     }
 }

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/matcher/ViewMatchers.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/matcher/ViewMatchers.kt
@@ -7,7 +7,7 @@ import androidx.appcompat.widget.AppCompatSeekBar
 import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
-import com.wix.detox.espresso.common.SliderHelper
+import com.wix.detox.espresso.common.ReactSliderHelper
 import org.hamcrest.*
 import org.hamcrest.Matchers.*
 import kotlin.math.abs
@@ -60,7 +60,7 @@ fun toHaveSliderPosition(expectedValuePct: Double, tolerance: Double): Matcher<V
         }
 
         override fun matchesSafely(view: AppCompatSeekBar): Boolean {
-            val sliderHelper = SliderHelper.create(view)
+            val sliderHelper = ReactSliderHelper.create(view)
             val progressPct = sliderHelper.getCurrentProgressPct()
             return (abs(progressPct - expectedValuePct) <= tolerance)
         }

--- a/detox/android/detox/src/testFull/java/com/wix/detox/espresso/common/MaterialSliderHelperTest.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/espresso/common/MaterialSliderHelperTest.kt
@@ -1,0 +1,33 @@
+package com.wix.detox.espresso.common
+
+import android.view.View
+import com.google.android.material.slider.Slider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MaterialSliderHelperTest {
+    @Test
+    fun `should return value if view is a slider`() {
+        val slider: Slider = mock {
+            on { value } doReturn 0.2f
+        }
+
+        val uut = MaterialSliderHelper(slider)
+
+        assertThat(uut.getValueIfSlider()).isEqualTo(0.2)
+    }
+
+    @Test
+    fun `should return null if view is not a slider`() {
+        val view: View = mock()
+
+        val uut = MaterialSliderHelper(view)
+
+        assertThat(uut.getValueIfSlider()).isNull()
+    }
+}

--- a/detox/android/detox/src/testFull/java/com/wix/detox/espresso/common/MaterialSliderHelperTest.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/espresso/common/MaterialSliderHelperTest.kt
@@ -19,7 +19,7 @@ class MaterialSliderHelperTest {
 
         val uut = MaterialSliderHelper(slider)
 
-        assertThat(uut.getValueIfSlider()).isEqualTo(0.2)
+        assertThat(uut.getValueIfSlider()).isEqualTo(0.2f)
     }
 
     @Test

--- a/detox/android/detox/src/testFull/java/com/wix/detox/espresso/common/ReactSliderHelperTest.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/espresso/common/ReactSliderHelperTest.kt
@@ -15,14 +15,14 @@ import org.robolectric.RobolectricTestRunner
  * to avoid having to install the community slider under node_modules just for this.
  */
 @RunWith(RobolectricTestRunner::class)
-class SliderHelperTest {
+class ReactSliderHelperTest {
     lateinit var slider: ReactSlider
-    lateinit var uut: SliderHelper
+    lateinit var uut: ReactSliderHelper
 
     @Before
     fun setup() {
         slider = mock()
-        uut = SliderHelper.create(slider)
+        uut = ReactSliderHelper.create(slider)
     }
 
     private fun givenNativeProgressTraits(current: Int, max: Int) {


### PR DESCRIPTION
This fixes a `ClassNotFoundException` error that is thrown when the Slider class from the `com.google.android.material.slider` package is not found at runtime.

The solution is to use reflection instead of importing the Slider class, which may not necessarily exist in the app.

Also, I made a light refactoring for get-attributes related code.