### PR TITLE
feat(cli): detached runner

### DIFF
--- a/detox/detox.d.ts
+++ b/detox/detox.d.ts
@@ -236,6 +236,13 @@ declare global {
              */
             bail?: boolean;
             /**
+             * When true, tells `detox test` to spawn the test runner in a detached mode.
+             * This is useful in CI environments, where you want to intercept SIGINT and SIGTERM signals to gracefully shut down the test runner and the device.
+             * Instead of passing the kill signal to the child process (the test runner), Detox will send an emergency shutdown request to all the workers, and then it will wait for them to finish.
+             * @default false
+             */
+            detached?: boolean;
+            /**
              * Custom handler to process --inspect-brk CLI flag.
              * Use it when you rely on another test runner than Jest to mutate the config.
              */

--- a/detox/internals.d.ts
+++ b/detox/internals.d.ts
@@ -116,8 +116,9 @@ declare global {
       /**
        * Workaround for Jest exiting abruptly in --bail mode.
        * Makes sure that all workers and their test environments are properly torn down.
+       * @param [permanent] - forbids further retries
        */
-      unsafe_conductEarlyTeardown(): Promise<void>;
+      unsafe_conductEarlyTeardown(permanent?: boolean): Promise<void>;
       /**
        * Reports to Detox CLI about passed and failed test files.
        * The failed test files might be re-run again if

--- a/detox/local-cli/test.test.js
+++ b/detox/local-cli/test.test.js
@@ -5,6 +5,7 @@ if (process.platform === 'win32') {
 
 jest.mock('../src/logger/DetoxLogger');
 jest.mock('./utils/jestInternals');
+jest.mock('./utils/interruptListeners');
 
 const cp = require('child_process');
 const cpSpawn = cp.spawn;
@@ -17,6 +18,8 @@ const _ = require('lodash');
 const { buildMockCommand, callCli } = require('../__tests__/helpers');
 
 const { DEVICE_LAUNCH_ARGS_DEPRECATION } = require('./testCommand/warnings');
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe('CLI', () => {
   let _env;
@@ -140,6 +143,38 @@ describe('CLI', () => {
       test('should not hint essential environment variables', () => {
         expect(cliCall().fullCommand).not.toMatch(/\bDETOX_CONFIG_PATH=.*\bexecutable\b/);
       });
+    });
+  });
+
+  describe('detached runner', () => {
+    beforeEach(() => {
+      detoxConfig.testRunner.detached = true;
+    });
+
+    test('should be able to run as you would normally expect', async () => {
+      await run();
+      expect(_.last(cliCall().argv)).toEqual('e2e/config.json');
+    });
+
+    test('should intercept SIGINT and SIGTERM', async () => {
+      const { subscribe, unsubscribe } = jest.requireMock('./utils/interruptListeners');
+      const simulateSIGINT = () => subscribe.mock.calls[0][0]();
+
+      mockExitCode(1);
+      mockLongRun(2000);
+
+      await Promise.all([
+        run('--retries 2').catch(_.noop),
+        sleep(1000).then(() => {
+          simulateSIGINT();
+          simulateSIGINT();
+          expect(unsubscribe).not.toHaveBeenCalled();
+        }),
+      ]);
+
+      expect(unsubscribe).toHaveBeenCalled();
+      expect(cliCall(0)).not.toBe(null);
+      expect(cliCall(1)).toBe(null);
     });
   });
 
@@ -618,6 +653,11 @@ describe('CLI', () => {
 
   function mockExitCode(code) {
     mockExecutable.options.exitCode = code;
+    detoxConfig.testRunner.args.$0 = mockExecutable.cmd;
+  }
+
+  function mockLongRun(ms) {
+    mockExecutable.options.sleep = ms;
     detoxConfig.testRunner.args.$0 = mockExecutable.cmd;
   }
 });

--- a/detox/local-cli/utils/interruptListeners.js
+++ b/detox/local-cli/utils/interruptListeners.js
@@ -1,0 +1,15 @@
+function subscribe(listener) {
+  process.on('SIGINT', listener);
+  process.on('SIGTERM', listener);
+}
+
+function unsubscribe(listener) {
+  process.removeListener('SIGINT', listener);
+  process.removeListener('SIGTERM', listener);
+}
+
+module.exports = {
+  subscribe,
+  unsubscribe,
+};
+

--- a/detox/runners/jest/testEnvironment/index.js
+++ b/detox/runners/jest/testEnvironment/index.js
@@ -73,7 +73,9 @@ class DetoxCircusEnvironment extends NodeEnvironment {
   // @ts-expect-error TS2425
   async handleTestEvent(event, state) {
     if (detox.session.unsafe_earlyTeardown) {
-      throw new Error('Detox halted test execution due to an early teardown request');
+      if (event.name === 'test_fn_start' || event.name === 'hook_start') {
+        throw new Error('Detox halted test execution due to an early teardown request');
+      }
     }
 
     this._timer.schedule(state.testTimeout != null ? state.testTimeout : this.setupTimeout);
@@ -107,6 +109,10 @@ class DetoxCircusEnvironment extends NodeEnvironment {
    * @protected
    */
   async initDetox() {
+    if (detox.session.unsafe_earlyTeardown) {
+      throw new Error('Detox halted test execution due to an early teardown request');
+    }
+
     const opts = {
       global: this.global,
       workerId: `w${process.env.JEST_WORKER_ID}`,

--- a/detox/src/configuration/composeRunnerConfig.js
+++ b/detox/src/configuration/composeRunnerConfig.js
@@ -32,6 +32,7 @@ function composeRunnerConfig(opts) {
       retries: 0,
       inspectBrk: inspectBrkHookDefault,
       forwardEnv: false,
+      detached: false,
       bail: false,
       jest: {
         setupTimeout: 300000,
@@ -56,8 +57,9 @@ function composeRunnerConfig(opts) {
 
   if (typeof merged.inspectBrk === 'function') {
     if (cliConfig.inspectBrk) {
-      merged.retries = 0;
+      merged.detached = false;
       merged.forwardEnv = true;
+      merged.retries = 0;
       merged.inspectBrk(merged);
     }
 

--- a/detox/src/configuration/composeRunnerConfig.test.js
+++ b/detox/src/configuration/composeRunnerConfig.test.js
@@ -46,6 +46,7 @@ describe('composeRunnerConfig', () => {
       },
       retries: 0,
       bail: false,
+      detached: false,
       forwardEnv: false,
     });
   });
@@ -60,6 +61,7 @@ describe('composeRunnerConfig', () => {
       },
       bail: true,
       retries: 1,
+      detached: true,
       forwardEnv: true,
     };
 
@@ -77,6 +79,7 @@ describe('composeRunnerConfig', () => {
       },
       bail: true,
       retries: 1,
+      detached: true,
       forwardEnv: true,
     });
   });
@@ -92,6 +95,7 @@ describe('composeRunnerConfig', () => {
       },
       bail: true,
       retries: 1,
+      detached: true,
       forwardEnv: true,
     };
 
@@ -109,6 +113,7 @@ describe('composeRunnerConfig', () => {
       },
       bail: true,
       retries: 1,
+      detached: true,
       forwardEnv: true,
     });
   });
@@ -222,6 +227,7 @@ describe('composeRunnerConfig', () => {
         reportSpecs: true,
       },
       bail: true,
+      detached: true,
       retries: 1,
     };
 
@@ -236,6 +242,7 @@ describe('composeRunnerConfig', () => {
         reportSpecs: false,
       },
       bail: false,
+      detached: false,
       retries: 3,
     };
 
@@ -256,6 +263,7 @@ describe('composeRunnerConfig', () => {
         reportWorkerAssign: true,
       },
       bail: false,
+      detached: false,
       retries: 3,
       forwardEnv: false,
     });

--- a/detox/src/ipc/IPCClient.js
+++ b/detox/src/ipc/IPCClient.js
@@ -86,8 +86,8 @@ class IPCClient {
     this._sessionState.patch(sessionState);
   }
 
-  async conductEarlyTeardown() {
-    const sessionState = await this._emit('conductEarlyTeardown', {});
+  async conductEarlyTeardown({ permanent }) {
+    const sessionState = await this._emit('conductEarlyTeardown', { permanent });
     this._sessionState.patch(sessionState);
   }
 

--- a/detox/src/ipc/IPCServer.js
+++ b/detox/src/ipc/IPCServer.js
@@ -73,6 +73,7 @@ class IPCServer {
     this._ipc.server.emit(socket, 'registerContextDone', {
       testResults: this._sessionState.testResults,
       testSessionIndex: this._sessionState.testSessionIndex,
+      unsafe_earlyTeardown: this._sessionState.unsafe_earlyTeardown,
     });
   }
 
@@ -90,10 +91,11 @@ class IPCServer {
     }
   }
 
-  onConductEarlyTeardown(_data = null, socket = null) {
-    // Note that we don't save `unsafe_earlyTeardown` in the primary session state
-    // because it's transient and needed only to make the workers quit early.
+  onConductEarlyTeardown({ permanent }, socket = null) {
     const newState = { unsafe_earlyTeardown: true };
+    if (permanent) {
+      Object.assign(this._sessionState, newState);
+    }
 
     if (socket) {
       this._ipc.server.emit(socket, 'conductEarlyTeardownDone', newState);

--- a/detox/src/ipc/ipc.test.js
+++ b/detox/src/ipc/ipc.test.js
@@ -129,6 +129,36 @@ describe('IPC', () => {
       });
     });
 
+    describe('conductEarlyTeardown', () => {
+      beforeEach(() => ipcServer.init());
+
+      describe('(permanent)', () => {
+        beforeEach(() => ipcServer.onConductEarlyTeardown({ permanent: true }));
+
+        it('should change the session state', async () => {
+          expect(ipcServer.sessionState.unsafe_earlyTeardown).toEqual(true);
+        });
+
+        it('should pass the session state to the client', async () => {
+          await ipcClient1.init();
+          expect(ipcClient1.sessionState.unsafe_earlyTeardown).toEqual(true);
+        });
+      });
+
+      describe('(transient)', () => {
+        beforeEach(() => ipcServer.onConductEarlyTeardown({ permanent: false }));
+
+        it('should not change the session state', async () => {
+          expect(ipcServer.sessionState.unsafe_earlyTeardown).toBe(undefined);
+        });
+
+        it('should not pass the session state to the client', async () => {
+          await ipcClient1.init();
+          expect(ipcClient1.sessionState.unsafe_earlyTeardown).toBe(undefined);
+        });
+      });
+    });
+
     describe('dispose()', () => {
       it('should resolve if there are no connected clients', async () => {
         await ipcServer.init();
@@ -278,7 +308,7 @@ describe('IPC', () => {
           expect(ipcClient1.sessionState).toEqual(expect.objectContaining({ unsafe_earlyTeardown: undefined }));
           expect(ipcClient2.sessionState).toEqual(expect.objectContaining({ unsafe_earlyTeardown: undefined }));
 
-          await ipcClient1.conductEarlyTeardown();
+          await ipcClient1.conductEarlyTeardown({ permanent: false });
           expect(ipcClient1.sessionState).toEqual(expect.objectContaining({ unsafe_earlyTeardown: true }));
           await sleep(10); // broadcasting might happen with a delay
           expect(ipcClient2.sessionState).toEqual(expect.objectContaining({ unsafe_earlyTeardown: true }));
@@ -287,7 +317,7 @@ describe('IPC', () => {
         it('should broadcast early teardown in all connected clients (from server)', async () => {
           expect(ipcClient1.sessionState).toEqual(expect.objectContaining({ unsafe_earlyTeardown: undefined }));
           expect(ipcClient2.sessionState).toEqual(expect.objectContaining({ unsafe_earlyTeardown: undefined }));
-          await ipcServer.onConductEarlyTeardown();
+          await ipcServer.onConductEarlyTeardown({ permanent: false });
           await sleep(10); // broadcasting might happen with a delay
           expect(ipcClient1.sessionState).toEqual(expect.objectContaining({ unsafe_earlyTeardown: true }));
           expect(ipcClient2.sessionState).toEqual(expect.objectContaining({ unsafe_earlyTeardown: true }));

--- a/detox/src/realms/DetoxContext.js
+++ b/detox/src/realms/DetoxContext.js
@@ -102,7 +102,7 @@ class DetoxContext {
   /** @abstract */
   [symbols.reportTestResults](_testResults) {}
   /** @abstract */
-  [symbols.conductEarlyTeardown]() {}
+  [symbols.conductEarlyTeardown](_permanent) {}
   /**
    * @abstract
    * @param {Partial<DetoxInternals.DetoxInitOptions>} _opts

--- a/detox/src/realms/DetoxPrimaryContext.js
+++ b/detox/src/realms/DetoxPrimaryContext.js
@@ -51,9 +51,9 @@ class DetoxPrimaryContext extends DetoxContext {
     }
   }
 
-  [symbols.conductEarlyTeardown] = async () => {
+  [symbols.conductEarlyTeardown] = async (permanent = false) => {
     if (this[_ipcServer]) {
-      await this[_ipcServer].onConductEarlyTeardown();
+      await this[_ipcServer].onConductEarlyTeardown({ permanent });
     }
   };
 

--- a/detox/src/realms/DetoxSecondaryContext.js
+++ b/detox/src/realms/DetoxSecondaryContext.js
@@ -33,9 +33,9 @@ class DetoxSecondaryContext extends DetoxContext {
     }
   }
 
-  [symbols.conductEarlyTeardown] = async () => {
+  [symbols.conductEarlyTeardown] = async (permanent = false) => {
     if (this[_ipcClient]) {
-      await this[_ipcClient].conductEarlyTeardown();
+      await this[_ipcClient].conductEarlyTeardown({ permanent });
     } else {
       throw new DetoxInternalError('Detected an attempt to report early teardown using a non-initialized context.');
     }

--- a/detox/test/e2e/detox.config.js
+++ b/detox/test/e2e/detox.config.js
@@ -12,8 +12,10 @@ const config = {
     args: {
       $0: 'nyc jest',
       config: 'e2e/jest.config.js',
-      _: ['e2e/']
+      forceExit: process.env.CI ? true : undefined,
+      _: ['e2e/'],
     },
+    detached: !!process.env.CI,
     retries: process.env.CI ? 1 : undefined,
     jest: {
       setupTimeout: +`${process.env.DETOX_JEST_SETUP_TIMEOUT || 300000}`,

--- a/detox/test/integration/jest.config.js
+++ b/detox/test/integration/jest.config.js
@@ -1,3 +1,5 @@
+process.env.CI = ''; // disable CI-specific behavior for integration tests
+
 module.exports = {
   "maxWorkers": 1,
   "testMatch": ["<rootDir>/*.test.js"],

--- a/docs/config/testRunner.mdx
+++ b/docs/config/testRunner.mdx
@@ -142,6 +142,16 @@ Default: `false`.
 When true, tells `detox test` to cancel next retrying if it gets at least one report about a [permanent test suite failure](../api/internals.mdx#reporting-test-results).
 Has no effect, if [`testRunner.retries`] is undefined or set to zero.
 
+### `testRunner.detached` \[boolean]
+
+Default: `false`.
+
+When true, tells `detox test` to spawn the test runner in a detached mode.
+
+This is useful in CI environments, where you want to intercept SIGINT and SIGTERM signals to gracefully shut down the test runner and the device.
+
+Instead of passing the kill signal to the child process (the test runner), Detox will send an emergency shutdown request to all the workers, and then it will wait for them to finish.
+
 ### `testRunner.forwardEnv` \[boolean]
 
 Default: `false`.


### PR DESCRIPTION
## Description

In this pull request, I have added a new feature, **detached mode** for test runners.

### `testRunner.detached` \[boolean]

Default: `false`.

When true, tells `detox test` to spawn the test runner in a detached mode.

This is useful in CI environments, where you want to intercept SIGINT and SIGTERM signals to gracefully shut down the test runner and the device.

Instead of passing the kill signal to the child process (the test runner), Detox will send an emergency shutdown request to all the workers, and then it will wait for them to finish.

### Example

```diff
     args: {
       $0: 'jest',
       config: 'e2e/jest.config.js',
+      forceExit: process.env.CI ? true : undefined,
       _: ['e2e/'],
     },
+    detached: !!process.env.CI,
     retries: process.env.CI ? 1 : undefined,
```

Detox will exit indirectly through Jest using the same mechanism as in our `--bail` workaround (#4115). If some tests don't clean up well, `--forceExit` will help to shut down in time.

---

> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
