### PR TITLE
fix(iOS): dispatch input event when changing web inner-element's value.

### DIFF
--- a/detox/ios/Detox/Invocation/WebCodeBuilder+createTypeAction.swift
+++ b/detox/ios/Detox/Invocation/WebCodeBuilder+createTypeAction.swift
@@ -70,6 +70,9 @@ extension WebCodeBuilder {
 				element.value += textToType.charAt(currentIndex);
 			}
 
+			const inputEvent = new Event('input', { bubbles: true, cancelable: true });
+			element.dispatchEvent(inputEvent);
+
 			\(createMoveCursorToEndAction(selector: selector))
 
 			currentIndex++;


### PR DESCRIPTION
Hopefully fixes: https://github.com/wix/Detox/issues/4437

TODO:
- [ ] add a test that uses a React web page since our current test suite uses a simple HTML page..