### PR TITLE
chore: update lerna to latest legacy version

### DIFF
--- a/.github/workflows/rapid-test.yml
+++ b/.github/workflows/rapid-test.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - name: Bootstrap Lerna
-        run: npx lerna@3 bootstrap --no-ci
+        run: npx lerna@6 bootstrap --no-ci
         env:
           DETOX_DISABLE_POD_INSTALL: true
           DETOX_DISABLE_POSTINSTALL: true
@@ -64,7 +64,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - name: Bootstrap Lerna (Light)
-        run: npx lerna@3 bootstrap --no-ci --include-dependents --include-dependencies --scope=detox-test
+        run: npx lerna@6 bootstrap --no-ci --include-dependents --include-dependencies --scope=detox-test
         env:
           DETOX_DISABLE_POD_INSTALL: true
           DETOX_DISABLE_POSTINSTALL: true

--- a/docs/contributing/code/setting-up-the-dev-environment.md
+++ b/docs/contributing/code/setting-up-the-dev-environment.md
@@ -17,7 +17,7 @@ To set up the monorepo locally, follow these steps:
 Install the monorepo management tool, `lerna`:
 
 ```bash npm2yarn
-npm install lerna@3.x.x --global
+npm install lerna@6.x.x --global
 ```
 
 Clone the repository and navigate to the project directory:

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
-  "lerna": "3.22.1",
+  "lerna": "6.6.2",
+  "useWorkspaces": false,
   "packages": [
     "detox",
     "detox-cli",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "chalk": "^4.0.0",
     "dictionary-en": "^3.1.0",
-    "lerna": "3.22.1",
+    "lerna": "^6.6.2",
     "lodash": "4.17.x",
     "markdownlint-cli": "^0.29.0",
     "remark": "^14.0.1",

--- a/scripts/ci.android-release.js
+++ b/scripts/ci.android-release.js
@@ -10,7 +10,7 @@ function run() {
 
   const npmTag = getReleaseNpmTag();
   const preid = npmTag === 'latest'? '': `--preid=${npmTag}`;
-  exec.execSync(`lerna version --yes ${versionType} ${preid} --no-git-tag-version --no-push`);
+  exec.execSync(`lerna version --yes ${versionType} ${preid} --no-git-tag-version --force-publish=detox --no-push`);
   const futureVersion = getVersionSafe();
   log('Version is: ' + futureVersion);
   exec.execSync('git reset --hard');

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,5 +3,5 @@
 echo "Node version:"
 node --version
 
-npm install -g lerna@3.22.1
+npm install -g lerna@6.6.2
 npm install -g react-native-cli >/dev/null 2>&1


### PR DESCRIPTION
## Description

Maintenance PR. Updates Lerna to 6.5.0 (the latest is 8.x.x, but it has significant breaking changes).