### PR TITLE
build: run xcodebuild in isolated env.

### DIFF
--- a/detox/scripts/build_xcuitest.ios.sh
+++ b/detox/scripts/build_xcuitest.ios.sh
@@ -15,4 +15,4 @@ mkdir -p "${XCUITEST_OUTPUT_DIR}"
 
 # Build Simulator version
 
-xcodebuild -project "${XCODEPROJ}" -scheme "${PROJECT_NAME}" -UseNewBuildSystem="YES" -configuration "${CONFIGURATION}" -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath "${XCUITEST_OUTPUT_DIR}" build-for-testing -quiet
+env -i bash -c "xcodebuild -project \"${XCODEPROJ}\" -scheme \"${PROJECT_NAME}\" -UseNewBuildSystem=\"YES\" -configuration \"${CONFIGURATION}\" -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath \"${XCUITEST_OUTPUT_DIR}\" build-for-testing -quiet"


### PR DESCRIPTION
`env -i bash -c <command>` runs the specified command in an isolated environment with no inherited environment variables.

- **`env -i`**: Starts a command with an empty environment, ignoring all inherited environment variables.
- **`bash -c`**: Executes a given command string in a new `bash` shell instance.

I've tested this locally on our xcodebuild with @igorgn 👑 