### PR TITLE
chore: bump jest-allure-reporter@2.0.0-alpha.11

### DIFF
--- a/.github/workflows/rapid-test.yml
+++ b/.github/workflows/rapid-test.yml
@@ -76,7 +76,7 @@ jobs:
         working-directory: detox/test
       - name: Pack Allure results
         run: |
-          Compress-Archive -Path detox/allure-results, detox/test/allure-results -DestinationPath allure-results.zip
+          Compress-Archive -Path detox/allure-results -DestinationPath allure-results.zip
         shell: pwsh
       - name: Upload Allure results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/rapid-test.yml
+++ b/.github/workflows/rapid-test.yml
@@ -75,7 +75,9 @@ jobs:
         run: npm run integration
         working-directory: detox/test
       - name: Pack Allure results
-        run: zip -r allure-results.zip detox/allure-results detox/test/allure-results
+        run: |
+          Compress-Archive -Path detox/allure-results, detox/test/allure-results -DestinationPath allure-results.zip
+        shell: pwsh
       - name: Upload Allure results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/rapid-test.yml
+++ b/.github/workflows/rapid-test.yml
@@ -47,6 +47,14 @@ jobs:
       - name: Generation tests
         run: npm test
         working-directory: generation
+      - name: Upload Allure results
+        uses: actions/upload-artifact@v3
+        with:
+          name: allure-results-linux
+          path: |
+            detox/allure-results
+            detox/test/allure-results
+            generation/allure-results
 
   windows:
     name: Windows
@@ -67,3 +75,10 @@ jobs:
       - name: Integration tests
         run: npm run integration
         working-directory: detox/test
+      - name: Upload Allure results
+        uses: actions/upload-artifact@v3
+        with:
+          name: allure-results-windows
+          path: |
+            detox/allure-results
+            detox/test/allure-results

--- a/.github/workflows/rapid-test.yml
+++ b/.github/workflows/rapid-test.yml
@@ -47,14 +47,13 @@ jobs:
       - name: Generation tests
         run: npm test
         working-directory: generation
+      - name: Pack Allure results
+        run: zip -r allure-results.zip detox/allure-results detox/test/allure-results generation/allure-results
       - name: Upload Allure results
         uses: actions/upload-artifact@v3
         with:
           name: allure-results-linux
-          path: |
-            detox/allure-results
-            detox/test/allure-results
-            generation/allure-results
+          path: allure-results.zip
 
   windows:
     name: Windows
@@ -75,10 +74,10 @@ jobs:
       - name: Integration tests
         run: npm run integration
         working-directory: detox/test
+      - name: Pack Allure results
+        run: zip -r allure-results.zip detox/allure-results detox/test/allure-results
       - name: Upload Allure results
         uses: actions/upload-artifact@v3
         with:
           name: allure-results-windows
-          path: |
-            detox/allure-results
-            detox/test/allure-results
+          path: allure-results.zip

--- a/detox/package.json
+++ b/detox/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-unicorn": "^47.0.0",
     "jest": "^28.1.3",
-    "jest-allure2-reporter": "2.0.0-alpha.10",
+    "jest-allure2-reporter": "2.0.0-alpha.11",
     "mockdate": "^2.0.1",
     "prettier": "^2.4.1",
     "react-native": "0.71.10",

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -63,7 +63,7 @@
     "express": "^4.15.3",
     "glob": "^7.2.0",
     "jest": "^29.2.1",
-    "jest-allure2-reporter": "2.0.0-alpha.10",
+    "jest-allure2-reporter": "2.0.0-alpha.11",
     "jest-junit": "^10.0.0",
     "lodash": "^4.14.1",
     "metro-react-native-babel-preset": "0.73.9",

--- a/generation/package.json
+++ b/generation/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "jest": "^27.0.0",
-    "jest-allure2-reporter": "2.0.0-alpha.10",
+    "jest-allure2-reporter": "2.0.0-alpha.11",
     "lint-staged": "^6.0.0",
     "prettier": "^1.8.2"
   },


### PR DESCRIPTION
## Description

This pull request brings the new version of Allure reporter [with basic support for the "Executor Info" widget](https://github.com/wix-incubator/jest-allure2-reporter/pull/18) (contains links to the CI build, info about the build agent, etc).

That's why I added also an upload step to our Github Actions pipelines so that we can see how well it works.