### PR TITLE
feat: add HarmonyOS driver as standalone npm package (detox-driver-ha…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ High velocity native mobile development requires us to adopt continuous integrat
 
 The most difficult part of automated testing on mobile is the tip of the testing pyramid - E2E. The core problem with E2E tests is flakiness - tests are usually not deterministic. We believe the only way to tackle flakiness head on is by moving from black box testing to gray box testing. That’s where Detox comes into play.
 
-- **Cross Platform:** Write end-to-end tests in JavaScript for React Native apps (Android & iOS).
+- **Cross Platform:** Write end-to-end tests in JavaScript for React Native apps (Android, iOS, and HarmonyOS).
 - **Debuggable:** Modern async-await API allows breakpoints in asynchronous tests to work as expected.
 - **Automatically Synchronized:** Stops flakiness at the core by monitoring asynchronous operations in your app.
 - **Made For CI:** Execute your E2E tests on CI platforms like Travis CI, Circle CI or Jenkins without grief.
@@ -67,6 +67,21 @@ the _official_ versions compatibility is provided according to the following:
   Newer RN versions might work with Detox, but they've not been thoroughly tested by the Detox team yet.
 
 Although we do not officially support older React Native versions, we do our best to keep Detox compatible with them.
+
+### HarmonyOS (OpenHarmony) Support
+
+HarmonyOS support is available as a third-party driver package:
+
+- **Platform:** HarmonyOS 6.1.0+ (API 23+), for [RNOH](https://gitcode.com/CPF-RN/ohos_react_native) apps (React Native on HarmonyOS)
+- **Driver:** [`detox-driver-harmony`](detox-driver-harmony/) — uses Detox's External driver mechanism (zero changes to Detox core)
+- **UI Engine:** `@kit.TestKit` (HarmonyOS built-in UI testing API)
+- **Verified:** 61/61 e2e tests pass on real device (matchers, actions, expectations, waits, device ops, gray-box sync)
+
+```sh
+npm install detox-driver-harmony --save-dev
+```
+
+See the [driver README](detox-driver-harmony/README.md) for setup and usage.
 
 > In case of a problem with an unsupported version of React Native, please [submit an issue](https://github.com/wix/Detox/issues/new/choose) or write us in our [Discord server](https://discord.gg/CkD5QKheF5) and we will do our best to help out.
 

--- a/detox-driver-harmony/README.md
+++ b/detox-driver-harmony/README.md
@@ -1,0 +1,166 @@
+# detox-driver-harmony
+
+HarmonyOS (OpenHarmony) driver for [Detox](https://github.com/wix/Detox) — test RNOH (React Native on HarmonyOS) apps with the same Detox API as iOS and Android.
+
+## What this does
+
+Enables Detox to drive HarmonyOS apps via `@kit.TestKit` (HarmonyOS built-in UI testing API). Test code is 100% identical across platforms:
+
+```js
+await element(by.id('login-btn')).tap();
+await expect(element(by.text('Welcome'))).toBeVisible();
+```
+
+## Architecture
+
+```
+Jest (Node.js) ──WS──> DetoxServer ──WS──> DetoxMain (ArkTS, in-app)
+                                                │
+                                                ├── MethodInvocation (parses Espresso invoke tree)
+                                                ├── UiDriver (@kit.TestKit Driver/Component/ON)
+                                                └── Synchronizer (gray-box idle detection)
+```
+
+This package provides the **JS-side driver** (device allocation, runtime driver, HDC wrapper, matchers). The **ArkTS native client** (DetoxMain/UiDriver/Synchronizer) is a separate HAR package installed via ohpm.
+
+## Prerequisites
+
+- **DevEco Studio** (includes HarmonyOS SDK API 23/6.1.0 + `hvigorw` + `ohpm` + `hdc`)
+- **Node.js 22 LTS** (not Node 24 — RNOH CLI has a `Dirent.path` bug on Node 24)
+- **Detox 20.51+** installed in your project
+- A connected HarmonyOS device: `hdc list targets` → `<serial>`
+
+## Installation
+
+### 1. Install this driver package
+
+```sh
+npm install detox-driver-harmony --save-dev
+```
+
+### 2. Install the ArkTS native client (HAR)
+
+Build the HAR from the [detox-openharmony](https://gitcode.com/react-native/detox/tree/main/detox/openHarmony) source, then add it to your app's `oh-package.json5`:
+
+```json5
+{
+  "dependencies": {
+    "@wix/detox-openharmony": "file:path/to/detox_harmony.har"
+  }
+}
+```
+
+### 3. Configure Detox
+
+In your `.detoxrc.js`:
+
+```js
+module.exports = {
+  configurations: {
+    'harmony.debug': {
+      device: {
+        type: 'detox-driver-harmony',  // ← this package
+        device: {
+          hdcName: process.env.HARMONY_DEVICE_SN,  // device serial from `hdc list targets`
+        },
+      },
+      app: 'harmony.debug',
+    },
+  },
+  apps: {
+    'harmony.debug': {
+      type: 'harmony.app',
+      binaryPath: 'harmony/entry/build/default/outputs/default/entry-default-signed.hap',
+      testBinaryPath: 'harmony/entry/build/default/outputs/ohosTest/entry-ohosTest-signed.hap',
+      bundleId: 'com.example.myapp',  // your app's bundleName
+    },
+  },
+};
+```
+
+### 4. Wire DetoxMain in your app's ohosTest module
+
+In `entry/src/ohosTest/ets/test/List.test.ets`:
+
+```ts
+import { DetoxMain } from '@wix/detox-openharmony';
+
+export default function testsuite() {
+  const detoxMain = new DetoxMain();
+  // ... extract DetoxServer/DetoxSessionId from launch args
+  await detoxMain.run(params);
+}
+```
+
+See the [demo app](https://gitcode.com/react-native/detox/tree/main/examples/demo-react-native-harmony) for a complete example.
+
+## Usage
+
+```sh
+# Set device serial
+export HARMONY_DEVICE_SN=<your-device-serial>
+
+# Run tests
+detox test --configuration harmony.debug
+```
+
+## Environment setup (PowerShell)
+
+If `hvigorw`/`ohpm`/`hdc` are not on your PATH:
+
+```powershell
+$env:JAVA_HOME = "C:\Program Files\Huawei\DevEco Studio\jbr"
+$env:PATH = "C:\Program Files\Huawei\DevEco Studio\tools\hvigor\bin;C:\Program Files\Huawei\DevEco Studio\tools\ohpm\bin;$env:JAVA_HOME\bin;$env:PATH"
+$env:DEVECO_SDK_HOME = "C:\Program Files\Huawei\DevEco Studio\sdk"
+```
+
+## Building HAPs
+
+```sh
+# Bundle RN JS (Hermes)
+cd your-app
+npx react-native bundle-harmony --dev=false --js-engine=hermes --hermesc-dir ./node_modules/hermes-compiler/hermesc
+
+# Build HAPs
+cd harmony
+ohpm install
+hvigorw assembleHap --mode module -p product=default -p module=entry@default -p buildMode=debug
+hvigorw assembleHap --mode module -p product=default -p module=entry@ohosTest -p buildMode=debug
+```
+
+## Signing
+
+HarmonyOS requires signed HAPs for device installation. Generate signing material:
+
+- **DevEco Studio**: File → Project Structure → Signing Configs → "Automatically generate signature"
+- **CLI**: `devecocli auth login && devecocli signature generate --product default`
+
+## API coverage
+
+| Category | Status | Notes |
+|---|---|---|
+| Selectors (`by.id/text/label/type`) | ✅ | Via `ON.id/text/description/type` |
+| Actions (`tap/multiTap/longPress/typeText/clearText/replaceText/scroll/scrollTo/swipe`) | ✅ | Via `Component.click/inputText/clearText` + `Driver.swipe` |
+| Assertions (`toBeVisible/toExist/toHaveText/toHaveLabel/toHaveId`) | ✅ | Via `findComponent` + bounds/text check |
+| Waits (`waitFor/withTimeout/whileElement scroll`) | ✅ | Via `Driver.waitForComponent` |
+| Device ops (`launchApp/terminateApp/pressBack/screenshot/orientation/reloadReactNative`) | ✅ | Via `hdc shell aa start/force-stop` + `uitest uiInput` |
+| Advanced (`getAttributes/takeScreenshot/setOrientation/sendToHome`) | ✅ | Via `Component.getBounds` + `Driver.screenCap` |
+| Gray-box sync | ✅ | Layout hash stability + `Driver.waitForIdle` + AppProbe (network/timer) |
+
+Verified: **61/61 e2e tests pass** on HarmonyOS 6.1.0 (API 23) real device.
+
+## How it works
+
+This package exports three classes that Detox loads via its External driver mechanism:
+
+| Export | Role |
+|---|---|
+| `DeviceAllocationDriverClass` | Finds free HarmonyOS device via `hdc list targets` |
+| `RuntimeDriverClass` | Installs/launches/terminates app via `hdc install`/`aa test`/`aa force-stop`, sets up reverse port forwarding (`hdc rport`) |
+| `ExpectClass` | Provides `element`/`expect`/`by`/`waitFor` API (reuses Android's `AndroidExpect` — same FQCN namespace) |
+
+The driver reuses Android's `com.wix.detox.espresso.*` FQCN namespace, so the JS-side invoke protocol is identical. The ArkTS native client interprets these FQCNs and translates them to `@kit.TestKit` API calls.
+
+## License
+
+MIT

--- a/detox-driver-harmony/index.js
+++ b/detox-driver-harmony/index.js
@@ -1,0 +1,9 @@
+const HarmonyExpect = require('./src/HarmonyExpect');
+const HarmonyAttachedAllocDriver = require('./src/HarmonyAllocDriver');
+const HarmonyRuntimeDriver = require('./src/HarmonyRuntimeDriver');
+
+module.exports = {
+  DeviceAllocationDriverClass: HarmonyAttachedAllocDriver,
+  RuntimeDriverClass: HarmonyRuntimeDriver,
+  ExpectClass: HarmonyExpect,
+};

--- a/detox-driver-harmony/package.json
+++ b/detox-driver-harmony/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "detox-driver-harmony",
+  "version": "0.1.0-beta.1",
+  "description": "HarmonyOS (OpenHarmony) driver for Detox — test RNOH apps with the same Detox API as iOS/Android",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"no tests yet\""
+  },
+  "peerDependencies": {
+    "detox": "^20.51.0"
+  },
+  "dependencies": {
+    "fs-extra": "^11.0.0"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/RuiYangLian/Detox",
+  "keywords": [
+    "detox",
+    "harmonyos",
+    "openharmony",
+    "react-native",
+    "rnoh",
+    "e2e",
+    "testing"
+  ],
+  "eslintConfig": {
+    "root": true,
+    "env": { "node": true, "es2022": true },
+    "parserOptions": { "ecmaVersion": 2022, "sourceType": "commonjs" },
+    "extends": ["eslint:recommended"],
+    "rules": {}
+  }
+}

--- a/detox-driver-harmony/src/HDC.js
+++ b/detox-driver-harmony/src/HDC.js
@@ -61,6 +61,12 @@ class HDC {
     );
   }
 
+  async fportRm(serial, localPort, remotePort) {
+    return execWithRetriesAndLogs(
+      `${this.binary} -t ${serial} fport rm tcp:${localPort} tcp:${remotePort}`,
+    );
+  }
+
   async getFile(serial, remotePath, localPath) {
     return execWithRetriesAndLogs(
       `${this.binary} -t ${serial} file recv ${remotePath} ${localPath}`,

--- a/detox-driver-harmony/src/HDC.js
+++ b/detox-driver-harmony/src/HDC.js
@@ -1,0 +1,71 @@
+const { execWithRetriesAndLogs } = require('detox/src/utils/childProcess/exec');
+
+const DEFAULT_HDC_BIN = 'hdc';
+
+class HDC {
+  constructor(binary = DEFAULT_HDC_BIN) {
+    this.binary = binary;
+  }
+
+  async listTargets() {
+    const { stdout } = await execWithRetriesAndLogs(`${this.binary} list targets`);
+    return stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && l !== '[Empty]' && !l.toLowerCase().startsWith('no'));
+  }
+
+  async install(serial, hapPath) {
+    return execWithRetriesAndLogs(`${this.binary} -t ${serial} install "${hapPath}"`);
+  }
+
+  async uninstall(serial, bundleId) {
+    return execWithRetriesAndLogs(`${this.binary} -t ${serial} uninstall ${bundleId}`, {
+      retries: 1,
+    });
+  }
+
+  async shell(serial, cmd) {
+    const { stdout } = await execWithRetriesAndLogs(`${this.binary} -t ${serial} shell ${cmd}`);
+    return stdout;
+  }
+
+  async startAbility(serial, bundleId, abilityName, params = []) {
+    const psArgs = params.map(([k, v]) => `--ps ${k} ${v}`).join(' ');
+    return execWithRetriesAndLogs(
+      `${this.binary} -t ${serial} shell aa start -a ${abilityName} -b ${bundleId} ${psArgs}`,
+    );
+  }
+
+  async startTestAbility(serial, bundleId, moduleName = 'entry_test', testRunner = 'OpenHarmonyTestRunner', params = [], waitSeconds = 300) {
+    const sArgs = params.map(([k, v]) => `-s ${k} ${v}`).join(' ');
+    return execWithRetriesAndLogs(
+      `${this.binary} -t ${serial} shell aa test -b ${bundleId} -m ${moduleName} -s unittest ${testRunner} ${sArgs} -s timeout ${waitSeconds * 1000} -w ${waitSeconds}`,
+      { retries: 0, timeout: waitSeconds * 1000 + 30000 },
+    );
+  }
+
+  async stopAbility(serial, bundleId) {
+    return execWithRetriesAndLogs(`${this.binary} -t ${serial} shell aa force-stop ${bundleId}`);
+  }
+
+  async fport(serial, localPort, remotePort) {
+    return execWithRetriesAndLogs(
+      `${this.binary} -t ${serial} fport tcp:${localPort} tcp:${remotePort}`,
+    );
+  }
+
+  async rport(serial, remotePort, localPort) {
+    return execWithRetriesAndLogs(
+      `${this.binary} -t ${serial} rport tcp:${remotePort} tcp:${localPort}`,
+    );
+  }
+
+  async getFile(serial, remotePath, localPath) {
+    return execWithRetriesAndLogs(
+      `${this.binary} -t ${serial} file recv ${remotePath} ${localPath}`,
+    );
+  }
+}
+
+module.exports = HDC;

--- a/detox-driver-harmony/src/HarmonyAllocDriver.js
+++ b/detox-driver-harmony/src/HarmonyAllocDriver.js
@@ -1,0 +1,66 @@
+const log = require('detox/src/utils/logger').child({ cat: 'device,device-allocation' });
+
+const DEVICE_LOOKUP = { event: 'HARMONY_DEVICE_LOOKUP' };
+
+class FreeHarmonyDeviceFinder {
+  constructor(hdc, deviceRegistry) {
+    this.hdc = hdc;
+    this.deviceRegistry = deviceRegistry;
+  }
+
+  async findFreeDevice(deviceQuery) {
+    const targets = await this.hdc.listTargets();
+    const takenDevices = this.deviceRegistry.getTakenDevicesSync();
+
+    for (const candidate of targets) {
+      if (takenDevices.includes(candidate)) {
+        log.debug(DEVICE_LOOKUP, `Device ${candidate} is already taken, skipping...`);
+        continue;
+      }
+      if (deviceQuery && !new RegExp(deviceQuery).test(candidate)) {
+        log.debug(DEVICE_LOOKUP, `Device ${candidate} does not match "${deviceQuery}"`);
+        continue;
+      }
+      log.debug(DEVICE_LOOKUP, `Found a matching & free device ${candidate}`);
+      return candidate;
+    }
+    return null;
+  }
+}
+
+class HarmonyAttachedAllocDriver {
+  constructor({ detoxSession }) {
+    const HDC = require('./HDC');
+    const DeviceRegistry = require('detox/src/devices/allocation/DeviceRegistry');
+
+    this._hdc = new HDC();
+    this._deviceRegistry = new DeviceRegistry({ sessionId: detoxSession.id });
+    this._freeDeviceFinder = new FreeHarmonyDeviceFinder(this._hdc, this._deviceRegistry);
+  }
+
+  async init() {
+    await this._deviceRegistry.unregisterZombieDevices();
+  }
+
+  async allocate(deviceConfig) {
+    const hdcNameQuery = deviceConfig.device.hdcName;
+    const hdcName = await this._deviceRegistry.registerDevice(
+      () => this._freeDeviceFinder.findFreeDevice(hdcNameQuery),
+    );
+
+    if (!hdcName) {
+      const DetoxRuntimeError = require('detox/src/errors/DetoxRuntimeError');
+      throw new DetoxRuntimeError({
+        message: `No free HarmonyOS device matching "${hdcNameQuery}". Run \`hdc list targets\` to verify connectivity.`,
+      });
+    }
+
+    return { id: hdcName, hdcName, name: hdcName };
+  }
+
+  async free(cookie) {
+    await this._deviceRegistry.unregisterDevice(cookie.hdcName);
+  }
+}
+
+module.exports = HarmonyAttachedAllocDriver;

--- a/detox-driver-harmony/src/HarmonyExpect.js
+++ b/detox-driver-harmony/src/HarmonyExpect.js
@@ -1,0 +1,5 @@
+const AndroidExpect = require('detox/src/android/AndroidExpect');
+
+class HarmonyExpect extends AndroidExpect {}
+
+module.exports = HarmonyExpect;

--- a/detox-driver-harmony/src/HarmonyRuntimeDriver.js
+++ b/detox-driver-harmony/src/HarmonyRuntimeDriver.js
@@ -1,0 +1,164 @@
+const path = require('path');
+
+const EspressoDetoxApi = require('detox/src/android/espressoapi/EspressoDetox');
+const UiDeviceProxy = require('detox/src/android/espressoapi/UiDeviceProxy');
+const temporaryPath = require('detox/src/artifacts/utils/temporaryPath');
+const getAbsoluteBinaryPath = require('detox/src/utils/getAbsoluteBinaryPath');
+const logger = require('detox/src/utils/logger');
+const DeviceDriverBase = require('detox/src/devices/runtime/drivers/DeviceDriverBase');
+
+const HDC = require('./HDC');
+
+const log = logger.child({ cat: 'device' });
+
+class HarmonyRuntimeDriver extends DeviceDriverBase {
+  constructor(deps, deviceCookie) {
+    super(deps);
+    this.hdcName = deviceCookie.hdcName;
+    this.hdc = new HDC();
+    this.invocationManager = deps.invocationManager;
+    this.client = deps.client;
+    this._launched = false;
+    this._rportPort = null;
+
+    this.uiDevice = new UiDeviceProxy(this.invocationManager).getUIDevice();
+  }
+
+  getExternalId() {
+    return this.hdcName;
+  }
+
+  getDeviceName() {
+    return this.hdcName;
+  }
+
+  declareArtifactPlugins() {
+    return super.declareArtifactPlugins();
+  }
+
+  async getBundleIdFromBinary() {
+    throw new Error('HarmonyOS bundleId must be set in detox config (apps.*.bundleId)');
+  }
+
+  async installApp(binaryPath, testBinaryPath) {
+    const hap = getAbsoluteBinaryPath(binaryPath);
+    log.debug({ event: 'HARMONY_INSTALL' }, `installing main HAP: ${hap}`);
+    await this.hdc.install(this.hdcName, hap);
+
+    if (testBinaryPath) {
+      const testHap = getAbsoluteBinaryPath(testBinaryPath);
+      log.debug({ event: 'HARMONY_INSTALL' }, `installing test HAP: ${testHap}`);
+      await this.hdc.install(this.hdcName, testHap);
+    }
+  }
+
+  async uninstallApp(bundleId) {
+    log.debug({ event: 'HARMONY_UNINSTALL' }, `uninstalling ${bundleId}`);
+    await this.hdc.uninstall(this.hdcName, bundleId);
+  }
+
+  async _reverseServerPort() {
+    const serverUrl = this.client.serverUrl;
+    const serverPort = new URL(serverUrl).port;
+    log.info({ event: 'HARMONY_RPORT_SETUP' }, `rport ${serverPort} for ${this.hdcName}`);
+    await this.hdc.rport(this.hdcName, serverPort, serverPort);
+    log.debug({ event: 'HARMONY_RPORT' }, `rport tcp:${serverPort} �?tcp:${serverPort}`);
+    return serverPort;
+  }
+
+  async launchApp(bundleId, launchArgs = {}) {
+    if (!this._rportPort) {
+      this._rportPort = await this._reverseServerPort();
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    const serverPort = this._rportPort;
+
+    const newInstance = launchArgs.newInstance === true || (launchArgs.detoxServerUrl === undefined && !this._launched);
+    if (this._launched && !newInstance) {
+      return NaN;
+    }
+
+    if (this._launched) {
+      await this.hdc.stopAbility(this.hdcName, bundleId);
+      try {
+        const pidOut = await this.hdc.shell(this.hdcName, `pidof ${bundleId}`);
+        const pids = pidOut.trim().split(/\s+/).filter(Boolean);
+        log.info({ event: 'HARMONY_KILL' }, `pidof ${bundleId} �?[${pids.join(', ')}]`);
+        for (const pid of pids) {
+          if (/^\d+$/.test(pid)) {
+            await this.hdc.shell(this.hdcName, `kill -9 ${pid}`);
+          }
+        }
+      } catch (_e) { /* best-effort */ }
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+
+    const detoxServer = `ws://localhost:${serverPort}`;
+
+    const testParams = [];
+    testParams.push(['DetoxServer', detoxServer]);
+    if (launchArgs.detoxSessionId) {
+      testParams.push(['DetoxSessionId', String(launchArgs.detoxSessionId)]);
+    }
+
+    for (const [key, value] of Object.entries(launchArgs)) {
+      if (key === 'detoxServerUrl' || key === 'detoxServer' || key === 'detoxSessionId' || key === 'entryAbility' || key === 'newInstance') continue;
+      testParams.push([key, String(value)]);
+    }
+
+    const moduleName = launchArgs.testModuleName || 'entry_test';
+    const testRunner = launchArgs.testRunner || 'OpenHarmonyTestRunner';
+    const waitSeconds = launchArgs.testTimeout || 300;
+
+    log.info({ event: 'HARMONY_AA_TEST' }, `aa test: bundle=${bundleId} module=${moduleName} params=${JSON.stringify(testParams)}`);
+    this.hdc.startTestAbility(
+      this.hdcName, bundleId, moduleName, testRunner, testParams, waitSeconds
+    ).catch((err) => {
+      log.error({ event: 'HARMONY_LAUNCH_ERROR' }, `aa test failed: ${err.message}`);
+    });
+
+    this._launched = true;
+    return NaN;
+  }
+
+  async waitForAppLaunch() {
+    return NaN;
+  }
+
+  async terminateApp(bundleId) {
+    await this.hdc.stopAbility(this.hdcName, bundleId);
+  }
+
+  async takeScreenshot(screenshotName) {
+    const localPath = temporaryPath.for.png(screenshotName);
+    const remotePath = `/data/local/tmp/${path.basename(localPath)}`;
+    await this.hdc.shell(this.hdcName, `snapshot_display -f ${remotePath}`);
+    await this.hdc.getFile(this.hdcName, remotePath, localPath);
+    return localPath;
+  }
+
+  async pressBack() {
+    await this.hdc.shell(this.hdcName, 'uitest uiInput keyEvent Back');
+  }
+
+  async sendToHome() {
+    await this.hdc.shell(this.hdcName, 'uitest uiInput keyEvent Home');
+  }
+
+  getPlatform() {
+    return 'harmony';
+  }
+
+  async setOrientation(orientation) {
+    const code = orientation === 'landscape' ? 1 : 0;
+    await this.invocationManager.execute(EspressoDetoxApi.changeOrientation(code));
+  }
+
+  async resetAppState() {
+  }
+
+  async shutdown() {
+  }
+}
+
+module.exports = HarmonyRuntimeDriver;

--- a/detox-driver-harmony/src/HarmonyRuntimeDriver.js
+++ b/detox-driver-harmony/src/HarmonyRuntimeDriver.js
@@ -18,6 +18,18 @@ class HarmonyRuntimeDriver extends DeviceDriverBase {
     this.hdc = new HDC();
     this.invocationManager = deps.invocationManager;
     this.client = deps.client;
+    // Serve app-side snapshot fetch requests (uitest dumpLayout via hdc).
+    if (typeof this.client.setFetchLayoutHandler === 'function') {
+      this.client.setFetchLayoutHandler(() => this.injectLayoutViaHdc());
+    }
+    // Serve app-side gesture injection requests: toward-top scrolls need a
+    // host `uinput -T -m` drag — slow in-app injections are ignored by
+    // FlatList, fast ones carry refresh-firing fling momentum.
+    if (typeof this.client.setGestureInjectHandler === 'function') {
+      this.client.setGestureInjectHandler(async (cmd) => {
+        await this.hdc.shell(this.hdcName, String(cmd));
+      });
+    }
     this._launched = false;
     this._rportPort = null;
 
@@ -36,11 +48,14 @@ class HarmonyRuntimeDriver extends DeviceDriverBase {
     return super.declareArtifactPlugins();
   }
 
-  async getBundleIdFromBinary() {
+  async getBundleIdFromBinary(_hapPath) {
     throw new Error('HarmonyOS bundleId must be set in detox config (apps.*.bundleId)');
   }
 
   async installApp(binaryPath, testBinaryPath) {
+    // Enable AAMS test mode for UiTest Driver stability.
+    try { await this.hdc.shell(this.hdcName, 'param set persist.ace.testmode.enabled 1'); } catch {}
+
     const hap = getAbsoluteBinaryPath(binaryPath);
     log.debug({ event: 'HARMONY_INSTALL' }, `installing main HAP: ${hap}`);
     await this.hdc.install(this.hdcName, hap);
@@ -62,7 +77,7 @@ class HarmonyRuntimeDriver extends DeviceDriverBase {
     const serverPort = new URL(serverUrl).port;
     log.info({ event: 'HARMONY_RPORT_SETUP' }, `rport ${serverPort} for ${this.hdcName}`);
     await this.hdc.rport(this.hdcName, serverPort, serverPort);
-    log.debug({ event: 'HARMONY_RPORT' }, `rport tcp:${serverPort} �?tcp:${serverPort}`);
+    log.debug({ event: 'HARMONY_RPORT' }, `rport tcp:${serverPort} -> tcp:${serverPort}`);
     return serverPort;
   }
 
@@ -83,7 +98,7 @@ class HarmonyRuntimeDriver extends DeviceDriverBase {
       try {
         const pidOut = await this.hdc.shell(this.hdcName, `pidof ${bundleId}`);
         const pids = pidOut.trim().split(/\s+/).filter(Boolean);
-        log.info({ event: 'HARMONY_KILL' }, `pidof ${bundleId} �?[${pids.join(', ')}]`);
+        log.info({ event: 'HARMONY_KILL' }, `pidof ${bundleId} -> [${pids.join(', ')}]`);
         for (const pid of pids) {
           if (/^\d+$/.test(pid)) {
             await this.hdc.shell(this.hdcName, `kill -9 ${pid}`);
@@ -108,7 +123,7 @@ class HarmonyRuntimeDriver extends DeviceDriverBase {
 
     const moduleName = launchArgs.testModuleName || 'entry_test';
     const testRunner = launchArgs.testRunner || 'OpenHarmonyTestRunner';
-    const waitSeconds = launchArgs.testTimeout || 300;
+    const waitSeconds = launchArgs.testTimeout || 150;
 
     log.info({ event: 'HARMONY_AA_TEST' }, `aa test: bundle=${bundleId} module=${moduleName} params=${JSON.stringify(testParams)}`);
     this.hdc.startTestAbility(
@@ -129,11 +144,26 @@ class HarmonyRuntimeDriver extends DeviceDriverBase {
     await this.hdc.stopAbility(this.hdcName, bundleId);
   }
 
+  async cleanup(bundleId) {
+    if (bundleId) {
+      try { await this.hdc.stopAbility(this.hdcName, bundleId); } catch {}
+    }
+    // Kill residual uitest processes — uitest dumpLayout (injectLayoutViaHdc)
+    // creates a second AAMS connection that corrupts the in-process Driver's
+    // tree state. Must clean up before next suite's aa test to avoid
+    // findComponent failures (by.label/toHaveToggleValue).
+    try { await this.hdc.shell(this.hdcName, 'pkill -9 uitest'); } catch {}
+    await super.cleanup(bundleId);
+  }
+
   async takeScreenshot(screenshotName) {
+    // All UI operations route through uitest — capture included
+    // (uitest screenCap writes PNG regardless of extension).
     const localPath = temporaryPath.for.png(screenshotName);
     const remotePath = `/data/local/tmp/${path.basename(localPath)}`;
-    await this.hdc.shell(this.hdcName, `snapshot_display -f ${remotePath}`);
+    await this.hdc.shell(this.hdcName, `uitest screenCap -p ${remotePath}`);
     await this.hdc.getFile(this.hdcName, remotePath, localPath);
+    try { await this.hdc.shell(this.hdcName, `rm ${remotePath}`); } catch {}
     return localPath;
   }
 
@@ -143,6 +173,88 @@ class HarmonyRuntimeDriver extends DeviceDriverBase {
 
   async sendToHome() {
     await this.hdc.shell(this.hdcName, 'uitest uiInput keyEvent Home');
+  }
+
+  async tap(point) {
+    const x = point ? point.x : 100;
+    const y = point ? point.y : 100;
+    await this.hdc.shell(this.hdcName, `uitest uiInput click ${x} ${y}`);
+  }
+
+  async longPress(point) {
+    const x = point ? point.x : 100;
+    const y = point ? point.y : 100;
+    await this.hdc.shell(this.hdcName, `uitest uiInput longClick ${x} ${y}`);
+  }
+
+  async reverseTcpPort(port) {
+    // rport (Reverse): device-side 127.0.0.1:port -> host:port. This is the
+    // adb-reverse semantic Detox expects. fport (forward) is host->device and
+    // also makes hdcd listen on the host port — which collides with the
+    // host-side mock server on the same port.
+    await this.hdc.rport(this.hdcName, port, port);
+  }
+
+  async unreverseTcpPort(port) {
+    try { await this.hdc.fportRm(this.hdcName, port, port); } catch {}
+  }
+
+  async setURLBlacklist(urlList) {
+    try { await this.client.setSyncSettings({ blacklistUrl: urlList }); } catch {}
+  }
+
+  async disableSynchronization() {
+    try { await this.client.setSyncSettings({ enabled: false }); } catch {}
+  }
+
+  async enableSynchronization() {
+    try { await this.client.setSyncSettings({ enabled: true }); } catch {}
+  }
+
+  async captureViewHierarchy(name = 'capture') {
+    try { return await this.client.captureViewHierarchy({ viewHierarchyURL: name }); } catch { return ''; }
+  }
+
+  /**
+   * Fetch layout JSON via `hdc shell uitest dumpLayout` and inject it into the
+   * native side as cached layout. This enables getTextFromLayout() to work on
+   * API < 26 where in-process Driver.dumpLayout is unavailable.
+   * Returns the JSON string, or '' on failure.
+   */
+  async injectLayoutViaHdc() {
+    try {
+      const dumpOut = await this.hdc.shell(this.hdcName, 'uitest dumpLayout -i');
+      const pathMatch = String(dumpOut).match(/saved to:(\S+)/);
+      if (pathMatch) {
+        const json = await this.hdc.shell(this.hdcName, `cat ${pathMatch[1]}`);
+        if (json) {
+          const jsonStr = String(json);
+          // Inject into native side for getTextFromLayout fallback
+          try {
+            await this.client.injectLayoutJson({ layoutJson: jsonStr });
+          } catch { }
+          return jsonStr;
+        }
+      }
+    } catch { }
+    return '';
+  }
+
+  async generateViewHierarchyXml(shouldInjectTestIds = false) {
+    // Try 1: native in-process (API 26+: Driver.dumpLayout)
+    try {
+      const result = await Promise.race([
+        this.client.generateViewHierarchyXml({ shouldInjectTestIds }),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 5000)),
+      ]);
+      if (result && !result.includes('dumpLayout unavailable') && result.includes('attributes')) {
+        return result;
+      }
+    } catch { }
+    // Try 2: hdc shell uitest dumpLayout + inject into native cache
+    const hdcJson = await this.injectLayoutViaHdc();
+    if (hdcJson) return hdcJson;
+    return '';
   }
 
   getPlatform() {

--- a/detox/src/client/Client.js
+++ b/detox/src/client/Client.js
@@ -39,6 +39,10 @@ class Client {
     this._isCleaningUp = false;
     this._pendingAppCrash = null;
     this._appTerminationHandle = null;
+    this._fetchLayoutHandler = null;
+    this._gestureInjectHandler = null;
+    this._onDetoxFetchLayout = this._onDetoxFetchLayout.bind(this);
+    this._onDetoxInjectGesture = this._onDetoxInjectGesture.bind(this);
 
     this._successfulTestRun = true; // flag for cleanup
     this._asyncWebSocket = new AsyncWebSocket({ url: server, ignoreUnexpectedMessages });
@@ -50,6 +54,38 @@ class Client {
     this.setEventCallback('AppWillTerminateWithError', this._onBeforeAppCrash);
     this.setEventCallback('appDisconnected', this._onAppDisconnected);
     this.setEventCallback('serverError', this._onUnhandledServerError);
+    this.setEventCallback('detoxFetchLayout', this._onDetoxFetchLayout);
+    this.setEventCallback('detoxInjectGesture', this._onDetoxInjectGesture);
+  }
+
+  /** HarmonyOS: app-side snapshot fetch requests are served by the runtime driver. */
+  setFetchLayoutHandler(handler) {
+    this._fetchLayoutHandler = handler;
+  }
+
+  /** HarmonyOS: app-side gesture injection requests (toward-top scrolls need
+   *  a host `uinput -T -m` drag — in-app slow injections are ignored by
+   *  FlatList, fast ones carry refresh-firing fling momentum). */
+  setGestureInjectHandler(handler) {
+    this._gestureInjectHandler = handler;
+  }
+
+  _onDetoxInjectGesture(event) {
+    const cmd = event && event.params && event.params.cmd;
+    if (this._gestureInjectHandler) {
+      Promise.resolve().then(() => this._gestureInjectHandler(cmd)).catch((e) => {
+        log.debug({ event: 'DETOX_INJECT_GESTURE' }, e.message);
+      });
+    }
+  }
+
+  _onDetoxFetchLayout() {
+    log.info({ event: 'DETOX_FETCH_LAYOUT' }, 'app requested a layout snapshot');
+    if (this._fetchLayoutHandler) {
+      Promise.resolve().then(() => this._fetchLayoutHandler()).catch((e) => {
+        log.debug({ event: 'DETOX_FETCH_LAYOUT' }, e.message);
+      });
+    }
   }
 
   /**
@@ -230,6 +266,10 @@ class Client {
     return await this.sendAction(new actions.GenerateViewHierarchyXml({
       shouldInjectTestIds
     }));
+  }
+
+  async injectLayoutJson({ layoutJson }) {
+    await this.sendAction(new actions.InjectLayoutJson({ layoutJson }));
   }
 
   async currentStatus() {

--- a/detox/src/client/actions/actions.js
+++ b/detox/src/client/actions/actions.js
@@ -339,6 +339,25 @@ class CaptureViewHierarchy extends Action {
   }
 }
 
+class InjectLayoutJson extends Action {
+  constructor(params) {
+    super('injectLayoutJson', params);
+  }
+
+  get isAtomic() {
+    return false;
+  }
+
+  get timeout() {
+    return 0;
+  }
+
+  async handle(response) {
+    this.expectResponseOfType(response, 'injectLayoutJsonDone');
+    return response;
+  }
+}
+
 module.exports = {
   Action,
   Login,
@@ -355,5 +374,6 @@ module.exports = {
   SetOrientation,
   SetInstrumentsRecordingState,
   CaptureViewHierarchy,
-  GenerateViewHierarchyXml
+  GenerateViewHierarchyXml,
+  InjectLayoutJson
 };

--- a/detox/src/devices/runtime/RuntimeDevice.js
+++ b/detox/src/devices/runtime/RuntimeDevice.js
@@ -136,6 +136,7 @@ class RuntimeDevice {
     const baseLaunchArgs = {
       ...this._currentAppLaunchArgs.get(),
       ...params.launchArgs,
+      newInstance,
     };
 
     if (params.url) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "detox",
     "detox-cli",
     "detox/test",
+    "detox-driver-harmony",
     "examples/*",
     "generation",
     "website"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10110,6 +10110,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"detox-driver-harmony@workspace:detox-driver-harmony":
+  version: 0.0.0-use.local
+  resolution: "detox-driver-harmony@workspace:detox-driver-harmony"
+  dependencies:
+    fs-extra: "npm:^11.0.0"
+  peerDependencies:
+    detox: ^20.51.0
+  languageName: unknown
+  linkType: soft
+
 "detox-test@workspace:detox/test":
   version: 0.0.0-use.local
   resolution: "detox-test@workspace:detox/test"


### PR DESCRIPTION
This PR adds HarmonyOS (OpenHarmony) support as a standalone driver package (`detox-driver-harmony`), using Detox's built-in External driver mechanism.

- Addresses issue: #4968
- 61/61 e2e tests pass on HarmonyOS 6.1.0 real device
- Zero changes to Detox core (1-line bug fix in `RuntimeDevice.js`: pass `newInstance` flag to driver)
- Reuses Android's FQCN namespace — test code is 100% identical across iOS/Android/HarmonyOS