### PR TITLE
fix(android): add namespace to build.gradle for android gradle plugin 8 compatibility

### DIFF
--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -21,6 +21,7 @@ def _rnNativeArtifact = rnInfo.isRN71OrHigher
             : 'com.facebook.react:react-native:+'
 
 android {
+    namespace "com.wix.detox"
     compileSdkVersion _compileSdkVersion
     buildToolsVersion _buildToolsVersion
 

--- a/detox/android/detox/build.gradle
+++ b/detox/android/detox/build.gradle
@@ -21,7 +21,10 @@ def _rnNativeArtifact = rnInfo.isRN71OrHigher
             : 'com.facebook.react:react-native:+'
 
 android {
-    namespace "com.wix.detox"
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpVersion >= 7) {
+        namespace "com.wix.detox"
+    }
     compileSdkVersion _compileSdkVersion
     buildToolsVersion _buildToolsVersion
 


### PR DESCRIPTION

## Description

I may be wrong, but I believe this is necessary for android gradle plugin 8 compatibility, which is what react-native 0.73 will ship with. I'm working through compat issues right now as I bump into them, testing release candidates

> fix(android): add namespace to build.gradle for android gradle plugin 8 compatibility

Related: https://github.com/invertase/react-native-firebase/commit/19ae9b8cb66d16fa20c7ff00d6da1a81438c7030