### PR TITLE
Removing Expo E2E docs link which no longer mention anything about Detox

### DIFF
--- a/docs/introduction/partials/_getting-started-expo.md
+++ b/docs/introduction/partials/_getting-started-expo.md
@@ -7,12 +7,8 @@ There is no special support for Expo projects in Detox, and we do not maintain a
 
 :::
 
-There is a tutorial on how to set up Detox with Expo projects, which you can find on Expo official documentation site: [Running E2E tests on EAS Build]. It is a great starting point for projects that are using Expo.
-
 For support on how to use Detox with Expo, you should contact the Expo team or the Expo community.
 
 If you are experiencing a bug, which you believe is a Detox issue, please [open an issue] on our GitHub repository.
 
 [open an issue]: https://github.com/wix/Detox/issues
-
-[Running E2E tests on EAS Build]: https://docs.expo.dev/build-reference/e2e-tests/

--- a/website/versioned_docs/version-20.x/introduction/partials/_getting-started-expo.md
+++ b/website/versioned_docs/version-20.x/introduction/partials/_getting-started-expo.md
@@ -7,12 +7,8 @@ There is no special support for Expo projects in Detox, and we do not maintain a
 
 :::
 
-There is a tutorial on how to set up Detox with Expo projects, which you can find on Expo official documentation site: [Running E2E tests on EAS Build]. It is a great starting point for projects that are using Expo.
-
 For support on how to use Detox with Expo, you should contact the Expo team or the Expo community.
 
 If you are experiencing a bug, which you believe is a Detox issue, please [open an issue] on our GitHub repository.
 
 [open an issue]: https://github.com/wix/Detox/issues
-
-[Running E2E tests on EAS Build]: https://docs.expo.dev/build-reference/e2e-tests/


### PR DESCRIPTION
## Description

The link removed has no info on setting up Detox with Expo apps, it appears it was updated to integrate Maestro with EAS Workflows. Also couldn't find any Expo docs on configuring Detox.

I see Detox docs are versioned, I'm not sure it's worth creating a new version for simple changes?

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
