### PR TITLE
fix: stop pid override in logs

### DIFF
--- a/detox/src/utils/childProcess/spawn.js
+++ b/detox/src/utils/childProcess/spawn.js
@@ -45,7 +45,7 @@ async function interruptProcess(childProcessPromise, schedule) {
   const childProcess = childProcessPromise.childProcess;
   const cpid = childProcess.pid;
   const spawnargs = childProcess.spawnargs.join(' ');
-  const log = rootLogger.child({ event: 'SPAWN_KILL', pid: cpid });
+  const log = rootLogger.child({ event: 'SPAWN_KILL', cpid });
 
   const handles = _.mapValues({ ...DEFAULT_KILL_SCHEDULE, ...schedule }, (ms, signal) => {
     return setTimeout(() => {


### PR DESCRIPTION
## Description

This is a very minor internal issue. When releasing Detox 20.0.0, I missed this place, and it distorts a bit our logs in non-sanitized mode.

We never noticed `pid → pid` overwrite only because I implemented sanitization and it gets written as `pid$` in our logs.
Nevertheless, my original intent was to keep this as `cpid`. I have `cpid` (child process id) name in other places, and this one was just accidentally left.