### PR TITLE
fix: stabilize artifacts flushing

### DIFF
--- a/detox/runners/jest/testEnvironment/index.js
+++ b/detox/runners/jest/testEnvironment/index.js
@@ -64,7 +64,8 @@ class DetoxCircusEnvironment extends WithEmitter(NodeEnvironment) {
       WorkerAssignReporter,
     });
 
-    this.testEvents.on('*', this._onTestEvent.bind(this));
+    // Artifacts flushing should be delayed to avoid conflicts with third-party reporters
+    this.testEvents.on('*', this._onTestEvent.bind(this), 1e6);
   }
 
   /** @override */


### PR DESCRIPTION
## Description

This PR should fix a race condition between Detox and Allure integration, where Detox moves the artifacts before the runtime finishes flushing.

Example of a race condition can be seen here:
https://buildkite.com/wix-mobile-oss/detox/builds/3287#018d9774-bbde-42bf-9877-1efe5c77cde7

```
01:46:30.916 detox[61279] i (node:61279) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 33)
(Use `node --trace-warnings ...` to show where the warning was created)
 FAIL  e2e/32.visibility-debug-artifacts.test.js (12.563 s)
 
  ● Test suite failed to run
 
    ENOENT: no such file or directory, rename '/Users/builder/build_tmp/detox-allure2-filtered-7688c9a12dc5de47.log' -> '/Users/builder/work/detox/test/allure-results/attachments/b0217737-5296-4f48-9f62-905e6df0b7d4.log'
 
  ● Test suite failed to run
 
    ENOENT: no such file or directory, rename '/Users/builder/build_tmp/detox-allure2-filtered-7688c9a12dc5de47.log' -> '/Users/builder/work/detox/test/allure-results/attachments/b0217737-5296-4f48-9f62-905e6df0b7d4.log'
 
01:46:31.329 detox[61278] i 24.uidevice.test.js is assigned to 0D628E70-168F-49DD-875D-6FBC8D4E8146 (iPhone 15 Pro Max)
01:46:31.333 detox[61278] i :android: UIDevice: device.getUiDevice() + getDisplayHeight() + getDisplayWidth() + click()
01:46:31.334 detox[61278] i :android: UIDevice: device.getUiDevice() + getDisplayHeight() + getDisplayWidth() + click() [SKIPPED]
01:46:31.334 detox[61278] i :android: UIDevice: should type in an element using pressKeyCode()
01:46:31.335 detox[61278] i :android: UIDevice: should type in an element using pressKeyCode() [SKIPPED]
 
01:46:35.372 detox[61279] i 23.flows.test.js is assigned to 28F300CF-0166-4EA2-AA1D-D30670D80777 (iPhone 15 Pro Max)
01:46:35.884 detox[61278] i 30.custom-keyboard.test.js is assigned to 0D628E70-168F-49DD-875D-6FBC8D4E8146 (iPhone 15 Pro Max)
01:46:39.227 detox[61279] i com.wix.detox-example launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 28F300CF-0166-4EA2-AA1D-D30670D80777 log stream --level debug --style compact --predicate 'process == "example"'
01:46:40.248 detox[61278] i com.wix.detox-example launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 0D628E70-168F-49DD-875D-6FBC8D4E8146 log stream --level debug --style compact --predicate 'process == "example"'
01:46:42.067 detox[61279] i Flows > - app termination -: should exit without timeouts if app was terminated inside test
01:46:42.571 detox[61278] i :ios: Custom Keyboard: should interact with keyboard when field is first responder
01:46:43.706 detox[61279] i com.wix.detox-example launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 28F300CF-0166-4EA2-AA1D-D30670D80777 log stream --level debug --style compact --predicate 'process == "example"'
01:46:46.517 detox[61279] i Flows > - app termination -: should exit without timeouts if app was terminated inside test [OK]
01:46:46.519 detox[61279] i Flows > - app termination -: should be able to start the next test with the terminated app
01:46:46.526 detox[61279] i (node:61279) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 34)
01:46:46.533 detox[61279] i (node:61279) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 36)
01:46:46.631 detox[61279] i Flows > - app termination -: should be able to start the next test with the terminated app [FAIL]
01:46:46.633 detox[61279] i Flows > - beforeAll hooks -: trigger false test_start glitch
01:46:46.634 detox[61279] i (node:61279) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 37)
01:46:46.634 detox[61279] i Flows > - beforeAll hooks -: trigger false test_start glitch [SKIPPED]
01:46:49.351 detox[61278] i :ios: Custom Keyboard: should interact with keyboard when field is first responder [OK]
01:46:49.353 detox[61278] i :ios: Custom Keyboard: should obscure elements at bottom of screen when visible
01:46:54.042 detox[61278] i :ios: Custom Keyboard: should obscure elements at bottom of screen when visible [OK]
 
 PASS  e2e/30.custom-keyboard.test.js (22.531 s)
  :ios: Custom Keyboard
    ✓ should interact with keyboard when field is first responder (6722 ms)
    ✓ should obscure elements at bottom of screen when visible (4634 ms)
 
01:46:58.824 detox[61278] i 15.urls-and-launchArgs.test.js is assigned to 0D628E70-168F-49DD-875D-6FBC8D4E8146 (iPhone 15 Pro Max)
01:46:58.838 detox[61278] i :android: Launch arguments while handing launch URLs: should pass user args in normally
01:46:58.860 detox[61278] i :android: Launch arguments while handing launch URLs: should pass user args in normally [SKIPPED]
 
01:46:59.636 detox[61279] i com.wix.detox-example launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 28F300CF-0166-4EA2-AA1D-D30670D80777 log stream --level debug --style compact --predicate 'process == "example"'
01:47:01.841 detox[61279] i Flows > - beforeAll hooks - > inner suite: should tap on "Sanity"
01:47:02.853 detox[61279] i Flows > - beforeAll hooks - > inner suite: should tap on "Sanity" [OK]
 
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^
 
[Error: ENOENT: no such file or directory, rename '/Users/builder/build_tmp/detox-allure2-filtered-7688c9a12dc5de47.log' -> '/Users/builder/work/detox/test/allure-results/attachments/b0217737-5296-4f48-9f62-905e6df0b7d4.log'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'rename',
  path: '/Users/builder/build_tmp/detox-allure2-filtered-7688c9a12dc5de47.log',
  dest: '/Users/builder/work/detox/test/allure-results/attachments/b0217737-5296-4f48-9f62-905e6df0b7d4.log'
}
 
Node.js v20.11.0
01:47:04.152 detox[61278] i 06.device-orientation.test.js is assigned to 0D628E70-168F-49DD-875D-6FBC8D4E8146 (iPhone 15 Pro Max)
01:47:10.252 detox[61278] i com.wix.detox-example launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 0D628E70-168F-49DD-875D-6FBC8D4E8146 log stream --level debug --style compact --predicate 'process == "example"'
01:47:13.472 detox[61278] i Device Orientation: OrientationLandscape
01:47:15.724 detox[61278] i Device Orientation: OrientationLandscape [OK]
01:47:15.726 detox[61278] i Device Orientation: OrientationPortrait
01:47:17.843 detox[61278] i Device Orientation: OrientationPortrait [OK]
 
 PASS  e2e/06.device-orientation.test.js (18.418 s)
  Device Orientation
    ✓ OrientationLandscape (2195 ms)
    ✓ OrientationPortrait (2056 ms)
 
01:47:23.161 detox[61278] i 08.stress-root.test.js is assigned to 0D628E70-168F-49DD-875D-6FBC8D4E8146 (iPhone 15 Pro Max)
01:47:27.655 detox[61278] i com.wix.detox-example launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 0D628E70-168F-49DD-875D-6FBC8D4E8146 log stream --level debug --style compact --predicate 'process == "example"'
01:47:29.861 detox[61278] i StressRoot: should switch root view controller from RN to native
01:47:34.322 detox[61278] i com.wix.detox-example launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 0D628E70-168F-49DD-875D-6FBC8D4E8146 log stream --level debug --style compact --predicate 'process == "example"'
01:47:38.372 detox[61278] i StressRoot: should switch root view controller from RN to native [OK]
01:47:38.381 detox[61278] i StressRoot: :ios: should switch root view controller from RN to RN
01:47:43.843 detox[61278] i com.wix.detox-example launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 0D628E70-168F-49DD-875D-6FBC8D4E8146 log stream --level debug --style compact --predicate 'process == "example"'
01:47:48.624 detox[61278] i StressRoot: :ios: should switch root view controller from RN to RN [OK]
01:47:50.468 detox[61278] i com.wix.detox-example launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 0D628E70-168F-49DD-875D-6FBC8D4E8146 log stream --level debug --style compact --predicate 'process == "example"'
 
 PASS  e2e/08.stress-root.test.js (35.197 s)
  StressRoot
    ✓ should switch root view controller from RN to native (8438 ms)
    ✓ :ios: should switch root view controller from RN to RN (10182 ms)
 
01:47:54.290 detox[69041] i 23.flows.test.js is assigned to 0477A899-F7A1-440F-8F3F-AEA35C5729AC (iPhone 15 Pro Max)
/Users/builder/work/detox/node_modules/bunyamin/dist/index.umd.js:375
      throw error;
      ^
 
Error: Unexpected state: root describe block already exists
    at [ADD_DESCRIBE_BLOCK] (/Users/builder/work/detox/node_modules/jest-metadata/dist/metadata/containers/TestFileMetadata.js:25:19)
    at start_describe_definition (/Users/builder/work/detox/node_modules/jest-metadata/dist/metadata/MetadataEventHandler.js:23:70)
    at MetadataEventHandler.handle (/Users/builder/work/detox/node_modules/jest-metadata/dist/metadata/MetadataEventHandler.js:159:9)
    at /Users/builder/work/detox/node_modules/jest-metadata/dist/realms/BaseRealm.js:10:30
    at /Users/builder/work/detox/node_modules/jest-metadata/dist/utils/emitters/SerialEmitter.js:81:25
    at Bunyamin._completeInternal2 (/Users/builder/work/detox/node_modules/bunyamin/dist/index.umd.js:356:39)
    at Bunyamin._complete2 (/Users/builder/work/detox/node_modules/bunyamin/dist/index.umd.js:342:83)
    at SerialEmitter.emit (/Users/builder/work/detox/node_modules/jest-metadata/dist/utils/emitters/SerialEmitter.js:77:29)
    at IPCServer._onClientMessageBatch (/Users/builder/work/detox/node_modules/jest-metadata/dist/ipc/IPCServer.js:77:31)
    at Server.emit (/Users/builder/work/detox/node_modules/event-pubsub/es5.js:74:21)
    at Server.gotData (/Users/builder/work/detox/node_modules/node-ipc/dao/socketServer.js:190:14)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Readable.push (node:internal/streams/readable:390:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
```