### PR TITLE
fix(genycloud): reallocate unresponsive devices

### DIFF
--- a/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/android/genycloud/GenyAllocDriver.js
@@ -102,6 +102,16 @@ class GenyAllocDriver {
    * @return {Promise<void>}
    */
   async free(cookie, options = {}) {
+    try {
+      if (!options.shutdown) {
+        await Timer.run(10000, 'waiting for device to respond', async () => {
+          await this._adb.shell(cookie.adbName, 'echo ok');
+        });
+      }
+    } catch {
+      options.shutdown = true;
+    }
+
     // Known issue: cookie won't have a proper 'instance' field due to (de)serialization
     if (options.shutdown) {
       this._genyRegistry.removeInstance(cookie.id);


### PR DESCRIPTION
## Description

When Detox is in the middle of something (i.e., it does not need to shutdown), we're adding an additional check — if Genymotion device is answering at all (`echo ok`). And if it is not responsive, we're forcing shutdown so that the next Detox worker, in case it requires a device, will trigger a fresh allocation (of hopefully a less problematic device).