### PR TITLE
build(cli): replace execa with native spawn in AppStartCommand

### DIFF
--- a/detox/local-cli/startCommand/AppStartCommand.js
+++ b/detox/local-cli/startCommand/AppStartCommand.js
@@ -1,4 +1,4 @@
-const execa = require('execa');
+const { spawn } = require('child_process');
 
 const detox = require('../../internals');
 const { DetoxRuntimeError } = require('../../src/errors');
@@ -36,9 +36,9 @@ class AppStartCommand {
       }
     };
 
-    this._cpHandle = execa.command(cmd, {
+    this._cpHandle = spawn(cmd, [], {
       stdio: ['ignore', 'inherit', 'inherit'],
-      shell: true
+      shell: true,
     });
     this._cpHandle.on('error', onError);
     this._cpHandle.on('exit', (code, signal) => {
@@ -58,7 +58,14 @@ class AppStartCommand {
 
   async stop() {
     if (this._cpHandle) {
-      this._cpHandle.kill();
+      this._cpHandle.kill('SIGTERM');
+      const killTimer = setTimeout(() => {
+        if (this._cpHandle) {
+          this._cpHandle.kill('SIGKILL');
+        }
+      }, 5000);
+      killTimer.unref();
+      return this._cpDeferred.promise.finally(() => clearTimeout(killTimer));
     }
 
     return this._cpDeferred.promise;

--- a/detox/local-cli/startCommand/AppStartCommand.test.js
+++ b/detox/local-cli/startCommand/AppStartCommand.test.js
@@ -1,0 +1,55 @@
+const { EventEmitter } = require('events');
+
+jest.mock('child_process');
+jest.mock('../../src/utils/logger');
+jest.mock('../../internals', () => ({
+  log: require('../../src/utils/logger'),
+}));
+
+describe('AppStartCommand', () => {
+  let AppStartCommand, spawn, mockChild;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    spawn = require('child_process').spawn;
+    AppStartCommand = require('./AppStartCommand');
+    mockChild = Object.assign(new EventEmitter(), { kill: jest.fn() });
+    spawn.mockReturnValue(mockChild);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetModules();
+  });
+
+  it('escalates to SIGKILL if process does not exit after SIGTERM', async () => {
+    const cmd = new AppStartCommand({ cmd: 'sleep 100', forceSpawn: true });
+    cmd.execute();
+
+    const stopPromise = cmd.stop();
+    expect(mockChild.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(mockChild.kill).not.toHaveBeenCalledWith('SIGKILL');
+
+    jest.advanceTimersByTime(5001);
+    expect(mockChild.kill).toHaveBeenCalledWith('SIGKILL');
+
+    // Simulate the process finally exiting so stop() resolves
+    mockChild.emit('exit', 1, null);
+    await stopPromise;
+  });
+
+  it('does not send SIGKILL if process exits before the timeout fires', async () => {
+    const cmd = new AppStartCommand({ cmd: 'sleep 100', forceSpawn: true });
+    cmd.execute();
+
+    const stopPromise = cmd.stop();
+    expect(mockChild.kill).toHaveBeenCalledWith('SIGTERM');
+
+    // Process exits shortly after SIGTERM — before the 5s timer fires
+    mockChild.emit('exit', 0, null);
+    await stopPromise;
+
+    jest.advanceTimersByTime(5001);
+    expect(mockChild.kill).not.toHaveBeenCalledWith('SIGKILL');
+  });
+});

--- a/detox/package.json
+++ b/detox/package.json
@@ -85,6 +85,7 @@
     "react-native": "0.83.0",
     "react-native-codegen": "^0.0.8",
     "typescript": "^5.8.3",
+    "tinyexec": "^0.3.0",
     "wtfnode": "^0.9.1"
   },
   "dependencies": {
@@ -95,7 +96,6 @@
     "bunyan-debug-stream": "^3.1.0",
     "caf": "^15.0.1",
     "chalk": "^4.0.0",
-    "execa": "^5.1.1",
     "find-up": "^5.0.0",
     "fs-extra": "^11.0.0",
     "funpermaproxy": "^1.1.0",

--- a/detox/test/integration/bail-test.test.js
+++ b/detox/test/integration/bail-test.test.js
@@ -1,22 +1,21 @@
-const _ = require('lodash');
-const execa = require('execa');
+const tinyexec = require('tinyexec');
 
 describe('jest --bail tests', () => {
   test.each([
     `detox test -c stub --config integration/e2e/config.js --bail --maxWorkers 2 --retries 1 flaky passing-simple`,
-    `cross-env DETOX_CONFIGURATION=stub jest --config integration/e2e/config.js --bail --runInBand passing-simple`,
+    `cross-env DETOX_CONFIGURATION=stub jest --config integration/e2e/config.js --bail --runInBand passing-simple`
   ])('should pass: %s', async (cmd) => {
     console.log(`Running: ${cmd}`);
-    const handle = execa.commandSync(cmd, { stdio: 'inherit', shell: true });
+    const handle = await tinyexec.x(cmd, [], { nodeOptions: { stdio: 'inherit', shell: true } });
     expect(handle.exitCode).toBe(0);
   });
 
   test.each([
     `detox test -c stub --config integration/e2e/config.js --bail --runInBand --retries 0 flaky passing-simple`,
-    `cross-env DETOX_CONFIGURATION=stub jest --config integration/e2e/config.js --maxWorkers 4 flaky passing`,
+    `cross-env DETOX_CONFIGURATION=stub jest --config integration/e2e/config.js --maxWorkers 4 flaky passing`
   ])('should fail: %s', async (cmd) => {
     console.log(`Running: ${cmd}`);
-    const handle = _.attempt(() => execa.commandSync(cmd, { stdio: 'inherit', shell: true }));
+    const handle = await tinyexec.x(cmd, [], { nodeOptions: { stdio: 'inherit', shell: true } });
     expect(handle.exitCode).not.toBe(0);
   });
 });

--- a/detox/test/integration/initialization-test.test.js
+++ b/detox/test/integration/initialization-test.test.js
@@ -1,4 +1,4 @@
-const execa = require('execa');
+const tinyexec = require('tinyexec');
 
 describe('Initialization (context) tests', () => {
   test.each([
@@ -8,9 +8,9 @@ describe('Initialization (context) tests', () => {
     `cross-env DETOX_CONFIGURATION=stub jest --config integration/e2e/config.js --runInBand passing-simple`,
 
     `detox test -c stub --config integration/e2e/config.js --maxWorkers 2 --retries 1 flaky passing-simple`,
-    `cross-env DETOX_CONFIGURATION=stub jest --config integration/e2e/config.js --maxWorkers 2 passing-simple`,
+    `cross-env DETOX_CONFIGURATION=stub jest --config integration/e2e/config.js --maxWorkers 2 passing-simple`
   ])('should run: %s', async (cmd) => {
-    const handle = execa.commandSync(cmd, { stdio: 'inherit', shell: true });
+    const handle = await tinyexec.x(cmd, [], { nodeOptions: { stdio: 'inherit', shell: true } });
     expect(handle.exitCode).toBe(0);
   });
 });

--- a/detox/test/package.json
+++ b/detox/test/package.json
@@ -72,7 +72,6 @@
     "eslint": "^8.56.0",
     "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-unicorn": "^50.0.1",
-    "execa": "^5.1.1",
     "express": "^4.15.3",
     "glob": "^7.2.0",
     "jest": "^30.0.3",
@@ -81,6 +80,7 @@
     "nyc": "^15.1.0",
     "p-iteration": "^1.1.8",
     "pngjs": "^3.4.0",
+    "tinyexec": "^0.3.0",
     "typescript": "^5.8.3"
   },
   "jest-junit": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10206,7 +10206,6 @@ __metadata:
     eslint: "npm:^8.56.0"
     eslint-plugin-jest: "npm:^28.11.0"
     eslint-plugin-unicorn: "npm:^50.0.1"
-    execa: "npm:^5.1.1"
     express: "npm:^4.15.3"
     glob: "npm:^7.2.0"
     jest: "npm:^30.0.3"
@@ -10222,6 +10221,7 @@ __metadata:
     react-native-permissions: "npm:^5.2.1"
     react-native-webview: "npm:^13.13.1"
     ssim.js: "npm:^3.5.0"
+    tinyexec: "npm:^0.3.0"
     typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
@@ -10261,7 +10261,6 @@ __metadata:
     eslint-plugin-no-only-tests: "npm:^3.1.0"
     eslint-plugin-node: "npm:^11.1.0"
     eslint-plugin-unicorn: "npm:^50.0.1"
-    execa: "npm:^5.1.1"
     find-up: "npm:^5.0.0"
     fs-extra: "npm:^11.0.0"
     funpermaproxy: "npm:^1.1.0"
@@ -10290,6 +10289,7 @@ __metadata:
     stream-json: "npm:^1.7.4"
     strip-ansi: "npm:^6.0.1"
     telnet-client: "npm:1.2.8"
+    tinyexec: "npm:^0.3.0"
     tmp: "npm:^0.2.1"
     trace-event-lib: "npm:^1.3.1"
     typescript: "npm:^5.8.3"
@@ -25837,6 +25837,13 @@ __metadata:
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
   checksum: 10/da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.0":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10/b9d5fed3166fb1acd1e7f9a89afcd97ccbe18b9c1af0278e429455f6976d69271ba2d21797e7c36d57d6b05025e525d2882d88c2ab435b60d1ddf2fea361de57
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #4930. Inspired by @stianjensen's original PR — tinyexec was the first choice but caused Windows CI failures due to `windowsHide`, PATH augmentation, and `path.normalize()` behaviors that execa never had. Production code now uses Node's built-in `child_process.spawn()` instead; tinyexec is kept for the integration test runner.

## Changes

**`AppStartCommand.js`**
- Replaces `execa.command(cmd, {shell:true})` with `spawn(cmd, [], {shell:true})` — equivalent behavior, zero new production dependencies.
- `stop()` now sends SIGTERM then escalates to SIGKILL after 5 seconds if the process hasn't exited (restores original behavior that was lost in earlier drafts).

**Integration tests** (`detox/test/integration/`)
- Replaces synchronous `execa.commandSync()` with async `tinyexec.x()` in `bail-test.test.js` and `initialization-test.test.js`.

**Package changes**
- `execa` removed from production `dependencies`.
- `tinyexec` added to `devDependencies` (only used in integration tests).

**New `AppStartCommand.test.js`**
- Unit tests for the SIGKILL escalation path using `jest.useFakeTimers()`, covering lines that were missing from the coverage threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)