### PR TITLE
fix(android): webElement.runScript(fn, args)

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/web/WebElement.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/web/WebElement.java
@@ -62,12 +62,12 @@ public class WebElement {
         return getWebViewInteraction().withElement(get()).perform(DriverAtoms.getText()).get();
     }
 
-    public Evaluation runScript(String script) {
-        return getWebViewInteraction().withElement(get()).perform(new SimpleAtom(script)).get();
+    public Object runScript(String script) {
+        return getWebViewInteraction().withElement(get()).perform(new SimpleAtom(script)).get().getValue();
     }
 
-    public Evaluation runScriptWithArgs(String script, final ArrayList<Object> args) {
-        return getWebViewInteraction().withElement(get()).perform(Atoms.scriptWithArgs(script, args)).get();
+    public Object runScriptWithArgs(String script, final ArrayList<Object> args) {
+        return getWebViewInteraction().withElement(get()).perform(Atoms.scriptWithArgs(script, args)).get().getValue();
     }
 
     public String getCurrentUrl() {

--- a/detox/android/detox/src/full/java/com/wix/invoke/types/Invocation.java
+++ b/detox/android/detox/src/full/java/com/wix/invoke/types/Invocation.java
@@ -68,9 +68,9 @@ public class Invocation {
                 argument = args.get(i);
             } else if(args.get(i).getClass() == JSONArray.class) {
                 JSONArray jsonArray = (JSONArray) args.get(i);
-                List<String> list = new ArrayList<>();
+                List<Object> list = new ArrayList<>();
                 for (int j = 0; j < jsonArray.length(); j++) {
-                    list.add(jsonArray.getString(j));
+                    list.add(jsonArray.get(j));
                 }
                 argument = list;
             } else {

--- a/detox/android/detox/src/testFull/java/com/wix/invoke/JsonParserTest.java
+++ b/detox/android/detox/src/testFull/java/com/wix/invoke/JsonParserTest.java
@@ -7,6 +7,7 @@ import com.wix.invoke.types.ClassTarget;
 import com.wix.invoke.types.Invocation;
 import com.wix.invoke.types.InvocationTarget;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -21,20 +22,20 @@ public class JsonParserTest {
     @Test
     public void targetClassStaticMethodNoParams() {
         Invocation invocation = new Invocation(new ClassTarget("java.lang.System"), "lineSeparator");
-        assertThat(parse("targetClassStaticMethodNoParams.json")).isEqualToComparingFieldByFieldRecursively(invocation);
+        assertThat(parse("targetClassStaticMethodNoParams.json")).usingRecursiveComparison().isEqualTo(invocation);
     }
 
     @Test
     public void parseTargetClassStaticMethodOneParam() {
         Invocation invocation = new Invocation(new ClassTarget("java.lang.String"), "valueOf", 1.0f);
-        assertThat(parse("targetClassStaticMethodOneParam.json")).isEqualToComparingFieldByFieldRecursively(invocation);
+        assertThat(parse("targetClassStaticMethodOneParam.json")).usingRecursiveComparison().isEqualTo(invocation);
     }
 
     @Test
     public void targetInvocationMethodOfClassStaticMethodOneParam() {
         Invocation innerInvocation = new Invocation(new ClassTarget("java.lang.String"), "valueOf", 1.0f);
         Invocation outerInvocation = new Invocation(new InvocationTarget(innerInvocation), "length");
-        assertThat(parse("targetInvocationMethodOfClassStaticMethodOneParam.json")).isEqualToComparingFieldByFieldRecursively(outerInvocation);
+        assertThat(parse("targetInvocationMethodOfClassStaticMethodOneParam.json")).usingRecursiveComparison().isEqualTo(outerInvocation);
     }
 
     @Test
@@ -46,7 +47,7 @@ public class JsonParserTest {
         Invocation perform = new Invocation(new InvocationTarget(onView), "perform", click);
 
 
-        assertThat(parse("targetInvocationEspresso.json")).isEqualToComparingFieldByFieldRecursively(perform);
+        assertThat(parse("targetInvocationEspresso.json")).usingRecursiveComparison().isEqualTo(perform);
     }
 
 
@@ -59,7 +60,7 @@ public class JsonParserTest {
         Invocation click = new Invocation(new ClassTarget("android.support.test.espresso.action.ViewActions"), "click");
         Invocation perform = new Invocation(new ClassTarget("com.wix.detox.espresso.EspressoDetox"), "perform", onView, click);
 
-        assertThat(parse("targetInvocationEspressoDetox.json")).isEqualToComparingFieldByFieldRecursively(perform);
+        assertThat(parse("targetInvocationEspressoDetox.json")).usingRecursiveComparison().isEqualTo(perform);
     }
 
     @Test
@@ -74,11 +75,26 @@ public class JsonParserTest {
     }
 
     @Test
+    public void fromJsonTargetInvocationEspressoWebDetoxScript() throws JSONException {
+        Invocation getWebView = new Invocation(new ClassTarget("com.wix.detox.espresso.web.EspressoWebDetox"), "getWebView");
+        Invocation matcher = new Invocation(new ClassTarget("com.wix.detox.espresso.web.DetoxWebAtomMatcher"), "matcherForId", "textInput");
+        Invocation element = new Invocation(new InvocationTarget(getWebView), "element", matcher, 0);
+
+        String script = "function(el,arg1){}";
+        ArrayList<Object> scriptArguments = new ArrayList<>();
+        JSONArray arg1 = new JSONArray("[{ \"b\": true, \"n\": 1, \"s\": \"1\" }]");
+        scriptArguments.add(arg1);
+
+        Invocation runScriptWithArgs = new Invocation(new InvocationTarget(element), "runScriptWithArgs", script, scriptArguments);
+        assertThat(parse("targetInvocationEspressoWebDetoxScript.json")).usingRecursiveComparison().isEqualTo(runScriptWithArgs);
+    }
+
+    @Test
     public void fromJsonTargetInvocationWithListParams() {
         ArrayList<String> params = new ArrayList<>();
         params.add(".*10.0.2.2.*");
         Invocation test = new Invocation(new ClassTarget("com.wix.detox.espresso.EspressoDetox"), "setURLBlacklist", params);
-        assertThat(parse("fromJsonTargetInvocationWithListParams.json")).isEqualToComparingFieldByFieldRecursively(test);
+        assertThat(parse("fromJsonTargetInvocationWithListParams.json")).usingRecursiveComparison().isEqualTo(test);
     }
 
     public Invocation parseString(String jsonString) {

--- a/detox/android/detox/src/testFull/resources/targetInvocationEspressoWebDetoxScript.json
+++ b/detox/android/detox/src/testFull/resources/targetInvocationEspressoWebDetoxScript.json
@@ -1,0 +1,47 @@
+{
+  "target":{
+    "type":"Invocation",
+    "value":{
+      "target":{
+        "type":"Invocation",
+        "value":{
+          "target":{
+            "type":"Class",
+            "value":"com.wix.detox.espresso.web.EspressoWebDetox"
+          },
+          "method":"getWebView",
+          "args":[
+
+          ]
+        }
+      },
+      "method":"element",
+      "args":[
+        {
+          "type":"Invocation",
+          "value":{
+            "target":{
+              "type":"Class",
+              "value":"com.wix.detox.espresso.web.DetoxWebAtomMatcher"
+            },
+            "method":"matcherForId",
+            "args":[
+              "textInput"
+            ]
+          }
+        },
+        {
+          "type":"Integer",
+          "value":0
+        }
+      ]
+    }
+  },
+  "method": "runScriptWithArgs",
+  "args": [
+    "function(el,arg1){}",
+    [
+      [{ "b": true, "n": 1, "s": "1" }]
+    ]
+  ]
+}

--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -1571,19 +1571,22 @@ declare global {
             moveCursorToEnd(): Promise<void>;
 
             /**
-             * Running a script on the element
-             * @param script a method that accept the element as its first arg
-             * @example function foo(element) { console.log(element); }
+             * Running a JavaScript function on the element.
+             * The first argument to the function will be the element itself.
+             * The rest of the arguments will be forwarded to the JavaScript function as is.
+             *
+             * @param script a callback function in stringified form, or a plain function reference
+             * without closures, bindings etc. that will be converted to a string.
+             * @param args optional args to pass to the script
+             *
+             * @example
+             * await webElement.runScript('(el) => el.click()');
+             * await webElement.runScript(function setText(element, text) {
+             *   element.textContent = text;
+             * }, ['Custom Title']);
              */
-            runScript(script: string): Promise<any>;
-
-            /**
-             * Running a script on the element that accept args
-             * @param script a method that accept few args, and the element as the last arg.
-             * @param args a list of args to pass to the script
-             * @example function foo(a, b, c, element) { console.log(`${a}, ${b}, ${c}, ${element}`)}
-             */
-            runScriptWithArgs(script: string, args: any[]): Promise<any>;
+            runScript(script: string, args?: unknown[]): Promise<any>;
+            runScript<F>(script: (...args: any[]) => F, args?: unknown[]): Promise<F>;
 
             /**
              * Gets the current page url

--- a/detox/src/android/AndroidExpect.test.js
+++ b/detox/src/android/AndroidExpect.test.js
@@ -528,10 +528,10 @@ describe('AndroidExpect', () => {
       });
 
       it('runScript', async () => {
-        const script = 'function foo(el) {}';
-        await e.web.element(e.by.web.id('id')).runScript(script);
-        await e.web.element(e.by.web.className('className')).runScript(script);
-        await e.web.element(e.by.web.cssSelector('cssSelector')).runScript(script);
+        const script = 'function named(el) { return el.textContent; }';
+        await e.web.element(e.by.web.id('id')).runScript(function () {});
+        await e.web.element(e.by.web.className('className')).runScript((el) => el.textContent);
+        await e.web.element(e.by.web.cssSelector('cssSelector')).runScript(function named(...args) {});
         await e.web.element(e.by.web.name('name')).runScript(script);
         await e.web.element(e.by.web.xpath('xpath')).runScript(script);
         await e.web.element(e.by.web.href('linkText')).runScript(script);
@@ -539,26 +539,23 @@ describe('AndroidExpect', () => {
         await e.web.element(e.by.web.tag('tag')).runScript(script);
       });
 
-      it('runScriptWithArgs', async () => {
-        const script = 'function bar(a,b) {}';
-        const argsArr = ['fooA','barB'];
-        await e.web.element(e.by.web.id('id')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.web.className('className')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.web.cssSelector('cssSelector')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.web.name('name')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.web.xpath('xpath')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.web.href('linkText')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.web.hrefContains('partialLinkText')).runScriptWithArgs(script, argsArr);
-        await e.web.element(e.by.web.tag('tag')).runScriptWithArgs(script, argsArr);
+      it('runScript (unhappy)', async () => {
+        await expect(e.web.element(e.by.web.id('id')).runScript(/nonsense/)).rejects.toThrow(/script should be a string, but got \/nonsense\//);
+        await expect(e.web.element(e.by.web.id('id')).runScript(null, [])).rejects.toThrow(/script should be a string, but got null/);
+        await expect(e.web.element(e.by.web.id('id')).runScript('return el.textContent')).rejects.toThrow(/Expected a valid function string, but got: return el.textContent/);
       });
 
-      it('runScriptWithArgs (unhappy paths)', async () => {
+      it('runScript (with args)', async () => {
         const script = 'function bar(a,b) {}';
-        const someElement = e.web.element(e.by.web.id('id'));
-
-        await expect(someElement.runScriptWithArgs(script, 42)).rejects.toThrowError(/args must be an array/);
-        await expect(someElement.runScriptWithArgs(script, null)).rejects.toThrowError(/args must be an array/);
-        await expect(someElement.runScriptWithArgs(script, {})).rejects.toThrowError(/args must be an array/);
+        const argsArr = ['fooA', 40];
+        await e.web.element(e.by.web.id('id')).runScript(script, argsArr);
+        await e.web.element(e.by.web.className('className')).runScript(script, argsArr);
+        await e.web.element(e.by.web.cssSelector('cssSelector')).runScript(script, argsArr);
+        await e.web.element(e.by.web.name('name')).runScript(script, argsArr);
+        await e.web.element(e.by.web.xpath('xpath')).runScript(script, argsArr);
+        await e.web.element(e.by.web.href('linkText')).runScript(script, argsArr);
+        await e.web.element(e.by.web.hrefContains('partialLinkText')).runScript(script, argsArr);
+        await e.web.element(e.by.web.tag('tag')).runScript(script, argsArr);
       });
 
       it('getCurrentUrl', async () => {

--- a/detox/src/android/core/WebElement.js
+++ b/detox/src/android/core/WebElement.js
@@ -1,5 +1,7 @@
 const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
 const invoke = require('../../invoke');
+const assertIsFunction = require('../../utils/assertIsFunction');
+const isArrowFunction = require('../../utils/isArrowFunction');
 const actions = require('../actions/web');
 const EspressoWebDetoxApi = require('../espressoapi/web/EspressoWebDetox');
 const WebViewElementApi = require('../espressoapi/web/WebViewElement');
@@ -73,12 +75,14 @@ class WebElement {
     return await new ActionInteraction(this[_invocationManager], new actions.WebMoveCursorEnd(this)).execute();
   }
 
-  async runScript(script) {
-    return await new ActionInteraction(this[_invocationManager], new actions.WebRunScriptAction(this, script)).execute();
-  }
+  async runScript(maybeFunction, args) {
+    const script = stringifyScript(maybeFunction);
 
-  async runScriptWithArgs(script, args) {
-    return await new ActionInteraction(this[_invocationManager], new actions.WebRunScriptWithArgsAction(this, script, args)).execute();
+    if (args) {
+      return await new ActionInteraction(this[_invocationManager], new actions.WebRunScriptWithArgsAction(this, script, args)).execute();
+    } else {
+      return await new ActionInteraction(this[_invocationManager], new actions.WebRunScriptAction(this, script)).execute();
+    }
   }
 
   async getCurrentUrl() {
@@ -118,6 +122,20 @@ class WebViewElement {
 
     throw new DetoxRuntimeError(`element() argument is invalid, expected a web matcher, but got ${typeof element}`);
   }
+}
+
+function stringifyScript(maybeFunction) {
+  if (typeof maybeFunction !== 'string' && typeof maybeFunction !== 'function') {
+    return maybeFunction;
+  }
+
+  const script = (typeof maybeFunction === 'function' ? maybeFunction.toString() : assertIsFunction(maybeFunction)).trim();
+  // WebElement interactions don't support arrow functions for some reason.
+  if (isArrowFunction(script)) {
+    return `function arrowWorkaround() { return (${script}).apply(this, arguments); }`;
+  }
+
+  return script;
 }
 
 module.exports = {

--- a/detox/src/android/espressoapi/web/WebElement.js
+++ b/detox/src/android/espressoapi/web/WebElement.js
@@ -76,10 +76,7 @@ class WebElement {
     return {
       target: element,
       method: "runScriptWithArgs",
-      args: [script, {
-        type: "ArrayList<Object>",
-        value: args
-      }]
+      args: [script, args]
     };
   }
 

--- a/detox/src/utils/assertIsFunction.js
+++ b/detox/src/utils/assertIsFunction.js
@@ -1,0 +1,35 @@
+const isArrowFunction = require('./isArrowFunction');
+
+const EXAMPLE = `Here are some examples of valid function strings:
+
+1. function(el) { el.click(); }
+2. el => el.click()
+3. (el) => el.click()
+`;
+
+/**
+ * Dynamically evaluates a string as a function and throws an error if it's not a function
+ * @param {string} str serialized function like 'function() { return 42; }'
+ */
+function assertIsFunction(str) {
+  let isFunction;
+
+  try {
+    isFunction = isFunctionDeclaration(str) && Function(`return typeof (${str})`)() === 'function';
+  } catch (e) {
+    isFunction = false;
+  }
+
+  if (!isFunction) {
+    throw new TypeError(`Expected a valid function string, but got: ${str}\n\n${EXAMPLE}`);
+  }
+
+  return str;
+}
+
+function isFunctionDeclaration(rawStr) {
+  const str = rawStr.trimStart();
+  return str.startsWith('async') || str.startsWith('function') || isArrowFunction(str);
+}
+
+module.exports = assertIsFunction;

--- a/detox/src/utils/assertIsFunction.test.js
+++ b/detox/src/utils/assertIsFunction.test.js
@@ -1,0 +1,23 @@
+const assertIsFunction = require('./assertIsFunction');
+
+describe('assertIsFunction', function() {
+  test.each([
+    ['function() { return 42; }'],
+    ['function(x) { return x; }'],
+    ['function(x = () => {}) { return x; }'],
+    ['function() { return x => x; }'],
+    ['() => {}'],
+    ['x => x'],
+    ['(x = () => {}) => x'],
+    ['function*() { yield 42; }'],
+  ])(`given a valid function string %s should return it`, (fn) => {
+    expect(assertIsFunction(fn)).toBe(fn);
+  });
+
+  test.each([
+    ['function() { return 42; /* forgot to close the function'],
+    ['x = () => {}'],
+  ])(`given an invalid function string %s should throw`, (fn) => {
+    expect(() => assertIsFunction(fn)).toThrow();
+  });
+});

--- a/detox/src/utils/isArrowFunction.js
+++ b/detox/src/utils/isArrowFunction.js
@@ -1,0 +1,24 @@
+function isArrowFunction(code) {
+  if (!code.includes('=>')) {
+    return false;
+  }
+
+  const syncCode = removeAsync(code.trimStart());
+  return syncCode.startsWith('(') || isSimpleArrowFunction(code);
+}
+
+function removeAsync(code) {
+  return code.startsWith('async') ? code.slice(5).trimStart() : code;
+}
+
+function isSimpleArrowFunction(code) {
+  const [signature] = code.split('=>', 1);
+
+  return isAlphanumericId(removeAsync(signature.trim()));
+}
+
+function isAlphanumericId(code) {
+  return /^[a-zA-Z0-9]+$/.test(code);
+}
+
+module.exports = isArrowFunction;

--- a/detox/src/utils/isArrowFunction.test.js
+++ b/detox/src/utils/isArrowFunction.test.js
@@ -1,0 +1,16 @@
+const isArrowFunction = require('./isArrowFunction');
+
+describe('isArrowFunction', () => {
+  test.each([
+    [() => {}, true],
+    [x => x, true],
+    [(x = () => {}) => x, true],
+    [async()=>{}, true],
+    [async x => x, true],
+    [function*() { yield 42; }, false],
+    [function(x = () => {}) { return x; }, false],
+    [function() { return x => x; }, false],
+  ])(`given %s should return %s`, (fn, expected) => {
+    expect(isArrowFunction(fn.toString())).toBe(expected);
+  });
+});

--- a/detox/test/types/detox-global-tests.ts
+++ b/detox/test/types/detox-global-tests.ts
@@ -92,6 +92,12 @@ describe("Test", () => {
             .scroll(50, "down");
 
         await web.element(by.web.id("btnSave")).tap();
+        await web.element(by.web.id("btnSave")).runScript('(el) => el.click()');
+        const scriptResult = await web.element(by.web.id("btnSave")).runScript(function (el: any, text: string) {
+          el.textContent = text;
+          return text.length;
+        }, ['new button text']);
+        assertType<number>(scriptResult);
         await web.element(by.web.className("scroll-end")).atIndex(0).scrollToView();
 
         const webview = web(by.id("webview"));

--- a/docs/api/webviews.md
+++ b/docs/api/webviews.md
@@ -234,32 +234,25 @@ This action is currently supported for content-editable elements only.
 await web.element(by.web.id('identifier')).moveCursorToEnd();
 ```
 
-### `runScript(script)`
+### `runScript(script[, args])`
 
 Run the specified script on the element.
-
 The script should be a string that contains a valid JavaScript function.
-It will be called with that element as the first argument.
+It will be called with that element as the first argument:
 
 ```js
 const webElement = web.element(by.web.id('identifier'));
-await webElement.runScript(`function foo(element) {
-  console.log(element);
-}`);
+await webElement.runScript('(el) => el.click()');
 ```
 
-### `runScriptWithArgs(script, ...args)`
+For convenience, you can pass a function instead of a string, but please note that this will not work if the function uses any variables from the outer scope:
 
-Run the specified script on the element with extra arguments.
-
-The script should be a string that contains a valid JavaScript function.
-It will be called with the specified arguments and the element itself as the last argument.
+The script can accept additional arguments and return a value. Make sure the values are primitive types or serializable objects, as they will be converted to JSON and back:
 
 ```js
-const webElement = web.element(by.web.id('identifier'));
-await webElement.runScriptWithArgs(`function foo(arg1, arg2, element) {
-  console.log(arg1, arg2, element);
-}`, "foo", 123);
+const text = await webElement.runScript(function get(element, property) {
+  return element[property];
+}, ['textContent']);
 ```
 
 ### `getCurrentUrl()`

--- a/generation/core/generator.js
+++ b/generation/core/generator.js
@@ -202,6 +202,7 @@ module.exports = function getGenerator({
     'id<GREYMatcher>',
     'GREYElementInteraction*',
     'String',
+    'ArrayList<Object>',
     'ArrayList<String>',
     'ViewAction'
   ];

--- a/website/versioned_docs/version-20.x/api/webviews.md
+++ b/website/versioned_docs/version-20.x/api/webviews.md
@@ -234,32 +234,25 @@ This action is currently supported for content-editable elements only.
 await web.element(by.web.id('identifier')).moveCursorToEnd();
 ```
 
-### `runScript(script)`
+### `runScript(script[, args])`
 
 Run the specified script on the element.
-
 The script should be a string that contains a valid JavaScript function.
-It will be called with that element as the first argument.
+It will be called with that element as the first argument:
 
 ```js
 const webElement = web.element(by.web.id('identifier'));
-await webElement.runScript(`function foo(element) {
-  console.log(element);
-}`);
+await webElement.runScript('(el) => el.click()');
 ```
 
-### `runScriptWithArgs(script, ...args)`
+For convenience, you can pass a function instead of a string, but please note that this will not work if the function uses any variables from the outer scope:
 
-Run the specified script on the element with extra arguments.
-
-The script should be a string that contains a valid JavaScript function.
-It will be called with the specified arguments and the element itself as the last argument.
+The script can accept additional arguments and return a value. Make sure the values are primitive types or serializable objects, as they will be converted to JSON and back:
 
 ```js
-const webElement = web.element(by.web.id('identifier'));
-await webElement.runScriptWithArgs(`function foo(arg1, arg2, element) {
-  console.log(arg1, arg2, element);
-}`, "foo", 123);
+const text = await webElement.runScript(function get(element, property) {
+  return element[property];
+}, ['textContent']);
 ```
 
 ### `getCurrentUrl()`


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #4127.

In this pull request, I removed `runScriptWithArgs` from Web Elements API since it has never worked.

Instead, I fixed `runScript` and extended its capabilities (in a backward-compatible way) as follows:

### `runScript(script[, args])`

Run the specified script on the element.
The script should be a string that contains a valid JavaScript function.
It will be called with that element as the first argument:

```js
const webElement = web.element(by.web.id('identifier'));
await webElement.runScript('(el) => el.click()');
```

For convenience, you can pass a function instead of a string, but please note that this will not work if the function uses any variables from the outer scope:

The script can accept additional arguments and return a value. Make sure the values are primitive types or serializable objects, as they will be converted to JSON and back:

```js
const text = await webElement.runScript(function get(element, property) {
  return element[property];
}, ['textContent']);
```

> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.