### PR TITLE
Daemon: Add preliminary ADB server-start in Genycloud

### DIFF
--- a/detox/src/devices/allocation/DeviceAllocator.js
+++ b/detox/src/devices/allocation/DeviceAllocator.js
@@ -4,6 +4,8 @@
  * @typedef {import('../common/drivers/DeviceCookie').DeviceCookie} DeviceCookie
  */
 
+const _ = require('lodash');
+
 const log = require('../../utils/logger').child({ cat: 'device,device-allocation' });
 const traceMethods = require('../../utils/traceMethods');
 
@@ -16,6 +18,11 @@ class DeviceAllocator {
     this._counter = 0;
     this._ids = new Map();
     traceMethods(log, this, ['init', 'cleanup', 'emergencyCleanup']);
+
+    // Init and cleanup should be called once for each allocation driver type
+    this.init = _.once(this.init.bind(this));
+    this.cleanup = _.once(this.cleanup.bind(this));
+    this.emergencyCleanup = _.once(this.emergencyCleanup.bind(this));
   }
 
   /**

--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
@@ -41,7 +41,7 @@ class GenyAllocDriver {
   }
 
   async init() {
-    await this._adb.startDaemon();
+    await this._startAdbDaemon();
   }
 
   /**
@@ -119,6 +119,8 @@ class GenyAllocDriver {
 
     const deletionLeaks = (await Promise.all(killPromises)).filter(Boolean);
     this._reportGlobalCleanupSummary(deletionLeaks);
+
+    await this._killAdbDaemon();
   }
 
   emergencyCleanup() {
@@ -150,6 +152,22 @@ class GenyAllocDriver {
       log.info(events.GENYCLOUD_TEARDOWN, 'Instances teardown completed with warnings');
     } else {
       log.info(events.GENYCLOUD_TEARDOWN, 'Instances teardown completed successfully');
+    }
+  }
+
+  async _startAdbDaemon() {
+    try {
+      await this._adb.startDaemon();
+    } catch (e) {
+      log.warn('ADB daemon start failed; error ignored', e);
+    }
+  }
+
+  async _killAdbDaemon() {
+    try {
+      await this._adb.killDaemon();
+    } catch (e) {
+      log.warn('ADB daemon kill failed; error ignored', e);
     }
   }
 }

--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
@@ -55,7 +55,7 @@ class GenyAllocDriver {
     const recipe = await this._recipeQuerying.getRecipeFromQuery(deviceQuery);
     this._assertRecipe(deviceQuery, recipe);
 
-    await this._initAdbDaemon();
+    await this._startAdbDaemon();
 
     let instance = this._genyRegistry.findFreeInstance(recipe);
     if (!instance) {
@@ -156,7 +156,7 @@ class GenyAllocDriver {
     }
   }
 
-  async _initAdbDaemon() {
+  async _startAdbDaemon() {
     const _startDaemon = async () => {
       try {
         log.info(events.GENYCLOUD_INIT, 'Starting ADB daemon...');

--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
@@ -54,7 +54,6 @@ class GenyAllocDriver {
    * @return {Promise<GenycloudEmulatorCookie>}
    */
   async allocate(deviceConfig) {
-    await new Promise((resolve) => setTimeout(resolve, 10000));
     const deviceQuery = deviceConfig.device;
     const recipe = await this._recipeQuerying.getRecipeFromQuery(deviceQuery);
     this._assertRecipe(deviceQuery, recipe);

--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
@@ -40,6 +40,10 @@ class GenyAllocDriver {
     this._instanceCounter = 0;
   }
 
+  async init() {
+    await this._adb.startDaemon();
+  }
+
   /**
    * @param deviceConfig { Object }
    * @return {Promise<GenycloudEmulatorCookie>}

--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
@@ -55,7 +55,7 @@ class GenyAllocDriver {
     const recipe = await this._recipeQuerying.getRecipeFromQuery(deviceQuery);
     this._assertRecipe(deviceQuery, recipe);
 
-    await this._startAdbDaemon();
+    await this._initAdbDaemon();
 
     let instance = this._genyRegistry.findFreeInstance(recipe);
     if (!instance) {
@@ -156,7 +156,7 @@ class GenyAllocDriver {
     }
   }
 
-  async _startAdbDaemon() {
+  async _initAdbDaemon() {
     const _startDaemon = async () => {
       try {
         log.info(events.GENYCLOUD_INIT, 'Starting ADB daemon...');

--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
@@ -10,7 +10,6 @@ const log = require('../../../../../utils/logger').child({ cat: 'device' });
 const GenyRegistry = require('./GenyRegistry');
 
 const events = {
-  GENYCLOUD_INIT: { event: 'GENYCLOUD_INIT' },
   GENYCLOUD_TEARDOWN: { event: 'GENYCLOUD_TEARDOWN' },
 };
 
@@ -18,10 +17,6 @@ const events = {
  * @implements {AllocationDriverBase}
  */
 class GenyAllocDriver {
-
-  /** @type { Promise<any> | null } */
-  static _adbDaemonStart = null;
-
   /**
    * @param {object} options
    * @param {import('../../../../common/drivers/android/exec/ADB')} options.adb
@@ -45,6 +40,10 @@ class GenyAllocDriver {
     this._instanceCounter = 0;
   }
 
+  async init() {
+    await this._startAdbDaemon();
+  }
+
   /**
    * @param deviceConfig { Object }
    * @return {Promise<GenycloudEmulatorCookie>}
@@ -54,8 +53,6 @@ class GenyAllocDriver {
     const deviceQuery = deviceConfig.device;
     const recipe = await this._recipeQuerying.getRecipeFromQuery(deviceQuery);
     this._assertRecipe(deviceQuery, recipe);
-
-    await this._initAdbDaemon();
 
     let instance = this._genyRegistry.findFreeInstance(recipe);
     if (!instance) {
@@ -122,6 +119,8 @@ class GenyAllocDriver {
 
     const deletionLeaks = (await Promise.all(killPromises)).filter(Boolean);
     this._reportGlobalCleanupSummary(deletionLeaks);
+
+    await this._killAdbDaemon();
   }
 
   emergencyCleanup() {
@@ -156,20 +155,20 @@ class GenyAllocDriver {
     }
   }
 
-  async _initAdbDaemon() {
-    const _startDaemon = async () => {
-      try {
-        log.info(events.GENYCLOUD_INIT, 'Starting ADB daemon...');
-        await this._adb.startDaemon();
-      } catch (e) {
-        log.warn('ADB daemon start failed; error ignored', e);
-      }
-    };
-
-    if (GenyAllocDriver._adbDaemonStart === null) {
-      GenyAllocDriver._adbDaemonStart = _startDaemon();
+  async _startAdbDaemon() {
+    try {
+      await this._adb.startDaemon();
+    } catch (e) {
+      log.warn('ADB daemon start failed; error ignored', e);
     }
-    await GenyAllocDriver._adbDaemonStart;
+  }
+
+  async _killAdbDaemon() {
+    try {
+      await this._adb.killDaemon();
+    } catch (e) {
+      log.warn('ADB daemon kill failed; error ignored', e);
+    }
   }
 }
 

--- a/detox/src/devices/common/drivers/android/exec/ADB.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.js
@@ -16,6 +16,10 @@ class ADB {
     this.adbBin = getAdbPath();
   }
 
+  async startDaemon() {
+    await this.adbCmd('', 'start-server');
+  }
+
   async devices() {
     const { stdout } = await this.adbCmd('', 'devices', { verbosity: 'high' });
     /** @type {DeviceHandle[]} */

--- a/detox/src/devices/common/drivers/android/exec/ADB.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.js
@@ -20,10 +20,6 @@ class ADB {
     await this.adbCmd('', 'start-server', { retries: 0, verbosity: 'high' });
   }
 
-  async killDaemon() {
-    await this.adbCmd('', 'kill-server', { retries: 0, verbosity: 'high' });
-  }
-
   async devices() {
     const { stdout } = await this.adbCmd('', 'devices', { verbosity: 'high' });
     /** @type {DeviceHandle[]} */

--- a/detox/src/devices/common/drivers/android/exec/ADB.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.js
@@ -17,7 +17,11 @@ class ADB {
   }
 
   async startDaemon() {
-    await this.adbCmd('', 'start-server');
+    await this.adbCmd('', 'start-server', { retries: 0, verbosity: 'high' });
+  }
+
+  async killDaemon() {
+    await this.adbCmd('', 'kill-server', { retries: 0, verbosity: 'high' });
   }
 
   async devices() {

--- a/detox/src/devices/common/drivers/android/exec/ADB.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.js
@@ -20,6 +20,10 @@ class ADB {
     await this.adbCmd('', 'start-server', { retries: 0, verbosity: 'high' });
   }
 
+  async killDaemon() {
+    await this.adbCmd('', 'kill-server', { retries: 0, verbosity: 'high' });
+  }
+
   async devices() {
     const { stdout } = await this.adbCmd('', 'devices', { verbosity: 'high' });
     /** @type {DeviceHandle[]} */

--- a/detox/src/devices/common/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.test.js
@@ -86,7 +86,12 @@ describe('ADB', () => {
   describe('ADB Daemon (server)', () => {
     it('should start the daemon', async () => {
       await adb.startDaemon();
-      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  start-server`, { retries: 1 });
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  start-server`, { retries: 0, verbosity: 'high' });
+    });
+
+    it('should kill the daemon', async () => {
+      await adb.killDaemon();
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  kill-server`, { retries: 0, verbosity: 'high' });
     });
   });
 

--- a/detox/src/devices/common/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.test.js
@@ -88,11 +88,6 @@ describe('ADB', () => {
       await adb.startDaemon();
       expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  start-server`, { retries: 0, verbosity: 'high' });
     });
-
-    it('should kill the daemon', async () => {
-      await adb.killDaemon();
-      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  kill-server`, { retries: 0, verbosity: 'high' });
-    });
   });
 
   it('should await device boot', async () => {

--- a/detox/src/devices/common/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.test.js
@@ -83,6 +83,13 @@ describe('ADB', () => {
     });
   });
 
+  describe('ADB Daemon (server)', () => {
+    it('should start the daemon', async () => {
+      await adb.startDaemon();
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  start-server`, { retries: 1 });
+    });
+  });
+
   it('should await device boot', async () => {
     await adb.waitForDevice(deviceId);
 

--- a/detox/src/devices/common/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.test.js
@@ -88,6 +88,11 @@ describe('ADB', () => {
       await adb.startDaemon();
       expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  start-server`, { retries: 0, verbosity: 'high' });
     });
+
+    it('should kill the daemon', async () => {
+      await adb.killDaemon();
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  kill-server`, { retries: 0, verbosity: 'high' });
+    });
   });
 
   it('should await device boot', async () => {


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: N/A

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have introduced a preliminary `adb start-server` command to the Genymotion-cloud case.

This comes as a potential workaround for some instabilities that we've seen which seem to stem from the daemon being down during initial `gmsaas adbconnect` command.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
