### PR TITLE
chore(package): bump `@react-native-community/datetimepicker`.

### DIFF
--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.17.3",
     "@react-native-community/checkbox": "0.5.16",
-    "@react-native-community/datetimepicker": "^6.7.1",
+    "@react-native-community/datetimepicker": "^7.6.3",
     "@react-native-community/geolocation": "^2.0.2",
     "@react-native-community/slider": "4.5.0",
     "@react-native-picker/picker": "^2.1.0",


### PR DESCRIPTION
This resolves an issue with Xcode 15.3, see original fix: https://github.com/react-native-datetimepicker/datetimepicker/pull/868