### PR TITLE
Bugfix/2787 scrollto gets stuck on android

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/DeviceDisplay.kt
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/DeviceDisplay.kt
@@ -17,7 +17,7 @@ object DeviceDisplay {
     }
 
     @JvmStatic
-    fun getScreenSizeInPX(): FloatArray? {
+    fun getScreenSizeInPX(): FloatArray {
         val metrics = getDisplayMetrics()
         return floatArrayOf(metrics.widthPixels.toFloat(), metrics.heightPixels.toFloat())
     }

--- a/detox/android/detox/src/main/java/com/wix/detox/espresso/scroll/ScrollHelper.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/espresso/scroll/ScrollHelper.java
@@ -143,7 +143,7 @@ public class ScrollHelper {
         return range;
     }
 
-    private static int[] getScrollStartCoordinatesInView(View view, @MotionDir int direction, Float startOffsetPercentX, Float startOffsetPercentY) {
+    private static int[] getScrollStartOffsetInView(View view, @MotionDir int direction, Float startOffsetPercentX, Float startOffsetPercentY) {
         final int safetyOffset = DeviceDisplay.convertDpiToPx(1);
         float offsetFactorX;
         float offsetFactorY;
@@ -197,10 +197,10 @@ public class ScrollHelper {
         Point result = getGlobalViewLocation(view);
 
         // 1. Calculate the scroll start point, with respect to the view's location.
-        int[] coordinates = getScrollStartCoordinatesInView(view, direction, startOffsetPercentX, startOffsetPercentY);
+        int[] coordinates = getScrollStartOffsetInView(view, direction, startOffsetPercentX, startOffsetPercentY);
 
         // 2. Make sure that the start point is within the scrollable area, taking into account the system gesture insets.
-        coordinates = calculateScrollStartWithNavigationGestureInsets(view, direction, coordinates[0], coordinates[1]);
+        coordinates = applyScreenInsets(view, direction, coordinates[0], coordinates[1]);
 
         result.offset(coordinates[0], coordinates[1]);
         return result;
@@ -214,7 +214,7 @@ public class ScrollHelper {
      * @param y The scroll start point, with respect to the view's location.
      * @return an array of two integers, denoting the scroll start point, with respect to the system gesture insets.
      */
-    private static int[] calculateScrollStartWithNavigationGestureInsets(View view, int direction, int x, int y) {
+    private static int[] applyScreenInsets(View view, int direction, int x, int y) {
         // System gesture insets are only available on Android Q (29) and above.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             return new int[]{x, y};

--- a/detox/android/detox/src/testFull/java/com/wix/detox/espresso/scroll/ScrollHelperTest.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/espresso/scroll/ScrollHelperTest.kt
@@ -1,0 +1,89 @@
+package com.wix.detox.espresso.scroll
+
+import android.graphics.Insets
+import android.view.MotionEvent
+import android.view.View
+import android.view.WindowInsets
+import androidx.test.espresso.UiController
+import androidx.test.platform.app.InstrumentationRegistry
+import com.wix.detox.action.common.MOTION_DIR_DOWN
+import com.wix.detox.espresso.DeviceDisplay
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+@Config(qualifiers = "xxxhdpi", sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class ScrollHelperTest {
+
+    private val display = DeviceDisplay.getScreenSizeInPX()
+    private val displayWidth = display[0].toInt()
+    private val displayHeight = display[1].toInt()
+
+    private val uiController = mock<UiController>()
+    private val view = mockView(displayWidth, displayHeight)
+
+    @Test
+    fun `perform scroll down for 200 dp on full screen view`() {
+        val amountInDp = 200.0
+        val amountInPx = amountInDp * DeviceDisplay.getDensity()
+        val touchSlopPx = ScrollHelper.getViewConfiguration().scaledTouchSlop
+
+        ScrollHelper.perform(uiController, view, MOTION_DIR_DOWN, amountInDp, null, null)
+        val capture = argumentCaptor<Iterable<MotionEvent>>()
+        verify(uiController).injectMotionEventSequence(capture.capture())
+
+        val listOfCapturedEvents = capture.firstValue.toList()
+        val lastEvent = listOfCapturedEvents.last() // The last event is the UP event with the target coordinates
+        // the joinery of the swipe is not interesting
+        val lastEventX = lastEvent.x
+        val lastEventY = lastEvent.y
+        assertEquals(displayWidth / 2.0, lastEventX.toDouble(), 0.0)
+        assertEquals(displayHeight - amountInPx - touchSlopPx - DeviceDisplay.convertDpiToPx(1.0), lastEventY.toDouble(), 0.0)
+    }
+
+    @Test
+    fun `perform scroll down for 200 dp on full screen view with offset y`() {
+        val amountInDp = 200.0
+        val amountInPx = amountInDp * DeviceDisplay.getDensity()
+        val touchSlopPx = ScrollHelper.getViewConfiguration().scaledTouchSlop
+        val offsetPercent = 0.9f
+
+        ScrollHelper.perform(uiController, view, MOTION_DIR_DOWN, amountInDp, null, offsetPercent)
+        val capture = argumentCaptor<Iterable<MotionEvent>>()
+        verify(uiController).injectMotionEventSequence(capture.capture())
+
+        val listOfCapturedEvents = capture.firstValue.toList()
+        val lastEvent = listOfCapturedEvents.last() // The last event is the UP event with the target coordinates
+        // the joinery of the swipe is not interesting
+        val lastEventX = lastEvent.x
+        val lastEventY = lastEvent.y
+        assertEquals(displayWidth / 2.0, lastEventX.toDouble(), 0.0)
+        assertEquals(displayHeight - amountInPx - touchSlopPx  - DeviceDisplay.convertDpiToPx(1.0), lastEventY.toDouble(), 0.0)
+
+    }
+
+    private fun mockView(displayWidth: Int, displayHeight: Int): View {
+        val windowInsets = mock<WindowInsets>() {
+            whenever(it.systemGestureInsets).thenReturn(
+                Insets.of(88, 88, 88, 100)
+            )
+        }
+
+        val view = mock<View>() {
+            whenever(it.width).thenReturn(displayWidth)
+            whenever(it.height).thenReturn(displayHeight)
+            whenever(it.canScrollVertically(any())).thenReturn(true) // We allow endless scroll
+            whenever(it.context).thenReturn(InstrumentationRegistry.getInstrumentation().targetContext)
+            whenever(it.rootWindowInsets).thenReturn(windowInsets)
+        }
+        return view
+    }
+}

--- a/detox/android/detox/src/testFull/java/com/wix/detox/espresso/scroll/ScrollHelperTest.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/espresso/scroll/ScrollHelperTest.kt
@@ -36,33 +36,27 @@ class ScrollHelperTest {
     private val viewMock = mockViewWithGestureNavigation(displayWidth, displayHeight)
 
     @Test
-    fun `perform scroll down for 200 dp on full screen view with gesture navigation enabled`() {
+    fun `should take gesture navigation into account when scrolling down`() {
         val amountInDp = 200.0
         val amountInPx = amountInDp * DeviceDisplay.getDensity()
 
-        // Perform the scroll
         ScrollHelper.perform(uiControllerMock, viewMock, MOTION_DIR_DOWN, amountInDp, null, null)
 
-        // Verify start and end coordinates
         val upEvent = getUpEvent()
-        val x = upEvent.x
-        val y = upEvent.y
         // Verify that the scroll started at the center of the view
-        assertEquals(displayWidth / 2.0, x.toDouble(), 0.0)
+        assertEquals(displayWidth / 2.0, upEvent.x.toDouble(), 0.0)
         // Verify that the scroll ended at the center of the view minus the requested amount
-        assertEquals(displayHeight - amountInPx - touchSlopPx - safetyMarginPx - INSETS_SIZE, y.toDouble(), 0.0)
+        assertEquals(displayHeight - amountInPx - touchSlopPx - safetyMarginPx - INSETS_SIZE, upEvent.y.toDouble(), 0.0)
     }
 
     @Test
-    fun `perform scroll down to edge on full screen view with gesture navigation enabled`() {
+    fun `should scroll down to edge on full screen view when gesture navigation enabled`() {
         ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_DOWN)
         val upEvent = getUpEvent()
-        val x = upEvent.x
-        val y = upEvent.y
         val amountInPx = getViewSafeScrollableRangePix(viewMock, MOTION_DIR_DOWN).toFloat()
 
-        assertEquals(displayWidth / 2.0, x.toDouble(), 0.0)
-        assertEquals(displayHeight - amountInPx - touchSlopPx - safetyMarginPx - INSETS_SIZE, y, 0.0f)
+        assertEquals(displayWidth / 2.0, upEvent.x.toDouble(), 0.0)
+        assertEquals(displayHeight - amountInPx - touchSlopPx - safetyMarginPx - INSETS_SIZE, upEvent.y, 0.0f)
 
     }
 

--- a/detox/android/detox/src/testFull/java/com/wix/detox/espresso/scroll/ScrollHelperTest.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/espresso/scroll/ScrollHelperTest.kt
@@ -72,7 +72,7 @@ class ScrollHelperTest {
 
     @Test
     fun `should scroll down to edge on full screen view when gesture navigation enabled`() {
-        ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_DOWN)
+        ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_DOWN, null, null)
         val upEvent = getUpEvent()
         val amountInPx = displayHeight * SCROLL_RANGE_SAFE_PERCENT
 
@@ -88,7 +88,7 @@ class ScrollHelperTest {
 
     @Test
     fun `should scroll left to edge on full screen view when gesture navigation enabled`() {
-        ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_LEFT)
+        ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_LEFT, null, null)
         val upEvent = getUpEvent()
         val amountInPx = displayWidth * SCROLL_RANGE_SAFE_PERCENT
 
@@ -103,7 +103,7 @@ class ScrollHelperTest {
 
     @Test
     fun `should scroll up to edge on full screen view when gesture navigation enabled`() {
-        ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_UP)
+        ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_UP,null, null)
         val upEvent = getUpEvent()
         val amountInPx = displayHeight * SCROLL_RANGE_SAFE_PERCENT
 
@@ -118,7 +118,7 @@ class ScrollHelperTest {
 
     @Test
     fun `should scroll right to edge on full screen view when gesture navigation enabled`() {
-        ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_RIGHT)
+        ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_RIGHT,  null, null)
         val upEvent = getUpEvent()
         val amountInPx = displayWidth * SCROLL_RANGE_SAFE_PERCENT
 

--- a/detox/android/detox/src/testFull/java/com/wix/detox/espresso/scroll/ScrollHelperTest.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/espresso/scroll/ScrollHelperTest.kt
@@ -7,8 +7,10 @@ import android.view.WindowInsets
 import androidx.test.espresso.UiController
 import androidx.test.platform.app.InstrumentationRegistry
 import com.wix.detox.action.common.MOTION_DIR_DOWN
+import com.wix.detox.action.common.MOTION_DIR_LEFT
+import com.wix.detox.action.common.MOTION_DIR_RIGHT
+import com.wix.detox.action.common.MOTION_DIR_UP
 import com.wix.detox.espresso.DeviceDisplay
-import com.wix.detox.espresso.scroll.ScrollHelper.getViewSafeScrollableRangePix
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -21,8 +23,12 @@ import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 
 private const val INSETS_SIZE = 100
+private const val SCROLL_RANGE_SAFE_PERCENT = 0.9f // ScrollHelper.SCROLL_RANGE_SAFE_PERCENT
 
-@Config(qualifiers = "xxxhdpi", sdk = [33])
+@Config(
+    qualifiers = "xxxhdpi", // 1280x1880
+    sdk = [33]
+)
 @RunWith(RobolectricTestRunner::class)
 class ScrollHelperTest {
 
@@ -36,7 +42,7 @@ class ScrollHelperTest {
     private val viewMock = mockViewWithGestureNavigation(displayWidth, displayHeight)
 
     @Test
-    fun `should take gesture navigation into account when scrolling down`() {
+    fun `should scrolling down by 200 when gesture navigation enabled`() {
         val amountInDp = 200.0
         val amountInPx = amountInDp * DeviceDisplay.getDensity()
 
@@ -50,14 +56,80 @@ class ScrollHelperTest {
     }
 
     @Test
+    fun `should scrolling down by 200 when gesture navigation disabled`() {
+        val amountInDp = 200.0
+        val amountInPx = amountInDp * DeviceDisplay.getDensity()
+
+        val viewMock = mockViewWithoutGestureNavigation(displayWidth, displayHeight)
+        ScrollHelper.perform(uiControllerMock, viewMock, MOTION_DIR_DOWN, amountInDp, null, null)
+
+        val upEvent = getUpEvent()
+        // Verify that the scroll started at the center of the view
+        assertEquals(displayWidth / 2.0, upEvent.x.toDouble(), 0.0)
+        // Verify that the scroll ended at the center of the view minus the requested amount
+        assertEquals(displayHeight - amountInPx - touchSlopPx - safetyMarginPx, upEvent.y.toDouble(), 0.0)
+    }
+
+    @Test
     fun `should scroll down to edge on full screen view when gesture navigation enabled`() {
         ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_DOWN)
         val upEvent = getUpEvent()
-        val amountInPx = getViewSafeScrollableRangePix(viewMock, MOTION_DIR_DOWN).toFloat()
+        val amountInPx = displayHeight * SCROLL_RANGE_SAFE_PERCENT
+
+        // Calculate where the scroll should end
+        val targetY = displayHeight - amountInPx -
+            touchSlopPx -
+            safetyMarginPx -
+            INSETS_SIZE
 
         assertEquals(displayWidth / 2.0, upEvent.x.toDouble(), 0.0)
-        assertEquals(displayHeight - amountInPx - touchSlopPx - safetyMarginPx - INSETS_SIZE, upEvent.y, 0.0f)
+        assertEquals(targetY, upEvent.y, 0.0f)
+    }
 
+    @Test
+    fun `should scroll left to edge on full screen view when gesture navigation enabled`() {
+        ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_LEFT)
+        val upEvent = getUpEvent()
+        val amountInPx = displayWidth * SCROLL_RANGE_SAFE_PERCENT
+
+        // Calculate where the scroll should end
+        val targetX = amountInPx +
+            touchSlopPx +
+            INSETS_SIZE
+
+        assertEquals(targetX, upEvent.x, 0.0f)
+        assertEquals(displayHeight / 2.0, upEvent.y.toDouble(), 0.0)
+    }
+
+    @Test
+    fun `should scroll up to edge on full screen view when gesture navigation enabled`() {
+        ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_UP)
+        val upEvent = getUpEvent()
+        val amountInPx = displayHeight * SCROLL_RANGE_SAFE_PERCENT
+
+        // Calculate where the scroll should end
+        val targetY = amountInPx +
+            touchSlopPx +
+            INSETS_SIZE
+
+        assertEquals(displayWidth / 2.0, upEvent.x.toDouble(), 0.0)
+        assertEquals(targetY, upEvent.y, 0.0f)
+    }
+
+    @Test
+    fun `should scroll right to edge on full screen view when gesture navigation enabled`() {
+        ScrollHelper.performOnce(uiControllerMock, viewMock, MOTION_DIR_RIGHT)
+        val upEvent = getUpEvent()
+        val amountInPx = displayWidth * SCROLL_RANGE_SAFE_PERCENT
+
+        // Calculate where the scroll should end
+        val targetX = displayWidth - amountInPx -
+            touchSlopPx -
+            safetyMarginPx -
+            INSETS_SIZE
+
+        assertEquals(targetX, upEvent.x, 0.0f)
+        assertEquals(displayHeight / 2.0, upEvent.y.toDouble(), 0.0)
     }
 
     /**
@@ -73,6 +145,17 @@ class ScrollHelperTest {
         return listOfCapturedEvents.last()
     }
 
+    private fun mockViewWithoutGestureNavigation(displayWidth: Int, displayHeight: Int): View {
+        // This is how we disable gesture navigation
+        val windowInsets = mock<WindowInsets>() {
+            whenever(it.systemGestureInsets).thenReturn(
+                Insets.of(0, 0, 0, 0)
+            )
+        }
+
+        return mockView(displayWidth, displayHeight, windowInsets)
+    }
+
     /**
      * Mock a view with gesture navigation enabled
      */
@@ -84,10 +167,19 @@ class ScrollHelperTest {
             )
         }
 
+        return mockView(displayWidth, displayHeight, windowInsets)
+    }
+
+    private fun mockView(
+        displayWidth: Int,
+        displayHeight: Int,
+        windowInsets: WindowInsets
+    ): View {
         val view = mock<View>() {
             whenever(it.width).thenReturn(displayWidth)
             whenever(it.height).thenReturn(displayHeight)
             whenever(it.canScrollVertically(any())).thenReturn(true) // We allow endless scroll
+            whenever(it.canScrollHorizontally(any())).thenReturn(true) // We allow endless scroll
             whenever(it.context).thenReturn(InstrumentationRegistry.getInstrumentation().targetContext)
             whenever(it.rootWindowInsets).thenReturn(windowInsets)
         }


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request fixes #2787, fixes #4312

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have fixed the problem with interfering with gesture navigation. 
Used an Android API for getting the gesture insets and shifted the scroll starting point from the edge of the screen

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
