### PR TITLE
feat: configurable client login handshake timeout (session.loginTimeout)

### DIFF
--- a/detox/detox.d.ts
+++ b/detox/detox.d.ts
@@ -133,6 +133,12 @@ declare global {
         interface DetoxSessionConfig {
             autoStart?: boolean;
             debugSynchronization?: number;
+            /**
+             * Milliseconds the tester waits for the initial "login" handshake with the Detox server
+             * before timing out. Defaults to 1000. Increase it for cloud/remote devices where device
+             * allocation adds latency before the server responds.
+             */
+            loginTimeout?: number;
             ignoreUnexpectedMessages?: boolean;
             server?: string;
             sessionId?: string;

--- a/detox/detox.d.ts
+++ b/detox/detox.d.ts
@@ -133,11 +133,6 @@ declare global {
         interface DetoxSessionConfig {
             autoStart?: boolean;
             debugSynchronization?: number;
-            /**
-             * Milliseconds the tester waits for the initial "login" handshake with the Detox server
-             * before timing out. Defaults to 1000. Increase it for cloud/remote devices where device
-             * allocation adds latency before the server responds.
-             */
             loginTimeout?: number;
             ignoreUnexpectedMessages?: boolean;
             server?: string;

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -20,8 +20,9 @@ class Client {
    * @param {string} server
    * @param {string} sessionId
    * @param {boolean} [ignoreUnexpectedMessages]
+   * @param {number} [loginTimeout]
    */
-  constructor({ debugSynchronization, server, sessionId, ignoreUnexpectedMessages }) {
+  constructor({ debugSynchronization, server, sessionId, ignoreUnexpectedMessages, loginTimeout }) {
     this._onAppConnected = this._onAppConnected.bind(this);
     this._onAppReady = this._onAppReady.bind(this);
     this._onAppUnresponsive = this._onAppUnresponsive.bind(this);
@@ -31,6 +32,7 @@ class Client {
     this._logError = this._logError.bind(this);
 
     this._sessionId = sessionId;
+    this._loginTimeout = loginTimeout;
     this._slowInvocationTimeout = debugSynchronization;
     this._slowInvocationStatusHandle = null;
     this._whenAppIsConnected = this._invalidState('before connecting to the app');
@@ -72,7 +74,7 @@ class Client {
 
   async connect() {
     await this.open();
-    const sessionStatus = await this.sendAction(new actions.Login(this._sessionId));
+    const sessionStatus = await this.sendAction(new actions.Login(this._sessionId, this._loginTimeout));
     if (sessionStatus.appConnected) {
       this._onAppConnected();
     }

--- a/detox/src/client/Client.test.js
+++ b/detox/src/client/Client.test.js
@@ -225,6 +225,11 @@ describe('Client', () => {
       await expect(withoutTimeout.timeout).toEqual(1000);
     });
 
+    it('should return the configured value for login timeout', async () => {
+      const withTimeout = new actions.Login(123, 5000);
+      await expect(withTimeout.timeout).toEqual(5000);
+    });
+
     it('should schedule "currentStatus" query when it takes too long', async () => {
       const { action } = await simulateInFlightAction();
       expect(mockAws.send).toHaveBeenCalledWith(action, SEND_OPTIONS.DEFAULT);

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -28,12 +28,13 @@ class Action {
 }
 
 class Login extends Action {
-  constructor(sessionId) {
+  constructor(sessionId, timeout) {
     const params = {
       sessionId: sessionId,
       role: 'tester'
     };
     super('login', params);
+    this._timeout = timeout;
   }
 
   get isAtomic() {
@@ -41,7 +42,7 @@ class Login extends Action {
   }
 
   get timeout() {
-    return 1000;
+    return this._timeout != null ? this._timeout : 1000;
   }
 
   async handle(response) {

--- a/detox/src/configuration/composeSessionConfig.js
+++ b/detox/src/configuration/composeSessionConfig.js
@@ -37,6 +37,13 @@ async function composeSessionConfig(options) {
     }
   }
 
+  if (session.loginTimeout != null) {
+    const value = session.loginTimeout;
+    if (typeof value !== 'number' || value < 0) {
+      throw errorComposer.invalidLoginTimeoutProperty();
+    }
+  }
+
   if (session.ignoreUnexpectedMessages != null) {
     const value = session.ignoreUnexpectedMessages;
     if (typeof value !== 'boolean') {

--- a/detox/src/configuration/composeSessionConfig.test.js
+++ b/detox/src/configuration/composeSessionConfig.test.js
@@ -138,6 +138,33 @@ describe('composeSessionConfig', () => {
     });
   });
 
+  describe('loginTimeout', function () {
+    it('should be undefined by default', async () => {
+      expect(await compose()).not.toHaveProperty('loginTimeout');
+    });
+
+    it('should pass validations', async () => {
+      globalConfig.session = { loginTimeout: -1 };
+      await expect(compose()).rejects.toThrow(errorComposer.invalidLoginTimeoutProperty());
+
+      globalConfig.session = { loginTimeout: '3000' };
+      await expect(compose()).rejects.toThrow(errorComposer.invalidLoginTimeoutProperty());
+    });
+
+    describe('when defined', () => {
+      it('should use the global value', async () => {
+        globalConfig.session = { loginTimeout: 9999 };
+        expect(await compose()).toMatchObject({ loginTimeout: 9999 });
+      });
+
+      it('should let local config override global', async () => {
+        globalConfig.session = { loginTimeout: 9999 };
+        localConfig.session = { loginTimeout: 20000 };
+        expect(await compose()).toMatchObject({ loginTimeout: 20000 });
+      });
+    });
+  });
+
   describe('debugSynchronization', function () {
     describe('by default', () => {
       it('should be 10000ms', async () => {

--- a/detox/src/errors/DetoxConfigErrorComposer.js
+++ b/detox/src/errors/DetoxConfigErrorComposer.js
@@ -694,6 +694,18 @@ Examine your Detox config${this._atPath()}`,
     });
   }
 
+  invalidLoginTimeoutProperty() {
+    return new DetoxConfigError({
+      message: `session.loginTimeout should be a positive number`,
+      hint: `Check that in your Detox config${this._atPath()}`,
+      inspectOptions: { depth: 3 },
+      debugInfo: _.omitBy({
+        session: _.get(this.contents, ['session']),
+        ...this._focusOnConfiguration(c => _.pick(c, ['session'])),
+      }, _.isEmpty),
+    });
+  }
+
   invalidIgnoreUnexpectedMessagesProperty() {
     return new DetoxConfigError({
       message: `session.ignoreUnexpectedMessages should be a boolean value`,

--- a/docs/config/session.mdx
+++ b/docs/config/session.mdx
@@ -110,6 +110,20 @@ Seeing logs like these usually indicates certain issues in your application, as 
 
 For extended, more detailed information on iOS, refer to the `DetoxSync` project's [Status Documentation](https://github.com/wix-incubator/DetoxSync/blob/master/StatusDocumentation.md).
 
+### `session.loginTimeout` \[number]
+
+**Disabled by default**, in which case Detox waits `1000`ms for the initial `login` handshake.
+
+Tells Detox how long (in milliseconds) to wait for the server to acknowledge the tester's `login` message before timing out. Increase it when the server needs longer than a second to become ready — for example, remotely-managed devices whose allocation adds latency before the server responds.
+
+```json
+{
+  "session": {
+    "loginTimeout": 30000
+  }
+}
+```
+
 ### `session.ignoreUnexpectedMessages` \[boolean]
 
 Default: `false`.


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #4964

In this pull request, I have made the client's initial `login` handshake timeout configurable via a new
`session.loginTimeout` option (in milliseconds).

Today `Login.timeout` is hard-coded to `1000`ms (`detox/src/client/actions/actions.js`). That is fine
for a locally-managed emulator/simulator, but too short when the server takes longer than a second to
acknowledge `login` — e.g. remotely-managed or slowly-allocated devices — where the run fails with:

```
The tester has not received a response within 1000ms timeout to the message: Login { ... }
```

The only workarounds so far are forking Detox or monkey-patching `Login.prototype.timeout`. This adds a
first-class, opt-in config option that mirrors the existing `session.debugSynchronization`.

**How it works:** `session.loginTimeout` is validated in `composeSessionConfig`, threaded through
`Client` to the `Login` action, and `Login.timeout` returns the configured value or falls back to
`1000`. It is fully backward-compatible — when unset, the timeout stays `1000`ms.

```js
// .detoxrc.js
module.exports = {
  session: {
    server: 'ws://localhost:8099',
    loginTimeout: 30000, // wait up to 30s for the server to ack `login`
  },
  // ...
};
```

Changes:
- `detox/src/client/actions/actions.js` — `Login` accepts and uses a configurable timeout (default 1000).
- `detox/src/client/Client.js` — reads `loginTimeout` from the session config and passes it to `Login`.
- `detox/src/configuration/composeSessionConfig.js` — validates `session.loginTimeout`.
- `detox/src/errors/DetoxConfigErrorComposer.js` — adds `invalidLoginTimeoutProperty()`.
- `detox/detox.d.ts` — adds `DetoxSessionConfig.loginTimeout`.
- Tests: `detox/src/configuration/composeSessionConfig.test.js`, `detox/src/client/Client.test.js`.
- Docs: `docs/config/session.mdx`.

---


> _For features/enhancements:_
 - [x] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [x] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
