### PR TITLE
docs(troubleshooting): suggest double-checking NetworkSecurityConfig if app won't load

### DIFF
--- a/docs/troubleshooting/running-tests.md
+++ b/docs/troubleshooting/running-tests.md
@@ -33,6 +33,7 @@ This can be a result of various reasons. It is generally up to you to debug and 
 - You might have forgotten to run `device.launchApp()` in the beginning of your test.
 - The app might have crashed before Detox has had a chance to connect to it. To get the crash details, you can run Detox tests with `--record-logs all` CLI option and then inspect the device logs in the artifacts' folder.
 - **On Android**, there might be a problem with the native test code in the `DetoxTest.java` file. Revisit the [associated section](../introduction/project-setup.mdx#step-4-additional-android-configuration) in the setup guide.
+- **On Android**, your `Network Security Config` may not be recognized. Revisit the [associated section](../introduction/project-setup.mdx#43-enabling-unencrypted-traffic-for-detox) in the setup guide.
 
 ### If you _do_ see your app running on the device
 


### PR DESCRIPTION
## Description

[This page](https://wix.github.io/Detox/docs/troubleshooting/running-tests#if-you-do-not-see-your-app-running-on-the-device) provides a _very_ helpful list of reasons why a Detox app might not load.

**However, I managed to run into a new one!** 😨

-------------------

Thanks to an errant `git` command, I mistakenly removed [my `network_security_config.xml` file](https://wix.github.io/Detox/docs/introduction/project-setup#43-enabling-unencrypted-traffic-for-detox) and the reference to it in `AndroidManifest.xml`. In the process, the app I was testing stopped loading on my physical Android device.

> I confirmed this was the root cause by:
> 1) trying lots of other things that didn't work 🙃
> 2) restoring my Network Security Config
> 3) confirming that my app launched as expected 🎉 

I thought I'd add this scenario to the list mentioned above, lest somebody else fall down the same rabbit hole. 🙂 

