### PR TITLE
fix(iOS): clamp Double values before converting to Integer.

### DIFF
--- a/detox/ios/Detox/Utilities/ViewHierarchyGenerator.swift
+++ b/detox/ios/Detox/Utilities/ViewHierarchyGenerator.swift
@@ -129,8 +129,8 @@ struct ViewHierarchyGenerator {
     ) -> String {
         var attributes: [String: String] = [
             "class": "\(type(of: view))",
-            "width": "\(Int(view.frame.size.width))",
-            "height": "\(Int(view.frame.size.height))",
+            "width": "\(toClampedInt(view.frame.size.width))",
+            "height": "\(toClampedInt(view.frame.size.height))",
             "visibility": view.isHidden ? "invisible" : "visible",
             "alpha": "\(view.alpha)",
             "focused": "\(view.isFocused)",
@@ -144,8 +144,9 @@ struct ViewHierarchyGenerator {
 
         if let superview = view.superview {
             let location = view.convert(view.bounds.origin, to: superview)
-            attributes["x"] = "\(Int(location.x))"
-            attributes["y"] = "\(Int(location.y))"
+            // todo: error
+            attributes["x"] = "\(toClampedInt(location.x))"
+            attributes["y"] = "\(toClampedInt(location.y))"
         }
 
         if shouldInjectIdentifiers {
@@ -220,4 +221,8 @@ class WebViewHandler: NSObject, WKNavigationDelegate {
             loadCompletion?(.failure(error))
         }
     }
+}
+
+func toClampedInt(_ value: Double) -> Int {
+    return Int(min(max(value, Double(Int.min)), Double(Int.max)))
 }


### PR DESCRIPTION
After investigation, I discovered that when `UIDatePicker` is set to `UIDatePickerStyle.wheels` (Spinner mode), it assigns unusual coordinate values for off-screen wheel cells (falling below `Int.min` and above `Int.max`). This leads to a conversion error in `ViewHierarchyGenerator` when attempting to cast these `Double` values to `Int`, resulting in:

```
Double value cannot be converted to Int because the result would be less than Int.min
```

To address this, I kept the `Int` conversion but applied clamping (instead of representing it as a `Double` in the string) for the following reasons:

- Double values can be excessively long, adding unnecessary complexity to the view hierarchy.
- On 32-bit systems, `Int` ranges from -2,147,483,648 to 2,147,483,647, and on 64-bit systems, from -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807, indicating an internal issue with these extreme values.
- Any element positioned outside standard `Int` bounds is irrelevant to our use case, so these values can safely be ignored without impacting functionality.