### PR TITLE
fix(ios): streaming parsing for applesimutils --list

### DIFF
--- a/detox/src/utils/argparse.js
+++ b/detox/src/utils/argparse.js
@@ -2,8 +2,6 @@ const path = require('path');
 
 const _ = require('lodash');
 
-const { escape } = require('./pipeCommands');
-
 function getEnvValue(key) {
   const envKey = _.findKey(process.env, matchesKey(
     `DETOX_${_.snakeCase(key)}`.toUpperCase()
@@ -23,16 +21,7 @@ function matchesKey(key) {
     : (value, envKey) => envKey === key;
 }
 
-const DEFAULT_JOIN_ARGUMENTS_OPTIONS = {
-  prefix: '--',
-  joiner: ' ',
-};
-
-function joinArgs(keyValues, options = DEFAULT_JOIN_ARGUMENTS_OPTIONS) {
-  const { prefix, joiner } = options === DEFAULT_JOIN_ARGUMENTS_OPTIONS
-    ? options
-    : { ...DEFAULT_JOIN_ARGUMENTS_OPTIONS, ...options };
-
+function joinArgs(keyValues, prefix = '--') {
   const argArray = [];
 
   for (const [key, value] of Object.entries(keyValues)) {
@@ -40,22 +29,14 @@ function joinArgs(keyValues, options = DEFAULT_JOIN_ARGUMENTS_OPTIONS) {
       continue;
     }
 
-    let arg = (!key.startsWith('-') ? prefix : '') + key;
-
-    if (value !== true) {
-      arg += joiner;
-
-      if (_.isString(value) && value.includes(' ')) {
-        arg += `"${escape.inQuotedString(value)}"`;
-      } else {
-        arg += value;
-      }
-    }
-
+    const arg = (key.startsWith('-') ? '' : prefix) + key;
     argArray.push(arg);
+    if (value !== true) {
+      argArray.push(String(value));
+    }
   }
 
-  return argArray.join(' ');
+  return argArray;
 }
 
 function getCurrentCommand() {

--- a/detox/src/utils/argparse.test.js
+++ b/detox/src/utils/argparse.test.js
@@ -45,7 +45,7 @@ describe('argparse', () => {
       argparse = require('./argparse');
     });
 
-    it('should convert key-values to args string', () => {
+    it('should convert key-values to string array', () => {
       expect(argparse.joinArgs({
         optional: undefined,
         debug: true,
@@ -53,17 +53,16 @@ describe('argparse', () => {
         logLevel: 'verbose',
         '-w': 1,
         'device-name': 'iPhone X'
-      })).toBe('--debug --timeout 3000 --logLevel verbose -w 1 --device-name "iPhone X"');
+      })).toEqual(['--debug', '--timeout', '3000', '--logLevel', 'verbose', '-w', '1', '--device-name', 'iPhone X']);
     });
 
-    it('should accept options', () => {
-      const options = { prefix: '-', joiner: '=' };
+    it('should accept a custom prefix', () => {
       const argsObject = {
         'version': 100,
         '--help': true
       };
 
-      expect(argparse.joinArgs(argsObject, options)).toBe('-version=100 --help');
+      expect(argparse.joinArgs(argsObject, '-')).toEqual(['-version', '100', '--help']);
     });
   });
 


### PR DESCRIPTION
## Description

This solves an issue with very dirty iOS environments, where there are just way too many simulators.

As this solution is implemented via a streaming parser, we should no longer have issues with the magic `maxBuffer` number.