### PR TITLE
docs: update Launch Args guide

### DIFF
--- a/docs/guide/launch-args.md
+++ b/docs/guide/launch-args.md
@@ -41,5 +41,5 @@ Examples:
 
 Our official recommendation for getting the arguments inside the app is by integrating the [react-native-launch-arguments](https://github.com/iamolegga/react-native-launch-arguments) project, which provides that seamlessly. For those who are interested, here are the underlying details:
 
-- On iOS, the specified launch arguments are passed as the process launch arguments and available through normal means, such as accesing `[[NSProcessInfo processInfo] arguments]`. 
+- On iOS, the specified launch arguments are passed as the process launch arguments and available through normal means, such as accesing `[[NSProcessInfo processInfo] arguments]`.
 - On Android, the launch arguments are set as bundle-extra’s into the activity’s intent. They are therefore accessible on the native side via the current activity as: `currentActivity.getIntent().getBundleExtra("launchArgs")`.

--- a/docs/guide/launch-args.md
+++ b/docs/guide/launch-args.md
@@ -41,5 +41,5 @@ Examples:
 
 Our official recommendation for getting the arguments inside the app is by integrating the [react-native-launch-arguments](https://github.com/iamolegga/react-native-launch-arguments) project, which provides that seamlessly. For those who are interested, here are the underlying details:
 
-- On iOS, the specified launch arguments are passed as the process launch arguments and available through normal means.
+- On iOS, the specified launch arguments are passed as the process launch arguments and available through normal means, such as accesing `[[NSProcessInfo processInfo] arguments]`. 
 - On Android, the launch arguments are set as bundle-extra’s into the activity’s intent. They are therefore accessible on the native side via the current activity as: `currentActivity.getIntent().getBundleExtra("launchArgs")`.


### PR DESCRIPTION
## Description
The existing docs describe how to grab the launchArgs natively on Android, but not on iOS, so after doing some research, I wanted to add this here so iOS is also described. 

Very simple change to explain what is meant by "normal means", which required a bit of research on my end. Since this is a very small docs change, I hope you don't mind that I didn't flesh out the entire PR checklist.