### PR TITLE
chore: upgrade @react-native-community/datetimepicker

### DIFF
--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.17.3",
     "@react-native-community/checkbox": "0.5.16",
-    "@react-native-community/datetimepicker": "^6.7.1",
+    "@react-native-community/datetimepicker": "^7.6.3",
     "@react-native-community/geolocation": "^2.0.2",
     "@react-native-community/slider": "4.5.0",
     "@react-native-picker/picker": "^2.1.0",


### PR DESCRIPTION
## Description

This should fix a compilation error in `detox/test` on Xcode 15.3.
I confirmed that it works on Xcode 15.2 locally as well.