### PR TITLE
feat(android): add dialog root fallback for React Native Modal support

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAssertion.java
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/DetoxAssertion.java
@@ -9,8 +9,10 @@ import junit.framework.AssertionFailedError;
 
 import org.hamcrest.Matcher;
 
+import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.espresso.ViewAction;
 import androidx.test.espresso.ViewInteraction;
+import androidx.test.espresso.matcher.RootMatchers;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
@@ -32,9 +34,14 @@ public class DetoxAssertion {
 
     /**
      * Asserts the given matcher for the provided view interaction.
+     * Falls back to dialog root if the assertion fails in the default root.
      */
     public static ViewInteraction assertMatcher(ViewInteraction viewInteraction, Matcher<View> viewMatcher) {
-        return viewInteraction.check(matches(viewMatcher));
+        try {
+            return viewInteraction.check(matches(viewMatcher));
+        } catch (NoMatchingViewException e) {
+            return viewInteraction.inRoot(RootMatchers.isDialog()).check(matches(viewMatcher));
+        }
     }
 
     /**
@@ -60,6 +67,7 @@ public class DetoxAssertion {
 
     /**
      * Waits until the provided matcher matches the view interaction or a timeout occurs.
+     * Tries both the default root and dialog root on each iteration.
      */
     public static void waitForAssertMatcher(final ViewInteraction viewInteraction, final Matcher<View> viewMatcher, double timeoutSeconds) {
         final long startTime = System.nanoTime();
@@ -77,7 +85,21 @@ public class DetoxAssertion {
                 viewInteraction.check(matches(viewMatcher));
                 break;
             } catch (AssertionFailedError err) {
-                UiAutomatorHelper.espressoSync(20);
+                // Try dialog root as fallback
+                try {
+                    viewInteraction.inRoot(RootMatchers.isDialog()).check(matches(viewMatcher));
+                    break;
+                } catch (Exception dialogErr) {
+                    UiAutomatorHelper.espressoSync(20);
+                }
+            } catch (NoMatchingViewException e) {
+                // Try dialog root as fallback
+                try {
+                    viewInteraction.inRoot(RootMatchers.isDialog()).check(matches(viewMatcher));
+                    break;
+                } catch (Exception dialogErr) {
+                    UiAutomatorHelper.espressoSync(20);
+                }
             }
         }
     }

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/performer/MultipleViewsActionPerformer.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/performer/MultipleViewsActionPerformer.kt
@@ -6,7 +6,9 @@ import com.wix.detox.espresso.errors.DetoxNoMatchingViewException
 
 import android.view.View
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAction
+import androidx.test.espresso.matcher.RootMatchers
 import org.hamcrest.Matcher
 
 class MultipleViewsActionPerformer(
@@ -20,7 +22,12 @@ class MultipleViewsActionPerformer(
             val indexedMatcher = DetoxMatcher.matcherForAtIndex(index, matcher)
 
             try {
-                onView(indexedMatcher).perform(action)
+                try {
+                    onView(indexedMatcher).perform(action)
+                } catch (e: NoMatchingViewException) {
+                    // Fallback: try dialog root (e.g. React Native Modal)
+                    onView(indexedMatcher).inRoot(RootMatchers.isDialog()).perform(action)
+                }
 
                 (action as? ViewActionWithResult<*>)?.getResult()?.let { results.add(it) }
 

--- a/detox/android/detox/src/full/java/com/wix/detox/espresso/performer/SingleViewActionPerformer.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/espresso/performer/SingleViewActionPerformer.kt
@@ -6,13 +6,19 @@ import android.view.View
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAction
+import androidx.test.espresso.matcher.RootMatchers
 import org.hamcrest.Matcher
 
 class SingleViewActionPerformer(
     private val action: ViewAction
 ) : ViewActionPerformer {
     override fun performOn(matcher: Matcher<View>): Any? {
-        onView(matcher).perform(action)
+        try {
+            onView(matcher).perform(action)
+        } catch (e: NoMatchingViewException) {
+            // Fallback: try dialog root (e.g. React Native Modal)
+            onView(matcher).inRoot(RootMatchers.isDialog()).perform(action)
+        }
 
         return (action as? ViewActionWithResult<*>)?.getResult()
     }


### PR DESCRIPTION
## Summary

Adds automatic `inRoot(RootMatchers.isDialog())` fallback on Android to support interactions with elements rendered inside React Native `<Modal>`.

Fixes #4928

## Problem

On Android, React Native's `<Modal>` component renders its content in a separate dialog window root. Espresso's default view matching only searches the main window root, causing `NoMatchingViewException` for any element inside a Modal — even though the element is visible on screen.

This makes it impossible to test flows involving Modal (e.g. pickers, confirmation dialogs, bottom sheets) without manual `inRoot` workarounds, which Detox does not currently expose.

## Solution

When a view interaction fails with `NoMatchingViewException`, automatically retry with `.inRoot(RootMatchers.isDialog())`. This is applied to:

- **Assertions** (`DetoxAssertion.java`): `assertMatcher` and `waitForAssertMatcher`
- **Actions** (`SingleViewActionPerformer.kt`, `MultipleViewsActionPerformer.kt`): `perform`

The fallback only triggers on `NoMatchingViewException`, so there is no impact on views found in the default root.

## Changes

| File | Change |
|---|---|
| `DetoxAssertion.java` | Dialog root fallback in `assertMatcher()` and `waitForAssertMatcher()` |
| `SingleViewActionPerformer.kt` | Dialog root fallback in `performOn()` |
| `MultipleViewsActionPerformer.kt` | Dialog root fallback in `performOn()` |

## Test plan

- Verified with a React Native app using `<Modal visible={true}>` containing tappable elements and assertions
- Existing tests unaffected (fallback only activates on `NoMatchingViewException`)

