### PR TITLE
Fix test build type in proguard config documentation

### DIFF
--- a/docs/guide/proguard-configuration.md
+++ b/docs/guide/proguard-configuration.md
@@ -78,7 +78,7 @@ Following the example, you would then have to adjust your `build` and `binaryPat
 -      binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
 +      binaryPath: 'android/app/build/outputs/apk/releaseE2E/app-releaseE2E.apk',
 -      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release'
-+      build: 'cd android && ./gradlew assembleReleaseE2E assembleAndroidTest -DtestBuildType=release'
++      build: 'cd android && ./gradlew assembleReleaseE2E assembleAndroidTest -DtestBuildType=releaseE2E'
      },`
 ```
 


### PR DESCRIPTION
## Description

I followed the [guide on proguard configuration](https://wix.github.io/Detox/docs/guide/proguard-configuration/#obfuscation) and noticed an issue in the docs where the `testBuildType` parameter is not correct.

It is 

```diff
{
  apps: {
     'android.release': {
       type: 'android.apk',
-      binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
+      binaryPath: 'android/app/build/outputs/apk/releaseE2E/app-releaseE2E.apk',
-      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release'
+      build: 'cd android && ./gradlew assembleReleaseE2E assembleAndroidTest -DtestBuildType=release'
     },`
```

but should be 


```diff
{
  apps: {
     'android.release': {
       type: 'android.apk',
-      binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
+      binaryPath: 'android/app/build/outputs/apk/releaseE2E/app-releaseE2E.apk',
-      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=releaseE2E'
+      build: 'cd android && ./gradlew assembleReleaseE2E assembleAndroidTest -DtestBuildType=releaseE2E'
     },`
```

Otherwise the android test APK for the releaseE2E variant is not created.

You can see that others already use this for example here: https://github.com/wix/Detox/issues/3711

> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.