### PR TITLE
fix: find *.cjs configs

### DIFF
--- a/detox/src/configuration/__mocks__/configuration/cjs/.detoxrc.cjs
+++ b/detox/src/configuration/__mocks__/configuration/cjs/.detoxrc.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+    configurations: {
+        simple: {
+          device: {
+            type: "android.attached",
+            device: "Hello from .detoxrc",
+          },
+          apps: [],
+        },
+    },
+};

--- a/detox/src/configuration/loadExternalConfig.js
+++ b/detox/src/configuration/loadExternalConfig.js
@@ -10,9 +10,11 @@ const log = require('../utils/logger').child({ cat: 'config' });
 
 async function locateExternalConfig(cwd) {
   return findUp([
+    '.detoxrc.cjs',
     '.detoxrc.js',
     '.detoxrc.json',
     '.detoxrc',
+    'detox.config.cjs',
     'detox.config.js',
     'detox.config.json',
     'package.json',
@@ -20,7 +22,7 @@ async function locateExternalConfig(cwd) {
 }
 
 async function loadConfig(configPath) {
-  let config = path.extname(configPath) === '.js'
+  let config = isJS(path.extname(configPath))
     ? require(configPath)
     : JSON.parse(await fs.readFile(configPath, 'utf8'));
 
@@ -32,6 +34,10 @@ async function loadConfig(configPath) {
     config,
     filepath: configPath,
   };
+}
+
+function isJS(ext) {
+  return ext === '.js' || ext === '.cjs';
 }
 
 async function resolveConfigPath(configPath, cwd) {

--- a/detox/src/configuration/loadExternalConfig.test.js
+++ b/detox/src/configuration/loadExternalConfig.test.js
@@ -2,6 +2,7 @@ const os = require('os');
 const path = require('path');
 
 describe('loadExternalConfig', () => {
+  const DIR_CJS = path.join(__dirname, '__mocks__/configuration/cjs');
   const DIR_PACKAGEJSON = path.join(__dirname, '__mocks__/configuration/packagejson');
   const DIR_PRIORITY = path.join(__dirname, '__mocks__/configuration/priority');
   const DIR_EXTENDS = path.join(__dirname, '__mocks__/configuration/extends');
@@ -31,6 +32,13 @@ describe('loadExternalConfig', () => {
     const { filepath, config } = await loadExternalConfig({ cwd: DIR_PRIORITY });
 
     expect(filepath).toBe(path.join(DIR_PRIORITY, '.detoxrc.js'));
+    expect(config).toMatchObject({ configurations: expect.anything() });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('should implicitly use .detoxrc.cjs', async () => {
+    const { filepath, config } = await loadExternalConfig({ cwd: DIR_CJS });
+    expect(filepath).toBe(path.join(DIR_CJS, '.detoxrc.cjs'));
     expect(config).toMatchObject({ configurations: expect.anything() });
     expect(logger.warn).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #4352

In this pull request, I have added `.cjs` to the list of extensions of possible Detox configs.