### PR TITLE
feat(config): multi-app build and start scripts

### DIFF
--- a/detox/detox.d.ts
+++ b/detox/detox.d.ts
@@ -33,6 +33,10 @@ declare global {
             logger?: DetoxLoggerConfig;
             session?: DetoxSessionConfig;
             testRunner?: DetoxTestRunnerConfig;
+            /** Build command for the entire configuration, overriding individual app build commands. */
+            build?: string;
+            /** Start command for the entire configuration, overriding individual app start commands. */
+            start?: string;
         };
 
         interface DetoxArtifactsConfig {
@@ -268,6 +272,18 @@ declare global {
              * @see Device#selectApp
              */
             name?: string;
+            /**
+             * Build command to be executed when you run `detox build`
+             * @example 'cd ios && xcodebuild -workspace example.xcworkspace ...'
+             * @example 'cd android && ./gradlew assembleDebug ...'
+             */
+            build?: string;
+            /**
+             * Development server start command to be executed when you run `detox start`
+             * Usually used in debug mode, but it depends on your application setup.
+             * @example 'react-native start'
+             */
+            start?: string;
         };
 
         type DetoxDeviceConfig = DetoxBuiltInDeviceConfig | DetoxCustomDriverConfig;
@@ -317,8 +333,6 @@ declare global {
             type: 'ios.app';
             binaryPath: string;
             bundleId?: string;
-            build?: string;
-            start?: string;
             launchArgs?: Record<string, any>;
         }
 
@@ -326,8 +340,6 @@ declare global {
             type: 'android.apk';
             binaryPath: string;
             bundleId?: string;
-            build?: string;
-            start?: string;
             testBinaryPath?: string;
             launchArgs?: Record<string, any>;
             /**

--- a/detox/internals.d.ts
+++ b/detox/internals.d.ts
@@ -245,6 +245,7 @@ declare global {
 
     type RuntimeConfig = Readonly<{
       configurationName: string;
+      commands: Readonly<RuntimeCommandsGroup>[];
 
       /**
        * Dictionary of app configurations,
@@ -272,6 +273,12 @@ declare global {
         uiHierarchy: Readonly<Detox.DetoxUIHierarchyArtifactsPluginConfig>;
         [pluginId: string]: unknown;
       }>;
+    };
+
+    type RuntimeCommandsGroup = {
+      appName?: string;
+      build?: string;
+      start?: string;
     };
 
     type CLIConfig = Readonly<Partial<{

--- a/detox/local-cli/build.test.js
+++ b/detox/local-cli/build.test.js
@@ -17,6 +17,7 @@ describe('build', () => {
         apps: {},
         artifacts: {},
         behavior: {},
+        commands: [],
         errorComposer: new DetoxConfigErrorComposer(),
         device: {},
         session: {}
@@ -44,14 +45,15 @@ describe('build', () => {
   });
 
   it('runs the build script from the composed device config', async () => {
-    detox.config.apps.default = { build: 'yet another command' };
+    detox.config.commands = [{ appName: 'default', build: 'yet another command' }];
 
     await callCli('./build', 'build');
     expect(execSync).toHaveBeenCalledWith('yet another command', expect.anything());
   });
 
   it('skips building the app if the binary exists and --if-missing flag is set', async () => {
-    detox.config.apps.default = { build: 'yet another command', binaryPath: __filename };
+    detox.config.apps.default = { binaryPath: __filename };
+    detox.config.commands = [{ appName: 'default', build: 'yet another command' }];
 
     await callCli('./build', 'build -i');
     expect(execSync).not.toHaveBeenCalled();
@@ -64,6 +66,7 @@ describe('build', () => {
 
   it('fails with an error if a build script has not been found', async () => {
     detox.config.apps.default = {};
+    detox.config.commands = [{ appName: 'default', start: 'a command' }];
     await expect(callCli('./build', 'build')).rejects.toThrowError(/Failed to build/);
   });
 
@@ -74,7 +77,7 @@ describe('build', () => {
   });
 
   it('should print a warning upon user build script failure', async () => {
-    detox.config.apps.default = { build: 'a command' };
+    detox.config.commands = [{ appName: 'default', build: 'a command' }];
     execSync.mockImplementation(() => { throw new Error('Build failure'); });
     await expect(callCli('./build', 'build')).rejects.toThrowError(/Build failure/);
     expect(detox.log.warn).toHaveBeenCalledWith(expect.stringContaining('You are responsible'));
@@ -82,13 +85,16 @@ describe('build', () => {
 
   it('should print a warning if app is not found at binary path', async () => {
     detox.config.apps.default = { binaryPath: tempfile() };
+    detox.config.commands = [{ appName: 'default', build: ':' }];
+
     await expect(callCli('./build', 'build -s')).resolves.not.toThrowError();
     expect(detox.log.warn).toHaveBeenCalledWith(expect.stringContaining('could not find your app at the given binary path'));
   });
 
   it('should print extra message with the app name before building (in a multi-app configuration)', async () => {
-    detox.config.apps.app1 = { binaryPath: tempfile(), build: ':' };
-    detox.config.apps.app2 = { binaryPath: tempfile(), build: ':' };
+    detox.config.apps.app1 = { binaryPath: tempfile() };
+    detox.config.apps.app2 = { binaryPath: tempfile() };
+    detox.config.commands = [{ appName: 'app1', build: 'app1 build' }, { appName: 'app2', build: 'app2 build' }];
 
     await expect(callCli('./build', 'build -s')).resolves.not.toThrowError();
     expect(detox.log.info).toHaveBeenCalledWith(expect.stringContaining('app1'));
@@ -96,7 +102,8 @@ describe('build', () => {
   });
 
   it('should not print that extra message when the app is single', async () => {
-    detox.config.apps.default = { binaryPath: tempfile(), build: ':' };
+    detox.config.apps.default = { binaryPath: tempfile() };
+    detox.config.commands = [{ appName: 'default', build: ':' }];
 
     await expect(callCli('./build', 'build -s')).resolves.not.toThrowError();
     expect(detox.log.info).not.toHaveBeenCalledWith(expect.stringContaining('default'));

--- a/detox/local-cli/start.js
+++ b/detox/local-cli/start.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const detox = require('../internals');
 
 const AppStartCommand = require('./startCommand/AppStartCommand');
@@ -24,17 +22,13 @@ module.exports.builder = {
 };
 
 module.exports.handler = async function start(argv) {
-  const { apps: appsConfig } = await detox.resolveConfig({ argv });
-  const startCommands = _(appsConfig)
-    .values()
-    .map(app => app.start)
-    .filter(Boolean)
+  const { commands } = await detox.resolveConfig({ argv });
+  const startCommands = commands.map(s => s.start).filter(Boolean)
     .map(cmd => new AppStartCommand({
       cmd,
       passthrough: argv['--'],
       forceSpawn: argv.force,
-    }))
-    .value();
+    }));
 
   if (startCommands.length) {
     try {

--- a/detox/local-cli/start.test.js
+++ b/detox/local-cli/start.test.js
@@ -15,6 +15,7 @@ describe('start', () => {
         apps: {},
         artifacts: {},
         behavior: {},
+        commands: [],
         errorComposer: new DetoxConfigErrorComposer(),
         device: {},
         session: {}
@@ -54,7 +55,7 @@ describe('start', () => {
 
   it('spawns the start script from the composed apps config', async () => {
     cmd = buildMockCommand();
-    detox.config.apps.default = { start: `${cmd.cmd} --arg1=value1 --arg2 value2` };
+    detox.config.commands = [{ appName: 'default', start: `${cmd.cmd} --arg1=value1 --arg2 value2` }];
     await callCli('./start', 'start').catch(() => {});
 
     expect(cmd.calls).toEqual([
@@ -69,7 +70,7 @@ describe('start', () => {
 
   it('forwards passthrough arguments to the start script', async () => {
     cmd = buildMockCommand();
-    detox.config.apps.default = { start: `${cmd.cmd} --arg1` };
+    detox.config.commands = [{ appName: 'default', start: `${cmd.cmd} --arg1` }];
     await callCli('./start', 'start -- --arg2').catch(() => {});
 
     expect(cmd.calls).toEqual([
@@ -83,8 +84,8 @@ describe('start', () => {
 
   it('stops if one of the scripts is failing', async () => {
     cmd = buildMockCommand({ exitCode: 0, sleep: 100 });
-    detox.config.apps.app1 = { start: 'node --eval="process.exit(3)"' };
-    detox.config.apps.app2 = { start: cmd.cmd };
+    detox.config.commands.push({ appName: 'app1', start: 'node --eval="process.exit(3)"' });
+    detox.config.commands.push({ appName: 'app2', start: cmd.cmd });
     await expect(callCli('./start', 'start')).rejects.toThrowError(/Command exited with code 3/);
 
     expect(cmd.calls).toHaveLength(0);
@@ -95,8 +96,8 @@ describe('start', () => {
     ['--force'],
   ])('does not stop in %s mode if one of the scripts is failing', async (__force) => {
     cmd = buildMockCommand({ sleep: 100 });
-    detox.config.apps.app1 = { start: 'node --eval="process.exit(3)"' };
-    detox.config.apps.app2 = { start: cmd.cmd };
+    detox.config.commands.push({ appName: 'app1', start: 'node --eval="process.exit(3)"' });
+    detox.config.commands.push({ appName: 'app2', start: cmd.cmd });
 
     await callCli('./start', `start ${__force}`);
     expect(cmd.calls).toHaveLength(1);

--- a/detox/local-cli/testCommand/TestRunnerCommand.js
+++ b/detox/local-cli/testCommand/TestRunnerCommand.js
@@ -26,13 +26,13 @@ class TestRunnerCommand {
     const cliConfig = opts.config.cli;
     const deviceConfig = opts.config.device;
     const runnerConfig = opts.config.testRunner;
-    const appsConfig = opts.config.apps;
+    const commands = opts.config.commands;
 
     this._argv = runnerConfig.args;
     this._detached = runnerConfig.detached;
     this._retries = runnerConfig.retries;
     this._envHint = this._buildEnvHint(opts.env);
-    this._startCommands = this._prepareStartCommands(appsConfig, cliConfig);
+    this._startCommands = this._prepareStartCommands(commands, cliConfig);
     this._envFwd = {};
     this._terminating = false;
 
@@ -103,15 +103,14 @@ class TestRunnerCommand {
       .value();
   }
 
-  _prepareStartCommands(appsConfig, cliConfig) {
+  _prepareStartCommands(commands, cliConfig) {
     if (`${cliConfig.start}` === 'false') {
       return [];
     }
 
-    return _.values(appsConfig)
-      .filter(app => app.start)
-      .map(app => new AppStartCommand({
-        cmd: app.start,
+    return _.filter(commands, 'start')
+      .map(commands => new AppStartCommand({
+        cmd: commands.start,
         forceSpawn: cliConfig.start === 'force',
       }));
   }

--- a/detox/src/configuration/composeCommandsConfig.js
+++ b/detox/src/configuration/composeCommandsConfig.js
@@ -1,0 +1,42 @@
+/**
+ * @param {{
+ *  appsConfig: Record<string, Detox.DetoxAppConfig>
+ *  localConfig: Detox.DetoxConfiguration;
+ * }} options
+ * @returns {DetoxInternals.RuntimeCommandsGroup[]}
+ */
+function composeCommandsConfig(options) {
+  const { appsConfig, localConfig } = options;
+  /** @type {[string | undefined, Detox.DetoxAppConfig | Detox.DetoxConfiguration][]} */
+  const entries = [[undefined, localConfig], ...Object.entries(appsConfig)];
+
+  return entries.map(extractGroup).filter(hasCommands);
+}
+
+/**
+ * @param {[string | undefined, any]} script
+ * @param {number} index
+ * @param {[string | undefined, any][]} array
+ * @returns {DetoxInternals.RuntimeCommandsGroup}
+ */
+function extractGroup([appName, { build, start }], index, [[, config]]) {
+  if (index === 0) {
+    return { build, start };
+  }
+
+  return {
+    appName,
+    build: config.build ? undefined : build,
+    start: config.start ? undefined : start
+  };
+}
+
+/**
+ * @param {DetoxInternals.RuntimeCommandsGroup} script
+ * @returns {boolean}
+ */
+function hasCommands({ build, start }) {
+  return Boolean(build || start);
+}
+
+module.exports = composeCommandsConfig;

--- a/detox/src/configuration/composeCommandsConfig.test.js
+++ b/detox/src/configuration/composeCommandsConfig.test.js
@@ -1,0 +1,81 @@
+const composeCommandsConfig = require('./composeCommandsConfig');
+
+describe('composeCommandsConfig', () => {
+  let appsConfig, localConfig;
+
+  beforeEach(() => {
+    appsConfig = {};
+    localConfig = {};
+  });
+
+  const composed = () => composeCommandsConfig({ appsConfig, localConfig });
+
+  it('should return an empty array if no commands are defined', () => {
+    expect(composed()).toEqual([]);
+  });
+
+  it('should use commands from the local config', () => {
+    localConfig = {
+      build: 'multi build',
+      start: 'multi start'
+    };
+
+    expect(composed()).toEqual([
+      { build: 'multi build', start: 'multi start' }
+    ]);
+  });
+
+  it('should use app commands from the apps config', () => {
+    appsConfig = {
+      app1: { build: 'app1 build', start: 'app1 start' },
+      app2: { build: 'app2 build' }
+    };
+
+    expect(composed()).toEqual([
+      { appName: 'app1', build: 'app1 build', start: 'app1 start' },
+      { appName: 'app2', build: 'app2 build' }
+    ]);
+  });
+
+  it('should combine commands from localConfig and appsConfig', () => {
+    localConfig = {
+      build: 'global build',
+    };
+    appsConfig = {
+      app1: { build: 'app1 build', start: 'app1 start' },
+      app2: { build: 'app2 build' }
+    };
+
+    expect(composed()).toEqual([
+      { build: 'global build' },
+      { appName: 'app1', start: 'app1 start' },
+    ]);
+  });
+
+  it('should not include app commands if the local config has such commands', () => {
+    localConfig = {
+      build: 'global build',
+      start: 'global start'
+    };
+    appsConfig = {
+      app1: { build: 'app1 build', start: 'app1 start' }
+    };
+
+    expect(composed()).toEqual([
+      { build: 'global build', start: 'global start' },
+    ]);
+  });
+
+  it('should filter out entries without build or start commands', () => {
+    appsConfig = {
+      app1: { build: 'app1 build' },
+      app2: {},
+      app3: { start: 'app3 start' }
+    };
+
+    expect(composed()).toEqual([
+      { appName: 'app1', build: 'app1 build' },
+      { appName: 'app3', start: 'app3 start' }
+    ]);
+  });
+});

--- a/detox/src/configuration/index.js
+++ b/detox/src/configuration/index.js
@@ -7,6 +7,7 @@ const collectCliConfig = require('./collectCliConfig');
 const composeAppsConfig = require('./composeAppsConfig');
 const composeArtifactsConfig = require('./composeArtifactsConfig');
 const composeBehaviorConfig = require('./composeBehaviorConfig');
+const composeCommandsConfig = require('./composeCommandsConfig');
 const composeDeviceConfig = require('./composeDeviceConfig');
 const composeLoggerConfig = require('./composeLoggerConfig');
 const composeRunnerConfig = require('./composeRunnerConfig');
@@ -104,6 +105,11 @@ async function composeDetoxConfig({
     cliConfig,
   });
 
+  const commandsConfig = composeCommandsConfig({
+    appsConfig,
+    localConfig,
+  });
+
   const result = {
     configurationName,
 
@@ -111,6 +117,7 @@ async function composeDetoxConfig({
     artifacts: artifactsConfig,
     behavior: behaviorConfig,
     cli: cliConfig,
+    commands: commandsConfig,
     device: deviceConfig,
     logger: loggerConfig,
     testRunner: runnerConfig,

--- a/docs/config/apps.mdx
+++ b/docs/config/apps.mdx
@@ -74,7 +74,9 @@ To work with multiple apps within the same configuration you should be giving ea
   "configurations": {
     "ios.release": {
       "device": "simulator",
-      "apps": ["driver", "passenger"]
+      "apps": ["driver", "passenger"],
+      "build": "scripts/build-both-apps.sh",
+      "start": "scripts/start-both-apps.sh"
     }
   }
 }
@@ -90,6 +92,9 @@ await device.selectApp('passenger');
 await device.launchApp();
 // ... run tests ...
 ```
+
+As shown in the example above, you can override app build and start commands with a single, configuration-scoped one.
+This may be useful when you have smart scripts for building and starting multiple apps at once.
 
 [`detox build`]: ../cli/build.md
 [`detox start`]: ../cli/start.md


### PR DESCRIPTION
## Description

In this pull request, I have extended Detox config resolution so that it can take `build` and `start` scripts not only from every app, but it can take configuration-scoped overrides, where a single command does all the building or app server running.

> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.