### PR TITLE
Fix simctrl terminate message change on v19

### DIFF
--- a/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+++ b/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
@@ -272,7 +272,7 @@ class AppleSimUtils {
       // want to make sure it isn't now.
       if (err.code === 3 &&
           (err.stderr.includes(`the app is not currently running`) ||
-           err.stderr.includes(`The operation couldn’t be completed. found nothing to terminate`))) {
+           err.stderr.includes(`found nothing to terminate`))) {
         return;
       }
 


### PR DESCRIPTION
The simtrl terminate error has changed again which is causing the Detox tests to fail for people still using the v19.

Can we have a new release of 19.13.1 including this fix pls. Ty

This was already fixed for v20 https://github.com/wix/Detox/pull/4171
