### PR TITLE
Fixed iOS WebView typing to a text input without maxlength prop

### DIFF
--- a/detox/ios/Detox/Invocation/WebCodeBuilder+createTypeAction.swift
+++ b/detox/ios/Detox/Invocation/WebCodeBuilder+createTypeAction.swift
@@ -59,7 +59,8 @@ extension WebCodeBuilder {
 	let currentIndex = 0;
 	const delay = \(typeCharacterDelay);
 	const typeCharacters = () => {
-		if (isInputField && (element.value.length >= element.getAttribute('maxlength'))) {
+		const maxLength = element.getAttribute('maxlength');
+		if (isInputField && maxLength !== null && (element.value.length >= Number(maxLength))) {
 		  return;
 		}
 

--- a/detox/test/e2e/29.webview.test.js
+++ b/detox/test/e2e/29.webview.test.js
@@ -85,6 +85,7 @@ describe('WebView', () => {
     describe('actions', () => {
       describe('input', () => {
         const inputElement = web.element(by.web.id('fname'));
+        const inputElement2 = web.element(by.web.id('uncapped'));
 
         describe(':ios:', () => {
           it('should type text in input regardless of content-editable parameter on ios', async () => {
@@ -92,6 +93,13 @@ describe('WebView', () => {
             await inputElement.typeText('er', true);
 
             await expect(inputElement).toHaveText('Tester');
+          });
+
+          it('should type text in input with no maxlength', async () => {
+            await inputElement2.typeText('Test', false);
+            await inputElement2.typeText('er', true);
+
+            await expect(inputElement2).toHaveText('Tester');
           });
 
           it('should type text in input', async () => {
@@ -427,7 +435,7 @@ describe(':ios: WebView CORS (inner frame)', () => {
     });
 
     it('should find elements in cross-origin frame by type with `asSecured()`', async () => {
-      await expect(web.element(by.web.type('textField')).atIndex(1).asSecured()).toExist();
+      await expect(web.element(by.web.type('textField')).atIndex(2).asSecured()).toExist();
     });
 
     it('should find elements in cross-origin frame by label with `asSecured()`', async () => {
@@ -435,18 +443,18 @@ describe(':ios: WebView CORS (inner frame)', () => {
     });
 
     it('should type text in cross-origin frame with `asSecured()`', async () => {
-      await web.element(by.web.type('textField')).atIndex(1).asSecured().typeText('Test');
+      await web.element(by.web.type('textField')).atIndex(2).asSecured().typeText('Test');
       await expectElementSnapshotToMatch(webviewElement, 'cross-origin-frame.type-text-in', 0.97);
 
-      await web.element(by.web.type('textField')).asSecured().atIndex(1).replaceText('Test 2');
+      await web.element(by.web.type('textField')).asSecured().atIndex(2).replaceText('Test 2');
       await expectElementSnapshotToMatch(webviewElement, 'cross-origin-frame.replace-text', 0.97);
 
-      await web.element(by.web.type('textField')).asSecured().atIndex(1).clearText();
+      await web.element(by.web.type('textField')).asSecured().atIndex(2).clearText();
       await expectElementSnapshotToMatch(webviewElement, 'cross-origin-frame.clear-text', 0.97);
     });
 
     it('should tap on cross-origin frame element with `asSecured()`', async () => {
-      await web.element(by.web.type('textField')).asSecured().atIndex(1).typeText('Test');
+      await web.element(by.web.type('textField')).asSecured().atIndex(2).typeText('Test');
       await web.element(by.web.label('Submit')).asSecured().tap();
 
       await expectElementSnapshotToMatch(webviewElement, 'tap-on-cross-origin-frame-element');

--- a/detox/test/src/Screens/WebViewScreen.js
+++ b/detox/test/src/Screens/WebViewScreen.js
@@ -125,6 +125,8 @@ const webViewFormWithScrolling = `
             <label for="fname">Your name:</label><br>
             <input type="text" id="fname" name="fname" maxlength="10"><br>
             <input type="submit" id="submit" value="Submit" onclick="document.getElementById('resultFname').innerHTML = document.getElementById('fname').value; return false;">
+
+            <input type="text" id="uncapped" name="uncapped"><br>
         </form>
 
         <h2>Form Results</h2>


### PR DESCRIPTION
## Description

<!--
Thank you for contributing!

Step 1: Before submitting a pull request that introduces a new functionality or fixes a bug,
please open an issue where we could discuss the suggestion, problem - and potential ways to fix.
-->

- This pull request addresses the issue described here: [Issue](https://github.com/wix/Detox/issues/4975)

<!--
Step 2: Provide an overview of how your fix / enhancement works.
If possible, provide screenshots of the before and after states (even for simple command line options - show the terminal).
-->

In this pull request, I have fixed an bug on iOS where text input without a prop `maxlength` inside an WebView could not be typed into. Before this change that was not possible as `getAttribute('maxlength')` returns `null` or `string`. And in JavaScript a check `0 >= null` returns true. Which meant when trying to type into an empty text field (0 length) the function call would instantly be returned.

Added a new input field to the WebViewScreen.js test that does not have that `maxlength` prop and added a new test case for to test that too. Needed to touch couple more test cases as those included getting an text input element by index which is now +1 as this change introduced the new text input in the form.

<!--
Step 3: Please review the checklist below.
-->

---


> _For features/enhancements:_
 - [ ] I have added/updated the relevant references in the [documentation](https://github.com/wix/Detox/tree/master/docs) files.

> _For API changes:_
 - [ ] I have made the necessary changes in the [types index](https://github.com/wix/Detox/blob/master/detox/index.d.ts) file.
