### PR TITLE
Alleviate geny-cloud failures due to network hiccups

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "detox",
   "description": "E2E tests and automation for mobile",
-  "version": "20.32.0",
+  "version": "20.32.1-smoke.0",
   "bin": {
     "detox": "local-cli/cli.js"
   },

--- a/detox/package.json
+++ b/detox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "detox",
   "description": "E2E tests and automation for mobile",
-  "version": "20.32.1-smoke.0",
+  "version": "20.32.1-smoke.1",
   "bin": {
     "detox": "local-cli/cli.js"
   },

--- a/detox/src/devices/common/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.test.js
@@ -131,7 +131,7 @@ describe('ADB', () => {
   it('should install with proper spawning/retry options', async () => {
     const expectedOptions = {
       retries: 3,
-      timeout: 45000,
+      timeout: 60000,
       capture: ['stdout'],
     };
     await adb.install(deviceId, 'path/to/bin.apk');
@@ -139,9 +139,44 @@ describe('ADB', () => {
     expect(spawnWithRetriesAndLogs).toHaveBeenCalledWith(expect.any(String), expect.any(Array), expectedOptions);
   });
 
+  it('show allow for installing with external exec and install options', async () => {
+    adb.defaultExecOptions = {
+      retries: 66,
+      interval: 123123,
+    };
+    // Expect to override the default options
+    adb.installOptions = {
+      retries: 99,
+      timeout: 1337,
+    };
+    await adb.install(deviceId, 'dont-care/path');
+    expect(spawnWithRetriesAndLogs).toHaveBeenCalledWith(expect.any(String), expect.any(Array), expect.objectContaining({
+      retries: 99,
+      interval: 123123,
+      timeout: 1337,
+    }));
+  });
+
   it(`uninstall`, async () => {
     await adb.uninstall('com.package');
     expect(execWithRetriesAndLogs).toHaveBeenCalledTimes(1);
+  });
+
+  it('show allow for uninstalling with external exec options', async () => {
+    adb.defaultExecOptions = {
+      retries: 66,
+      interval: 123123,
+    };
+    // Expect to be ignored
+    adb.installOptions = {
+      retries: 99,
+      timeout: 1337,
+    };
+    await adb.uninstall('com.dontcare');
+    expect(execWithRetriesAndLogs).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+      retries: 66,
+      interval: 123123,
+    }));
   });
 
   it(`terminate`, async () => {
@@ -211,7 +246,7 @@ describe('ADB', () => {
   it('should remote-install with proper spawning/retry options', async () => {
     const expectedOptions = {
       retries: 3,
-      timeout: 45000,
+      timeout: 60000,
       capture: ['stdout'],
     };
     const binaryPath = '/mock-path/filename.mock';

--- a/detox/src/devices/runtime/drivers/android/genycloud/GenyCloudDriver.js
+++ b/detox/src/devices/runtime/drivers/android/genycloud/GenyCloudDriver.js
@@ -19,6 +19,12 @@ class GenyCloudDriver extends AndroidDriver {
   constructor(deps, { adbName, name }) {
     super(deps, { adbName });
 
+    // Make ADB more resilient to network latency and connection hiccups
+    this.adb.defaultExecOptions = {
+      retries: 5,
+      interval: 3000,
+      backoff: 'linear',
+    };
     this._instanceName = name;
   }
 

--- a/detox/src/devices/runtime/drivers/android/genycloud/GenyCloudDriver.test.js
+++ b/detox/src/devices/runtime/drivers/android/genycloud/GenyCloudDriver.test.js
@@ -6,6 +6,8 @@ describe('Genymotion-cloud driver', () => {
   });
 
   /** @type {jest.Mocked<*>} */
+  let adb;
+  /** @type {jest.Mocked<*>} */
   let aapt;
   /** @type {jest.Mocked<*>} */
   let eventEmitter;
@@ -21,6 +23,10 @@ describe('Genymotion-cloud driver', () => {
   let detoxGenymotionManager;
 
   beforeEach(() => {
+    jest.mock('../../../../common/drivers/android/exec/ADB');
+    const ADB = jest.requireMock('../../../../common/drivers/android/exec/ADB');
+    adb = new ADB();
+
     jest.mock('../../../../common/drivers/android/exec/AAPT');
     const AAPT = jest.requireMock('../../../../common/drivers/android/exec/AAPT');
     aapt = new AAPT();
@@ -58,8 +64,10 @@ describe('Genymotion-cloud driver', () => {
     let GenyCloudDriver;
     let uut;
     beforeEach(() => {
+      adb.defaultExecOptions = {};
       GenyCloudDriver = require('./GenyCloudDriver');
       uut = new GenyCloudDriver({
+        adb,
         aapt,
         apkValidator,
         invocationManager,
@@ -68,6 +76,14 @@ describe('Genymotion-cloud driver', () => {
         appInstallHelper,
         instrumentation,
       }, aCookie());
+    });
+
+    it('should ease the default ADB exec options with more cloud-suitable settings', () => {
+      expect(adb.defaultExecOptions).toEqual({
+        retries: 5,
+        interval: 3000,
+        backoff: 'linear',
+      });
     });
 
     it('should return the adb-name as the external ID', () => {

--- a/detox/src/utils/childProcess/exec.js
+++ b/detox/src/utils/childProcess/exec.js
@@ -12,6 +12,7 @@ async function execWithRetriesAndLogs(bin, options = {}) {
   const {
     retries = 9,
     interval = 1000,
+    backoff,
     prefix = null,
     args = null,
     timeout,
@@ -30,7 +31,7 @@ async function execWithRetriesAndLogs(bin, options = {}) {
   try {
     logger.debug({ event: 'EXEC_CMD' }, `${cmd}`);
 
-    await retry({ retries, interval }, async (tryNumber, lastError) => {
+    await retry({ retries, interval, backoff }, async (tryNumber, lastError) => {
       if (statusLogs.trying) {
         _logExecTrying(logger, statusLogs.trying, tryNumber, lastError);
       } else if (statusLogs.retrying) {

--- a/detox/src/utils/childProcess/spawn.js
+++ b/detox/src/utils/childProcess/spawn.js
@@ -26,11 +26,12 @@ async function spawnWithRetriesAndLogs(binary, flags, options = {}) {
   const {
     retries = 1,
     interval = 100,
+    backoff = 'none',
     ...spawnOptions
   } = _options;
 
   let result;
-  await retry({ retries, interval }, async (tryCount, lastError) => {
+  await retry({ retries, interval, backoff }, async (tryCount, lastError) => {
     _logSpawnRetrying(logger, tryCount, lastError);
     result = await _spawnAndLog(logger, binary, flags, command, spawnOptions, tryCount);
   });

--- a/detox/src/utils/childProcess/spawn.test.js
+++ b/detox/src/utils/childProcess/spawn.test.js
@@ -167,7 +167,7 @@ describe('Spawn utils', () => {
 
       it('should retry once, by default', async () => {
         await spawn.spawnWithRetriesAndLogs(command, flags);
-        expect(retry).toHaveBeenCalledWith({ retries: 1, interval: 100 }, expect.any(Function));
+        expect(retry).toHaveBeenCalledWith(expect.objectContaining({ retries: 1, interval: 100 }), expect.any(Function));
       });
 
       it('should log retry attempts', async () => {
@@ -194,8 +194,9 @@ describe('Spawn utils', () => {
       it('should honor retry options', async () => {
         const retries = 456456;
         const interval = 123123;
-        await spawn.spawnWithRetriesAndLogs(command, flags, { retries, interval });
-        expect(retry).toHaveBeenCalledWith({ retries, interval }, expect.any(Function));
+        const backoff = 'linear';
+        await spawn.spawnWithRetriesAndLogs(command, flags, { retries, interval, backoff });
+        expect(retry).toHaveBeenCalledWith({ retries, interval, backoff }, expect.any(Function));
       });
 
       it('should honor output-capturing options, but force stderr', async () => {

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-test",
-  "version": "20.32.1-smoke.0",
+  "version": "20.32.1-smoke.1",
   "private": true,
   "engines": {
     "node": ">=18"
@@ -65,7 +65,7 @@
     "@typescript-eslint/parser": "^6.16.0",
     "axios": "^1.7.7",
     "cross-env": "^7.0.3",
-    "detox": "^20.32.1-smoke.0",
+    "detox": "^20.32.1-smoke.1",
     "detox-allure2-adapter": "^1.0.0-alpha.8",
     "eslint": "^8.56.0",
     "eslint-plugin-unicorn": "^50.0.1",

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-test",
-  "version": "20.32.0",
+  "version": "20.32.1-smoke.0",
   "private": true,
   "engines": {
     "node": ">=18"
@@ -65,7 +65,7 @@
     "@typescript-eslint/parser": "^6.16.0",
     "axios": "^1.7.7",
     "cross-env": "^7.0.3",
-    "detox": "^20.32.0",
+    "detox": "^20.32.1-smoke.0",
     "detox-allure2-adapter": "^1.0.0-alpha.8",
     "eslint": "^8.56.0",
     "eslint-plugin-unicorn": "^50.0.1",

--- a/examples/demo-native-android/package.json
+++ b/examples/demo-native-android/package.json
@@ -1,13 +1,13 @@
 {
   "name": "detox-demo-native-android",
-  "version": "20.32.0",
+  "version": "20.32.1-smoke.0",
   "private": true,
   "scripts": {
     "packager": "react-native start",
     "detox-server": "detox run-server"
   },
   "devDependencies": {
-    "detox": "^20.32.0"
+    "detox": "^20.32.1-smoke.0"
   },
   "detox": {}
 }

--- a/examples/demo-native-android/package.json
+++ b/examples/demo-native-android/package.json
@@ -1,13 +1,13 @@
 {
   "name": "detox-demo-native-android",
-  "version": "20.32.1-smoke.0",
+  "version": "20.32.1-smoke.1",
   "private": true,
   "scripts": {
     "packager": "react-native start",
     "detox-server": "detox run-server"
   },
   "devDependencies": {
-    "detox": "^20.32.1-smoke.0"
+    "detox": "^20.32.1-smoke.1"
   },
   "detox": {}
 }

--- a/examples/demo-native-ios/package.json
+++ b/examples/demo-native-ios/package.json
@@ -1,9 +1,9 @@
 {
   "name": "detox-demo-native-ios",
-  "version": "20.32.1-smoke.0",
+  "version": "20.32.1-smoke.1",
   "private": true,
   "devDependencies": {
-    "detox": "^20.32.1-smoke.0"
+    "detox": "^20.32.1-smoke.1"
   },
   "detox": {
     "specs": "",

--- a/examples/demo-native-ios/package.json
+++ b/examples/demo-native-ios/package.json
@@ -1,9 +1,9 @@
 {
   "name": "detox-demo-native-ios",
-  "version": "20.32.0",
+  "version": "20.32.1-smoke.0",
   "private": true,
   "devDependencies": {
-    "detox": "^20.32.0"
+    "detox": "^20.32.1-smoke.0"
   },
   "detox": {
     "specs": "",

--- a/examples/demo-plugin/package.json
+++ b/examples/demo-plugin/package.json
@@ -1,12 +1,12 @@
 {
   "name": "demo-plugin",
-  "version": "20.32.0",
+  "version": "20.32.1-smoke.0",
   "private": true,
   "scripts": {
     "test:plugin": "detox test --configuration plugin -l verbose"
   },
   "devDependencies": {
-    "detox": "^20.32.0",
+    "detox": "^20.32.1-smoke.0",
     "jest": "^29.0.0"
   },
   "detox": {

--- a/examples/demo-plugin/package.json
+++ b/examples/demo-plugin/package.json
@@ -1,12 +1,12 @@
 {
   "name": "demo-plugin",
-  "version": "20.32.1-smoke.0",
+  "version": "20.32.1-smoke.1",
   "private": true,
   "scripts": {
     "test:plugin": "detox test --configuration plugin -l verbose"
   },
   "devDependencies": {
-    "detox": "^20.32.1-smoke.0",
+    "detox": "^20.32.1-smoke.1",
     "jest": "^29.0.0"
   },
   "detox": {

--- a/examples/demo-react-native-detox-instruments/package.json
+++ b/examples/demo-react-native-detox-instruments/package.json
@@ -1,10 +1,10 @@
 {
   "name": "demo-react-native-detox-instruments",
-  "version": "20.32.0",
+  "version": "20.32.1-smoke.0",
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "detox": "^20.32.0"
+    "detox": "^20.32.1-smoke.0"
   },
   "detox": {
     "configurations": {

--- a/examples/demo-react-native-detox-instruments/package.json
+++ b/examples/demo-react-native-detox-instruments/package.json
@@ -1,10 +1,10 @@
 {
   "name": "demo-react-native-detox-instruments",
-  "version": "20.32.1-smoke.0",
+  "version": "20.32.1-smoke.1",
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "detox": "^20.32.1-smoke.0"
+    "detox": "^20.32.1-smoke.1"
   },
   "detox": {
     "configurations": {

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "20.32.0",
+  "version": "20.32.1-smoke.0",
   "private": true,
   "scripts": {
     "start": "react-native start",
@@ -41,7 +41,7 @@
     "@types/jest": "^29.2.1",
     "@types/react": "^18.3.1",
     "@types/react-test-renderer": "^18.0.0",
-    "detox": "^20.32.0",
+    "detox": "^20.32.1-smoke.0",
     "fs-extra": "^9.1.0",
     "jest": "^29.6.3",
     "react-test-renderer": "18.3.1",

--- a/examples/demo-react-native/package.json
+++ b/examples/demo-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "20.32.1-smoke.0",
+  "version": "20.32.1-smoke.1",
   "private": true,
   "scripts": {
     "start": "react-native start",
@@ -41,7 +41,7 @@
     "@types/jest": "^29.2.1",
     "@types/react": "^18.3.1",
     "@types/react-test-renderer": "^18.0.0",
-    "detox": "^20.32.1-smoke.0",
+    "detox": "^20.32.1-smoke.1",
     "fs-extra": "^9.1.0",
     "jest": "^29.6.3",
     "react-test-renderer": "18.3.1",

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,7 @@
     "generation",
     "."
   ],
-  "version": "20.32.1-smoke.0",
+  "version": "20.32.1-smoke.1",
   "npmClient": "npm",
   "command": {
     "publish": {

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,7 @@
     "generation",
     "."
   ],
-  "version": "20.32.0",
+  "version": "20.32.1-smoke.0",
   "npmClient": "npm",
   "command": {
     "publish": {

--- a/package.json
+++ b/package.json
@@ -55,5 +55,5 @@
     "shell-utils": "1.x.x",
     "unified": "^10.1.0"
   },
-  "version": "20.32.1-smoke.0"
+  "version": "20.32.1-smoke.1"
 }

--- a/package.json
+++ b/package.json
@@ -55,5 +55,5 @@
     "shell-utils": "1.x.x",
     "unified": "^10.1.0"
   },
-  "version": "20.32.0"
+  "version": "20.32.1-smoke.0"
 }


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #<?>

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have introduced a work-around for recurring issues with Genymotion tunnel connections. Empirically, the connection shows hiccups from time to time, which makes ADB disconnect the device altogether. This PR tackles that by setting longer timeouts and more retries, so as to allow for the gmsaas tunnel to reconnect automatically.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
