### PR TITLE
Fix refs and docs involving testBinaryPath

### DIFF
--- a/detox/src/devices/common/drivers/android/tools/ApkValidator.js
+++ b/detox/src/devices/common/drivers/android/tools/ApkValidator.js
@@ -1,6 +1,6 @@
 const DetoxRuntimeError = require('../../../../../errors/DetoxRuntimeError');
 
-const setupGuideHint = 'For further assistance, visit the Android setup guide: https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md';
+const setupGuideHint = 'For further assistance, visit the project setup guide (select the Android tabs): https://wix.github.io/Detox/docs/introduction/project-setup';
 
 class ApkValidator {
   constructor(aapt) {

--- a/detox/src/devices/common/drivers/android/tools/ApkValidator.test.js
+++ b/detox/src/devices/common/drivers/android/tools/ApkValidator.test.js
@@ -1,3 +1,4 @@
+
 describe('APK validation', () => {
 
   const binaryPath = 'mock-bin-path';

--- a/detox/src/devices/common/drivers/android/tools/ApkValidator.test.js
+++ b/detox/src/devices/common/drivers/android/tools/ApkValidator.test.js
@@ -1,4 +1,3 @@
-
 describe('APK validation', () => {
 
   const binaryPath = 'mock-bin-path';

--- a/detox/src/devices/common/drivers/android/tools/__snapshots__/ApkValidator.test.js.snap
+++ b/detox/src/devices/common/drivers/android/tools/__snapshots__/ApkValidator.test.js.snap
@@ -4,7 +4,7 @@ exports[`APK validation App APK validation should throw a descriptive error if a
 "App APK at path mock-bin-path was detected as the *test* APK!
 
 HINT: Your binary path was probably wrongly set in the active Detox configuration.
-For further assistance, visit the Android setup guide: https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md"
+For further assistance, visit the project setup guide (select the Android tabs): https://wix.github.io/Detox/docs/introduction/project-setup"
 `;
 
 exports[`APK validation App APK validation should throw a specific error if AAPT throws 1`] = `
@@ -12,14 +12,14 @@ exports[`APK validation App APK validation should throw a specific error if AAPT
 Error: mock error
 
 HINT: Check that the binary path in the active Detox configuration has been set to a path of an APK file.
-For further assistance, visit the Android setup guide: https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md"
+For further assistance, visit the project setup guide (select the Android tabs): https://wix.github.io/Detox/docs/introduction/project-setup"
 `;
 
 exports[`APK validation Test APK validation should throw a descriptive error if APK happens to be an app APK 1`] = `
 "Test APK at path mock-test-bin-path was detected as the *app* APK!
 
 HINT: Your test test-binary path was probably wrongly set in the active Detox configuration.
-For further assistance, visit the Android setup guide: https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md"
+For further assistance, visit the project setup guide (select the Android tabs): https://wix.github.io/Detox/docs/introduction/project-setup"
 `;
 
 exports[`APK validation Test APK validation should throw a specific error if AAPT throws 1`] = `
@@ -27,5 +27,5 @@ exports[`APK validation Test APK validation should throw a specific error if AAP
 Error: mock error
 
 HINT: Check that the test-binary path in the active Detox configuration has been set to a path of an APK file.
-For further assistance, visit the Android setup guide: https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md"
+For further assistance, visit the project setup guide (select the Android tabs): https://wix.github.io/Detox/docs/introduction/project-setup"
 `;

--- a/detox/src/devices/runtime/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/runtime/drivers/android/AndroidDriver.js
@@ -280,7 +280,7 @@ class AndroidDriver extends DeviceDriverBase {
       throw new DetoxRuntimeError({
         message: `The test APK could not be found at path: '${testApkPath}'`,
         hint: 'Try running the detox build command, and make sure it was configured to execute a build command (e.g. \'./gradlew assembleAndroidTest\')' +
-          '\nFor further assistance, visit the Android setup guide: https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md',
+          '\nFor further assistance, visit the project setup guide (select the Android tabs): https://wix.github.io/Detox/docs/introduction/project-setup',
       });
     }
     return testApkPath;

--- a/detox/src/devices/runtime/drivers/android/__snapshots__/AndroidDriver.test.js.snap
+++ b/detox/src/devices/runtime/drivers/android/__snapshots__/AndroidDriver.test.js.snap
@@ -4,5 +4,5 @@ exports[`Android driver App installation should throw if auto test-binary path r
 "The test APK could not be found at path: 'testApkPathOf(absolutePathOf(mock-bin-path))'
 
 HINT: Try running the detox build command, and make sure it was configured to execute a build command (e.g. './gradlew assembleAndroidTest')
-For further assistance, visit the Android setup guide: https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md"
+For further assistance, visit the project setup guide (select the Android tabs): https://wix.github.io/Detox/docs/introduction/project-setup"
 `;

--- a/docs/introduction/partials/_project-setup-apps-android.mdx
+++ b/docs/introduction/partials/_project-setup-apps-android.mdx
@@ -2,7 +2,8 @@
 
 import FlavorizedCodeBlock from '@site/src/components/FlavorizedCodeBlock';
 
-Check **binaryPath** and **build** configs for `android.debug` and `android.release` mode in your Detox config:
+Check the **build**, **binaryPath** and **testBinaryPath** attributes for the `android.debug` and `android.release`
+configurations in your Detox config:
 
 ```js title=".detoxrc.js"
 module.exports = {
@@ -10,15 +11,16 @@ module.exports = {
     'android.debug': {
       type: 'android.apk',
       // highlight-start
-      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
-      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug'
+      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk'
       // highlight-end
     },
     'android.release': {
       type: 'android.apk',
       // highlight-start
+      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug',
       binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
-      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug'
+      testBinaryPath: 'android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk'
       // highlight-end
     },
     // ...
@@ -29,31 +31,42 @@ module.exports = {
 
 If you have a typical React Native project, these values should already be sufficient and correct.
 
-#### testBinaryPath
+> Mind that in `android.release` we propose to specify `testBinaryPath` explicitly, although optional. This is because
+we opt for the approach where, even though the app is built in _release_ mode, the test-related code is built and used in
+_debug_ mode, nonetheless (examine the `build` command closely). This helps simplify things and avoid potential build
+issues, but puts the test APK in a path that cannot be automatically resolved by Detox.
+>
+> As for the `android.debug` configuration: `testBinaryPath` is not required there, simply because in that case Detox
+can resolve the [default path](https://stackoverflow.com/questions/43670463/where-is-the-test-apk-located-in-android-project)
+automatically, based on the location of the app APK.
 
-In some projects, some choose to generate the Android _test_ APK (which is different from the _app_ APK) separately.
-It may therefore reside under a custom path, which Detox can't find by itself (Detox does resolve the
-[default path](https://stackoverflow.com/questions/43670463/where-is-the-test-apk-located-in-android-project) automatically).
-In this case, you have to specify the path explicitly by applying the `testBinaryPath` attributes. For example:
+#### Custom Binary Paths
+
+Besides the case in the previous section, there are other reasons why the app and test APK's (which are different), would
+reside in a custom, non-default paths. One such case is an optimization where the test APK (i.e. the test code) is prebuilt
+once and used in multiple app variations; But that's just an example.
+
+In any case, if this is how things work in your project, you have to specify non-default the custom paths under `binaryPath`,
+and apply the `testBinaryPath` attributes in _all_ configurations. For example:
 
 ```js title=".detoxrc.js"
 module.exports = {
   apps: {
     'android.debug': {
       type: 'android.apk',
-      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
+      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
       // highlight-start
-      testBinaryPath: 'custom/path/to/app-debug-androidTest.apk',
+      binaryPath: 'custom/path/to/app-debug.apk',
+      testBinaryPath: 'custom/path/to/app-debug-androidTest.apk'
       // highlight-end
-      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug'
     },
     'android.release': {
       type: 'android.apk',
-      binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
+      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug',
       // highlight-start
+      binaryPath: 'custom/path/to/app-release.apk',
       testBinaryPath: 'custom/path/to/app-debug-androidTest.apk',
       // highlight-end
-      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug'
     },
     // ...
   },
@@ -63,8 +76,9 @@ module.exports = {
 
 #### Product flavors
 
-On even more advanced use cases, apps may have additional, custom [`productFlavors`](https://developer.android.com/studio/build/build-variants#product-flavors)
-(consider the case of a `driver` and `passenger` flavors of a taxi application). In this case, you should rewrite your apps config,
+On even more advanced use cases, apps may have additional, custom
+[`productFlavors`](https://developer.android.com/studio/build/build-variants#product-flavors) (think of a
+`driver` and `passenger` flavors of a taxi application). In this case, you should rewrite your apps config,
 for both **debug** and **release** configurations, according to those flavors, e.g.:
 
 <FlavorizedCodeBlock
@@ -72,12 +86,12 @@ for both **debug** and **release** configurations, according to those flavors, e
   header={'   apps: {\n'}
   flavors={['Driver', 'Passenger']}
 >
-  {(conf) => `\
-     '${conf.toLowerCase()}.android.debug': {
+  {(flavor) => `\
+     '${flavor.toLowerCase()}.android.debug': {
        type: 'android.apk',
 -      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
-+      binaryPath: 'android/app/build/outputs/apk/${conf.toLowerCase()}/debug/app-${conf.toLowerCase()}-debug.apk',
++      binaryPath: 'android/app/build/outputs/apk/${flavor.toLowerCase()}/debug/app-${flavor.toLowerCase()}-debug.apk',
 -      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
-+      build: 'cd android && ./gradlew assemble${conf}Debug assemble${conf}DebugAndroidTest -DtestBuildType=debug',
++      build: 'cd android && ./gradlew assemble${flavor}Debug assemble${flavor}DebugAndroidTest -DtestBuildType=debug',
      },`}
 </FlavorizedCodeBlock>

--- a/docs/introduction/partials/_project-setup-apps-android.mdx
+++ b/docs/introduction/partials/_project-setup-apps-android.mdx
@@ -18,7 +18,7 @@ module.exports = {
       type: 'android.apk',
       // highlight-start
       binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
-      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release'
+      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug'
       // highlight-end
     },
     // ...
@@ -27,11 +27,45 @@ module.exports = {
 };
 ```
 
-If you have a typical React Native project, these values should already be correct.
+If you have a typical React Native project, these values should already be sufficient and correct.
 
-On the other hand, if your app has extra [`productFlavors`](https://developer.android.com/studio/build/build-variants#product-flavors)
-(let's imagine you have `driver` and `passenger` flavors of a taxi application), then you should rewrite your apps config
-for both **debug** and **release** configurations, e.g.:
+#### testBinaryPath
+
+In some projects, some choose to generate the Android _test_ APK (which is different from the _app_ APK) separately.
+It may therefore reside under a custom path, which Detox can't find by itself (Detox does resolve the
+[default path](https://stackoverflow.com/questions/43670463/where-is-the-test-apk-located-in-android-project) automatically).
+In this case, you have to specify the path explicitly by applying the `testBinaryPath` attributes. For example:
+
+```js title=".detoxrc.js"
+module.exports = {
+  apps: {
+    'android.debug': {
+      type: 'android.apk',
+      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
+      // highlight-start
+      testBinaryPath: 'custom/path/to/app-debug-androidTest.apk',
+      // highlight-end
+      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug'
+    },
+    'android.release': {
+      type: 'android.apk',
+      binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
+      // highlight-start
+      testBinaryPath: 'custom/path/to/app-debug-androidTest.apk',
+      // highlight-end
+      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug'
+    },
+    // ...
+  },
+  // ...
+};
+```
+
+#### Product flavors
+
+On even more advanced use cases, apps may have additional, custom [`productFlavors`](https://developer.android.com/studio/build/build-variants#product-flavors)
+(consider the case of a `driver` and `passenger` flavors of a taxi application). In this case, you should rewrite your apps config,
+for both **debug** and **release** configurations, according to those flavors, e.g.:
 
 <FlavorizedCodeBlock
   language="diff"

--- a/docs/introduction/partials/_project-setup-apps-android.mdx
+++ b/docs/introduction/partials/_project-setup-apps-android.mdx
@@ -2,8 +2,7 @@
 
 import FlavorizedCodeBlock from '@site/src/components/FlavorizedCodeBlock';
 
-Check the **build**, **binaryPath** and **testBinaryPath** attributes for the `android.debug` and `android.release`
-configurations in your Detox config:
+Check **binaryPath** and **build** configs for `android.debug` and `android.release` mode in your Detox config:
 
 ```js title=".detoxrc.js"
 module.exports = {
@@ -11,16 +10,15 @@ module.exports = {
     'android.debug': {
       type: 'android.apk',
       // highlight-start
-      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
-      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk'
+      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
+      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug'
       // highlight-end
     },
     'android.release': {
       type: 'android.apk',
       // highlight-start
-      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug',
       binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
-      testBinaryPath: 'android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk'
+      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug'
       // highlight-end
     },
     // ...
@@ -31,42 +29,31 @@ module.exports = {
 
 If you have a typical React Native project, these values should already be sufficient and correct.
 
-> Mind that in `android.release` we propose to specify `testBinaryPath` explicitly, although optional. This is because
-we opt for the approach where, even though the app is built in _release_ mode, the test-related code is built and used in
-_debug_ mode, nonetheless (examine the `build` command closely). This helps simplify things and avoid potential build
-issues, but puts the test APK in a path that cannot be automatically resolved by Detox.
->
-> As for the `android.debug` configuration: `testBinaryPath` is not required there, simply because in that case Detox
-can resolve the [default path](https://stackoverflow.com/questions/43670463/where-is-the-test-apk-located-in-android-project)
-automatically, based on the location of the app APK.
+#### testBinaryPath
 
-#### Custom Binary Paths
-
-Besides the case in the previous section, there are other reasons why the app and test APK's (which are different), would
-reside in a custom, non-default paths. One such case is an optimization where the test APK (i.e. the test code) is prebuilt
-once and used in multiple app variations; But that's just an example.
-
-In any case, if this is how things work in your project, you have to specify non-default the custom paths under `binaryPath`,
-and apply the `testBinaryPath` attributes in _all_ configurations. For example:
+In some projects, some choose to generate the Android _test_ APK (which is different from the _app_ APK) separately.
+It may therefore reside under a custom path, which Detox can't find by itself (Detox does resolve the
+[default path](https://stackoverflow.com/questions/43670463/where-is-the-test-apk-located-in-android-project) automatically).
+In this case, you have to specify the path explicitly by applying the `testBinaryPath` attributes. For example:
 
 ```js title=".detoxrc.js"
 module.exports = {
   apps: {
     'android.debug': {
       type: 'android.apk',
-      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
       // highlight-start
-      binaryPath: 'custom/path/to/app-debug.apk',
-      testBinaryPath: 'custom/path/to/app-debug-androidTest.apk'
+      testBinaryPath: 'custom/path/to/app-debug-androidTest.apk',
       // highlight-end
+      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug'
     },
     'android.release': {
       type: 'android.apk',
-      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug',
+      binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
       // highlight-start
-      binaryPath: 'custom/path/to/app-release.apk',
       testBinaryPath: 'custom/path/to/app-debug-androidTest.apk',
       // highlight-end
+      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug'
     },
     // ...
   },
@@ -76,9 +63,8 @@ module.exports = {
 
 #### Product flavors
 
-On even more advanced use cases, apps may have additional, custom
-[`productFlavors`](https://developer.android.com/studio/build/build-variants#product-flavors) (think of a
-`driver` and `passenger` flavors of a taxi application). In this case, you should rewrite your apps config,
+On even more advanced use cases, apps may have additional, custom [`productFlavors`](https://developer.android.com/studio/build/build-variants#product-flavors)
+(consider the case of a `driver` and `passenger` flavors of a taxi application). In this case, you should rewrite your apps config,
 for both **debug** and **release** configurations, according to those flavors, e.g.:
 
 <FlavorizedCodeBlock
@@ -86,12 +72,12 @@ for both **debug** and **release** configurations, according to those flavors, e
   header={'   apps: {\n'}
   flavors={['Driver', 'Passenger']}
 >
-  {(flavor) => `\
-     '${flavor.toLowerCase()}.android.debug': {
+  {(conf) => `\
+     '${conf.toLowerCase()}.android.debug': {
        type: 'android.apk',
 -      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
-+      binaryPath: 'android/app/build/outputs/apk/${flavor.toLowerCase()}/debug/app-${flavor.toLowerCase()}-debug.apk',
++      binaryPath: 'android/app/build/outputs/apk/${conf.toLowerCase()}/debug/app-${conf.toLowerCase()}-debug.apk',
 -      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
-+      build: 'cd android && ./gradlew assemble${flavor}Debug assemble${flavor}DebugAndroidTest -DtestBuildType=debug',
++      build: 'cd android && ./gradlew assemble${conf}Debug assemble${conf}DebugAndroidTest -DtestBuildType=debug',
      },`}
 </FlavorizedCodeBlock>

--- a/docs/introduction/partials/_project-setup-apps-android.mdx
+++ b/docs/introduction/partials/_project-setup-apps-android.mdx
@@ -2,7 +2,7 @@
 
 import FlavorizedCodeBlock from '@site/src/components/FlavorizedCodeBlock';
 
-Check **binaryPath** and **build** configs for `android.debug` and `android.release` mode in your Detox config:
+Check the **build** and **binaryPath** attributes for the `android.debug` and `android.release` Detox configs:
 
 ```js title=".detoxrc.js"
 module.exports = {
@@ -10,15 +10,15 @@ module.exports = {
     'android.debug': {
       type: 'android.apk',
       // highlight-start
-      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
-      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug'
+      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk'
       // highlight-end
     },
     'android.release': {
       type: 'android.apk',
       // highlight-start
-      binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
-      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug'
+      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+      binaryPath: 'android/app/build/outputs/apk/release/app-release.apk'
       // highlight-end
     },
     // ...
@@ -31,35 +31,44 @@ If you have a typical React Native project, these values should already be suffi
 
 #### testBinaryPath
 
-In some projects, some choose to generate the Android _test_ APK (which is different from the _app_ APK) separately.
-It may therefore reside under a custom path, which Detox can't find by itself (Detox does resolve the
-[default path](https://stackoverflow.com/questions/43670463/where-is-the-test-apk-located-in-android-project) automatically).
-In this case, you have to specify the path explicitly by applying the `testBinaryPath` attributes. For example:
+In Android automation testing, there are in fact 2 app binaries involved:
+1. The _app_ APK, containing your app's code.
+2. The _test_ APK, containing _test_ code. That includes Detox's native code, Espresso and more.
+
+In some projects, it might make sense for the test APK to be generated over a separate flow, through which is may end up
+being put it some custom,
+[non-default path](https://stackoverflow.com/questions/43670463/where-is-the-test-apk-located-in-android-project).
+One such example is an optimization where the test APK is prebuilt once and used across multiple app variations. This is
+a place where the `testBinaryPath` attribute can come to the rescue; It can be applied in order to set the custom path
+to the test APK explicitly:
 
 ```js title=".detoxrc.js"
 module.exports = {
   apps: {
     'android.debug': {
       type: 'android.apk',
+      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
       binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
       // highlight-start
-      testBinaryPath: 'custom/path/to/app-debug-androidTest.apk',
+      testBinaryPath: 'custom/path/to/app-debug-androidTest.apk'
       // highlight-end
-      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug'
     },
     'android.release': {
       type: 'android.apk',
       binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
+      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
       // highlight-start
-      testBinaryPath: 'custom/path/to/app-debug-androidTest.apk',
+      testBinaryPath: 'custom/path/to/app-release-androidTest.apk'
       // highlight-end
-      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug'
     },
     // ...
   },
   // ...
 };
 ```
+
+> Mind that in the common case, the `testBinaryPath` attributes is not explicitly required, simply because Detox knows
+how to locate it in one of the default paths automatically.
 
 #### Product flavors
 
@@ -72,12 +81,12 @@ for both **debug** and **release** configurations, according to those flavors, e
   header={'   apps: {\n'}
   flavors={['Driver', 'Passenger']}
 >
-  {(conf) => `\
-     '${conf.toLowerCase()}.android.debug': {
+  {(flavor) => `\
+     '${flavor.toLowerCase()}.android.debug': {
        type: 'android.apk',
 -      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
-+      binaryPath: 'android/app/build/outputs/apk/${conf.toLowerCase()}/debug/app-${conf.toLowerCase()}-debug.apk',
++      binaryPath: 'android/app/build/outputs/apk/${flavor.toLowerCase()}/debug/app-${flavor.toLowerCase()}-debug.apk',
 -      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
-+      build: 'cd android && ./gradlew assemble${conf}Debug assemble${conf}DebugAndroidTest -DtestBuildType=debug',
++      build: 'cd android && ./gradlew assemble${flavor}Debug assemble${flavor}DebugAndroidTest -DtestBuildType=debug',
      },`}
 </FlavorizedCodeBlock>

--- a/examples/demo-react-native/detox.config.js
+++ b/examples/demo-react-native/detox.config.js
@@ -37,8 +37,7 @@ module.exports = {
     "android.release": {
       "type": "android.apk",
       "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
-      "testBinaryPath": "android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk",
-      "build": "cd android ; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug ; cd -",
+      "build": "cd android ; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release ; cd -",
     }
   },
   devices: {

--- a/examples/demo-react-native/detox.config.js
+++ b/examples/demo-react-native/detox.config.js
@@ -37,7 +37,8 @@ module.exports = {
     "android.release": {
       "type": "android.apk",
       "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
-      "build": "cd android ; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release ; cd -",
+      "testBinaryPath": "android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk",
+      "build": "cd android ; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=debug ; cd -",
     }
   },
   devices: {


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request stems from this discussion: https://github.com/wix/Detox/discussions/4307

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have fixed inline code-refs to the Android setup guide, in places where the usage of `testBinaryPath` was not clear.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
