### PR TITLE
fix: avoid duplicated declaration error on xml generation.

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/hierarchy/ViewHierarchyGenerator.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/hierarchy/ViewHierarchyGenerator.kt
@@ -16,10 +16,10 @@ import kotlin.coroutines.resume
 
 
 private const val GET_HTML_SCRIPT = """
+(function() {
     const blacklistedTags = ['script', 'style', 'head', 'meta'];
     const blackListedTagsSelector = blacklistedTags.join(',');
 
-    (function() {
     // Clone the entire document
     var clonedDoc = document.documentElement.cloneNode(true);
 

--- a/detox/ios/Detox/Utilities/ViewHierarchyGenerator.swift
+++ b/detox/ios/Detox/Utilities/ViewHierarchyGenerator.swift
@@ -11,10 +11,10 @@ import UIKit
 import WebKit
 
 private let GET_HTML_SCRIPT = """
+    (function() {
     const blacklistedTags = ['script', 'style', 'head', 'meta'];
     const blackListedTagsSelector = blacklistedTags.join(',');
 
-    (function() {
     // Clone the entire document
     var clonedDoc = document.documentElement.cloneNode(true);
 

--- a/detox/test/e2e/06.device.view-hierarchy.test.js
+++ b/detox/test/e2e/06.device.view-hierarchy.test.js
@@ -1,5 +1,7 @@
 const {expectViewHierarchySnapshotToMatch} = require("./utils/snapshot");
 
+const jestExpect = require('expect').default;
+
 describe('generate view hierarchy', () => {
   beforeAll(async () => {
     await device.launchApp();
@@ -25,5 +27,14 @@ describe('generate view hierarchy', () => {
     await element(by.text('WebView')).tap();
     const hierarchy = await device.generateViewHierarchyXml();
     await expectViewHierarchySnapshotToMatch(hierarchy, `view-hierarchy-web-view`);
+  });
+
+  it('generateViewHierarchyXml() - should generate consistent consecutive view hierarchies', async () => {
+    await element(by.text('WebView')).tap();
+
+    const hierarchy1 = await device.generateViewHierarchyXml();
+    const hierarchy2 = await device.generateViewHierarchyXml();
+
+    jestExpect(hierarchy1).toEqual(hierarchy2);
   });
 });


### PR DESCRIPTION
Fixing a JS error when injecting JS to webviews to generate XML view hierarchy.
The declarations are now made inside the injected JS function and not on the higher scope.