### PR TITLE
Remove globals from typescript interface definition

### DIFF
--- a/detox/index.d.ts
+++ b/detox/index.d.ts
@@ -11,14 +11,6 @@
 import { BunyanDebugStreamOptions } from 'bunyan-debug-stream';
 
 declare global {
-    const detox: Detox.DetoxExportWrapper;
-    const device: Detox.DetoxExportWrapper['device'];
-    const element: Detox.DetoxExportWrapper['element'];
-    const waitFor: Detox.DetoxExportWrapper['waitFor'];
-    const expect: Detox.DetoxExportWrapper['expect'];
-    const by: Detox.DetoxExportWrapper['by'];
-    const web: Detox.DetoxExportWrapper['web'];
-
     namespace NodeJS {
         interface Global {
             detox: Detox.DetoxExportWrapper;


### PR DESCRIPTION

## Description

This pull request addresses the issue described here: #4223

This is as straightforward as can be: the globals definitions prevent proper automatic imports by IDE to happen correctly, and imports must be explicit anyway to avoid runtime bugs. Removing those definitions fixes the problem.
