### PR TITLE
fix(ios, webviews): workaround selection on non-text input types.

### DIFF
--- a/detox/ios/Detox/Invocation/WebCodeBuilder+createMoveCursorToEndAction.swift
+++ b/detox/ios/Detox/Invocation/WebCodeBuilder+createMoveCursorToEndAction.swift
@@ -30,7 +30,14 @@ extension WebCodeBuilder {
 
 	if (typeof element.setSelectionRange === 'function') {
 		const length = getLength(element);
+
+		/* This is a workaround. See: https://w3.org/Bugs/Public/show_bug.cgi?id=24796 */
+		const originalType = element.getAttribute('type');
+		element.setAttribute('type', 'text');
+
 		element.setSelectionRange(length, length);
+
+		element.setAttribute('type', originalType);
 	} else {
 		var range = element.ownerDocument.createRange();
 

--- a/detox/test/e2e/29.webview.test.js
+++ b/detox/test/e2e/29.webview.test.js
@@ -95,6 +95,14 @@ describe('Web View', () => {
             await expect(inputElement).toHaveText('Tester');
           });
 
+          it('should type text in input with `email` type', async () => {
+            await inputElement.runScript((el) => { el.type = 'email'; });
+
+            await inputElement.typeText('Tester');
+
+            await expect(inputElement).toHaveText('Tester');
+          });
+
           it('should keep cursor position on end while typing', async () => {
             await inputElement.typeText('Test');
             await expectWebViewToMatchSnapshot('typing-keep-cursor-position-webview-input-1');

--- a/detox/test/src/Screens/WebViewScreen.js
+++ b/detox/test/src/Screens/WebViewScreen.js
@@ -80,7 +80,7 @@ const webViewFormWithScrolling = `
               margin: 20px;
             }
 
-            input[type=text] {
+            input[type=text], input[type=email] {
               width: 100%;
               padding: 12px 20px;
               margin: 8px 0;


### PR DESCRIPTION
Resolves https://github.com/wix/Detox/issues/4426

See: https://w3.org/Bugs/Public/show_bug.cgi?id=24796