### PR TITLE
Genycloud debug: ADB devices dump before each adbconnect retry

### DIFF
--- a/detox/src/devices/allocation/drivers/android/genycloud/exec/GenyCloudExec.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/exec/GenyCloudExec.js
@@ -28,7 +28,7 @@ class GenyCloudExec {
   }
 
   adbConnect(instanceUUID) {
-    return this._exec(`instances adbconnect ${instanceUUID}`);
+    return this._exec(`instances adbconnect ${instanceUUID}`, { retries: 0 });
   }
 
   stopInstance(instanceUUID) {

--- a/detox/src/devices/allocation/drivers/android/genycloud/exec/GenyCloudExec.test.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/exec/GenyCloudExec.test.js
@@ -46,9 +46,9 @@ describe('Genymotion-cloud executable', () => {
     ['Get Instance', () => uut.getInstance(instanceUUID), `"mock/path/to/gmsaas" --format compactjson instances get ${instanceUUID}`],
     ['Get Instances', () => uut.getInstances(), `"mock/path/to/gmsaas" --format compactjson instances list -q`],
     ['Start Instance', () => uut.startInstance(recipeUUID, instanceName), `"mock/path/to/gmsaas" --format compactjson instances start --no-wait ${recipeUUID} "${instanceName}"`, { retries: 0 }],
-    ['ADB Connect', () => uut.adbConnect(instanceUUID), `"mock/path/to/gmsaas" --format compactjson instances adbconnect ${instanceUUID}`],
+    ['ADB Connect', () => uut.adbConnect(instanceUUID), `"mock/path/to/gmsaas" --format compactjson instances adbconnect ${instanceUUID}`, { retries: 0 }],
     ['Stop Instance', () => uut.stopInstance(instanceUUID), `"mock/path/to/gmsaas" --format compactjson instances stop ${instanceUUID}`, { retries: 3 }],
-])(`%s command`, (commandName, commandExecFn, expectedExec, expectedExecOptions) => {
+  ])(`%s command`, (commandName, commandExecFn, expectedExec, expectedExecOptions) => {
     it('should execute command by name', async () => {
       givenSuccessResult();
 

--- a/detox/src/devices/allocation/drivers/android/genycloud/services/GenyInstanceLifecycleService.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/services/GenyInstanceLifecycleService.js
@@ -1,8 +1,16 @@
+const log = require('../../../../../../utils/logger').child({ cat: 'device' });
+const retry = require('../../../../../../utils/retry');
+
 const Instance = require('./dto/GenyInstance');
 
 class GenyInstanceLifecycleService {
-  constructor(genyCloudExec) {
+  /**
+   * @param { import('../exec/GenyCloudExec') } genyCloudExec
+   * @param { import('../../../../../common/drivers/android/exec/ADB') } adb
+   */
+  constructor(genyCloudExec, adb) {
     this._genyCloudExec = genyCloudExec;
+    this._adb = adb;
   }
 
   async createInstance(recipeUUID, instanceName) {
@@ -10,8 +18,24 @@ class GenyInstanceLifecycleService {
     return new Instance(result.instance);
   }
 
-  async adbConnectInstance(instanceUUID) {
-    const result = (await this._genyCloudExec.adbConnect(instanceUUID));
+  async adbConnectInstance(instanceUUID){
+    const doAdbConnect = async () =>
+      this._genyCloudExec.adbConnect(instanceUUID);
+    const beforeEachRetry = async () => {
+      try {
+        const { stdout } = await this._adb.devices({ retries: 0, verbosity: 'low' });
+        log.warn('adb-connect command failed, current ADB devices list:\n', stdout);
+      } catch (e) {
+        log.warn('adb-connect command failed; couldn\'t get the list of current devices (see error)', e);
+      }
+      return true;
+    };
+    const options = {
+      conditionFn: beforeEachRetry,
+      retries: 2,
+    };
+
+    const result = await retry(options, doAdbConnect);
     return new Instance(result.instance);
   }
 

--- a/detox/src/devices/allocation/factories/android.js
+++ b/detox/src/devices/allocation/factories/android.js
@@ -66,7 +66,7 @@ class Genycloud extends DeviceAllocatorFactory {
     const recipeService = new RecipesService(exec);
 
     const InstanceLifecycleService = require('../drivers/android/genycloud/services/GenyInstanceLifecycleService');
-    const instanceLifecycleService = new InstanceLifecycleService(exec);
+    const instanceLifecycleService = new InstanceLifecycleService(exec, adb);
 
     const RecipeQuerying = require('../drivers/android/genycloud/GenyRecipeQuerying');
     const recipeQuerying = new RecipeQuerying(recipeService);

--- a/detox/src/devices/common/drivers/android/exec/ADB.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.js
@@ -20,12 +20,8 @@ class ADB {
     await this.adbCmd('', 'start-server', { retries: 0, verbosity: 'high' });
   }
 
-  async killDaemon() {
-    await this.adbCmd('', 'kill-server', { retries: 0, verbosity: 'high' });
-  }
-
-  async devices() {
-    const { stdout } = await this.adbCmd('', 'devices', { verbosity: 'high' });
+  async devices(options) {
+    const { stdout } = await this.adbCmd('', 'devices', { verbosity: 'high', ...options });
     /** @type {DeviceHandle[]} */
     const devices = _.chain(stdout)
       .trim()

--- a/detox/src/devices/common/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.test.js
@@ -81,17 +81,22 @@ describe('ADB', () => {
       const { devices } = await adb.devices();
       expect(devices.length).toEqual(0);
     });
+
+    it(`should allow for option overrides`, async () => {
+      const options = {
+        retries: 100,
+        verbosity: 'low',
+      };
+
+      await adb.devices(options);
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(expect.any(String), options);
+    });
   });
 
   describe('ADB Daemon (server)', () => {
     it('should start the daemon', async () => {
       await adb.startDaemon();
       expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  start-server`, { retries: 0, verbosity: 'high' });
-    });
-
-    it('should kill the daemon', async () => {
-      await adb.killDaemon();
-      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(`"${adbBinPath}"  kill-server`, { retries: 0, verbosity: 'high' });
     });
   });
 


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: N/A

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have injected an `adb device` output logging for whenever an `adbconnect` fails. This is meant to help debug recently occurring issues associated with `gmsaas adbconnect`.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
