### PR TITLE
fix(webviews): apply suggested changes from #4394.

### DIFF
--- a/detox/src/android/core/WebElement.js
+++ b/detox/src/android/core/WebElement.js
@@ -132,7 +132,7 @@ class WebViewElement {
 
   atIndex(_index) {
     // Not implemented yet
-    throw new Error('atIndex() is not supported for Android WebViewElement');
+    throw new DetoxRuntimeError('atIndex() is not supported for Android WebViewElement');
   }
 }
 

--- a/detox/test/e2e/29.webview.test.js
+++ b/detox/test/e2e/29.webview.test.js
@@ -200,9 +200,23 @@ describe('Web View', () => {
         await expect(headline).toHaveText('Changed');
       });
 
+      it('should run script with non-string function as parameter', async () => {
+        const headline = web.element(by.web.id('pageHeadline'));
+        await headline.runScript((el) => { el.textContent = "Changed"; });
+
+        await expect(headline).toHaveText('Changed');
+      });
+
       it('should run script with arguments', async () => {
         const headline = web.element(by.web.id('pageHeadline'));
         await headline.runScript('(el, text) => { el.textContent = text; }', ['Changed']);
+
+        await expect(headline).toHaveText('Changed');
+      });
+
+      it('should run script with arguments with non-string function as parameter', async () => {
+        const headline = web.element(by.web.id('pageHeadline'));
+        await headline.runScript((el, text) => { el.textContent = text; }, ['Changed']);
 
         await expect(headline).toHaveText('Changed');
       });


### PR DESCRIPTION
In this PR, I:
- Add missing tests for `runScript` with non-string function as param.
- Replace thrown `Error` with `DetoxRuntimeError` on `WebElement.js`.