### PR TITLE
fix(iOS): add `@retroactive` for protocol conformance (Xcode 16 compliance).

### DIFF
--- a/detox/ios/Detox/Utilities/String+LocalizedError.swift
+++ b/detox/ios/Detox/Utilities/String+LocalizedError.swift
@@ -6,6 +6,13 @@
 //  Copyright © 2020 Wix. All rights reserved.
 //
 
+#if hasFeature(RetroactiveAttribute)
+extension String: @retroactive Error {}
+extension String: @retroactive LocalizedError {
+    public var errorDescription: String? { return self }
+}
+#else
 extension String: LocalizedError {
     public var errorDescription: String? { return self }
 }
+#endif


### PR DESCRIPTION
Our `String` extension declares a conformance to the protocols `LocalizedError` and `Error`. 
This will not behave correctly if Swift introduces this conformance in the future. Xcode 16 started to warn when not using this new syntax.

See original Swift proposal: 
https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md