### PR TITLE
fix(local-cli): respect detox build --if-missing for multi-app builds

### DIFF
--- a/detox/local-cli/build.test.js
+++ b/detox/local-cli/build.test.js
@@ -64,6 +64,32 @@ describe('build', () => {
     expect(detox.log.info).toHaveBeenCalledWith('Skipping build for "default" app...');
   });
 
+  it('should not skip building the app if the test binary does not exist', async () => {
+    detox.config.apps.default = { binaryPath: __filename, testBinaryPath: __filename + '.doesnotexist' };
+    detox.config.commands = [{ appName: 'default', build: 'yet another command' }];
+
+    await callCli('./build', 'build --if-missing');
+    expect(execSync).toHaveBeenCalled();
+  });
+
+  it('skips building the multi-app build command if all apps exist and --if-missing flag is set', async () => {
+    detox.config.apps.app1 = { binaryPath: __filename };
+    detox.config.apps.app2 = { binaryPath: __filename };
+    detox.config.commands = [
+      { build: 'yet another command' },
+      { appName: 'app1' },
+      { appName: 'app2' },
+    ];
+
+    await callCli('./build', 'build -i');
+    expect(execSync).not.toHaveBeenCalled();
+
+    await callCli('./build', 'build --if-missing');
+    expect(execSync).not.toHaveBeenCalled();
+
+    expect(detox.log.info).toHaveBeenCalledWith('Skipping build...');
+  });
+
   it('fails with an error if a build script has not been found', async () => {
     detox.config.apps.default = {};
     detox.config.commands = [{ appName: 'default', start: 'a command' }];


### PR DESCRIPTION
## Description

Makes `detox build` respect `--if-missing` flag for missing `testBinaryPath`'s, and also for multi-app build commands.