### PR TITLE
feat(android): add biometrics support for Android emulators

### DIFF
--- a/detox/detox.d.ts
+++ b/detox/detox.d.ts
@@ -697,6 +697,23 @@ declare global {
         type Digit = 0 | DigitWithoutZero;
         type BatteryLevel = `${Digit}` | `${DigitWithoutZero}${Digit}` | "100";
 
+        /**
+         * Options for {@link Device.setBiometricEnrollment}.
+         *
+         * On iOS, these options have no effect: iOS simulators enroll both Face ID and Touch ID together.
+         * On Android, the default modality is fingerprint (Virtual Fingerprint HAL); pass `androidFace: true`
+         * to instead enroll the Virtual Face HAL — note this requires a userdebug AVD and incurs an emulator
+         * reboot (~30s) due to the Virtual Face HAL's feature-flag + sensor-props setup.
+         */
+        interface BiometricEnrollmentOptions {
+            /**
+             * Android emulator only. When `true`, `setBiometricEnrollment` sets up the Virtual Face HAL
+             * (enables the feature flag, sets sensor type/strength, reboots the emulator, then enrolls a
+             * virtual face). When `false` or omitted, the Virtual Fingerprint HAL path is used (no reboot).
+             */
+            androidFace?: boolean;
+        }
+
         interface Device {
             /**
              * Holds the environment-unique ID of the device, namely, the adb ID on Android (e.g. emulator-5554) and the Mac-global simulator UDID on iOS -
@@ -1064,29 +1081,40 @@ declare global {
             shake(): Promise<void>;
 
             /**
-             * Toggles device enrollment in biometric auth (TouchID or FaceID) (iOS Only)
+             * Toggles device enrollment in biometric auth (TouchID/FaceID on iOS; fingerprint by default on Android emulators).
+             *
+             * Android: supported on Android emulators (AVDs) only; requires a userdebug emulator image.
+             * Defaults to fingerprint enrollment via the Virtual Fingerprint HAL. Pass `{ androidFace: true }`
+             * to enroll via the Virtual Face HAL instead — note this requires enabling a feature flag and
+             * reboots the emulator, so expect ~30s extra latency per call.
+             *
              * @example await device.setBiometricEnrollment(true);
              * @example await device.setBiometricEnrollment(false);
+             * @example await device.setBiometricEnrollment(true, { androidFace: true });
              */
-            setBiometricEnrollment(enabled: boolean): Promise<void>;
+            setBiometricEnrollment(enabled: boolean, options?: BiometricEnrollmentOptions): Promise<void>;
 
             /**
-             * Simulates the success of a face match via FaceID (iOS Only)
+             * Simulates the success of a face match via FaceID (iOS) or the Virtual Face HAL (Android emulator).
+             * Android: emulator (AVD) only, and requires a prior call to `setBiometricEnrollment(true, { androidFace: true })`.
              */
             matchFace(): Promise<void>;
 
             /**
-             * Simulates the failure of a face match via FaceID (iOS Only)
+             * Simulates the failure of a face match via FaceID (iOS) or the Virtual Face HAL (Android emulator).
+             * Android: emulator (AVD) only, and requires a prior call to `setBiometricEnrollment(true, { androidFace: true })`.
              */
             unmatchFace(): Promise<void>;
 
             /**
-             * Simulates the success of a finger match via TouchID (iOS Only)
+             * Simulates the success of a finger match via TouchID (iOS) or the Virtual Fingerprint HAL (Android emulator).
+             * Android: emulator (AVD) only.
              */
             matchFinger(): Promise<void>;
 
             /**
-             * Simulates the failure of a finger match via TouchID (iOS Only)
+             * Simulates the failure of a finger match via TouchID (iOS) or the Virtual Fingerprint HAL (Android emulator).
+             * Android: emulator (AVD) only.
              */
             unmatchFinger(): Promise<void>;
 

--- a/detox/detox.d.ts
+++ b/detox/detox.d.ts
@@ -697,6 +697,23 @@ declare global {
         type Digit = 0 | DigitWithoutZero;
         type BatteryLevel = `${Digit}` | `${DigitWithoutZero}${Digit}` | "100";
 
+        /**
+         * Options for {@link Device.setBiometricEnrollment}.
+         *
+         * On iOS, these options have no effect: iOS simulators enroll both Face ID and Touch ID together.
+         * On Android, the default modality is fingerprint (Virtual Fingerprint HAL); pass `androidFace: true`
+         * to instead enroll the Virtual Face HAL — note this requires a userdebug AVD and incurs an emulator
+         * reboot (~30s) due to the Virtual Face HAL's feature-flag + sensor-props setup.
+         */
+        interface BiometricEnrollmentOptions {
+            /**
+             * Android emulator only. When `true`, `setBiometricEnrollment` sets up the Virtual Face HAL
+             * (enables the feature flag, sets sensor type/strength, reboots the emulator, then enrolls a
+             * virtual face). When `false` or omitted, the Virtual Fingerprint HAL path is used (no reboot).
+             */
+            androidFace?: boolean;
+        }
+
         interface Device {
             /**
              * Holds the environment-unique ID of the device, namely, the adb ID on Android (e.g. emulator-5554) and the Mac-global simulator UDID on iOS -
@@ -1068,29 +1085,40 @@ declare global {
             shake(): Promise<void>;
 
             /**
-             * Toggles device enrollment in biometric auth (TouchID or FaceID) (iOS Only)
+             * Toggles device enrollment in biometric auth (TouchID/FaceID on iOS; fingerprint by default on Android emulators).
+             *
+             * Android: supported on Android emulators (AVDs) only; requires a userdebug emulator image.
+             * Defaults to fingerprint enrollment via the Virtual Fingerprint HAL. Pass `{ androidFace: true }`
+             * to enroll via the Virtual Face HAL instead — note this requires enabling a feature flag and
+             * reboots the emulator, so expect ~30s extra latency per call.
+             *
              * @example await device.setBiometricEnrollment(true);
              * @example await device.setBiometricEnrollment(false);
+             * @example await device.setBiometricEnrollment(true, { androidFace: true });
              */
-            setBiometricEnrollment(enabled: boolean): Promise<void>;
+            setBiometricEnrollment(enabled: boolean, options?: BiometricEnrollmentOptions): Promise<void>;
 
             /**
-             * Simulates the success of a face match via FaceID (iOS Only)
+             * Simulates the success of a face match via FaceID (iOS) or the Virtual Face HAL (Android emulator).
+             * Android: emulator (AVD) only, and requires a prior call to `setBiometricEnrollment(true, { androidFace: true })`.
              */
             matchFace(): Promise<void>;
 
             /**
-             * Simulates the failure of a face match via FaceID (iOS Only)
+             * Simulates the failure of a face match via FaceID (iOS) or the Virtual Face HAL (Android emulator).
+             * Android: emulator (AVD) only, and requires a prior call to `setBiometricEnrollment(true, { androidFace: true })`.
              */
             unmatchFace(): Promise<void>;
 
             /**
-             * Simulates the success of a finger match via TouchID (iOS Only)
+             * Simulates the success of a finger match via TouchID (iOS) or the Virtual Fingerprint HAL (Android emulator).
+             * Android: emulator (AVD) only.
              */
             matchFinger(): Promise<void>;
 
             /**
-             * Simulates the failure of a finger match via TouchID (iOS Only)
+             * Simulates the failure of a finger match via TouchID (iOS) or the Virtual Fingerprint HAL (Android emulator).
+             * Android: emulator (AVD) only.
              */
             unmatchFinger(): Promise<void>;
 

--- a/detox/src/devices/common/drivers/android/exec/ADB.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.js
@@ -6,6 +6,7 @@ const { execWithRetriesAndLogs, spawnWithRetriesAndLogs, spawnAndLog } = require
 const { getAdbPath } = require('../../../../../utils/environment');
 const logger = require('../../../../../utils/logger');
 const { escape } = require('../../../../../utils/pipeCommands');
+const retry = require('../../../../../utils/retry');
 const DeviceHandle = require('../tools/DeviceHandle');
 const EmulatorHandle = require('../tools/EmulatorHandle');
 
@@ -18,6 +19,14 @@ const DEFAULT_INSTALL_OPTIONS = {
   timeout: 60000,
   retries: 3,
 };
+
+const ENROLLED_FINGER_ID = 1;
+const UNENROLLED_FINGER_ID = 99;
+const DEFAULT_BIOMETRIC_PIN = '0000';
+const ENROLLED_FACE_HIT = 1;
+const UNENROLLED_FACE_HIT = 2;
+const BOOT_WAIT_RETRIES = 240;
+const BOOT_WAIT_INTERVAL_MS = 2500;
 
 class ADB {
   constructor() {
@@ -44,6 +53,11 @@ class ADB {
         : new DeviceHandle(s))
       .value();
     return { devices, stdout };
+  }
+
+  async root(deviceId) {
+    await this.adbCmd(deviceId, 'root');
+    await this.adbCmd(deviceId, 'wait-for-device');
   }
 
   async getState(deviceId) {
@@ -373,6 +387,111 @@ class ADB {
 
   async emu(deviceId, cmd, options) {
     return (await this.adbCmd(deviceId, `emu "${escape.inQuotedString(cmd)}"`, options)).stdout.trim();
+  }
+
+  async matchFinger(deviceId) {
+    await this.emu(deviceId, `finger touch ${ENROLLED_FINGER_ID}`);
+    await this.emu(deviceId, `finger remove`);
+  }
+
+  async unmatchFinger(deviceId) {
+    await this.emu(deviceId, `finger touch ${UNENROLLED_FINGER_ID}`);
+    await this.emu(deviceId, `finger remove`);
+  }
+
+  async setBiometricEnrollment(deviceId, enabled) {
+    await this.root(deviceId);
+    if (enabled) {
+      await this.shell(deviceId, `locksettings clear --old ${DEFAULT_BIOMETRIC_PIN}`).catch(() => {});
+      await this.shell(deviceId, `locksettings set-pin ${DEFAULT_BIOMETRIC_PIN}`);
+      await this.shell(deviceId, `setprop persist.vendor.fingerprint.virtual.enrollments 1`);
+      await this.shell(deviceId, `cmd fingerprint sync`);
+    } else {
+      await this.shell(deviceId, `cmd fingerprint sync`);
+      await this.shell(deviceId, `setprop persist.vendor.fingerprint.virtual.enrollments 0`);
+      await this.shell(deviceId, `locksettings clear --old ${DEFAULT_BIOMETRIC_PIN}`).catch(() => {});
+    }
+  }
+
+  async setFaceEnrollment(deviceId, enabled) {
+    await this.root(deviceId);
+    if (enabled) {
+      const alreadyActive = await this._isFaceVirtualHalActive(deviceId);
+      if (!alreadyActive) {
+        await this.shell(deviceId, `device_config set_sync_disabled_for_tests persistent`).catch(() => {});
+        await this.shell(deviceId, `device_config put biometrics_framework com.android.server.biometrics.face_vhal_feature true`);
+        await this.shell(deviceId, `settings put secure biometric_virtual_enabled 1`);
+        await this.shell(deviceId, `setprop persist.vendor.face.virtual.strength strong`);
+        await this.shell(deviceId, `setprop persist.vendor.face.virtual.type RGB`);
+        const reverses = await this._listReverses(deviceId);
+        await this.reboot(deviceId);
+        await this.root(deviceId);
+        await this._restoreReverses(deviceId, reverses);
+      }
+      await this.shell(deviceId, `locksettings clear --old ${DEFAULT_BIOMETRIC_PIN}`).catch(() => {});
+      await this.shell(deviceId, `locksettings set-pin ${DEFAULT_BIOMETRIC_PIN}`);
+      await this.shell(deviceId, `setprop persist.vendor.face.virtual.enrollments 1`);
+      await this.shell(deviceId, `cmd face sync`);
+    } else {
+      await this.shell(deviceId, `cmd face sync`).catch(() => {});
+      await this.shell(deviceId, `setprop persist.vendor.face.virtual.enrollments 0`);
+      await this.shell(deviceId, `locksettings clear --old ${DEFAULT_BIOMETRIC_PIN}`).catch(() => {});
+    }
+  }
+
+  async _isFaceVirtualHalActive(deviceId) {
+    try {
+      const virtualEnabled = await this.shell(deviceId, `settings get secure biometric_virtual_enabled`, { silent: true, retries: 0 });
+      const featureFlag = await this.shell(deviceId, `device_config get biometrics_framework com.android.server.biometrics.face_vhal_feature`, { silent: true, retries: 0 });
+      return String(virtualEnabled).trim() === '1' && String(featureFlag).trim() === 'true';
+    } catch (_) {
+      return false;
+    }
+  }
+
+  async _listReverses(deviceId) {
+    try {
+      const { stdout } = await this.adbCmd(deviceId, 'reverse --list');
+      return (stdout || '')
+        .split('\n')
+        .map(line => line.match(/(tcp:\d+)\s+(tcp:\d+)/))
+        .filter(Boolean)
+        .map(m => ({ local: m[1], remote: m[2] }));
+    } catch (_) {
+      return [];
+    }
+  }
+
+  async _restoreReverses(deviceId, reverses) {
+    for (const { local, remote } of reverses) {
+      await this.adbCmd(deviceId, `reverse ${local} ${remote}`).catch(() => {});
+    }
+  }
+
+  async matchFace(deviceId) {
+    await this.root(deviceId);
+    await this.shell(deviceId, `setprop vendor.face.virtual.enrollment_hit ${ENROLLED_FACE_HIT}`);
+  }
+
+  async unmatchFace(deviceId) {
+    await this.root(deviceId);
+    await this.shell(deviceId, `setprop vendor.face.virtual.enrollment_hit ${UNENROLLED_FACE_HIT}`);
+  }
+
+  async reboot(deviceId) {
+    await this.adbCmd(deviceId, 'reboot');
+    await this.adbCmd(deviceId, 'wait-for-device');
+    await this._waitForBootComplete(deviceId);
+  }
+
+  async _waitForBootComplete(deviceId) {
+    await retry({ retries: BOOT_WAIT_RETRIES, interval: BOOT_WAIT_INTERVAL_MS, shouldUnref: true }, async () => {
+      if (!await this.isBootComplete(deviceId)) {
+        throw new DetoxRuntimeError({
+          message: `Waited for ${deviceId} to complete booting for too long!`,
+        });
+      }
+    });
   }
 
   async reverse(deviceId, port) {

--- a/detox/src/devices/common/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.test.js
@@ -204,6 +204,196 @@ describe('ADB', () => {
       expect.anything());
   });
 
+  describe('root', () => {
+    it('issues adb -s <deviceId> root and waits for the daemon to reconnect', async () => {
+      await adb.root(deviceId);
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator root`),
+        expect.anything());
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator wait-for-device`),
+        expect.anything());
+    });
+  });
+
+  describe('biometrics', () => {
+    it('matchFinger issues an emu finger touch with enrolled id, then finger remove', async () => {
+      await adb.matchFinger(deviceId);
+
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator emu "finger touch 1"`),
+        expect.anything());
+
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator emu "finger remove"`),
+        expect.anything());
+    });
+
+    it('unmatchFinger issues an emu finger touch with unenrolled id, then finger remove', async () => {
+      await adb.unmatchFinger(deviceId);
+
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator emu "finger touch 99"`),
+        expect.anything());
+
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator emu "finger remove"`),
+        expect.anything());
+    });
+
+    describe('setBiometricEnrollment', () => {
+      it('when enabled, sets PIN, sets virtual enrollment prop, and syncs the fingerprint service', async () => {
+        await adb.setBiometricEnrollment(deviceId, true);
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator root`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "locksettings clear --old 0000"`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "locksettings set-pin 0000"`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.fingerprint.virtual.enrollments 1"`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "cmd fingerprint sync"`),
+          expect.anything());
+      });
+
+      it('when disabled, syncs the fingerprint service, clears virtual enrollment prop, and removes PIN', async () => {
+        await adb.setBiometricEnrollment(deviceId, false);
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator root`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "cmd fingerprint sync"`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.fingerprint.virtual.enrollments 0"`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "locksettings clear --old 0000"`),
+          expect.anything());
+      });
+    });
+
+    describe('face (virtual HAL)', () => {
+      beforeEach(() => {
+        // Stub the reboot wait loop to avoid real sleeps.
+        jest.spyOn(adb, 'reboot').mockResolvedValue(undefined);
+      });
+
+      it('matchFace sets vendor.face.virtual.enrollment_hit to an enrolled id', async () => {
+        await adb.matchFace(deviceId);
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator root`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "setprop vendor.face.virtual.enrollment_hit 1"`),
+          expect.anything());
+      });
+
+      it('unmatchFace sets vendor.face.virtual.enrollment_hit to an unenrolled id', async () => {
+        await adb.unmatchFace(deviceId);
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator root`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "setprop vendor.face.virtual.enrollment_hit 2"`),
+          expect.anything());
+      });
+
+      describe('setFaceEnrollment', () => {
+        it('when enabled, flips the feature flag, enables virtual biometrics, sets sensor props, reboots, sets PIN, and syncs face', async () => {
+          await adb.setFaceEnrollment(deviceId, true);
+
+          expect(adb.reboot).toHaveBeenCalledWith(deviceId);
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "device_config put biometrics_framework com.android.server.biometrics.face_vhal_feature true"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "settings put secure biometric_virtual_enabled 1"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.face.virtual.strength strong"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.face.virtual.type RGB"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "locksettings set-pin 0000"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.face.virtual.enrollments 1"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "cmd face sync"`),
+            expect.anything());
+        });
+
+        it('when enabled and face HAL is already active, skips feature-flag setup and reboot', async () => {
+          // Simulate a device where the Virtual Face HAL is already configured.
+          jest.spyOn(adb, 'shell').mockImplementation(async (_deviceId, cmd) => {
+            if (cmd.includes('settings get secure biometric_virtual_enabled')) return '1';
+            if (cmd.includes('device_config get biometrics_framework com.android.server.biometrics.face_vhal_feature')) return 'true';
+            return '';
+          });
+
+          await adb.setFaceEnrollment(deviceId, true);
+
+          expect(adb.reboot).not.toHaveBeenCalled();
+          expect(adb.shell).not.toHaveBeenCalledWith(
+            deviceId,
+            expect.stringContaining('device_config put'));
+          // But still enrolls
+          expect(adb.shell).toHaveBeenCalledWith(
+            deviceId,
+            expect.stringContaining('setprop persist.vendor.face.virtual.enrollments 1'));
+          expect(adb.shell).toHaveBeenCalledWith(
+            deviceId,
+            expect.stringContaining('cmd face sync'));
+        });
+
+        it('when disabled, syncs face, clears face enrollment prop, and removes PIN', async () => {
+          await adb.setFaceEnrollment(deviceId, false);
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "cmd face sync"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.face.virtual.enrollments 0"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "locksettings clear --old 0000"`),
+            expect.anything());
+        });
+      });
+    });
+  });
+
   it(`pidof (success)`, async () => {
     jest.spyOn(adb, 'shell').mockImplementation(async () =>
       `u0_a19        2199  1701 3554600  70264 0                   0 s com.google.android.ext.services `);

--- a/detox/src/devices/common/drivers/android/exec/ADB.test.js
+++ b/detox/src/devices/common/drivers/android/exec/ADB.test.js
@@ -214,6 +214,196 @@ describe('ADB', () => {
       expect.anything());
   });
 
+  describe('root', () => {
+    it('issues adb -s <deviceId> root and waits for the daemon to reconnect', async () => {
+      await adb.root(deviceId);
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator root`),
+        expect.anything());
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator wait-for-device`),
+        expect.anything());
+    });
+  });
+
+  describe('biometrics', () => {
+    it('matchFinger issues an emu finger touch with enrolled id, then finger remove', async () => {
+      await adb.matchFinger(deviceId);
+
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator emu "finger touch 1"`),
+        expect.anything());
+
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator emu "finger remove"`),
+        expect.anything());
+    });
+
+    it('unmatchFinger issues an emu finger touch with unenrolled id, then finger remove', async () => {
+      await adb.unmatchFinger(deviceId);
+
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator emu "finger touch 99"`),
+        expect.anything());
+
+      expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+        expect.stringContaining(`-s mockEmulator emu "finger remove"`),
+        expect.anything());
+    });
+
+    describe('setBiometricEnrollment', () => {
+      it('when enabled, sets PIN, sets virtual enrollment prop, and syncs the fingerprint service', async () => {
+        await adb.setBiometricEnrollment(deviceId, true);
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator root`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "locksettings clear --old 0000"`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "locksettings set-pin 0000"`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.fingerprint.virtual.enrollments 1"`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "cmd fingerprint sync"`),
+          expect.anything());
+      });
+
+      it('when disabled, syncs the fingerprint service, clears virtual enrollment prop, and removes PIN', async () => {
+        await adb.setBiometricEnrollment(deviceId, false);
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator root`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "cmd fingerprint sync"`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.fingerprint.virtual.enrollments 0"`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "locksettings clear --old 0000"`),
+          expect.anything());
+      });
+    });
+
+    describe('face (virtual HAL)', () => {
+      beforeEach(() => {
+        // Stub the reboot wait loop to avoid real sleeps.
+        jest.spyOn(adb, 'reboot').mockResolvedValue(undefined);
+      });
+
+      it('matchFace sets vendor.face.virtual.enrollment_hit to an enrolled id', async () => {
+        await adb.matchFace(deviceId);
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator root`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "setprop vendor.face.virtual.enrollment_hit 1"`),
+          expect.anything());
+      });
+
+      it('unmatchFace sets vendor.face.virtual.enrollment_hit to an unenrolled id', async () => {
+        await adb.unmatchFace(deviceId);
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator root`),
+          expect.anything());
+
+        expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+          expect.stringContaining(`-s mockEmulator shell "setprop vendor.face.virtual.enrollment_hit 2"`),
+          expect.anything());
+      });
+
+      describe('setFaceEnrollment', () => {
+        it('when enabled, flips the feature flag, enables virtual biometrics, sets sensor props, reboots, sets PIN, and syncs face', async () => {
+          await adb.setFaceEnrollment(deviceId, true);
+
+          expect(adb.reboot).toHaveBeenCalledWith(deviceId);
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "device_config put biometrics_framework com.android.server.biometrics.face_vhal_feature true"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "settings put secure biometric_virtual_enabled 1"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.face.virtual.strength strong"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.face.virtual.type RGB"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "locksettings set-pin 0000"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.face.virtual.enrollments 1"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "cmd face sync"`),
+            expect.anything());
+        });
+
+        it('when enabled and face HAL is already active, skips feature-flag setup and reboot', async () => {
+          // Simulate a device where the Virtual Face HAL is already configured.
+          jest.spyOn(adb, 'shell').mockImplementation(async (_deviceId, cmd) => {
+            if (cmd.includes('settings get secure biometric_virtual_enabled')) return '1';
+            if (cmd.includes('device_config get biometrics_framework com.android.server.biometrics.face_vhal_feature')) return 'true';
+            return '';
+          });
+
+          await adb.setFaceEnrollment(deviceId, true);
+
+          expect(adb.reboot).not.toHaveBeenCalled();
+          expect(adb.shell).not.toHaveBeenCalledWith(
+            deviceId,
+            expect.stringContaining('device_config put'));
+          // But still enrolls
+          expect(adb.shell).toHaveBeenCalledWith(
+            deviceId,
+            expect.stringContaining('setprop persist.vendor.face.virtual.enrollments 1'));
+          expect(adb.shell).toHaveBeenCalledWith(
+            deviceId,
+            expect.stringContaining('cmd face sync'));
+        });
+
+        it('when disabled, syncs face, clears face enrollment prop, and removes PIN', async () => {
+          await adb.setFaceEnrollment(deviceId, false);
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "cmd face sync"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "setprop persist.vendor.face.virtual.enrollments 0"`),
+            expect.anything());
+
+          expect(execWithRetriesAndLogs).toHaveBeenCalledWith(
+            expect.stringContaining(`-s mockEmulator shell "locksettings clear --old 0000"`),
+            expect.anything());
+        });
+      });
+    });
+  });
+
   it(`pidof (success)`, async () => {
     jest.spyOn(adb, 'shell').mockImplementation(async () =>
       `u0_a19        2199  1701 3554600  70264 0                   0 s com.google.android.ext.services `);

--- a/detox/src/devices/runtime/RuntimeDevice.js
+++ b/detox/src/devices/runtime/RuntimeDevice.js
@@ -211,9 +211,9 @@ class RuntimeDevice {
     await this.deviceDriver.waitForBackground();
   }
 
-  async setBiometricEnrollment(toggle) {
+  async setBiometricEnrollment(toggle, options) {
     const yesOrNo = toggle ? 'YES' : 'NO';
-    await this.deviceDriver.setBiometricEnrollment(yesOrNo);
+    await this.deviceDriver.setBiometricEnrollment(yesOrNo, options);
   }
 
   async matchFace() {

--- a/detox/src/devices/runtime/RuntimeDevice.js
+++ b/detox/src/devices/runtime/RuntimeDevice.js
@@ -212,9 +212,9 @@ class RuntimeDevice {
     await this.deviceDriver.waitForBackground();
   }
 
-  async setBiometricEnrollment(toggle) {
+  async setBiometricEnrollment(toggle, options) {
     const yesOrNo = toggle ? 'YES' : 'NO';
-    await this.deviceDriver.setBiometricEnrollment(yesOrNo);
+    await this.deviceDriver.setBiometricEnrollment(yesOrNo, options);
   }
 
   async matchFace() {

--- a/detox/src/devices/runtime/RuntimeDevice.test.js
+++ b/detox/src/devices/runtime/RuntimeDevice.test.js
@@ -740,7 +740,7 @@ describe('Device', () => {
     const device = await aValidDevice();
     await device.setBiometricEnrollment(true);
 
-    expect(driverMock.driver.setBiometricEnrollment).toHaveBeenCalledWith('YES');
+    expect(driverMock.driver.setBiometricEnrollment).toHaveBeenCalledWith('YES', undefined);
     expect(driverMock.driver.setBiometricEnrollment).toHaveBeenCalledTimes(1);
   });
 
@@ -748,8 +748,15 @@ describe('Device', () => {
     const device = await aValidDevice();
     await device.setBiometricEnrollment(false);
 
-    expect(driverMock.driver.setBiometricEnrollment).toHaveBeenCalledWith('NO');
+    expect(driverMock.driver.setBiometricEnrollment).toHaveBeenCalledWith('NO', undefined);
     expect(driverMock.driver.setBiometricEnrollment).toHaveBeenCalledTimes(1);
+  });
+
+  it(`setBiometricEnrollment(true, { androidFace: true }) should forward options to device driver`, async () => {
+    const device = await aValidDevice();
+    await device.setBiometricEnrollment(true, { androidFace: true });
+
+    expect(driverMock.driver.setBiometricEnrollment).toHaveBeenCalledWith('YES', { androidFace: true });
   });
 
   it(`matchFace() should pass to device driver`, async () => {

--- a/detox/src/devices/runtime/drivers/android/AndroidDriver.js
+++ b/detox/src/devices/runtime/drivers/android/AndroidDriver.js
@@ -242,6 +242,38 @@ class AndroidDriver extends DeviceDriverBase {
     return tempPath;
   }
 
+  async matchFace() {
+    throw new DetoxRuntimeError({
+      message: 'matchFace() is only supported on Android emulators (AVDs).',
+      hint: 'Use an emulator (AVD) and call setBiometricEnrollment(true, { androidFace: true }) once before matchFace(). If face-specific simulation is not required, matchFinger() works without any opt-in.',
+    });
+  }
+
+  async unmatchFace() {
+    throw new DetoxRuntimeError({
+      message: 'unmatchFace() is only supported on Android emulators (AVDs).',
+      hint: 'Use an emulator (AVD) and call setBiometricEnrollment(true, { androidFace: true }) once before unmatchFace(). If face-specific simulation is not required, unmatchFinger() works without any opt-in.',
+    });
+  }
+
+  async setBiometricEnrollment(_yesOrNo, _options) {
+    throw new DetoxRuntimeError({
+      message: 'setBiometricEnrollment() is only supported on Android emulators (AVDs).',
+    });
+  }
+
+  async matchFinger() {
+    throw new DetoxRuntimeError({
+      message: 'matchFinger() is only supported on Android emulators (AVDs).',
+    });
+  }
+
+  async unmatchFinger() {
+    throw new DetoxRuntimeError({
+      message: 'unmatchFinger() is only supported on Android emulators (AVDs).',
+    });
+  }
+
   async setOrientation(orientation) {
     const orientationMapping = {
       landscape: 1, // top at left side landscape

--- a/detox/src/devices/runtime/drivers/android/AndroidDriver.test.js
+++ b/detox/src/devices/runtime/drivers/android/AndroidDriver.test.js
@@ -625,6 +625,28 @@ describe('Android driver', () => {
     jest.mock('../../../allocation/DeviceRegistry');
   };
 
+  describe('biometrics', () => {
+    it('matchFace throws "only supported on Android emulators"', async () => {
+      await expect(uut.matchFace()).rejects.toThrow(/only supported on Android emulators/);
+    });
+
+    it('unmatchFace throws "only supported on Android emulators"', async () => {
+      await expect(uut.unmatchFace()).rejects.toThrow(/only supported on Android emulators/);
+    });
+
+    it('setBiometricEnrollment throws "only supported on Android emulators"', async () => {
+      await expect(uut.setBiometricEnrollment('YES')).rejects.toThrow(/only supported on Android emulators/);
+    });
+
+    it('matchFinger throws "only supported on Android emulators"', async () => {
+      await expect(uut.matchFinger()).rejects.toThrow(/only supported on Android emulators/);
+    });
+
+    it('unmatchFinger throws "only supported on Android emulators"', async () => {
+      await expect(uut.unmatchFinger()).rejects.toThrow(/only supported on Android emulators/);
+    });
+  });
+
   const mockGetAbsoluteBinaryPathImpl = (x) => `absolutePathOf(${x})`;
   const mockAPKPathGetTestApkPathImpl = (x) => `testApkPathOf(${x})`;
 

--- a/detox/src/devices/runtime/drivers/android/emulator/EmulatorDriver.js
+++ b/detox/src/devices/runtime/drivers/android/emulator/EmulatorDriver.js
@@ -39,6 +39,37 @@ class EmulatorDriver extends AndroidDriver {
     await this.adb.setLocation(this.adbName, lat, lon);
   }
 
+  async setBiometricEnrollment(yesOrNo, options) {
+    const enabled = yesOrNo === 'YES';
+    if (options && options.androidFace) {
+      // Face HAL activation may reboot the emulator; disarm the unexpected-
+      // termination handler so its adb-reverse cleanup doesn't fire while the
+      // device is offline.
+      if (this.instrumentation && this.instrumentation.setTerminationFn) {
+        this.instrumentation.setTerminationFn(null);
+      }
+      await this.adb.setFaceEnrollment(this.adbName, enabled);
+    } else {
+      await this.adb.setBiometricEnrollment(this.adbName, enabled);
+    }
+  }
+
+  async matchFinger() {
+    await this.adb.matchFinger(this.adbName);
+  }
+
+  async unmatchFinger() {
+    await this.adb.unmatchFinger(this.adbName);
+  }
+
+  async matchFace() {
+    await this.adb.matchFace(this.adbName);
+  }
+
+  async unmatchFace() {
+    await this.adb.unmatchFace(this.adbName);
+  }
+
   async __installAppBinaries(appBinaryPath, testBinaryPath) {
     await this.appInstallHelper.install(this.adbName, appBinaryPath, testBinaryPath);
   }

--- a/detox/src/devices/runtime/drivers/android/emulator/EmulatorDriver.test.js
+++ b/detox/src/devices/runtime/drivers/android/emulator/EmulatorDriver.test.js
@@ -1,0 +1,90 @@
+// @ts-nocheck
+describe('Emulator driver', () => {
+  const adbName = 'mock-emulator-5554';
+  const avdName = 'Pixel_API_34';
+
+  let adb;
+  let instrumentation;
+  let uut;
+
+  beforeEach(() => {
+    jest.mock('../../../../../utils/logger');
+
+    jest.mock('../../../../common/drivers/android/exec/ADB');
+    const ADB = jest.requireMock('../../../../common/drivers/android/exec/ADB');
+    adb = new ADB();
+
+    jest.mock('../../../../common/drivers/android/tools/MonitoredInstrumentation');
+    const MonitoredInstrumentation = jest.requireMock('../../../../common/drivers/android/tools/MonitoredInstrumentation');
+    instrumentation = new MonitoredInstrumentation();
+
+    const Emitter = jest.createMockFromModule('../../../../../utils/AsyncEmitter');
+    const eventEmitter = new Emitter();
+
+    const { InvocationManager } = jest.createMockFromModule('../../../../../invoke');
+    const invocationManager = new InvocationManager();
+
+    const EmulatorDriver = require('./EmulatorDriver');
+    uut = new EmulatorDriver({
+      adb,
+      instrumentation,
+      invocationManager,
+      eventEmitter,
+      client: {},
+    }, { adbName, avdName, forceAdbInstall: false });
+  });
+
+  describe('biometrics', () => {
+    it('setBiometricEnrollment("YES") delegates to adb with enabled=true', async () => {
+      await uut.setBiometricEnrollment('YES');
+      expect(adb.setBiometricEnrollment).toHaveBeenCalledWith(adbName, true);
+    });
+
+    it('setBiometricEnrollment("NO") delegates to adb with enabled=false', async () => {
+      await uut.setBiometricEnrollment('NO');
+      expect(adb.setBiometricEnrollment).toHaveBeenCalledWith(adbName, false);
+    });
+
+    it('matchFinger delegates to adb.matchFinger', async () => {
+      await uut.matchFinger();
+      expect(adb.matchFinger).toHaveBeenCalledWith(adbName);
+    });
+
+    it('unmatchFinger delegates to adb.unmatchFinger', async () => {
+      await uut.unmatchFinger();
+      expect(adb.unmatchFinger).toHaveBeenCalledWith(adbName);
+    });
+
+    it('matchFace delegates to adb.matchFace', async () => {
+      await uut.matchFace();
+      expect(adb.matchFace).toHaveBeenCalledWith(adbName);
+    });
+
+    it('unmatchFace delegates to adb.unmatchFace', async () => {
+      await uut.unmatchFace();
+      expect(adb.unmatchFace).toHaveBeenCalledWith(adbName);
+    });
+
+    it('setBiometricEnrollment with { androidFace: true } delegates to adb.setFaceEnrollment', async () => {
+      await uut.setBiometricEnrollment('YES', { androidFace: true });
+      expect(adb.setFaceEnrollment).toHaveBeenCalledWith(adbName, true);
+      expect(adb.setBiometricEnrollment).not.toHaveBeenCalled();
+    });
+
+    it('setBiometricEnrollment with { androidFace: true } clears instrumentation termination callback before the potentially-rebooting setup', async () => {
+      await uut.setBiometricEnrollment('YES', { androidFace: true });
+      expect(instrumentation.setTerminationFn).toHaveBeenCalledWith(null);
+    });
+
+    it('setBiometricEnrollment("NO") with { androidFace: true } delegates to adb.setFaceEnrollment(false)', async () => {
+      await uut.setBiometricEnrollment('NO', { androidFace: true });
+      expect(adb.setFaceEnrollment).toHaveBeenCalledWith(adbName, false);
+    });
+
+    it('setBiometricEnrollment without options still delegates to adb.setBiometricEnrollment (fingerprint path)', async () => {
+      await uut.setBiometricEnrollment('YES');
+      expect(adb.setBiometricEnrollment).toHaveBeenCalledWith(adbName, true);
+      expect(adb.setFaceEnrollment).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/detox/test/e2e/14.android-biometrics.test.js
+++ b/detox/test/e2e/14.android-biometrics.test.js
@@ -1,0 +1,49 @@
+describe(':android: Android biometrics', () => {
+  beforeAll(async () => {
+    await device.launchApp({ newInstance: true });
+  });
+
+  afterAll(async () => {
+    await device.setBiometricEnrollment(false).catch(() => {});
+    await device.setBiometricEnrollment(false, { androidFace: true }).catch(() => {});
+  });
+
+  describe('fingerprint (default)', () => {
+    it('setBiometricEnrollment(true) resolves without throwing', async () => {
+      await device.setBiometricEnrollment(true);
+    });
+
+    it('matchFinger resolves without throwing after enrollment', async () => {
+      await device.setBiometricEnrollment(true);
+      await device.matchFinger();
+    });
+
+    it('unmatchFinger resolves without throwing after enrollment', async () => {
+      await device.setBiometricEnrollment(true);
+      await device.unmatchFinger();
+    });
+
+    it('setBiometricEnrollment(false) resolves without throwing', async () => {
+      await device.setBiometricEnrollment(false);
+    });
+  });
+
+  describe('face (Virtual Face HAL, opt-in)', () => {
+    it('setBiometricEnrollment(true, { androidFace: true }) resolves without throwing (reboots emulator on first call)', async () => {
+      await device.setBiometricEnrollment(true, { androidFace: true });
+      await device.launchApp({ newInstance: true });
+    }, 240000);
+
+    it('matchFace resolves without throwing after face enrollment', async () => {
+      await device.matchFace();
+    });
+
+    it('unmatchFace resolves without throwing after face enrollment', async () => {
+      await device.unmatchFace();
+    });
+
+    it('setBiometricEnrollment(false, { androidFace: true }) resolves without throwing', async () => {
+      await device.setBiometricEnrollment(false, { androidFace: true });
+    });
+  });
+});

--- a/docs/api/device.md
+++ b/docs/api/device.md
@@ -532,9 +532,12 @@ const viewHierarchyXml = await device.generateViewHierarchyXml();
 
 Simulate shake
 
-### `device.setBiometricEnrollment(bool)` **iOS Only**
+### `device.setBiometricEnrollment(bool, options?)`
 
-Toggles device enrollment in biometric authentication (Touch ID or Face ID).
+Toggles device enrollment in biometric authentication.
+
+- **iOS:** Touch ID or Face ID on any simulator. `options` are ignored (iOS enrolls both modalities together).
+- **Android:** Emulators (AVDs) only. Detox calls `adb root` internally, sets a PIN of `0000`, flips the Virtual Fingerprint HAL enrollment flag, and syncs the fingerprint service. Requires a userdebug emulator image (standard Android Studio AVDs are userdebug); this will fail on non-userdebug images. Not supported on physical devices or Genymotion Cloud.
 
 ```js
 await device.setBiometricEnrollment(true);
@@ -542,21 +545,54 @@ await device.setBiometricEnrollment(true);
 await device.setBiometricEnrollment(false);
 ```
 
-### `device.matchFace()` **iOS Only**
+#### `options.androidFace` — Android Virtual Face HAL opt-in
 
-Simulates the success of a face match via Face ID
+Android emulators can also run a Virtual Face HAL, disabled by default. To enroll a face instead of a fingerprint on Android, pass `{ androidFace: true }`:
 
-### `device.unmatchFace()` **iOS Only**
+```js
+await device.setBiometricEnrollment(true, { androidFace: true });
+await device.launchApp({ newInstance: true });  // required after the first enable — see below
+await device.matchFace();
+// ... later
+await device.setBiometricEnrollment(false, { androidFace: true });
+```
 
-Simulates the failure of face match via Face ID
+The first enable call on a given AVD is heavier than fingerprint: Detox enables the `com.android.server.biometrics.face_vhal_feature` device config flag, sets `biometric_virtual_enabled=1`, applies the `persist.vendor.face.virtual.type` / `strength` sensor props, and **reboots the emulator** so the Face HAL picks up the new configuration. Expect ~20 seconds for this first call. Subsequent calls on the same AVD session detect the active HAL and skip the reboot (~3 seconds).
 
-### `device.matchFinger()` **iOS Only**
+**Caveats:**
+- **Requires a userdebug AVD.** Standard Android Studio AVD images are userdebug.
+- **Requires `launchApp({ newInstance: true })` after the first enable call** — the reboot kills the app process. Subsequent enable calls (when the HAL is already active) do not reboot and do not require a relaunch.
+- **Leaves `device_config` in `set_sync_disabled_for_tests persistent` mode** on the AVD so the feature flag survives the reboot. This suppresses the system server's periodic `device_config` sync for all namespaces — safe on throwaway CI AVDs but worth noting if you reuse warm AVDs across test runs. The disable path does not revert this; call `adb shell device_config set_sync_disabled_for_tests none` manually if you need to restore it.
 
-Simulates the success of a finger match via Touch ID
+The `androidFace` option is ignored on iOS.
 
-### `device.unmatchFinger()` **iOS Only**
+### `device.matchFace()`
 
-Simulates the failure of a finger match via Touch ID
+Simulates the success of a face match.
+
+- **iOS:** Face ID on any simulator.
+- **Android:** Emulator (AVD) only. Requires a prior `device.setBiometricEnrollment(true, { androidFace: true })`.
+
+### `device.unmatchFace()`
+
+Simulates the failure of a face match.
+
+- **iOS:** Face ID on any simulator.
+- **Android:** Emulator (AVD) only. Requires a prior `device.setBiometricEnrollment(true, { androidFace: true })`.
+
+### `device.matchFinger()`
+
+Simulates the success of a finger match.
+
+- **iOS:** Touch ID on any simulator.
+- **Android:** Fingerprint on emulators (AVDs) only; not supported on physical devices or Genymotion Cloud.
+
+### `device.unmatchFinger()`
+
+Simulates the failure of a finger match.
+
+- **iOS:** Touch ID on any simulator.
+- **Android:** Fingerprint on emulators (AVDs) only; not supported on physical devices or Genymotion Cloud.
 
 ### `device.clearKeychain()` **iOS Only**
 

--- a/docs/api/device.md
+++ b/docs/api/device.md
@@ -554,9 +554,12 @@ const viewHierarchyXml = await device.generateViewHierarchyXml();
 
 Simulate shake
 
-### `device.setBiometricEnrollment(bool)` **iOS Only**
+### `device.setBiometricEnrollment(bool, options?)`
 
-Toggles device enrollment in biometric authentication (Touch ID or Face ID).
+Toggles device enrollment in biometric authentication.
+
+- **iOS:** Touch ID or Face ID on any simulator. `options` are ignored (iOS enrolls both modalities together).
+- **Android:** Emulators (AVDs) only. Detox calls `adb root` internally, sets a PIN of `0000`, flips the Virtual Fingerprint HAL enrollment flag, and syncs the fingerprint service. Requires a userdebug emulator image (standard Android Studio AVDs are userdebug); this will fail on non-userdebug images. Not supported on physical devices or Genymotion Cloud.
 
 ```js
 await device.setBiometricEnrollment(true);
@@ -564,21 +567,54 @@ await device.setBiometricEnrollment(true);
 await device.setBiometricEnrollment(false);
 ```
 
-### `device.matchFace()` **iOS Only**
+#### `options.androidFace` — Android Virtual Face HAL opt-in
 
-Simulates the success of a face match via Face ID
+Android emulators can also run a Virtual Face HAL, disabled by default. To enroll a face instead of a fingerprint on Android, pass `{ androidFace: true }`:
 
-### `device.unmatchFace()` **iOS Only**
+```js
+await device.setBiometricEnrollment(true, { androidFace: true });
+await device.launchApp({ newInstance: true });  // required after the first enable — see below
+await device.matchFace();
+// ... later
+await device.setBiometricEnrollment(false, { androidFace: true });
+```
 
-Simulates the failure of face match via Face ID
+The first enable call on a given AVD is heavier than fingerprint: Detox enables the `com.android.server.biometrics.face_vhal_feature` device config flag, sets `biometric_virtual_enabled=1`, applies the `persist.vendor.face.virtual.type` / `strength` sensor props, and **reboots the emulator** so the Face HAL picks up the new configuration. Expect ~20 seconds for this first call. Subsequent calls on the same AVD session detect the active HAL and skip the reboot (~3 seconds).
 
-### `device.matchFinger()` **iOS Only**
+**Caveats:**
+- **Requires a userdebug AVD.** Standard Android Studio AVD images are userdebug.
+- **Requires `launchApp({ newInstance: true })` after the first enable call** — the reboot kills the app process. Subsequent enable calls (when the HAL is already active) do not reboot and do not require a relaunch.
+- **Leaves `device_config` in `set_sync_disabled_for_tests persistent` mode** on the AVD so the feature flag survives the reboot. This suppresses the system server's periodic `device_config` sync for all namespaces — safe on throwaway CI AVDs but worth noting if you reuse warm AVDs across test runs. The disable path does not revert this; call `adb shell device_config set_sync_disabled_for_tests none` manually if you need to restore it.
 
-Simulates the success of a finger match via Touch ID
+The `androidFace` option is ignored on iOS.
 
-### `device.unmatchFinger()` **iOS Only**
+### `device.matchFace()`
 
-Simulates the failure of a finger match via Touch ID
+Simulates the success of a face match.
+
+- **iOS:** Face ID on any simulator.
+- **Android:** Emulator (AVD) only. Requires a prior `device.setBiometricEnrollment(true, { androidFace: true })`.
+
+### `device.unmatchFace()`
+
+Simulates the failure of a face match.
+
+- **iOS:** Face ID on any simulator.
+- **Android:** Emulator (AVD) only. Requires a prior `device.setBiometricEnrollment(true, { androidFace: true })`.
+
+### `device.matchFinger()`
+
+Simulates the success of a finger match.
+
+- **iOS:** Touch ID on any simulator.
+- **Android:** Fingerprint on emulators (AVDs) only; not supported on physical devices or Genymotion Cloud.
+
+### `device.unmatchFinger()`
+
+Simulates the failure of a finger match.
+
+- **iOS:** Touch ID on any simulator.
+- **Android:** Fingerprint on emulators (AVDs) only; not supported on physical devices or Genymotion Cloud.
 
 ### `device.clearKeychain()` **iOS Only**
 


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #3198

In this pull request, I have added Android emulator support for Detox's biometrics API. Existing iOS
behavior is unchanged. Reviewed and tested end-to-end on a real emulator before submission.

- `device.setBiometricEnrollment(bool)` and `device.matchFinger()` / `unmatchFinger()` now work on
Android emulators (AVDs), using the Virtual Fingerprint HAL.
- `device.matchFace()` / `unmatchFace()` work on Android emulators via the Virtual Face HAL, opt-in
with `setBiometricEnrollment(true, { androidFace: true })`. The face path reboots the emulator on
first activation (~20s); subsequent calls short-circuit (~3s).
- Attached devices and Genymotion Cloud throw clear `"only supported on Android emulators (AVDs)"`
errors with actionable hints.
- Requires a userdebug AVD (standard Android Studio images).

## Test plan

- Unit: 3217 tests pass; new coverage across `ADB.test.js`, `AndroidDriver.test.js`, new `EmulatorDriver.test.js`, `RuntimeDevice.test.js`.
- E2E: 8/8 pass on a real Pixel 3a API 34 userdebug AVD (`detox/test/e2e/14.android-biometrics.test.js`), covering both fingerprint and face paths including idempotent re-enable.
- Backwards compatible — existing `setBiometricEnrollment(bool)` callers and all iOS behavior unchanged.

---

- [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files — `docs/api/device.md`.

- [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file — `detox/detox.d.ts` (new `BiometricEnrollmentOptions` type + refreshed JSDoc; `detox/index.d.ts` is a pass-through wrapper so no direct edit was needed).

---

_Code developed by Claude_