### PR TITLE
fix(android): enable kotlin 2.x compatibility w/opt-in for `.entries` usage

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/ReactNativeIdlingResources.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/ReactNativeIdlingResources.kt
@@ -115,6 +115,7 @@ class ReactNativeIdlingResources(
         loopers.clear()
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
     private fun unregisterIdlingResources() {
         IdlingResourcesName.entries.forEach {
             removeIdlingResource(it)


### PR DESCRIPTION
## Description

Kotlin 2.x appears to require an opt-in for the use of `.entries`, this has been logged for some time, this PR will fix it:

- Fixes #4678

There was an existing PR that also fixed this - and was in fact used by react-native-firebase's e2e project via patch-package but it had [unaddressed feedback](https://github.com/wix/Detox/pull/4698#discussion_r1944642470) from @gosha212 and was closed stale:

> I don't want to optin for the project. Please optin the specific file instead. You will need to use something like @OptIn(ExperimentalStdlibApi::class)

That's a good point. So I tried that locally and it seemed to work, and now I propose it here.
