### PR TITLE
fix(local-cli): respect detox build --if-missing for multi-app builds

### DIFF
--- a/detox/local-cli/build.js
+++ b/detox/local-cli/build.js
@@ -34,20 +34,20 @@ module.exports.builder = {
   },
 };
 
-function checkAppsExist(appsConfig, commands) {
+function checkWhichAppsExist(appsConfig) {
   const result = { '*': true };
 
-  for (const { appName } of commands) {
-    if (appName) {
-      result[appName] = true;
+  for (const appName of Object.keys(appsConfig)) {
+    result[appName] = true;
 
-      const app = appsConfig[appName] || {};
-      if (app.binaryPath && !fs.existsSync(app.binaryPath)) {
-        result[appName] = result['*'] = false;
-      }
-      if (app.testBinaryPath && !fs.existsSync(app.testBinaryPath)) {
-        result[appName] = result['*'] = false;
-      }
+    /* istanbul ignore next */
+    const app = appsConfig[appName] || {};
+    if (app.binaryPath && !fs.existsSync(app.binaryPath)) {
+      result[appName] = result['*'] = false;
+    }
+
+    if (app.testBinaryPath && !fs.existsSync(app.testBinaryPath)) {
+      result[appName] = result['*'] = false;
     }
   }
 
@@ -56,7 +56,7 @@ function checkAppsExist(appsConfig, commands) {
 
 module.exports.handler = async function build(argv) {
   const { apps, commands, errorComposer } = await detox.resolveConfig({ argv });
-  const appsExist = checkAppsExist(apps, commands);
+  const appsExist = checkWhichAppsExist(apps);
 
   let seenBuildCommands = false;
 

--- a/detox/local-cli/build.test.js
+++ b/detox/local-cli/build.test.js
@@ -77,8 +77,6 @@ describe('build', () => {
     detox.config.apps.app2 = { binaryPath: __filename };
     detox.config.commands = [
       { build: 'yet another command' },
-      { appName: 'app1' },
-      { appName: 'app2' },
     ];
 
     await callCli('./build', 'build -i');
@@ -88,6 +86,18 @@ describe('build', () => {
     expect(execSync).not.toHaveBeenCalled();
 
     expect(detox.log.info).toHaveBeenCalledWith('Skipping build...');
+  });
+
+  it('should not skip building the multi-app build command if one app does not exist', async () => {
+    detox.config.apps.app1 = { binaryPath: __filename };
+    detox.config.apps.app2 = { binaryPath: __filename + '.doesnotexist' };
+    detox.config.commands = [
+      { build: 'yet another command' },
+    ];
+
+    await callCli('./build', 'build --if-missing');
+    expect(execSync).toHaveBeenCalled();
+    expect(detox.log.info).not.toHaveBeenCalledWith('Skipping build...');
   });
 
   it('fails with an error if a build script has not been found', async () => {


### PR DESCRIPTION
## Description

Makes `detox build` respect `--if-missing` flag for missing `testBinaryPath`'s, and also for multi-app build commands.