### PR TITLE
Fix misleading filepaths for DetoxTest.java in project-setup.mdx

### DIFF
--- a/docs/introduction/project-setup.mdx
+++ b/docs/introduction/project-setup.mdx
@@ -140,7 +140,7 @@ patch or create if they are missing:
     * `android/build.gradle`
     * `android/app/build.gradle`
 * **Native test code:**
-    * `android/app/src/androidTest/java/com/<your.package>/DetoxTest.java`
+    * `android/app/src/androidTest/java/DetoxTest.java`
 * **Manifests:**
     * `android/app/src/main/AndroidManifest.xml`
     * `android/app/src/main/res/xml/network_security_config.xml`
@@ -252,7 +252,7 @@ which will be picked up by `testRunner` that you just added in the previous step
 Copy the snippet below to create a file under the following path (where `<your.package>` is your actual
 package name):
 
-```java title="android/app/src/androidTest/java/com/<your.package>/DetoxTest.java" showLineNumbers
+```java title="android/app/src/androidTest/java/DetoxTest.java" showLineNumbers
 // highlight-next-line
 package com.<your.package>; // (1)
 

--- a/docs/introduction/project-setup.mdx
+++ b/docs/introduction/project-setup.mdx
@@ -249,8 +249,7 @@ run tests with your app built in **release mode**.
 Detox requires that your project has a single dummy native Android test with some special content,
 which will be picked up by `testRunner` that you just added in the previous step, so let's create it now.
 
-Copy the snippet below to create a file under the following path (where `<your.package>` is your actual
-package name):
+Copy the snippet below to create a file under the following path:
 
 ```java title="android/app/src/androidTest/java/DetoxTest.java" showLineNumbers
 // highlight-next-line


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->


<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have fixed misleading filepaths in the documentation for Project Setup in Step 4: Additional Android configuration.

The issue with the misleading documentation lines are that they referenced the test code will reside at `android/app/src/androidTest/java/com/<you.package>/DetoxTest.java` however this is incorrect as it should instead reside at `android/app/src/androidTest/java/DetoxTest.java`.

I spent **2 hours debugging** an issue where Detox would build and attempt to run the test however it would not launch the app and would fail at `await device.launchApp()`:
```console
Detox can't seem to connect to the test app(s)!

HINT: The test app might have crashed prematurely, or has had trouble setting up the connection.
```
- I had properly setup the XML config for clear text traffic for Metro to connect
- I had used trace and record logs all options and read the Detox logs which indicated the clear text traffic was working:
```console
11-21 17:08:25.517 20209 20209 D NetworkSecurityConfig: Using Network Security Config from resource network_security_config debugBuild: true
```
- In the Detox logs I noticed the `adb ... shell am instrument` command returning `OK (0 tests)`:
```console
INSTRUMENTATION_RESULT: stream=

Time: 0

OK (0 tests)

INSTRUMENTATION_CODE: -1
```
- This was clearly an indication that Detox was attempting to start the app but the instrument command could not find the "dummy test" `DetoxTest.java`
- I tried many combinations of the filepath for `DetoxTest.java` in my source sets until I found that `androidTest/java/DetoxTest.java` was the working path
  - The official Android SDK docs directly support this idea (see Table 1.): https://developer.android.com/studio/test/advanced-test-setup 

Since I have fixed this issue after 2 hours of debugging I think it warrants the docs to be updated since two simple line changes would have saved me 2 hours.

**Note**: This solution is working for me with the following combinations:
- `"react-native": "0.70.5",`
- `"detox": "^20.13.5",`
- `targetSdkVersion = 32`
- `kotlinVersion = '1.7.0'`
- 3 custom `productFlavors`
- 2 standard `buildTypes`: `debug` and `release`

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
