### PR TITLE
fix(android): tap event on android API>31

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/action/common/MotionEvents.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/action/common/MotionEvents.kt
@@ -46,8 +46,35 @@ class MotionEvents {
                 0)
     }
 
-    fun obtainUpEvent(downEvent: MotionEvent, eventTime: Long, x: Float, y: Float): MotionEvent
-            = MotionEvent.obtain(downEvent.downTime, eventTime, MotionEvent.ACTION_UP, x, y, 0)!!
+    fun obtainUpEvent(downEvent: MotionEvent, eventTime: Long, x: Float, y: Float): MotionEvent {
+        val pointerProperties = MotionEvent.PointerProperties().apply {
+          id = 0
+          toolType = MotionEvent.TOOL_TYPE_UNKNOWN
+        }
+        val pointerCoords = MotionEvent.PointerCoords().apply {
+          clear()
+          this.x = x
+          this.y = y
+          this.pressure = 0f
+          this.size = 1f
+        }
+        return MotionEvent.obtain(
+              downEvent.downTime,
+              eventTime,
+              MotionEvent.ACTION_UP,
+              1, // pointerCounts
+              arrayOf(pointerProperties),
+              arrayOf(pointerCoords),
+              0, // metaState
+              downEvent.buttonState,
+              downEvent.xPrecision,
+              downEvent.yPrecision,
+              0, // deviceId
+              0, // edgeFlags
+              downEvent.source,
+              0
+        )
+    }
 
     fun sendDownAsync(uiController: UiController, x: Float, y: Float, precision: FloatArray = PRECISION): MotionEvent {
         val downEvent = obtainDownEvent(x, y, precision, null)


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue 3762 described here: https://github.com/wix/Detox/issues/3762

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have updated `obtainUpEvent` in `com.wix.detox.espresso.action.common.MotionEvent` to match more closely the implementation of `obtainUpEvent` in `androidx.test.espresso.action.MotionEvents`.



> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
