### PR TITLE
fix(sync): accept null one-time event objects

### DIFF
--- a/detox/src/client/actions/SyncStatusSchema.json
+++ b/detox/src/client/actions/SyncStatusSchema.json
@@ -114,7 +114,10 @@
                         "type":"string"
                       },
                       "object":{
-                        "type":"string"
+                        "type":[
+                          "string",
+                          "null"
+                        ]
                       }
                     },
                     "required":[

--- a/detox/src/client/actions/formatters/SyncStatusFormatter.test.js
+++ b/detox/src/client/actions/formatters/SyncStatusFormatter.test.js
@@ -150,6 +150,23 @@ describe('Sync Status Formatter', () => {
       await expect(format(busyStatus)).toMatchSnapshot();
     });
 
+    it('should format "one_time_events" correctly when object is null', async () => {
+      let busyStatus = {
+        app_status: 'busy',
+        busy_resources: [
+          {
+            name: 'one_time_events',
+            description: {
+              event: 'foo',
+              object: null
+            }
+          }
+        ]
+      };
+
+      await expect(format(busyStatus)).toMatchSnapshot();
+    });
+
     it('should format "one_time_events" correctly', async () => {
       let busyStatus = {
         app_status: 'busy',

--- a/detox/src/client/actions/formatters/__snapshots__/SyncStatusFormatter.test.js.snap
+++ b/detox/src/client/actions/formatters/__snapshots__/SyncStatusFormatter.test.js.snap
@@ -176,6 +176,11 @@ exports[`Sync Status Formatter busy status should format "one_time_events" corre
 • The event "foo" is taking place with object: "bar"."
 `;
 
+exports[`Sync Status Formatter busy status should format "one_time_events" correctly when object is null 1`] = `
+"The app is busy with the following tasks:
+• The event "foo" is taking place."
+`;
+
 exports[`Sync Status Formatter busy status should format "one_time_events" correctly when there is no object 1`] = `
 "The app is busy with the following tasks:
 • The event "foo" is taking place."

--- a/detox/src/client/actions/formatters/sync-resources/OneTimeEventsFormatter.js
+++ b/detox/src/client/actions/formatters/sync-resources/OneTimeEventsFormatter.js
@@ -3,6 +3,6 @@ const { makeResourceTitle } = require('./utils');
 module.exports = function(properties) {
   const objectName = properties.object;
   return makeResourceTitle(
-    `The event "${properties.event}" is taking place${(objectName === undefined) ? `.` : ` with object: "${objectName}".`}`
+    `The event "${properties.event}" is taking place${(objectName == null) ? `.` : ` with object: "${objectName}".`}`
   );
 };


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #4942

In this pull request, I have updated the sync status schema to accept `null` for `one_time_events.description.object`, matching the iOS payload described in the issue. The one-time event formatter now treats `null` the same as a missing object description, and a regression snapshot covers that path.

## Verification

- `corepack yarn workspace detox jest src/client/actions/formatters/SyncStatusFormatter.test.js --updateSnapshot --runInBand`
- `corepack yarn workspace detox eslint src/client/actions/formatters/SyncStatusFormatter.test.js src/client/actions/formatters/sync-resources/OneTimeEventsFormatter.js`
- `git diff --check`

---

> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.

This was implemented with Codex assistance, with the patch kept focused on the schema/formatter mismatch and reviewed against the existing unit tests.