### PR TITLE
fix(android): track all OkHttpClientProvider clients in network synchronization

### DIFF
--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/ReactNativeExtension.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/ReactNativeExtension.kt
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.wix.detox.LaunchArgs
 import com.wix.detox.reactnative.idlingresources.ReactNativeIdlingResources
+import com.wix.detox.reactnative.idlingresources.network.DetoxOkHttpClientTracker
 import com.wix.detox.reactnative.reloader.ReactNativeReloaderFactory
 
 private const val LOG_TAG = "DetoxRNExt"
@@ -28,6 +29,8 @@ object ReactNativeExtension {
         }
 
         ReactMarkersLogger.attach()
+        // Before any JS runs, so lazily-created OkHttp clients are tracked from the start.
+        DetoxOkHttpClientTracker.ensureInstalled()
     }
 
     /**

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/network/DetoxOkHttpClientTracker.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/network/DetoxOkHttpClientTracker.kt
@@ -1,0 +1,77 @@
+package com.wix.detox.reactnative.idlingresources.network
+
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
+import com.facebook.react.modules.network.OkHttpClientFactory
+import com.facebook.react.modules.network.OkHttpClientProvider
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
+import org.joor.Reflect
+import java.util.Collections
+import java.util.WeakHashMap
+
+/**
+ * Tracks every OkHttpClient created through React Native's [OkHttpClientProvider], so that
+ * [NetworkIdlingResource] can synchronize on all of them rather than only the NetworkingModule's
+ * own client. Modules such as expo/fetch (the global `fetch` on Expo SDK 56+) build separate
+ * clients through the same provider; their traffic is otherwise invisible to synchronization.
+ */
+object DetoxOkHttpClientTracker {
+    private const val LOG_TAG = "Detox"
+
+    // Keyed on the Dispatcher, not the OkHttpClient: consumers routinely derive
+    // clients via newBuilder() (which shares the Dispatcher) and drop the
+    // original — e.g. expo/fetch stores only its interceptor-decorated
+    // derivative. The Dispatcher is the object synchronization cares about, and
+    // it stays strongly reachable through ANY client sharing it.
+    private val dispatchers = Collections.synchronizedMap(WeakHashMap<Dispatcher, Unit>())
+    private var loggedInstallFailure = false
+
+    /**
+     * Wraps the app's registered [OkHttpClientFactory] (if any) with a recording delegate.
+     * Idempotent, and re-applied on every idle check so a factory the app installs after
+     * startup is re-wrapped. If the current factory cannot be read, nothing is installed:
+     * replacing an unknown factory could strip app-critical behavior such as TLS pinning.
+     */
+    fun ensureInstalled() {
+        try {
+            val current = Reflect.on(OkHttpClientProvider::class.java)
+                .field("factory")
+                .get<OkHttpClientFactory?>()
+            if (current is TrackingFactory) {
+                return
+            }
+            OkHttpClientProvider.setOkHttpClientFactory(TrackingFactory(current))
+        } catch (e: Throwable) {
+            if (!loggedInstallFailure) {
+                loggedInstallFailure = true
+                Log.e(
+                    LOG_TAG,
+                    "Could not inspect OkHttpClientProvider's factory; only the " +
+                        "NetworkingModule client will be network-synchronized",
+                    e
+                )
+            }
+        }
+    }
+
+    fun dispatchers(): List<Dispatcher> {
+        ensureInstalled()
+        synchronized(dispatchers) {
+            return dispatchers.keys.toList()
+        }
+    }
+
+    private class TrackingFactory(private val delegate: OkHttpClientFactory?) : OkHttpClientFactory {
+        override fun createNewNetworkModuleClient(): OkHttpClient {
+            // Without a delegate, replicate the provider's default for its Context overload
+            // (the one RN and Expo modules call).
+            val client = delegate?.createNewNetworkModuleClient()
+                ?: OkHttpClientProvider.createClientBuilder(
+                    InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+                ).build()
+            dispatchers[client.dispatcher] = Unit
+            return client
+        }
+    }
+}

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/network/NetworkIdlingResource.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/network/NetworkIdlingResource.kt
@@ -12,16 +12,26 @@ import java.util.regex.PatternSyntaxException
 /**
  * Created by simonracz on 09/10/2017.
  *
- * Idling Resource which monitors React Native's OkHttpClient.
+ * Idling Resource which monitors React Native's OkHttpClients.
  *
  *
  * Must call stop() on it, before removing it from Espresso.
  */
-class NetworkIdlingResource(private val dispatcher: Dispatcher) : DetoxIdlingResource(),
+class NetworkIdlingResource(private val dispatchersSupplier: () -> List<Dispatcher>) : DetoxIdlingResource(),
     Choreographer.FrameCallback {
     private val busyResources: MutableSet<String> = HashSet()
 
-    constructor(reactContext: ReactContext) : this(NetworkingModuleReflected(reactContext).getHttpClient()!!.dispatcher)
+    constructor(dispatcher: Dispatcher) : this({ listOf(dispatcher) })
+
+    // The NetworkingModule's client no longer serves all JS networking — modules like
+    // expo/fetch (the global `fetch` on Expo SDK 56+) build their own clients through
+    // OkHttpClientProvider. Resolve the full set lazily on every check: under bridgeless
+    // RN, modules and their clients can also be (re)created after registration.
+    constructor(reactContext: ReactContext) : this({
+        (listOfNotNull(NetworkingModuleReflected(reactContext).getHttpClient()?.dispatcher) +
+            DetoxOkHttpClientTracker.dispatchers())
+            .distinctBy { System.identityHashCode(it) }
+    })
 
     override fun getName(): String {
         return NetworkIdlingResource::class.java.name
@@ -52,12 +62,20 @@ class NetworkIdlingResource(private val dispatcher: Dispatcher) : DetoxIdlingRes
     override fun checkIdle(): Boolean {
         busyResources.clear()
 
-        val calls = dispatcher.runningCalls()
-        for (call in calls) {
-            val url = call.request().url.toString()
+        for (dispatcher in dispatchersSupplier()) {
+            for (call in dispatcher.runningCalls()) {
+                // A WebSocket occupies a running-calls slot for its entire lifetime
+                // (its reader loop runs inside the response callback). It is a
+                // long-lived channel, not pending work — never busy.
+                if (call.request().header("Upgrade").equals("websocket", ignoreCase = true)) {
+                    continue
+                }
 
-            if (!isUrlBlacklisted(url)) {
-                busyResources.add(url)
+                val url = call.request().url.toString()
+
+                if (!isUrlBlacklisted(url)) {
+                    busyResources.add(url)
+                }
             }
         }
 

--- a/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/network/NetworkingModuleReflected.kt
+++ b/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/network/NetworkingModuleReflected.kt
@@ -15,8 +15,15 @@ private const val FIELD_OKHTTP_CLIENT_PRE80 = "mClient"
 private const val FIELD_OKHTTP_CLIENT = "client"
 
 internal class NetworkingModuleReflected(private val reactContext: ReactContext) {
+    private companion object {
+        // getHttpClient() runs on every idle check; log failures only once.
+        private var loggedReflectException = false
+    }
+
     fun getHttpClient(): OkHttpClient? {
-        val networkNativeModule = reactContext.getNativeModule(NetworkingModule::class.java)
+        // Under bridgeless RN, TurboModules are lazy — the module may not exist yet.
+        val networkNativeModule =
+            reactContext.getNativeModule(NetworkingModule::class.java) ?: return null
         try {
             val fieldName = if ( ReactNativeInfo.rnVersion().minor > 79) {
                 FIELD_OKHTTP_CLIENT
@@ -26,7 +33,10 @@ internal class NetworkingModuleReflected(private val reactContext: ReactContext)
 
             return Reflect.on(networkNativeModule).field(fieldName).get()
         } catch (e: ReflectException) {
-            Log.e(LOG_TAG, "Can't set up Networking Module listener", e)
+            if (!loggedReflectException) {
+                loggedReflectException = true
+                Log.e(LOG_TAG, "Can't set up Networking Module listener", e)
+            }
             return null
         }
     }

--- a/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResourcesTest.kt
+++ b/detox/android/detox/src/testFull/java/com/wix/detox/reactnative/idlingresources/NetworkIdlingResourcesTest.kt
@@ -4,10 +4,14 @@ import com.wix.detox.UTHelpers.yieldToOtherThreads
 import com.wix.detox.reactnative.idlingresources.network.NetworkIdlingResource
 import org.assertj.core.api.Assertions.assertThat
 
+import okhttp3.Call
 import okhttp3.Dispatcher
+import okhttp3.Request
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.Executors
 
@@ -61,5 +65,38 @@ class NetworkIdlingResourcesTest {
         }
         yieldToOtherThreads(localExecutor)
         assertThat(idle).isTrue
+    }
+
+    @Test
+    fun `should consider calls from every supplied dispatcher`() {
+        val busyDispatcher = mockDispatcherWithRunningCall(
+            Request.Builder().url("https://example.com/query").build()
+        )
+        uut = NetworkIdlingResource { listOf(dispatcher, busyDispatcher) }
+
+        assertThat(uut.isIdleNow).isFalse
+        assertThat(uut.getBusyHint()["urls"] as List<*>).containsExactly("https://example.com/query")
+    }
+
+    @Test
+    fun `should not consider a websocket call busy`() {
+        val webSocketDispatcher = mockDispatcherWithRunningCall(
+            Request.Builder()
+                .url("https://example.com/realtime")
+                .header("Upgrade", "websocket")
+                .build()
+        )
+        uut = NetworkIdlingResource { listOf(webSocketDispatcher) }
+
+        assertThat(uut.isIdleNow).isTrue
+    }
+
+    private fun mockDispatcherWithRunningCall(request: Request): Dispatcher {
+        val call = mock<Call> {
+            on { request() } doReturn request
+        }
+        return mock<Dispatcher> {
+            on { runningCalls() } doReturn listOf(call)
+        }
     }
 }


### PR DESCRIPTION
## Description

- This pull request addresses the issue described here: #4973

In this pull request, I have taught Android network synchronization to track every OkHttp client created through RN's `OkHttpClientProvider`, instead of only the `NetworkingModule`'s. Modules increasingly create their own clients through the provider — most notably `expo/fetch`, the global `fetch` since Expo SDK 56 — leaving their traffic invisible to synchronization, so Detox performs actions while requests are in flight.

**How it works**: a new `DetoxOkHttpClientTracker` installs a delegating `OkHttpClientFactory` into `OkHttpClientProvider` (its public customization point) before the app launches, recording each created client's `Dispatcher`. `NetworkIdlingResource` checks the union of the `NetworkingModule` dispatcher and all recorded ones, resolved lazily on every check (under bridgeless RN, modules can be created or recreated after registration — this also fixes a `getHttpClient()!!` NPE on lazy TurboModules).

**Design notes:**
- The registry is weakly keyed on the `Dispatcher`, not the client: consumers often keep only a `newBuilder()` derivative (which shares the `Dispatcher`) and discard the provider's client — expo/fetch does. The dispatcher stays reachable through any derived client and is the object synchronization reads.
- WebSocket calls (`Upgrade: websocket`) are never busy: a socket occupies a `runningCalls()` slot for its entire lifetime, and RN 0.86's `WebSocketModule` connects through the provider — without this, an open socket (e.g. GraphQL subscriptions) blocks network-idle forever.
- The install wraps and delegates to any factory the app registered; if the current factory can't be read, nothing is installed (replacing an unknown one could strip behavior such as TLS pinning).

**Verified**: on an RN 0.86.2 / Expo SDK 57 app (bridgeless) whose Android suite failed deterministically at the first post-request tap, the full suite passes with this change. Unit tests added for multi-dispatcher aggregation and the WebSocket exclusion; full unit suite green (310 tests).

*Note: AI assistance was used to diagnose the issue and develop this fix; all findings and changes were manually checked and verified against real devices and Detox's test suite.*

---

> _For features/enhancements:_
 - [ ] N/A (bug fix)

> _For API changes:_
 - [ ] N/A (no JS API changes)