### PR TITLE
fix(iOS): active app under test on XCUITest interaction.

### DIFF
--- a/detox/ios/DetoxXCUITestRunner/DetoxXCUITestRunner/DetoxXCUITestRunner.swift
+++ b/detox/ios/DetoxXCUITestRunner/DetoxXCUITestRunner/DetoxXCUITestRunner.swift
@@ -16,11 +16,14 @@ final class DetoxXCUITestRunner: XCTestCase {
   }
 
   func testRunner() throws {
+    let appUnderTest = try XCUIApplication.appUnderTest()
+    appUnderTest.activate()
+
     let params = try InvocationParamsReader.readParams()
 
     let predicateHandler = PredicateHandler(
       springboardApp: XCUIApplication.springboard,
-      appUnderTest: try XCUIApplication.appUnderTest()
+      appUnderTest: appUnderTest
     )
 
     let element = predicateHandler.findElement(using: params)


### PR DESCRIPTION
This update ensures the app-under-test remains active and prevents device locks during each launch of the XCUITest runner process.


```swift
/*!
 * Activates the application synchronously. On return the application is ready to handle events.
 * If the application was not running prior, it will be launched automatically. If the application
 * would be launched as a result of this method and was previously launched via -launch, the launch
 * arguments and environment variables that were used then will be supplied again for the new launch.
 *
 * Unlike -launch, if the application is already running this call will not terminate the existing
 * instance.
 *
 * Any failure in the activation or launch sequence will be reported as a test failure and the test
 * will be halted at that point.
*/
- (void)activate;
```