### PR TITLE
fix(ios): element.takeScreenshot() invalid filename

### DIFF
--- a/detox/ios/Detox/Actions/NSObject+DetoxActions.m
+++ b/detox/ios/Detox/Actions/NSObject+DetoxActions.m
@@ -627,7 +627,12 @@ static void _DTXTypeText(NSString* text)
 {
     UIImage *image = [self.dtx_view dtx_imageFromView];
     NSURL *path = [NSURL elementsScreenshotPath];
-    NSString *fileName = [NSString stringWithFormat:@"ImageScreenshot_%@.png", name != nil ? name : self];
+    NSString *fileName;
+    if (name != nil) {
+        fileName = [NSString stringWithFormat:@"ImageScreenshot_%@.png", name];
+    } else {
+        fileName = [NSString stringWithFormat:@"ImageScreenshot_%p.png", self];
+    }
     [image dtx_saveToPath:path fileName:fileName];
 
     return [path URLByAppendingPathComponent:fileName isDirectory:false];;


### PR DESCRIPTION
## Description

Fixes errors like this:

```
ENAMETOOLONG: name too long, lstat '/Users/.../Library/Developer/CoreSimulator/Devices/B833321F-83AE-4B57-A042-835AC4460D0B/data/Containers/Data/Application/817BD36F-5DE8-4729-8FA8-740790D86D79/tmp/elementsScreenshot/ImageScreenshot_<RCTParagraphComponentView: 0x105b335e0; frame = (0 0; 60.3333 17); opaque = NO; tag = 244; layer = <CALayer: 0x6000002275c0>; attributedText = Say Hello{

          EventEmitter = {length = 8, bytes = 0xd858510300600000};
          NSBackgroundColor = "UIExtendedSRGBColorSpace 0 0 0 0";
          NSColor = "UIExtendedSRGBColorSpace 0 0 1 1";
          NSFont = "<UICTFont: 0x105c11f90> font-family: \".SFUI-Regular\"; font-weight: normal; font-style: normal; font-size: 14.00pt";
      }>.png'
```

This is... kinda a filename ↑. So, instead of `%@`, I suggest using `%p` (pointer), e.g.: `ImageScreenshot_0x105b335e0.png`. 