### PR TITLE
chore: upgrade jest-allure2-reporter

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-unicorn": "^50.0.1",
     "jest": "^29.6.3",
-    "jest-allure2-reporter": "^2.0.0-beta.5",
+    "jest-allure2-reporter": "^2.0.0-beta.9",
     "metro-react-native-babel-preset": "0.76.8",
     "prettier": "^3.1.1",
     "react-native": "0.73.2",

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -67,7 +67,7 @@
     "express": "^4.15.3",
     "glob": "^7.2.0",
     "jest": "^29.6.3",
-    "jest-allure2-reporter": "^2.0.0-beta.5",
+    "jest-allure2-reporter": "^2.0.0-beta.9",
     "jest-junit": "^10.0.0",
     "jest-metadata": "^1.3.1",
     "lodash": "^4.14.1",

--- a/generation/package.json
+++ b/generation/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "jest": "^27.0.0",
-    "jest-allure2-reporter": "^2.0.0-beta.5",
+    "jest-allure2-reporter": "^2.0.0-beta.9",
     "lint-staged": "^6.0.0",
     "prettier": "^1.8.2"
   },


### PR DESCRIPTION
Internal PR. Testing the new `beta.9` version