### PR TITLE
feat(android): return xml hierarchy on error

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/DetoxMain.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/DetoxMain.kt
@@ -5,6 +5,8 @@ import android.util.Log
 import com.wix.detox.adapters.server.*
 import com.wix.detox.common.DetoxLog
 import com.wix.detox.espresso.UiControllerSpy
+import com.wix.detox.espresso.DetoxFailureHandler
+import androidx.test.espresso.Espresso
 import com.wix.detox.instruments.DetoxInstrumentsManager
 import com.wix.detox.reactnative.ReactNativeExtension
 import com.wix.invoke.MethodInvocation
@@ -116,6 +118,9 @@ object DetoxMain {
 
     private fun initEspresso() {
         UiControllerSpy.attachThroughProxy()
+
+        // Set up custom failure handler that replaces human-readable hierarchy with XML format
+        Espresso.setFailureHandler(DetoxFailureHandler())
     }
 
     private fun initReactNative() {

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxFailureHandler.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxFailureHandler.kt
@@ -1,0 +1,47 @@
+package com.wix.detox.espresso
+
+import android.view.View
+import android.util.Log
+import androidx.test.espresso.FailureHandler
+import androidx.test.espresso.NoMatchingViewException
+import androidx.test.espresso.AmbiguousViewMatcherException
+import com.wix.detox.espresso.errors.DetoxNoMatchingViewException
+import com.wix.detox.espresso.errors.DetoxAmbiguousViewMatcherException
+import com.wix.detox.espresso.hierarchy.ViewHierarchyGenerator
+import org.hamcrest.Matcher
+
+private const val LOG_TAG = "DetoxFailureHandler"
+
+/**
+ * Enhanced failure handler that wraps Espresso exceptions with cleaned error messages
+ * and provides XML hierarchy for debugging while eliminating verbose view hierarchy
+ * from exception messages.
+ */
+class DetoxFailureHandler : FailureHandler {
+
+    override fun handle(error: Throwable, viewMatcher: Matcher<View>) {
+        when (error) {
+            is NoMatchingViewException -> {
+                val xmlHierarchy = getSafeViewHierarchy(error.rootView)
+                throw DetoxNoMatchingViewException(error, xmlHierarchy)
+            }
+            is AmbiguousViewMatcherException -> {
+                val xmlHierarchy = getSafeViewHierarchy(error.rootView)
+                throw DetoxAmbiguousViewMatcherException(error, xmlHierarchy)
+            }
+            else -> {
+                // For other exceptions, just re-throw as-is
+                throw error
+            }
+        }
+    }
+
+    private fun getSafeViewHierarchy(rootView: View): String {
+        return try {
+            ViewHierarchyGenerator.generateXml(rootView, shouldInjectTestIds = false)
+        } catch (hierarchyException: Exception) {
+            Log.w(LOG_TAG, "Failed to generate view hierarchy", hierarchyException)
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<ViewHierarchy>\n  <!-- Failed to generate hierarchy: ${hierarchyException.message} -->\n</ViewHierarchy>"
+        }
+    }
+}

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/errors/DetoxAmbiguousViewMatcherException.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/errors/DetoxAmbiguousViewMatcherException.kt
@@ -1,0 +1,17 @@
+package com.wix.detox.espresso.errors
+
+import android.view.View
+import androidx.test.espresso.AmbiguousViewMatcherException
+import androidx.test.espresso.RootViewException
+
+/**
+ * Detox wrapper for AmbiguousViewMatcherException that provides cleaned error messages
+ * and preserves the XML hierarchy for debugging.
+ */
+class DetoxAmbiguousViewMatcherException(
+    private val originalException: AmbiguousViewMatcherException,
+    override val xmlHierarchy: String
+) : RuntimeException(DetoxExceptionUtils.cleanEspressoMessage(originalException.message)), RootViewException, DetoxExceptionWithHierarchy {
+
+    override fun getRootView(): View = originalException.rootView
+}

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/errors/DetoxExceptionUtils.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/errors/DetoxExceptionUtils.kt
@@ -1,0 +1,12 @@
+package com.wix.detox.espresso.errors
+
+/**
+ * Utility class for cleaning and processing Espresso exception messages.
+ */
+object DetoxExceptionUtils {
+    fun cleanEspressoMessage(originalMessage: String?): String {
+        val message = originalMessage ?: ""
+        // Remove everything after "View Hierarchy:\n" (including it)
+        return message.substringBefore("View Hierarchy:\n").trim()
+    }
+}

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/errors/DetoxExceptionWithHierarchy.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/errors/DetoxExceptionWithHierarchy.kt
@@ -1,0 +1,10 @@
+package com.wix.detox.espresso.errors
+
+/**
+ * Interface for exceptions that provide XML view hierarchy for debugging.
+ * Exceptions implementing this interface will have their xmlHierarchy property
+ * extracted and used in error reporting.
+ */
+interface DetoxExceptionWithHierarchy {
+    val xmlHierarchy: String
+}

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/errors/DetoxNoMatchingViewException.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/errors/DetoxNoMatchingViewException.kt
@@ -1,0 +1,17 @@
+package com.wix.detox.espresso.errors
+
+import android.view.View
+import androidx.test.espresso.NoMatchingViewException
+import androidx.test.espresso.RootViewException
+
+/**
+ * Detox wrapper for NoMatchingViewException that provides cleaned error messages
+ * and preserves the XML hierarchy for debugging.
+ */
+class DetoxNoMatchingViewException(
+    private val originalException: NoMatchingViewException,
+    override val xmlHierarchy: String
+) : RuntimeException(DetoxExceptionUtils.cleanEspressoMessage(originalException.message)), RootViewException, DetoxExceptionWithHierarchy {
+
+    override fun getRootView(): View = originalException.rootView
+}

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/hierarchy/ViewHierarchyGenerator.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/hierarchy/ViewHierarchyGenerator.kt
@@ -49,6 +49,13 @@ object ViewHierarchyGenerator {
         }
     }
 
+    @JvmStatic
+    fun generateXml(rootView: View, shouldInjectTestIds: Boolean): String {
+        return runBlocking {
+            generateXmlFromViews(listOf(rootView), shouldInjectTestIds)
+        }
+    }
+
     private suspend fun generateXmlFromViews(rootViews: List<View?>?, shouldInjectTestIds: Boolean): String {
         return StringWriter().use { writer ->
             val serializer = Xml.newSerializer().apply {

--- a/detox/android/detox/src/testFull/java/com/wix/detox/espresso/errors/DetoxExceptionUtilsTest.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/espresso/errors/DetoxExceptionUtilsTest.kt
@@ -1,0 +1,56 @@
+package com.wix.detox.espresso.errors
+
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DetoxExceptionUtilsTest {
+
+    @Test
+    fun `should clean espresso message by removing view hierarchy`() {
+        val originalMessage = """androidx.test.espresso.NoMatchingViewException: No views in hierarchy found matching: (an instance of android.widget.TextView and view.getText() with or without transformation to match: is "supercalifragilisticexpialidocious" and view has effective visibility <VISIBLE>)
+
+View Hierarchy:
++>DecorView{id=-1, visibility=VISIBLE, width=1080, height=2400, has-focus=false, has-focusable=true, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params={(0,0)(fillxfill) sim={adjust=resize} ty=BASE_APPLICATION wanim=0x1030309
+  fl=LAYOUT_IN_SCREEN LAYOUT_INSET_DECOR SPLIT_TOUCH HARDWARE_ACCELERATED DRAWS_SYSTEM_BAR_BACKGROUNDS
+  pfl=NO_MOVE_ANIMATION EDGE_TO_EDGE_ENFORCED FORCE_DRAW_STATUS_BAR_BACKGROUND FIT_INSETS_CONTROLLED
+  bhv=DEFAULT
+  fitSides=
+  frameRateBoostOnTouch=true
+  dvrrWindowFrameRateHint=true}, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=1}"""
+
+        val cleanedMessage = DetoxExceptionUtils.cleanEspressoMessage(originalMessage)
+
+        val expectedMessage = """androidx.test.espresso.NoMatchingViewException: No views in hierarchy found matching: (an instance of android.widget.TextView and view.getText() with or without transformation to match: is "supercalifragilisticexpialidocious" and view has effective visibility <VISIBLE>)"""
+
+        Assertions.assertThat(cleanedMessage).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `should handle null message`() {
+        val cleanedMessage = DetoxExceptionUtils.cleanEspressoMessage(null)
+        Assertions.assertThat(cleanedMessage).isEqualTo("")
+    }
+
+    @Test
+    fun `should handle empty message`() {
+        val cleanedMessage = DetoxExceptionUtils.cleanEspressoMessage("")
+        Assertions.assertThat(cleanedMessage).isEqualTo("")
+    }
+
+    @Test
+    fun `should handle message without view hierarchy`() {
+        val message = "Simple error message without view hierarchy"
+        val cleanedMessage = DetoxExceptionUtils.cleanEspressoMessage(message)
+        Assertions.assertThat(cleanedMessage).isEqualTo(message)
+    }
+
+    @Test
+    fun `should trim whitespace`() {
+        val message = "  Error message with whitespace  "
+        val cleanedMessage = DetoxExceptionUtils.cleanEspressoMessage(message)
+        Assertions.assertThat(cleanedMessage).isEqualTo("Error message with whitespace")
+    }
+}


### PR DESCRIPTION
## Description

- A follow-up to https://github.com/wix/Detox/pull/4806

- This pull request is a pre-requisite to the issue described here: #2078 

So, here we replace Espresso's "human-readable" hierarchy with XML, to be later reused like in these examples:

https://wix.github.io/Detox/assets/example-hierarchy-no-bg.xml
https://wix.github.io/Detox/assets/example-hierarchy-bg.xml

<img width="240" alt="image" src="https://github.com/user-attachments/assets/b05ba833-e388-4e75-acd0-ab6ade696ca0" />
