### PR TITLE
fix(types): allow regex in toHaveText

### DIFF
--- a/detox/detox.d.ts
+++ b/detox/detox.d.ts
@@ -1516,9 +1516,10 @@ declare global {
             /**
              * In React Native apps, expect UI component of type <Text> to have text.
              * In native iOS apps, expect UI elements of type UIButton, UILabel, UITextField or UITextViewIn to have inputText with text.
-             * @example await expect(element(by.id('mainTitle'))).toHaveText('Welcome back!);
+             * @example await expect(element(by.id('mainTitle'))).toHaveText('Welcome back!');
+             * @example await expect(element(by.id('dynamicTitle'))).toHaveText(/^Welcome back/);
              */
-            toHaveText(text: string): R;
+            toHaveText(text: string | RegExp): R;
 
             /**
              * Expects a specific accessibilityLabel, as specified via the `accessibilityLabel` prop in React Native.

--- a/detox/test/types/detox-global-tests.ts
+++ b/detox/test/types/detox-global-tests.ts
@@ -80,9 +80,11 @@ describe("Test", () => {
         await expectElement.toBeFocused();
         await expectElement.not.toBeFocused();
         await expectElement.toBeNotFocused();
+        await expectElement.toHaveText(/dynamic text/);
 
         const waitForElement = waitFor(element(by.id("element")));
         await waitForElement.toBeVisible().withTimeout(2000);
+        await waitForElement.toHaveText(/dynamic text/).withTimeout(2000);
 
         await device.pressBack();
         await device.reverseTcpPort(32167);

--- a/detox/test/types/detox-module-tests.ts
+++ b/detox/test/types/detox-module-tests.ts
@@ -60,6 +60,7 @@ describe('Test', () => {
     await element(by.id('element')).scroll(50, 'down', 0.5, 0.5);
     await element(by.id('scrollView')).scrollTo('bottom');
     await expect(element(by.id('element')).atIndex(0)).toNotExist();
+    await expect(element(by.id('element'))).toHaveText(/dynamic text/);
     await element(by.id('scrollView')).swipe('down', 'fast', 0.2, 0.5, 0.5);
     await element(by.type('UIPickerView')).setColumnToValue(1, '6');
 
@@ -68,6 +69,9 @@ describe('Test', () => {
 
     await waitFor(element(by.id('element')))
       .toBeVisible()
+      .withTimeout(2000);
+    await waitFor(element(by.id('element')))
+      .toHaveText(/dynamic text/)
       .withTimeout(2000);
     await device.pressBack();
     await waitFor(element(by.text('Text5')))


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #4914

This updates the native `toHaveText` TypeScript declaration to accept `RegExp` as well as `string`. The Android expectation path already has runtime coverage for `toHaveText(/text/)`, so this keeps the public typings aligned with existing behavior and adds type-test coverage for both global and module import styles.

---

> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files. Not applicable: this is a typings parity fix for already-covered runtime behavior.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.

## Verification

- `yarn install --immutable --mode=skip-build` (completed with existing peer dependency warnings)
- `yarn --cwd detox/test test:types`
- `yarn --cwd detox/test eslint types/detox-global-tests.ts types/detox-module-tests.ts`
- `yarn --cwd detox jest src/android/AndroidExpect.test.js --runInBand`
- `git diff --check`

This was implemented with Codex assistance, with the patch kept focused and manually reviewed against the existing matcher/type path.