### PR TITLE
Implemented waitFor.swipe on android

### DIFF
--- a/detox/src/android/AndroidExpect.test.js
+++ b/detox/src/android/AndroidExpect.test.js
@@ -184,6 +184,10 @@ describe('AndroidExpect', () => {
       await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).scroll(50, 'down');
       await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).scroll(50);
 
+      await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).swipe('down');
+      await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).swipe('down', 'fast');
+      await e.waitFor(e.element(e.by.id('id'))).toBeVisible().whileElement(e.by.id('id2')).swipe('down', 'fast', 0.4, 0.5);
+
       await e.waitFor(e.element(e.by.id('id'))).toBeFocused().withTimeout(0);
       await e.waitFor(e.element(e.by.id('id'))).toBeNotFocused().withTimeout(0);
     });

--- a/detox/src/android/interactions/native.js
+++ b/detox/src/android/interactions/native.js
@@ -2,7 +2,7 @@ const DetoxRuntimeError = require('../../errors/DetoxRuntimeError');
 const { expectDescription, actionDescription } = require('../../utils/invocationTraceDescriptions');
 const log = require('../../utils/logger').child({ cat: 'ws-client, ws' });
 const traceInvocationCall = require('../../utils/traceInvocationCall').bind(null, log);
-const { ScrollAmountStopAtEdgeAction } = require('../actions/native');
+const { ScrollAmountStopAtEdgeAction, SwipeAction } = require('../actions/native');
 const { NativeMatcher } = require('../core/NativeMatcher');
 const DetoxAssertionApi = require('../espressoapi/DetoxAssertion');
 const EspressoDetoxApi = require('../espressoapi/EspressoDetox');
@@ -90,6 +90,12 @@ class WaitForActionInteraction extends WaitForActionInteractionBase {
   async scroll(amount, direction = 'down', scrollPositionX, scrollPositionY) {
     this._traceDescription = expectDescription.waitFor(actionDescription.scroll(amount, direction, scrollPositionX, scrollPositionY));
     this._prepare(new ScrollAmountStopAtEdgeAction(direction, amount, scrollPositionX, scrollPositionY));
+    await this.execute();
+  }
+
+  async swipe(direction, speed = 'fast', normalizedSwipeOffset = NaN, normalizedStartingPointX = NaN, normalizedStartingPointY = NaN) {
+    this._traceDescription = expectDescription.waitFor(actionDescription.swipe(direction, speed, normalizedSwipeOffset, normalizedStartingPointX, normalizedStartingPointY));
+    this._prepare(new SwipeAction(direction, speed, normalizedSwipeOffset, normalizedStartingPointX, normalizedStartingPointY));
     await this.execute();
   }
 }

--- a/detox/test/e2e/03.actions.visibility-workaround.test.js
+++ b/detox/test/e2e/03.actions.visibility-workaround.test.js
@@ -38,9 +38,7 @@ describe(':android: Visibility-bug workaround actions', () => {
     await expect(scrollViewDriver.lastItem()).toBeVisible();
   });
 
-  it('should be able to wait for element to be visible after swipe', async () => {
-    const targetItem = scrollViewDriver.listItem(49);
-
+  async function waitForSwipeToItem(targetItem) {
     await expect(scrollViewDriver.element()).toBeVisible();
     await expect(scrollViewDriver.firstItem()).toBeVisible();
     await expect(targetItem).not.toBeVisible();
@@ -48,6 +46,17 @@ describe(':android: Visibility-bug workaround actions', () => {
     await waitFor(targetItem)
       .toBeVisible()
       .whileElement(scrollViewDriver.byId())
-      .swipe( 'up', 'fast', 0.3);
+      .swipe('up', 'fast', 0.3);
+  }
+
+  it('should be able to wait for element to be visible after swipe when the target item is not last', async () => {
+    const targetItem = scrollViewDriver.listItem(25);
+    await waitForSwipeToItem(targetItem);
+  });
+
+
+  it('should be able to wait for element to be visible after swipe when the target item is last', async () => {
+    const targetItem = scrollViewDriver.lastItem()
+    await waitForSwipeToItem(targetItem);
   });
 });

--- a/detox/test/e2e/03.actions.visibility-workaround.test.js
+++ b/detox/test/e2e/03.actions.visibility-workaround.test.js
@@ -32,7 +32,7 @@ describe(':android: Visibility-bug workaround actions', () => {
     await expect(scrollViewDriver.firstItem()).toBeVisible();
     await expect(scrollViewDriver.lastItem()).not.toBeVisible();
 
-    await expectToThrow(() => scrollViewDriver.scrollBy(1000));
+    await expectToThrow(() => scrollViewDriver.scrollBy(3000));
 
     await expect(scrollViewDriver.firstItem()).not.toBeVisible();
     await expect(scrollViewDriver.lastItem()).toBeVisible();

--- a/detox/test/e2e/03.actions.visibility-workaround.test.js
+++ b/detox/test/e2e/03.actions.visibility-workaround.test.js
@@ -37,4 +37,17 @@ describe(':android: Visibility-bug workaround actions', () => {
     await expect(scrollViewDriver.firstItem()).not.toBeVisible();
     await expect(scrollViewDriver.lastItem()).toBeVisible();
   });
+
+  it('should be able to wait for element to be visible after swipe', async () => {
+    const targetItem = scrollViewDriver.listItem(49);
+
+    await expect(scrollViewDriver.element()).toBeVisible();
+    await expect(scrollViewDriver.firstItem()).toBeVisible();
+    await expect(targetItem).not.toBeVisible();
+
+    await waitFor(targetItem)
+      .toBeVisible()
+      .whileElement(scrollViewDriver.byId())
+      .swipe( 'up', 'fast', 0.3);
+  });
 });

--- a/detox/test/e2e/drivers/fs-scroll-driver.js
+++ b/detox/test/e2e/drivers/fs-scroll-driver.js
@@ -6,7 +6,7 @@ const scrollViewDriver = {
   secondItem: () => scrollViewDriver.listItem(2),
   secondPageItemIndex: () => 16,
   secondPageItem: () => scrollViewDriver.listItem(scrollViewDriver.secondPageItemIndex()),
-  lastItem: () => scrollViewDriver.listItem(20),
+  lastItem: () => scrollViewDriver.listItem(50),
   fakeItem: () => scrollViewDriver.listItem(1000),
   scrollBy: (amount) => scrollViewDriver.element().scroll(Math.abs(amount), (amount > 0 ? 'down' : 'up')),
 };

--- a/detox/test/src/Screens/ScrollActionsScreen.js
+++ b/detox/test/src/Screens/ScrollActionsScreen.js
@@ -22,7 +22,7 @@ export default class ScrollActionsScreen extends Component {
       <View style={{ flex: 1, justifyContent: 'flex-start', borderColor: '#c0c0c0', borderWidth: 1, backgroundColor: '#f8f8ff' }}>
         <ScrollView testID='FSScrollActions.scrollView'>
           {
-            Array.from({length: 20}, (_, index) => this.renderItem(index + 1))
+            Array.from({length: 50}, (_, index) => this.renderItem(index + 1))
           }
         </ScrollView>
       </View>


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #3662

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have added a new API for Android waitFor to support swipe action.
Added a few tests for edge cases

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
