### PR TITLE
fix(ios): prevent stdout buffer overflow with many simulators

### DIFF
--- a/detox/src/devices/allocation/drivers/ios/SimulatorAllocDriver.js
+++ b/detox/src/devices/allocation/drivers/ios/SimulatorAllocDriver.js
@@ -170,7 +170,10 @@ class SimulatorAllocDriver {
   async _queryDevices(deviceQuery) {
     const result = await this._applesimutils.list(
       deviceQuery,
-      `Searching for device ${deviceQuery} ...`
+      {
+        trying: `Searching for device ${deviceQuery} ...`,
+        fields: ['udid', 'os', 'identifier'],
+      }
     );
 
     if (_.isEmpty(result)) {

--- a/detox/src/utils/environment.js
+++ b/detox/src/utils/environment.js
@@ -177,6 +177,13 @@ const getDetoxVersion = _.once(() => {
   return require(path.join(__dirname, '../../package.json')).version;
 });
 
+const getAppleSimUtilsVersion = _.once(async () => {
+  const command = `applesimutils --version`;
+  const output = await execAsync(command);
+  const match = output.match(/(\d+\.\d+\.\d+)$/);
+  return match ? match[1] : '0.0.0';
+});
+
 const getBuildFolderName = _.once(async () => {
   const detoxVersion = getDetoxVersion();
   const xcodeVersion = await execAsync('xcodebuild -version');
@@ -232,6 +239,7 @@ module.exports = {
   getAvdHome,
   getAvdDir,
   getAvdManagerPath,
+  getAppleSimUtilsVersion,
   getAndroidSdkManagerPath,
   getGmsaasPath,
   getDetoxVersion,


### PR DESCRIPTION
## Description

Minimizes output from `applesimutils` to prevent potential `stdout` max buffer size reached in `child_process` calls.

Resolves issue mentioned in: https://github.com/wix/Detox/pull/4335
Related to: https://github.com/wix/AppleSimulatorUtils/issues/122

---

No on-surface changes.
