### PR TITLE
feat: detox pilot.init(config)

### DIFF
--- a/detox/detox.d.ts
+++ b/detox/detox.d.ts
@@ -9,7 +9,7 @@
 // * Dor Ben Baruch <https://github.com/Dor256>
 
 import { BunyanDebugStreamOptions } from 'bunyan-debug-stream';
-import type { Pilot, PromptHandler as _PromptHandler } from '@wix-pilot/core'
+import type { Config as PilotConfig, Pilot, PromptHandler as _PromptHandler } from '@wix-pilot/core'
 
 declare global {
     namespace Detox {
@@ -1358,9 +1358,31 @@ declare global {
              * Initializes the Pilot with the given prompt handler.
              * Must be called before any other Pilot methods.
              * @note Wix-Pilot APIs are still in experimental phase and are subject to changes in the near future.
-             * @param promptHandler The prompt handler to use.
+             * @param promptHandler The prompt handler to use. [DEPRECATED - use `init(config)` instead]
              */
-            init: (promptHandler: PromptHandler) => void;
+            init(promptHandler: PromptHandler): void;
+            /**
+             * Initializes the Pilot with the given config.
+             * Must be called before any other Pilot methods.
+             * @note Wix-Pilot APIs are still in experimental phase and are subject to changes in the near future.
+             * @param config The config to use.
+             * @example
+             * pilot.init({
+             *   promptHandler: myPromptHandler,
+             *   options: {
+             *     cacheOptions: {
+             *       shouldUseCache: true,
+             *       shouldOverrideCache: false,
+             *     },
+             *   }
+             * });
+             */
+            init(config: PilotConfig): void;
+            /**
+             * Sets the default values for the Pilot configuration.
+             * @internal
+             */
+            setDefaults(defaults: Partial<PilotConfig>): void;
         }
 
         type PromptHandler = _PromptHandler;

--- a/detox/package.json
+++ b/detox/package.json
@@ -68,8 +68,8 @@
     "wtfnode": "^0.9.1"
   },
   "dependencies": {
-    "@wix-pilot/core": "^3.3.0",
-    "@wix-pilot/detox": "^1.0.11",
+    "@wix-pilot/core": "^3.4.1",
+    "@wix-pilot/detox": "^1.0.13",
     "ajv": "^8.6.3",
     "bunyan": "^1.8.12",
     "bunyan-debug-stream": "^3.1.0",

--- a/detox/runners/jest/testEnvironment/index.js
+++ b/detox/runners/jest/testEnvironment/index.js
@@ -125,6 +125,12 @@ class DetoxCircusEnvironment extends WithEmitter(NodeEnvironment) {
       await detox.installWorker(opts);
     }
 
+    detox.worker.pilot.setDefaults({
+      testContext: {
+        getCurrentTestFilePath: () => path.resolve(this.testPath),
+      },
+    });
+
     return detox.worker;
   }
 

--- a/detox/src/pilot/DetoxPilot.js
+++ b/detox/src/pilot/DetoxPilot.js
@@ -5,11 +5,25 @@ const detox = require('../..');
 
 /** @type {Detox.PilotFacade} */
 class DetoxPilot {
-  init(promptHandler) {
-     this.pilot = new Pilot({
+  /**
+   * @param {Partial<import('@wix-pilot/core').Config>} [defaults] Arbitrary config defaults for the Pilot.
+   */
+  constructor(defaults = {}) {
+    this._defaults = defaults;
+  }
+
+  init(maybePromptHandler) {
+    const options = maybePromptHandler.promptHandler ? {
+      ...this._defaults,
       frameworkDriver: new DetoxFrameworkDriver(detox),
-      promptHandler: promptHandler
-    });
+      ...maybePromptHandler,
+    } : {
+      ...this._defaults,
+      frameworkDriver: new DetoxFrameworkDriver(detox),
+      promptHandler: maybePromptHandler,
+    };
+
+    this.pilot = new Pilot(options);
   }
 
   start(){
@@ -43,6 +57,14 @@ class DetoxPilot {
 
   isInitialized(){
     return !!this.pilot;
+  }
+
+  /**
+   * @param {Partial<import('@wix-pilot/core').Config>} [defaults] Arbitrary config defaults for the Pilot.
+   * @internal
+   */
+  setDefaults(defaults) {
+    Object.assign(this._defaults, defaults);
   }
 }
 

--- a/detox/src/pilot/DetoxPilot.test.js
+++ b/detox/src/pilot/DetoxPilot.test.js
@@ -21,12 +21,35 @@ describe('DetoxPilot', () => {
   });
 
   describe('init', () => {
-    it('should initialize pilot with correct parameters', () => {
+    it('should initialize pilot with correct parameters (legacy signature)', () => {
       detoxPilot.init(mockPromptHandler);
 
       expect(Pilot).toHaveBeenCalledWith({
         frameworkDriver: expect.any(DetoxFrameworkDriver),
         promptHandler: mockPromptHandler,
+      });
+    });
+
+    it('should initialize pilot with correct parameters (new signature)', () => {
+      detoxPilot.init({
+        promptHandler: mockPromptHandler,
+        options: {
+          cacheOptions: {
+            shouldUseCache: true,
+            shouldOverrideCache: false,
+          },
+        },
+      });
+
+      expect(Pilot).toHaveBeenCalledWith({
+        frameworkDriver: expect.any(DetoxFrameworkDriver),
+        promptHandler: mockPromptHandler,
+        options: {
+          cacheOptions: {
+            shouldUseCache: true,
+            shouldOverrideCache: false,
+          },
+        },
       });
     });
   });
@@ -84,6 +107,56 @@ describe('DetoxPilot', () => {
 
     it('should throw an error if pilot is not initialized', async () => {
       expect(() => detoxPilot.end()).toThrow('DetoxPilot is not initialized');
+    });
+  });
+
+  describe('setDefaults', () => {
+    it('should merge defaults into init configuration', () => {
+      const testDefaults = {
+        testContext: {
+          someProperty: 'test-value'
+        }
+      };
+
+      detoxPilot.setDefaults(testDefaults);
+      detoxPilot.init(mockPromptHandler);
+
+      expect(Pilot).toHaveBeenCalledWith({
+        frameworkDriver: expect.any(DetoxFrameworkDriver),
+        promptHandler: mockPromptHandler,
+        testContext: {
+          someProperty: 'test-value'
+        }
+      });
+    });
+
+    it('should work like merge - multiple setDefaults calls accumulate', () => {
+      const firstDefaults = {
+        testContext: {
+          property1: 'value1'
+        }
+      };
+
+      const secondDefaults = {
+        cacheOptions: {
+          property2: 'value2'
+        }
+      };
+
+      detoxPilot.setDefaults(firstDefaults);
+      detoxPilot.setDefaults(secondDefaults);
+      detoxPilot.init(mockPromptHandler);
+
+      expect(Pilot).toHaveBeenCalledWith({
+        frameworkDriver: expect.any(DetoxFrameworkDriver),
+        promptHandler: mockPromptHandler,
+        testContext: {
+          property1: 'value1'
+        },
+        cacheOptions: {
+          property2: 'value2'
+        }
+      });
     });
   });
 });

--- a/detox/test/e2e/utils/custom-describes.js
+++ b/detox/test/e2e/utils/custom-describes.js
@@ -23,7 +23,9 @@ describe.forPilot = (description, fn) => {
           console.warn('Cannot access the LLM service without Wix BO environment. Relying on cached responses only.');
         }
         try {
-          await pilot.init(new WixPromptHandler());
+          await pilot.init({
+            promptHandler: new WixPromptHandler(),
+          });
         } catch (error) {
           if (error.message.includes('Pilot has already been initialized')) {
             // Ignore already initialized error


### PR DESCRIPTION
## Description

This adds possibility to define entire Pilot config when needed (motivated by need to pass testPath for correct Detox pilot cache path calculation).

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
