### PR TITLE
fix: revert accidental Node 18.x bump

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -110,9 +110,9 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=14"
   },
   "browserslist": [
-    "node 18"
+    "node 14"
   ]
 }


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here:

![image](https://github.com/wix/Detox/assets/1962469/529dde42-3564-40f2-a227-6f3799050f34)

In this pull request, I have reverted the unintended breaking change.