### PR TITLE
fix: copilot legacy access

### DIFF
--- a/detox/src/DetoxWorker.js
+++ b/detox/src/DetoxWorker.js
@@ -63,6 +63,8 @@ class DetoxWorker {
     this.system = null;
     /** @type {Detox.PilotFacade} */
     this.pilot = null;
+    /** @type {Detox.PilotFacade} */
+    this.copilot = null;
 
     this._deviceCookie = null;
 
@@ -110,6 +112,13 @@ class DetoxWorker {
       }
     };
     this.pilot = new DetoxPilot();
+    Object.defineProperty(this, 'copilot', {
+      get: () => {
+        console.warn('Warning: "copilot" is deprecated. Please use "pilot" instead.');
+        return this.pilot;
+      },
+      configurable: true,
+    });
 
     yield this._client.connect();
 
@@ -169,10 +178,7 @@ class DetoxWorker {
       this._injectedGlobalProperties = Object.keys(injectedGlobals);
       Object.assign(DetoxWorker.global, injectedGlobals);
       Object.defineProperty(DetoxWorker.global, 'copilot', {
-        get: () => {
-          console.warn('Warning: "copilot" is deprecated. Please use "pilot" instead.');
-          return this.pilot;
-        },
+        get: () => this.copilot,
         configurable: true,
       });
     }

--- a/detox/test/e2e/pilot/01.pilot.sanity.test.js
+++ b/detox/test/e2e/pilot/01.pilot.sanity.test.js
@@ -1,3 +1,5 @@
+const { copilot } = require('detox');
+
 describe.forPilot('Pilot Sanity', () => {
   beforeEach(async () => {
     await pilot.perform(
@@ -19,6 +21,10 @@ describe.forPilot('Pilot Sanity', () => {
   });
 
   it('should show world screen after tap with Copilot (deprecated API)', async () => {
+    await global.copilot.autopilot('tap on the Say World button in the sanity screen and expect to see "World!!!" text displayed');
+  });
+
+  it('should access copilot via destructuring', async () => {
     await copilot.autopilot('tap on the Say World button in the sanity screen and expect to see "World!!!" text displayed');
   });
 });


### PR DESCRIPTION
## Description
 
* Fixes destructuring access: `const { copilot } = require('detox');`.
* Adds an extra test for this special case.
 
 