### PR TITLE
chore: bump jest-allure2-reporter

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-unicorn": "^47.0.0",
     "jest": "^28.1.3",
-    "jest-allure2-reporter": "2.0.0-alpha.8",
+    "jest-allure2-reporter": "2.0.0-alpha.10",
     "mockdate": "^2.0.1",
     "prettier": "^2.4.1",
     "react-native": "0.71.10",

--- a/detox/test/e2e/01.sanity.test.js
+++ b/detox/test/e2e/01.sanity.test.js
@@ -1,3 +1,13 @@
+/**
+ * Sanity suite
+ * ------------
+ *
+ * Tests in this suite ensure that the most basic functionality of Detox is
+ * working as expected: app launches, element matching, assertions, etc.
+ *
+ * @severity critical
+ * @tag sanity
+ */
 describe('Sanity', () => {
   beforeEach(async () => {
     await device.reloadReactNative();

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -63,7 +63,7 @@
     "express": "^4.15.3",
     "glob": "^7.2.0",
     "jest": "^29.2.1",
-    "jest-allure2-reporter": "2.0.0-alpha.8",
+    "jest-allure2-reporter": "2.0.0-alpha.10",
     "jest-junit": "^10.0.0",
     "lodash": "^4.14.1",
     "metro-react-native-babel-preset": "0.73.9",

--- a/generation/package.json
+++ b/generation/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "jest": "^27.0.0",
-    "jest-allure2-reporter": "2.0.0-alpha.8",
+    "jest-allure2-reporter": "2.0.0-alpha.10",
     "lint-staged": "^6.0.0",
     "prettier": "^1.8.2"
   },


### PR DESCRIPTION
## Description

Upgrades `jest-allure2-reporter` to `2.0.0-alpha.10` with improved support for docblocks and test file execution errors.