### PR TITLE
build(fix): avoid overriding the git remote url.

### DIFF
--- a/scripts/ci.release.js
+++ b/scripts/ci.release.js
@@ -28,8 +28,6 @@ function setupGitConfig() {
   exec.execSyncSilent(`git config --global push.default simple`);
   exec.execSyncSilent(`git config --global user.email "${process.env.GIT_EMAIL}"`);
   exec.execSyncSilent(`git config --global user.name "${process.env.GIT_USER}"`);
-  const remoteUrl = new RegExp(`https?://(\\S+)`).exec(exec.execSyncRead(`git remote -v`))[1];
-  exec.execSyncSilent(`git remote set-url origin "https://${process.env.GIT_USER}:${process.env.GIT_TOKEN}@${remoteUrl}"`);
 }
 
 function setupNpmConfig() {


### PR DESCRIPTION
Git repo is now being cloned with SSH instead of HTTPS.