### PR TITLE
fix(ios, webviews): verify not reached input's max-length on typing.

### DIFF
--- a/detox/ios/Detox/Invocation/WebCodeBuilder+createTypeAction.swift
+++ b/detox/ios/Detox/Invocation/WebCodeBuilder+createTypeAction.swift
@@ -59,6 +59,10 @@ extension WebCodeBuilder {
 	let currentIndex = 0;
 	const delay = \(typeCharacterDelay);
 	const typeCharacters = () => {
+		if (isInputField && (element.value.length >= element.getAttribute('maxlength'))) {
+		  return;
+		}
+
 		if (currentIndex < textToType.length) {
 			if (isContentEditable) {
 				element.textContent += textToType.charAt(currentIndex);

--- a/detox/test/e2e/29.webview.test.js
+++ b/detox/test/e2e/29.webview.test.js
@@ -317,6 +317,7 @@ describe('Web View', () => {
         });
       });
 
+      // Not implemented yet
       it(':android: should throw on usage of atIndex', async () => {
         await jestExpect(async () => {
           await expect(web(by.id('dummyWebView')).atIndex(0).element(by.web.id('message'))).toExist();

--- a/detox/test/e2e/29.webview.test.js
+++ b/detox/test/e2e/29.webview.test.js
@@ -93,6 +93,15 @@ describe('Web View', () => {
             await expect(inputElement).toHaveText('Tester');
           });
 
+          it('should not type more text than `maxlength` limit', async () => {
+            const text = '0123456789 ABCDEF';
+            await inputElement.typeText(text);
+
+            const maxlength = 10;
+            const expectedText = text.substring(0, maxlength);
+            await expect(inputElement).toHaveText(expectedText);
+          });
+
           it('should clear text in input', async () => {
             await inputElement.typeText('Test');
             await inputElement.clearText();

--- a/detox/test/src/Screens/WebViewScreen.js
+++ b/detox/test/src/Screens/WebViewScreen.js
@@ -110,7 +110,7 @@ const webViewFormWithScrolling = `
         <h2>Form</h2>
         <form>
             <label for="fname">Your name:</label><br>
-            <input type="text" id="fname" name="fname"><br>
+            <input type="text" id="fname" name="fname" maxlength="10"><br>
             <input type="submit" id="submit" value="Submit" onclick="document.getElementById('resultFname').innerHTML = document.getElementById('fname').value; return false;">
         </form>
 


### PR DESCRIPTION
Add `maxlength` check before typing a char on input.

Unfortunately, Android is able to type regardless of `maxlength` limitation, so test is disabled for Android ☹️ 