### PR TITLE
#4799 - react native 079 support for AppDelegate in iOS

### DIFF
--- a/detox/test/ios/AppDelegate.h
+++ b/detox/test/ios/AppDelegate.h
@@ -2,12 +2,27 @@
 #import <React/RCTBridge.h>
 #import <React-RCTAppDelegate/RCTReactNativeFactory.h>
 
+#import "ReactNativeVersionExtracted.h"
+
+#if REACT_NATIVE_VERSION_MINOR < 79
+#if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
+#import <React-RCTAppDelegate/RCTAppDelegate.h>
+#elif __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
+#import <React_RCTAppDelegate/RCTAppDelegate.h>
+#endif
+#endif
+
 @class ReactNativeDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(AppDelegate)
+
+#if REACT_NATIVE_VERSION_MINOR < 79
+@interface AppDelegate : RCTAppDelegate
+#else
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
+#endif
 
 @property (nonatomic, strong) UIWindow *window;
 @property (nonatomic, strong) id screenManager;

--- a/detox/test/ios/Podfile
+++ b/detox/test/ios/Podfile
@@ -68,4 +68,86 @@ post_install do |installer|
     config[:reactNativePath],
     :mac_catalyst_enabled => false
   )
+
+  extract_react_native_version_constants
+end
+
+
+def extract_react_native_version_constants
+  require 'json'
+  
+  Pod::UI.notice "POST INSTALL"
+  puts "Extracting React Native version from package.json..."
+  
+  package_json_path = "../package.json"
+  
+  begin
+    package_content = File.read(package_json_path)
+    package_data = JSON.parse(package_content)
+    
+    rn_version = nil
+    if package_data['dependencies'] && package_data['dependencies']['react-native']
+      rn_version = package_data['dependencies']['react-native']
+    elsif package_data['devDependencies'] && package_data['devDependencies']['react-native']
+      rn_version = package_data['devDependencies']['react-native']
+    end
+    
+    unless rn_version
+      Pod::UI.warn "Warning: react-native not found in package.json dependencies"
+      return
+    end
+    
+    Pod::UI.notice "React Native version from package.json: #{rn_version}"
+    
+    generate_rn_version_header(rn_version, package_json_path)
+end
+end
+
+
+def generate_rn_version_header(rn_version, source_path = nil)
+  puts " Generating React Native version header..."
+  
+  clean_version = rn_version.gsub(/^[\^~>=<]+/, '')
+  version_parts = clean_version.split('.')
+  
+  major = version_parts[0]&.to_i || 0
+  minor = version_parts[1]&.to_i || 0  
+  patch = version_parts[2]&.to_i || 0
+  
+  output_header = "ReactNativeVersionExtracted.h"
+  
+  header_content = <<~HEADER
+    //
+    // ReactNativeVersionExtracted.h
+    // React Native version constants extracted from package.json
+    // Generated on: #{Time.now}
+    // Source: #{File.expand_path(source_path)}
+    // Original version string: #{rn_version}
+    //
+    
+    #ifndef ReactNativeVersionExtracted_h
+    #define ReactNativeVersionExtracted_h
+    
+    #define REACT_NATIVE_VERSION_MAJOR #{major}
+    #define REACT_NATIVE_VERSION_MINOR #{minor}
+    #define REACT_NATIVE_VERSION_PATCH #{patch}
+    
+    #endif /* ReactNativeVersionExtracted_h */
+  HEADER
+  
+  begin
+    File.write(output_header, header_content)
+    
+    Pod::UI.notice "Successfully generated #{output_header}"
+    puts " Version constants:"
+    puts "   #define REACT_NATIVE_VERSION_MAJOR #{major}"
+    puts "   #define REACT_NATIVE_VERSION_MINOR #{minor}"
+    puts "   #define REACT_NATIVE_VERSION_PATCH #{patch}"
+    
+    return { major: major, minor: minor, patch: patch }
+    
+  rescue => e
+    Pod::UI.error "❌ Error writing version header: #{e.message}"
+    return nil
+  end
 end


### PR DESCRIPTION
## Description

This PR adds a script to the Podfile that reads the React-Native version from the package.json file and creates a header file for iOS with preprocessor flags to determine the React-Native version number in iOS

- This pull request addresses the issue described here: #4799](https://github.com/wix/Detox/issues/4799

The script reads the package.json and writes the major, minor and patch number to a file called ReactNativeVersionExtracted.h which in this PR the AppDelegate imports and according to the version of React-Native knows if to inherit from **RCTAppDelegate** or not.

_From version 0.79 the AppDelegate no longer inherits from the RCTAppDelegate._