### PR TITLE
CI: Restore omission of Genycloud ARM64 usage (Full rollout of #4825)

### DIFF
--- a/.buildkite/jobs/pipeline.android_rn_77.yml
+++ b/.buildkite/jobs/pipeline.android_rn_77.yml
@@ -4,6 +4,7 @@
       - "./scripts/ci.android.sh"
     env:
       REACT_NATIVE_VERSION: 0.77.2
+      RCT_NEW_ARCH_ENABLED: 1
       DETOX_DISABLE_POD_INSTALL: true
       DETOX_DISABLE_POSTINSTALL: true
     artifact_paths:

--- a/scripts/ci.android.sh
+++ b/scripts/ci.android.sh
@@ -26,12 +26,17 @@ pushd detox/test
 run_f "npm run build:android-debug" # Workaround for asyncstorage issue https://github.com/react-native-async-storage/async-storage/issues/1216. Can be removed after fixing it
 run_f "npm run build:android"
 
-if [ "$USE_GOOGLE_ARM64" = "true" ]; then
-  run_f "npm run e2e:android"
+if [ "$USE_GENYCLOUD_ARM64" = "true" ]; then
+  run_f "npm run e2e:android:genycloud-arm64"
+  cp coverage/lcov.info ../../coverage/e2e-genycloud-ci.lcov
 else
-  run_f "npm run e2e:android:genycloud"
+  run_f "npm run e2e:android"
+  cp coverage/lcov.info ../../coverage/e2e-emulator-ci.lcov
+
+  # Sanity-test support for genycloud (though not ARM)
+  run_f "npm run e2e:android:genycloud -- e2e/01* e2e/02* e2e/03.actions*"
+  cp coverage/lcov.info ../../coverage/e2e-genycloud-ci.lcov
 fi
-cp coverage/lcov.info ../../coverage/e2e-genycloud-ci.lcov
 
 run_f "scripts/ci_unhappy.sh android"
 


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: #<?>

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have restored the work of #4825 which has been accidentally disabled in the RN80 migration, all-the-while taking it to the full extent (relying only on Google in ARM64 emu's).

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
