### PR TITLE
Concurrent Runners set to 1

### DIFF
--- a/detox/test/e2e/jest.config.js
+++ b/detox/test/e2e/jest.config.js
@@ -4,7 +4,7 @@ const { resolveConfig } = require('detox/internals');
 
 const maxWorkersMap = {
   'android.emulator': 3,
-  'android.genycloud': 5,
+  'android.genycloud': 1,
   'ios.simulator': 2,
 };
 


### PR DESCRIPTION
This PR changes the
const maxWorkersMap = {
  'android.emulator': 3,
  'android.genycloud': 1,
  'ios.simulator': 2,
};

so that we set our concurrent runners to 1 ( 'android.genycloud': 1,)
