### PR TITLE
feat(ios): add booted query support

### DIFF
--- a/detox/detox.d.ts
+++ b/detox/detox.d.ts
@@ -408,6 +408,7 @@ declare global {
             type: string;
             name: string;
             os: string;
+            booted?: boolean;
         }
 
         type DetoxConfiguration = DetoxConfigurationCommon & (

--- a/detox/src/configuration/composeDeviceConfig.js
+++ b/detox/src/configuration/composeDeviceConfig.js
@@ -228,7 +228,7 @@ function unpackDeviceQuery(deviceConfig) {
 }
 
 const EXPECTED_DEVICE_MATCHER_PROPS = {
-  'ios.simulator': ['type', 'name', 'id'],
+  'ios.simulator': ['type', 'name', 'id', 'booted'],
   'android.attached': ['adbName'],
   'android.emulator': ['avdName'],
   'android.genycloud': ['recipeUUID', 'recipeName'],

--- a/detox/src/configuration/composeDeviceConfig.test.js
+++ b/detox/src/configuration/composeDeviceConfig.test.js
@@ -449,7 +449,7 @@ describe('composeDeviceConfig', () => {
       describe('Unhappy scenarios', () => {
         describe('missing device matcher properties', () => {
           test.each([
-            [['type', 'name', 'id'], 'ios.simulator'],
+            [['type', 'name', 'id', 'booted'], 'ios.simulator'],
             [['adbName'], 'android.attached'],
             [['avdName'], 'android.emulator'],
             [['recipeUUID', 'recipeName'], 'android.genycloud'],

--- a/detox/src/devices/allocation/drivers/ios/SimulatorQuery.js
+++ b/detox/src/devices/allocation/drivers/ios/SimulatorQuery.js
@@ -1,10 +1,11 @@
 class SimulatorQuery {
   /** @param {Partial<Detox.IosSimulatorQuery>} query */
-  constructor({ id, name, os, type }) {
+  constructor({ id, name, os, type, booted }) {
     if (id != null) this.byId = id;
     if (name != null) this.byName = name;
     if (os != null) this.byOS = os;
     if (type != null) this.byType = type;
+    if (booted != null) this.booted = booted;
   }
 
   getDeviceComment() {
@@ -17,6 +18,7 @@ class SimulatorQuery {
       this.byName && `by name = ${JSON.stringify(this.byName)}`,
       this.byType && `by type = ${JSON.stringify(this.byType)}`,
       this.byOS && `by OS = ${JSON.stringify(this.byOS)}`,
+      this.byBooted && `by booted = ${JSON.stringify(this.byBooted)}`,
     ].filter(Boolean).join(' and ');
   }
 }

--- a/docs/config/devices.mdx
+++ b/docs/config/devices.mdx
@@ -22,9 +22,10 @@ The format of Detox config allows you to define inside it multiple device config
   "device": {
     // one of these or a combination of them
     "id": "D53474CF-7DD1-4673-8517-E75DAD6C34D6",
-    "type": "iPhone 11 Pro",
+    "type": "iPhone 15 Pro Max",
     "name": "MySim",
-    "os": "iOS 13.0"
+    "os": "iOS 18.2",
+    "booted": true // any booted simulator
   },
 }
 ```


### PR DESCRIPTION
## Description

This pull request includes changes to add support for the `booted` property in the iOS simulator configuration within the Detox project. This translates to the call of `applesimutils` to find **any booted device** (when specified without any extra query parameters like type, OS, etc.):

```
applesimutils --list --booted
```

> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
