### PR TITLE
fix(android): escape instrumentation args

### DIFF
--- a/detox/src/devices/common/drivers/android/tools/instrumentationArgs.js
+++ b/detox/src/devices/common/drivers/android/tools/instrumentationArgs.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 
 const { encodeBase64 } = require('../../../../../utils/encoding');
+const { autoEscape } = require('../../../../../utils/shellUtils');
 
 const reservedInstrumentationArgs = new Set(['class', 'package', 'func', 'unit', 'size', 'perf', 'debug', 'log', 'emma', 'coverageFile']);
 const isReservedInstrumentationArg = (arg) => reservedInstrumentationArgs.has(arg);
@@ -17,7 +18,8 @@ function prepareInstrumentationArgs(args) {
       valueEncoded = encodeBase64(valueAsString);
     }
 
-    result.push('-e', key, valueEncoded);
+    const valueEscaped = hasLegacyIssues(key) ? valueEncoded : autoEscape.shell(valueEncoded);
+    result.push('-e', key, valueEscaped);
     return result;
   }, []);
 
@@ -25,6 +27,10 @@ function prepareInstrumentationArgs(args) {
     args: preparedLaunchArgs,
     usedReservedArgs,
   };
+}
+
+function hasLegacyIssues(key) {
+  return key === 'detoxURLBlacklistRegex';
 }
 
 module.exports = {

--- a/detox/test/e2e/15.urls.test.js
+++ b/detox/test/e2e/15.urls.test.js
@@ -8,7 +8,7 @@ describe('Open URLs', () => {
   });
 
   const withDefaultArgs = () => ({
-    url: 'detoxtesturlscheme://such-string',
+    url: 'detoxtesturlscheme://such-string?arg1=first&arg2=second',
     launchArgs: undefined,
   });
 
@@ -17,32 +17,23 @@ describe('Open URLs', () => {
     launchArgs: { detoxAndroidSingleInstanceActivity: true },
   });
 
-  [
-    {
-      platform: '',
-      ...withDefaultArgs(),
-    },
-    {
-      platform: 'android',
-      ...withSingleInstanceActivityArgs(),
-    }
-  ].forEach((testSpec) => {
-    const {platform, url, launchArgs} = testSpec;
-    const _platform = platform ? `:${platform}: ` : '';
-
-    it(`${_platform}device.launchApp() with a URL and a fresh app should launch app and trigger handling open url handling in app`, async () => {
+  describe.each([
+    ['(default)', withDefaultArgs()],
+    [':android: (single activity)', withSingleInstanceActivityArgs()],
+  ])('%s', (_platform, {url, launchArgs}) => {
+    it(`device.launchApp() with a URL and a fresh app should launch app and trigger handling open url handling in app`, async () => {
       await device.launchApp({newInstance: true, url, launchArgs});
       await expect(element(by.text(url))).toBeVisible();
     });
 
-    it(`${_platform}device.openURL() should trigger open url handling in app when app is in foreground`, async () => {
+    it(`device.openURL() should trigger open url handling in app when app is in foreground`, async () => {
       await device.launchApp({newInstance: true, launchArgs});
       await expect(element(by.text(url))).not.toBeVisible();
       await device.openURL({url});
       await expect(element(by.text(url))).toBeVisible();
     });
 
-    it(`${_platform}device.launchApp() with a URL should trigger url handling when app is in background`, async () => {
+    it(`device.launchApp() with a URL should trigger url handling when app is in background`, async () => {
       await device.launchApp({newInstance: true, launchArgs});
       await expect(element(by.text(url))).not.toBeVisible();
       await device.sendToHome();


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #4196 

In this pull request, I have added POSIX escaping for arguments passed to `adb shell ...` in one forgotten place.